### PR TITLE
feat: add ledger credit allocation UI

### DIFF
--- a/rentchain-frontend/src/api/leaseLedgerApi.test.ts
+++ b/rentchain-frontend/src/api/leaseLedgerApi.test.ts
@@ -36,4 +36,64 @@ describe("leaseLedgerApi", () => {
       },
     });
   });
+
+  it("fetches landlord credit allocation previews through the scoped endpoint", async () => {
+    const { fetchCreditAllocationPreview } = await import("./leaseLedgerApi");
+
+    await fetchCreditAllocationPreview("lease-1");
+
+    expect(mocks.apiFetch).toHaveBeenCalledWith("/landlord/leases/lease-1/credit-allocation-preview", {
+      method: "GET",
+      allowStatuses: [400, 403, 404, 409],
+    });
+  });
+
+  it("applies credit allocations with the reviewed preview payload", async () => {
+    const { applyCreditAllocation } = await import("./leaseLedgerApi");
+
+    await applyCreditAllocation("lease-1", {
+      obligationRowId: "obligation-1",
+      allocationAmountCents: 200000,
+      previewFingerprint: "preview-1",
+      idempotencyKey: "idem-1",
+    });
+
+    expect(mocks.apiFetch).toHaveBeenCalledWith("/landlord/leases/lease-1/credit-allocations", {
+      method: "POST",
+      body: {
+        obligationRowId: "obligation-1",
+        allocationAmountCents: 200000,
+        previewFingerprint: "preview-1",
+        idempotencyKey: "idem-1",
+      },
+      allowStatuses: [400, 409],
+    });
+  });
+
+  it("surfaces credit allocation API error codes", async () => {
+    const { applyCreditAllocation, CreditAllocationApiError } = await import("./leaseLedgerApi");
+    mocks.apiFetch.mockResolvedValueOnce({
+      ok: false,
+      code: "CREDIT_ALLOCATION_STATE_STALE",
+      message: "stale",
+      preview: { leaseId: "lease-1" },
+    });
+
+    try {
+      await applyCreditAllocation("lease-1", {
+        obligationRowId: "obligation-1",
+        allocationAmountCents: 200000,
+        previewFingerprint: "preview-1",
+        idempotencyKey: "idem-1",
+      });
+      throw new Error("expected allocation error");
+    } catch (err) {
+      expect(err).toBeInstanceOf(CreditAllocationApiError);
+      expect(err).toMatchObject({
+        name: "CreditAllocationApiError",
+        code: "CREDIT_ALLOCATION_STATE_STALE",
+        preview: { leaseId: "lease-1" },
+      });
+    }
+  });
 });

--- a/rentchain-frontend/src/api/leaseLedgerApi.ts
+++ b/rentchain-frontend/src/api/leaseLedgerApi.ts
@@ -127,6 +127,146 @@ export type LeaseLedgerResponse = {
   decisions?: DecisionItem[];
 };
 
+export type LeaseCreditAllocationStatus = "active" | "reversed";
+
+export type LeaseCreditAllocationPreviewObligation = {
+  obligationKey: string;
+  obligationRowId: string;
+  leaseId: string;
+  propertyId?: string | null;
+  unitId?: string | null;
+  tenantId?: string | null;
+  paymentIntentId?: string | null;
+  rentPaymentId?: string | null;
+  paymentDocumentId?: string | null;
+  dueDate?: string | null;
+  periodStart?: string | null;
+  periodEnd?: string | null;
+  expectedAmountCents: number;
+  paidAmountCents: number;
+  existingActiveAllocationAmountCents: number;
+  outstandingAmountCents: number;
+  currency: string;
+  suggestedAllocationAmountCents: number;
+  afterAvailableCreditCents: number;
+  obligationOutstandingAfterCents: number;
+};
+
+export type LeaseCreditAllocationSummary = {
+  allocationId: string;
+  landlordId: string;
+  leaseId: string;
+  propertyId?: string | null;
+  unitId?: string | null;
+  tenantId?: string | null;
+  obligationRowId: string;
+  obligationKey: string;
+  allocationAmountCents: number;
+  currency: string;
+  status: LeaseCreditAllocationStatus;
+  createdAt: string;
+  createdBy: string;
+  createdByEmail?: string | null;
+  reason?: string | null;
+  note?: string | null;
+  beforeAvailableCreditCents: number;
+  beforeOutstandingAmountCents: number;
+  afterAvailableCreditCents: number;
+  afterOutstandingAmountCents: number;
+  previewFingerprint: string;
+  idempotencyKey?: string | null;
+  reversedAt?: string | null;
+  reversedBy?: string | null;
+  reversedByEmail?: string | null;
+  reversalReason?: string | null;
+  sourceType: "lease_credit_allocation";
+};
+
+export type LeaseCreditAllocationSuggestion = {
+  obligationRowId: string;
+  obligationKey: string;
+  allocationAmountCents: number;
+  beforeAvailableCreditCents: number;
+  beforeOutstandingAmountCents: number;
+  afterAvailableCreditCents: number;
+  afterOutstandingAmountCents: number;
+};
+
+export type LeaseCreditAllocationPreview = {
+  ok?: boolean;
+  leaseId: string;
+  landlordId: string;
+  sourceType: "lease_credit_allocation";
+  aggregateBalanceCents: number;
+  sourceBalanceBeforeCents: number;
+  grossAvailableCreditCents: number;
+  activeAllocationAmountCents: number;
+  availableCreditCents: number;
+  eligibleObligations: LeaseCreditAllocationPreviewObligation[];
+  obligations: LeaseCreditAllocationPreviewObligation[];
+  suggestedAllocations: LeaseCreditAllocationSuggestion[];
+  totalOutstandingAmountCents: number;
+  totalSuggestedAllocationAmountCents: number;
+  remainingAvailableCreditCents: number;
+  previewFingerprint: string;
+  blockedReasons: string[];
+  allowed: boolean;
+  existingActiveAllocations: LeaseCreditAllocationSummary[];
+  reversedAllocations: LeaseCreditAllocationSummary[];
+  noLegalOrLifecycleEffect: boolean;
+};
+
+export type ApplyCreditAllocationPayload = {
+  obligationRowId: string;
+  allocationAmountCents: number;
+  previewFingerprint: string;
+  idempotencyKey: string;
+  note?: string;
+};
+
+export type ApplyCreditAllocationResponse = {
+  ok: true;
+  allocation: LeaseCreditAllocationSummary;
+  idempotentReplay: boolean;
+  beforePreview: LeaseCreditAllocationPreview;
+  preview: LeaseCreditAllocationPreview;
+  noLegalOrLifecycleEffect: boolean;
+};
+
+export type ReverseCreditAllocationResponse = {
+  ok: true;
+  allocation: LeaseCreditAllocationSummary;
+  preview: LeaseCreditAllocationPreview;
+  noLegalOrLifecycleEffect: boolean;
+};
+
+type CreditAllocationErrorResponse = {
+  ok: false;
+  error?: string;
+  code?: string;
+  message?: string;
+  preview?: LeaseCreditAllocationPreview;
+};
+
+export class CreditAllocationApiError extends Error {
+  code: string;
+  preview?: LeaseCreditAllocationPreview;
+
+  constructor(code: string, message?: string, preview?: LeaseCreditAllocationPreview) {
+    super(message || code);
+    this.name = "CreditAllocationApiError";
+    this.code = code;
+    this.preview = preview;
+  }
+}
+
+function assertCreditAllocationOk<T extends { ok?: boolean }>(response: T | CreditAllocationErrorResponse): T {
+  if (response && response.ok !== false) return response as T;
+  const errorResponse = response as CreditAllocationErrorResponse;
+  const code = errorResponse?.code || errorResponse?.error || "CREDIT_ALLOCATION_REQUEST_FAILED";
+  throw new CreditAllocationApiError(code, errorResponse?.message || code, errorResponse?.preview);
+}
+
 export async function fetchLeaseLedger(
   leaseId: string,
   from?: string,
@@ -139,6 +279,48 @@ export async function fetchLeaseLedger(
   return apiFetch(`/leases/${encodeURIComponent(leaseId)}/ledger${qs ? `?${qs}` : ""}`, {
     method: "GET",
   });
+}
+
+export async function fetchCreditAllocationPreview(leaseId: string): Promise<LeaseCreditAllocationPreview> {
+  const response = await apiFetch<LeaseCreditAllocationPreview | CreditAllocationErrorResponse>(
+    `/landlord/leases/${encodeURIComponent(leaseId)}/credit-allocation-preview`,
+    {
+      method: "GET",
+      allowStatuses: [400, 403, 404, 409],
+    }
+  );
+  return assertCreditAllocationOk<LeaseCreditAllocationPreview>(response);
+}
+
+export async function applyCreditAllocation(
+  leaseId: string,
+  payload: ApplyCreditAllocationPayload
+): Promise<ApplyCreditAllocationResponse> {
+  const response = await apiFetch<ApplyCreditAllocationResponse | CreditAllocationErrorResponse>(
+    `/landlord/leases/${encodeURIComponent(leaseId)}/credit-allocations`,
+    {
+      method: "POST",
+      body: payload,
+      allowStatuses: [400, 409],
+    }
+  );
+  return assertCreditAllocationOk<ApplyCreditAllocationResponse>(response);
+}
+
+export async function reverseCreditAllocation(
+  leaseId: string,
+  allocationId: string,
+  payload: { reason: string }
+): Promise<ReverseCreditAllocationResponse> {
+  const response = await apiFetch<ReverseCreditAllocationResponse | CreditAllocationErrorResponse>(
+    `/landlord/leases/${encodeURIComponent(leaseId)}/credit-allocations/${encodeURIComponent(allocationId)}/reverse`,
+    {
+      method: "POST",
+      body: payload,
+      allowStatuses: [400, 404, 409],
+    }
+  );
+  return assertCreditAllocationOk<ReverseCreditAllocationResponse>(response);
 }
 
 export async function addLeaseCharge(

--- a/rentchain-frontend/src/lib/decisions/decisionContext.test.ts
+++ b/rentchain-frontend/src/lib/decisions/decisionContext.test.ts
@@ -121,7 +121,7 @@ describe("decisionContext", () => {
     });
 
     expect(items).toEqual(
-      expect.arrayContaining([{ label: "Signal reason", value: "Obligation remains unmatched after due date" }])
+      expect.arrayContaining([{ label: "Signal reason", value: "Rent charge was not yet matched to available credit" }])
     );
     expect(items.map((item) => item.value)).not.toContain("obligation_pending_after_due_date");
   });

--- a/rentchain-frontend/src/lib/decisions/decisionContext.ts
+++ b/rentchain-frontend/src/lib/decisions/decisionContext.ts
@@ -63,9 +63,9 @@ function titleCase(value: unknown): string {
 }
 
 const signalReasonDisplayCopy: Record<string, string> = {
-  aggregate_credit_balance_with_unmatched_obligations: "Aggregate credit balance with unmatched obligations",
+  aggregate_credit_balance_with_unmatched_obligations: "Available credit needs rent charge review",
   manual_review_required: "Manual review required",
-  obligation_pending_after_due_date: "Obligation remains unmatched after due date",
+  obligation_pending_after_due_date: "Rent charge was not yet matched to available credit",
   provider_received: "Provider received payment evidence",
   rent_payment_checkout_created: "Provider checkout was created",
 };

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.css
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.css
@@ -101,6 +101,121 @@
   padding: 12px;
 }
 
+.lease-credit-allocation-panel {
+  display: grid;
+  gap: 12px;
+  min-width: 0;
+  border: 1px solid rgba(36, 88, 66, 0.22);
+  border-radius: 12px;
+  background: #f7fbf8;
+  box-shadow: 0 10px 24px rgba(36, 88, 66, 0.08);
+  color: #1f3529;
+  padding: 12px;
+}
+
+.lease-credit-allocation-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.lease-credit-allocation-header h2,
+.lease-credit-allocation-history h3 {
+  margin: 0;
+  color: #1f3529;
+  font-size: 1rem;
+}
+
+.lease-credit-allocation-header p,
+.lease-credit-allocation-history p,
+.lease-credit-allocation-note {
+  margin: 3px 0 0;
+  color: #3f5f4d;
+  font-size: 13px;
+}
+
+.lease-credit-allocation-metrics,
+.lease-credit-allocation-obligation,
+.lease-credit-allocation-history-item {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 170px), 1fr));
+  gap: 8px;
+}
+
+.lease-credit-allocation-metric,
+.lease-credit-allocation-obligation > div,
+.lease-credit-allocation-history-item > div {
+  min-width: 0;
+  border: 1px solid rgba(36, 88, 66, 0.16);
+  border-radius: 10px;
+  background: #ffffff;
+  padding: 10px;
+}
+
+.lease-credit-allocation-metric span,
+.lease-credit-allocation-obligation span,
+.lease-credit-allocation-history-item span {
+  display: block;
+  color: #3f5f4d;
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.lease-credit-allocation-metric strong,
+.lease-credit-allocation-obligation strong,
+.lease-credit-allocation-history-item strong {
+  display: block;
+  color: #1f3529;
+  overflow-wrap: anywhere;
+}
+
+.lease-credit-allocation-confirmation {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  width: fit-content;
+  max-width: 100%;
+  color: #1f3529;
+  font-weight: 800;
+}
+
+.lease-credit-allocation-confirmation input {
+  margin-top: 2px;
+}
+
+.lease-credit-allocation-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.lease-credit-allocation-success {
+  display: grid;
+  gap: 8px;
+  border: 1px solid #bbf7d0;
+  border-radius: 12px;
+  background: #f0fdf4;
+  color: #166534;
+  padding: 12px;
+}
+
+.lease-credit-allocation-error {
+  border: 1px solid #fecaca;
+  border-radius: 10px;
+  background: #fef2f2;
+  color: #991b1b;
+  padding: 10px;
+}
+
+.lease-credit-allocation-history {
+  display: grid;
+  gap: 8px;
+  border-top: 1px solid rgba(36, 88, 66, 0.16);
+  padding-top: 10px;
+}
+
 .lease-ledger-decision-summary {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(min(100%, 150px), 1fr));
@@ -210,6 +325,8 @@
   .lease-ledger-actions > a,
   .lease-ledger-actions > button,
   .lease-ledger-csv-card-header > button,
+  .lease-credit-allocation-header > button,
+  .lease-credit-allocation-actions > button,
   .lease-ledger-next-action > button {
     flex: 1 1 140px;
     min-width: 0;
@@ -509,6 +626,7 @@
 
   .lease-ledger-print-root .lease-ledger-actions,
   .lease-ledger-print-root .lease-ledger-csv-card,
+  .lease-ledger-print-root .lease-ledger-no-print,
   .lease-ledger-print-root input,
   .lease-ledger-print-root select,
   .lease-ledger-print-root textarea,

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.css
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.css
@@ -269,6 +269,22 @@
   display: none;
 }
 
+.lease-ledger-obligation-allocation-cell {
+  display: grid;
+  gap: 3px;
+  min-width: 150px;
+}
+
+.lease-ledger-obligation-allocation-cell strong {
+  color: #166534;
+}
+
+.lease-ledger-obligation-allocation-cell span {
+  display: block;
+  color: #475569;
+  font-size: 12px;
+}
+
 .lease-ledger-obligations-table,
 .lease-ledger-entries-table {
   max-width: 100%;

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
@@ -98,8 +98,70 @@ function buildCreditAllocationLedgerResponse(baseLedgerResponse: any, status: "r
   };
 }
 
+function buildCreditAllocationPreviewResponse(overrides: Record<string, any> = {}) {
+  const obligation = {
+    obligationKey: "lease-1:2026-06-01:200000",
+    obligationRowId: "obligation-pending-credit",
+    leaseId: "lease-1",
+    propertyId: "prop-1",
+    unitId: "unit-1",
+    tenantId: "tenant-1",
+    paymentIntentId: null,
+    rentPaymentId: null,
+    paymentDocumentId: null,
+    dueDate: "2026-06-01T00:00:00.000Z",
+    periodStart: "2026-06-01",
+    periodEnd: "2026-06-30",
+    expectedAmountCents: 200000,
+    paidAmountCents: 0,
+    existingActiveAllocationAmountCents: 0,
+    outstandingAmountCents: 200000,
+    currency: "cad",
+    suggestedAllocationAmountCents: 200000,
+    afterAvailableCreditCents: 676900,
+    obligationOutstandingAfterCents: 0,
+  };
+  return {
+    ok: true,
+    leaseId: "lease-1",
+    landlordId: "landlord-1",
+    sourceType: "lease_credit_allocation",
+    aggregateBalanceCents: -876900,
+    sourceBalanceBeforeCents: -876900,
+    grossAvailableCreditCents: 876900,
+    activeAllocationAmountCents: 0,
+    availableCreditCents: 876900,
+    eligibleObligations: [obligation],
+    obligations: [obligation],
+    suggestedAllocations: [
+      {
+        obligationRowId: "obligation-pending-credit",
+        obligationKey: "lease-1:2026-06-01:200000",
+        allocationAmountCents: 200000,
+        beforeAvailableCreditCents: 876900,
+        beforeOutstandingAmountCents: 200000,
+        afterAvailableCreditCents: 676900,
+        afterOutstandingAmountCents: 0,
+      },
+    ],
+    totalOutstandingAmountCents: 200000,
+    totalSuggestedAllocationAmountCents: 200000,
+    remainingAvailableCreditCents: 676900,
+    previewFingerprint: "preview-fingerprint-1",
+    blockedReasons: [],
+    allowed: true,
+    existingActiveAllocations: [],
+    reversedAllocations: [],
+    noLegalOrLifecycleEffect: true,
+    ...overrides,
+  };
+}
+
 const mocks = vi.hoisted(() => ({
   fetchLeaseLedger: vi.fn(),
+  fetchCreditAllocationPreview: vi.fn(),
+  applyCreditAllocation: vi.fn(),
+  reverseCreditAllocation: vi.fn(),
   addLeaseCharge: vi.fn(),
   addLeasePayment: vi.fn(),
   leaseLedgerExportUrl: vi.fn((_leaseId: string, _from?: string, _to?: string, format: "csv" | "pdf" = "csv") => `https://example.com/export.${format}`),
@@ -113,6 +175,9 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("../api/leaseLedgerApi", () => ({
   fetchLeaseLedger: mocks.fetchLeaseLedger,
+  fetchCreditAllocationPreview: mocks.fetchCreditAllocationPreview,
+  applyCreditAllocation: mocks.applyCreditAllocation,
+  reverseCreditAllocation: mocks.reverseCreditAllocation,
   addLeaseCharge: mocks.addLeaseCharge,
   addLeasePayment: mocks.addLeasePayment,
   leaseLedgerExportUrl: mocks.leaseLedgerExportUrl,
@@ -142,6 +207,9 @@ describe("LeaseLedgerPage", () => {
   beforeEach(() => {
     cleanup();
     vi.restoreAllMocks();
+    mocks.fetchCreditAllocationPreview.mockReset();
+    mocks.applyCreditAllocation.mockReset();
+    mocks.reverseCreditAllocation.mockReset();
     mocks.leaseLedgerExportUrl.mockImplementation(
       (_leaseId: string, _from?: string, _to?: string, format: "csv" | "pdf" = "csv") => `https://example.com/export.${format}`
     );
@@ -155,6 +223,78 @@ describe("LeaseLedgerPage", () => {
         get: () => null,
       },
     })) as unknown as typeof fetch;
+    mocks.fetchCreditAllocationPreview.mockResolvedValue(buildCreditAllocationPreviewResponse());
+    mocks.applyCreditAllocation.mockResolvedValue({
+      ok: true,
+      allocation: {
+        allocationId: "allocation-1",
+        landlordId: "landlord-1",
+        leaseId: "lease-1",
+        propertyId: "prop-1",
+        unitId: "unit-1",
+        tenantId: "tenant-1",
+        obligationRowId: "obligation-pending-credit",
+        obligationKey: "lease-1:2026-06-01:200000",
+        allocationAmountCents: 200000,
+        currency: "cad",
+        status: "active",
+        createdAt: "2026-07-15T00:00:00.000Z",
+        createdBy: "landlord-1",
+        createdByEmail: "landlord@example.com",
+        reason: "operator_credit_allocation",
+        note: null,
+        beforeAvailableCreditCents: 876900,
+        beforeOutstandingAmountCents: 200000,
+        afterAvailableCreditCents: 676900,
+        afterOutstandingAmountCents: 0,
+        previewFingerprint: "preview-fingerprint-1",
+        idempotencyKey: "idempotency-1",
+        sourceType: "lease_credit_allocation",
+      },
+      idempotentReplay: false,
+      beforePreview: buildCreditAllocationPreviewResponse(),
+      preview: buildCreditAllocationPreviewResponse({
+        availableCreditCents: 676900,
+        activeAllocationAmountCents: 200000,
+        eligibleObligations: [],
+        obligations: [],
+        suggestedAllocations: [],
+        totalOutstandingAmountCents: 0,
+        totalSuggestedAllocationAmountCents: 0,
+        remainingAvailableCreditCents: 676900,
+        allowed: false,
+        blockedReasons: ["no_outstanding_obligations"],
+        existingActiveAllocations: [
+          {
+            allocationId: "allocation-1",
+            landlordId: "landlord-1",
+            leaseId: "lease-1",
+            propertyId: "prop-1",
+            unitId: "unit-1",
+            tenantId: "tenant-1",
+            obligationRowId: "obligation-pending-credit",
+            obligationKey: "lease-1:2026-06-01:200000",
+            allocationAmountCents: 200000,
+            currency: "cad",
+            status: "active",
+            createdAt: "2026-07-15T00:00:00.000Z",
+            createdBy: "landlord-1",
+            createdByEmail: "landlord@example.com",
+            reason: "operator_credit_allocation",
+            note: null,
+            beforeAvailableCreditCents: 876900,
+            beforeOutstandingAmountCents: 200000,
+            afterAvailableCreditCents: 676900,
+            afterOutstandingAmountCents: 0,
+            previewFingerprint: "preview-fingerprint-1",
+            idempotencyKey: "idempotency-1",
+            sourceType: "lease_credit_allocation",
+          },
+        ],
+      }),
+      noLegalOrLifecycleEffect: true,
+    });
+    mocks.reverseCreditAllocation.mockResolvedValue({ ok: true });
     mocks.fetchLeaseLedger.mockResolvedValue({
       ok: true,
       leaseId: "lease-1",
@@ -638,6 +778,161 @@ describe("LeaseLedgerPage", () => {
     expect(screen.queryByText("Record payment or contact the tenant, then resolve once the ledger is updated.")).not.toBeInTheDocument();
   });
 
+  it("shows an operator-confirmed credit allocation panel when preview is available", async () => {
+    const baseLedgerResponse = await mocks.fetchLeaseLedger("lease-1");
+    mocks.fetchLeaseLedger.mockClear();
+    mocks.fetchLeaseLedger.mockResolvedValueOnce(buildCreditAllocationLedgerResponse(baseLedgerResponse, "reviewed"));
+
+    render(
+      <MemoryRouter initialEntries={["/leases/lease-1/ledger"]}>
+        <Routes>
+          <Route path="/leases/:leaseId/ledger" element={<LeaseLedgerPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await screen.findByRole("heading", { name: "Allocate available lease credit" });
+    await waitFor(() => expect(mocks.fetchCreditAllocationPreview).toHaveBeenCalledWith("lease-1"));
+    expect(screen.getByText("This lease has available credit, but one or more obligations remain unmatched. Review the suggested allocation before applying credit to the obligation.")).toBeInTheDocument();
+    expect(screen.getByText("Available credit")).toBeInTheDocument();
+    expect(screen.getAllByText("$8,769.00").length).toBeGreaterThan(0);
+    expect(screen.getByText("Outstanding obligation")).toBeInTheDocument();
+    expect(screen.getAllByText("$2,000.00").length).toBeGreaterThan(0);
+    expect(screen.getByText("Suggested allocation")).toBeInTheDocument();
+    expect(screen.getByText("Remaining credit after allocation")).toBeInTheDocument();
+    expect(screen.getByText("$6,769.00")).toBeInTheDocument();
+    expect(screen.getByText("Existing lease credit available for operator-reviewed allocation")).toBeInTheDocument();
+    expect(screen.queryByText(/collection resolved/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/legal compliance/i)).not.toBeInTheDocument();
+  });
+
+  it("keeps apply disabled until confirmation and sends the current preview fingerprint", async () => {
+    const baseLedgerResponse = await mocks.fetchLeaseLedger("lease-1");
+    mocks.fetchLeaseLedger.mockClear();
+    mocks.fetchLeaseLedger.mockResolvedValue(buildCreditAllocationLedgerResponse(baseLedgerResponse, "reviewed"));
+
+    render(
+      <MemoryRouter initialEntries={["/leases/lease-1/ledger"]}>
+        <Routes>
+          <Route path="/leases/:leaseId/ledger" element={<LeaseLedgerPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    const applyButton = await screen.findByRole("button", { name: "Apply credit allocation" });
+    expect(applyButton).toBeDisabled();
+
+    fireEvent.click(screen.getByLabelText("I have reviewed the credit balance and obligation details."));
+    expect(applyButton).not.toBeDisabled();
+    fireEvent.click(applyButton);
+
+    await waitFor(() => expect(mocks.applyCreditAllocation).toHaveBeenCalledWith(
+      "lease-1",
+      expect.objectContaining({
+        obligationRowId: "obligation-pending-credit",
+        allocationAmountCents: 200000,
+        previewFingerprint: "preview-fingerprint-1",
+        idempotencyKey: expect.stringContaining("lease-credit-allocation:lease-1:obligation-pending-credit:"),
+      })
+    ));
+    expect(mocks.applyCreditAllocation.mock.calls[0][1]).not.toHaveProperty("obligationKey");
+  });
+
+  it("renders allocation success details after apply", async () => {
+    const baseLedgerResponse = await mocks.fetchLeaseLedger("lease-1");
+    mocks.fetchLeaseLedger.mockClear();
+    mocks.fetchLeaseLedger.mockResolvedValue(buildCreditAllocationLedgerResponse(baseLedgerResponse, "reviewed"));
+
+    render(
+      <MemoryRouter initialEntries={["/leases/lease-1/ledger"]}>
+        <Routes>
+          <Route path="/leases/:leaseId/ledger" element={<LeaseLedgerPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByLabelText("I have reviewed the credit balance and obligation details."));
+    fireEvent.click(screen.getByRole("button", { name: "Apply credit allocation" }));
+
+    expect(await screen.findByText("Credit allocation recorded")).toBeInTheDocument();
+    expect(screen.getByText("Existing lease credit was applied to this obligation.")).toBeInTheDocument();
+    expect(screen.getByText("Historical payment records were not edited.")).toBeInTheDocument();
+    expect(screen.getAllByText("allocation-1").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("$6,769.00").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("$0.00").length).toBeGreaterThan(0);
+    expect(screen.getByText("This allocation records how existing lease credit was applied to an obligation. It does not edit historical payment records.")).toBeInTheDocument();
+    await waitFor(() => expect(mocks.fetchLeaseLedger).toHaveBeenCalledTimes(2));
+  });
+
+  it("renders stale preview errors with refresh-safe copy", async () => {
+    const baseLedgerResponse = await mocks.fetchLeaseLedger("lease-1");
+    mocks.fetchLeaseLedger.mockClear();
+    mocks.fetchLeaseLedger.mockResolvedValue(buildCreditAllocationLedgerResponse(baseLedgerResponse, "reviewed"));
+    mocks.applyCreditAllocation.mockRejectedValueOnce({ code: "CREDIT_ALLOCATION_STATE_STALE" });
+
+    render(
+      <MemoryRouter initialEntries={["/leases/lease-1/ledger"]}>
+        <Routes>
+          <Route path="/leases/:leaseId/ledger" element={<LeaseLedgerPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByLabelText("I have reviewed the credit balance and obligation details."));
+    fireEvent.click(screen.getByRole("button", { name: "Apply credit allocation" }));
+
+    expect(await screen.findByText("Ledger changed since this preview was generated. Refresh the allocation preview and try again.")).toBeInTheDocument();
+    expect(screen.queryByText("Credit allocation recorded")).not.toBeInTheDocument();
+  });
+
+  it("renders generic allocation failures with ledger-safe copy", async () => {
+    const baseLedgerResponse = await mocks.fetchLeaseLedger("lease-1");
+    mocks.fetchLeaseLedger.mockClear();
+    mocks.fetchLeaseLedger.mockResolvedValue(buildCreditAllocationLedgerResponse(baseLedgerResponse, "reviewed"));
+    mocks.applyCreditAllocation.mockRejectedValueOnce(new Error("network failed"));
+
+    render(
+      <MemoryRouter initialEntries={["/leases/lease-1/ledger"]}>
+        <Routes>
+          <Route path="/leases/:leaseId/ledger" element={<LeaseLedgerPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByLabelText("I have reviewed the credit balance and obligation details."));
+    fireEvent.click(screen.getByRole("button", { name: "Apply credit allocation" }));
+
+    expect(await screen.findByText("Credit allocation could not be recorded. No ledger records were changed.")).toBeInTheDocument();
+  });
+
+  it("does not show the allocation panel when the preview is blocked with no eligible obligations", async () => {
+    const baseLedgerResponse = await mocks.fetchLeaseLedger("lease-1");
+    mocks.fetchLeaseLedger.mockClear();
+    mocks.fetchLeaseLedger.mockResolvedValueOnce(buildCreditAllocationLedgerResponse(baseLedgerResponse, "reviewed"));
+    mocks.fetchCreditAllocationPreview.mockResolvedValueOnce(buildCreditAllocationPreviewResponse({
+      allowed: false,
+      eligibleObligations: [],
+      obligations: [],
+      suggestedAllocations: [],
+      blockedReasons: ["no_outstanding_obligations"],
+      totalOutstandingAmountCents: 0,
+      totalSuggestedAllocationAmountCents: 0,
+    }));
+
+    render(
+      <MemoryRouter initialEntries={["/leases/lease-1/ledger"]}>
+        <Routes>
+          <Route path="/leases/:leaseId/ledger" element={<LeaseLedgerPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Credit balance needs allocation review")).toBeInTheDocument();
+    await waitFor(() => expect(mocks.fetchCreditAllocationPreview).toHaveBeenCalledWith("lease-1"));
+    await waitFor(() => expect(screen.queryByText("Allocate available lease credit")).not.toBeInTheDocument());
+    expect(screen.queryByRole("button", { name: "Apply credit allocation" })).not.toBeInTheDocument();
+  });
+
   it("renders resolved allocation-review decisions as passive workflow state", async () => {
     const baseLedgerResponse = await mocks.fetchLeaseLedger("lease-1");
     mocks.fetchLeaseLedger.mockClear();
@@ -946,6 +1241,9 @@ describe("LeaseLedgerPage", () => {
       expect(printText).toContain("Review payment allocation");
       expect(printText).toContain("Allocation review");
       expect(printText).toContain("Payments exceed charges in aggregate, but one or more obligations remain unmatched.");
+      expect(printText).not.toContain("Allocate available lease credit");
+      expect(printText).not.toContain("Apply credit allocation");
+      expect(printText).not.toContain("I have reviewed the credit balance and obligation details.");
       expect(printDecisionText).toContain("Resolved outcome");
       expect(printDecisionText).toContain("Marked resolved as an allocation-review item. No rent-collection action should be taken until unmatched payments are reviewed.");
       expect(printDecisionText).not.toContain("Recommended next action");
@@ -964,6 +1262,7 @@ describe("LeaseLedgerPage", () => {
     );
 
     await screen.findByText("Review payment allocation");
+    await screen.findByText("Allocate available lease credit");
     fireEvent.click(screen.getByRole("button", { name: "Print / Save PDF" }));
 
     await waitFor(() => expect(printSpy).toHaveBeenCalled());

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
@@ -157,6 +157,49 @@ function buildCreditAllocationPreviewResponse(overrides: Record<string, any> = {
   };
 }
 
+function buildActiveCreditAllocationPreviewResponse(overrides: Record<string, any> = {}) {
+  return buildCreditAllocationPreviewResponse({
+    activeAllocationAmountCents: 200000,
+    availableCreditCents: 676900,
+    eligibleObligations: [],
+    obligations: [],
+    suggestedAllocations: [],
+    totalOutstandingAmountCents: 0,
+    totalSuggestedAllocationAmountCents: 0,
+    remainingAvailableCreditCents: 676900,
+    allowed: false,
+    blockedReasons: ["no_outstanding_obligations"],
+    existingActiveAllocations: [
+      {
+        allocationId: "allocation-1",
+        landlordId: "landlord-1",
+        leaseId: "lease-1",
+        propertyId: "prop-1",
+        unitId: "unit-1",
+        tenantId: "tenant-1",
+        obligationRowId: "obligation-pending-credit",
+        obligationKey: "lease-1:2026-06-01:200000",
+        allocationAmountCents: 200000,
+        currency: "cad",
+        status: "active",
+        createdAt: "2026-07-15T00:00:00.000Z",
+        createdBy: "landlord-1",
+        createdByEmail: "landlord@example.com",
+        reason: "operator_credit_allocation",
+        note: null,
+        beforeAvailableCreditCents: 876900,
+        beforeOutstandingAmountCents: 200000,
+        afterAvailableCreditCents: 676900,
+        afterOutstandingAmountCents: 0,
+        previewFingerprint: "preview-fingerprint-1",
+        idempotencyKey: "idempotency-1",
+        sourceType: "lease_credit_allocation",
+      },
+    ],
+    ...overrides,
+  });
+}
+
 const mocks = vi.hoisted(() => ({
   fetchLeaseLedger: vi.fn(),
   fetchCreditAllocationPreview: vi.fn(),
@@ -806,6 +849,33 @@ describe("LeaseLedgerPage", () => {
     expect(screen.queryByText(/legal compliance/i)).not.toBeInTheDocument();
   });
 
+  it("uses active allocation records to avoid stale outstanding warning copy after reload", async () => {
+    const baseLedgerResponse = await mocks.fetchLeaseLedger("lease-1");
+    mocks.fetchLeaseLedger.mockClear();
+    mocks.fetchLeaseLedger.mockResolvedValueOnce(buildCreditAllocationLedgerResponse(baseLedgerResponse, "reviewed"));
+    mocks.fetchCreditAllocationPreview.mockResolvedValueOnce(buildActiveCreditAllocationPreviewResponse());
+
+    render(
+      <MemoryRouter initialEntries={["/leases/lease-1/ledger"]}>
+        <Routes>
+          <Route path="/leases/:leaseId/ledger" element={<LeaseLedgerPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Remaining lease credit available")).toBeInTheDocument();
+    expect(screen.getByText(/unallocated credit remaining after applying \$2,000.00 to the unmatched obligation/i)).toBeInTheDocument();
+    expect(screen.getByText(/aggregate ledger balance remains -\$8,769.00/i)).toBeInTheDocument();
+    expect(screen.getByText(/Obligation outstanding after allocation: \$0.00/i)).toBeInTheDocument();
+    expect(screen.queryByText(/but \$2,000.00 remains outstanding on specific obligations/i)).not.toBeInTheDocument();
+    expect(screen.getByText("Active allocation history")).toBeInTheDocument();
+    expect(screen.getAllByText("$0.00 after allocation").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Allocated from credit: $2,000.00").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Original outstanding: $2,000.00").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Credit allocation recorded").length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Existing lease credit covers this obligation/i).length).toBeGreaterThan(0);
+  });
+
   it("keeps apply disabled until confirmation and sends the current preview fingerprint", async () => {
     const baseLedgerResponse = await mocks.fetchLeaseLedger("lease-1");
     mocks.fetchLeaseLedger.mockClear();
@@ -854,7 +924,7 @@ describe("LeaseLedgerPage", () => {
     fireEvent.click(await screen.findByLabelText("I have reviewed the credit balance and obligation details."));
     fireEvent.click(screen.getByRole("button", { name: "Apply credit allocation" }));
 
-    expect(await screen.findByText("Credit allocation recorded")).toBeInTheDocument();
+    expect((await screen.findAllByText("Credit allocation recorded")).length).toBeGreaterThan(0);
     expect(screen.getByText("Existing lease credit was applied to this obligation.")).toBeInTheDocument();
     expect(screen.getByText("Historical payment records were not edited.")).toBeInTheDocument();
     expect(screen.getAllByText("allocation-1").length).toBeGreaterThan(0);

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
@@ -863,6 +863,10 @@ describe("LeaseLedgerPage", () => {
     );
 
     expect(await screen.findByText("Remaining lease credit available")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Lease credit allocation recorded" })).toBeInTheDocument();
+    expect(screen.getByText("Available credit has been applied to this rent charge. These records show operator-reviewed allocations and do not edit historical payment records.")).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Allocate available lease credit" })).not.toBeInTheDocument();
+    expect(screen.queryByText("This lease has available credit, but a rent charge was not yet matched to that credit. Review and apply available credit to the rent charge.")).not.toBeInTheDocument();
     expect(screen.getByText(/available credit remaining after \$2,000.00 was applied to the rent charge/i)).toBeInTheDocument();
     expect(screen.getByText(/ledger balance remains -\$8,769.00/i)).toBeInTheDocument();
     expect(screen.getByText(/Rent charge outstanding after allocation: \$0.00/i)).toBeInTheDocument();
@@ -1299,6 +1303,41 @@ describe("LeaseLedgerPage", () => {
     );
     expect(document.querySelector('[data-print-root="true"].lease-ledger-print-root')).not.toBeInTheDocument();
     expect(document.body.hasAttribute("data-print-root-active")).toBe(false);
+    printSpy.mockRestore();
+  });
+
+  it("prints active allocation state with recorded-credit copy", async () => {
+    const baseLedgerResponse = await mocks.fetchLeaseLedger("lease-1");
+    mocks.fetchLeaseLedger.mockClear();
+    mocks.fetchLeaseLedger.mockResolvedValueOnce(buildCreditAllocationLedgerResponse(baseLedgerResponse, "reviewed"));
+    mocks.fetchCreditAllocationPreview.mockResolvedValueOnce(buildActiveCreditAllocationPreviewResponse());
+    const printSpy = vi.spyOn(window, "print").mockImplementation(() => {
+      const printRoot = document.querySelector('[data-print-root="true"].lease-ledger-print-root');
+      const printText = printRoot?.textContent || "";
+      expect(printText).toContain("Remaining lease credit available");
+      expect(printText).toContain("This lease has $6,769.00 of available credit remaining after $2,000.00 was applied to the rent charge.");
+      expect(printText).toContain("The ledger balance remains -$8,769.00 because historical payment records were not edited.");
+      expect(printText).toContain("Rent charge outstanding after allocation: $0.00.");
+      expect(printText).toContain("Ledger balance");
+      expect(printText).toContain("Credit applied");
+      expect(printText).toContain("Available credit after allocation");
+      expect(printText).not.toContain("This lease has available credit, but a rent charge was not yet matched to that credit.");
+      expect(printText).not.toContain("Apply credit allocation");
+      window.dispatchEvent(new Event("afterprint"));
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/leases/lease-1/ledger"]}>
+        <Routes>
+          <Route path="/leases/:leaseId/ledger" element={<LeaseLedgerPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await screen.findByRole("heading", { name: "Lease credit allocation recorded" });
+    fireEvent.click(screen.getByRole("button", { name: "Print / Save PDF" }));
+
+    await waitFor(() => expect(printSpy).toHaveBeenCalled());
     printSpy.mockRestore();
   });
 

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
@@ -785,7 +785,7 @@ describe("LeaseLedgerPage", () => {
     expect(screen.getAllByText(new Date(2026, 4, 5).toLocaleDateString()).length).toBeGreaterThan(0);
   });
 
-  it("explains aggregate credit balances when specific obligations remain outstanding", async () => {
+  it("explains available credit when a rent charge still needs review", async () => {
     const baseLedgerResponse = await mocks.fetchLeaseLedger("lease-1");
     mocks.fetchLeaseLedger.mockClear();
     mocks.fetchLeaseLedger.mockResolvedValueOnce(buildCreditAllocationLedgerResponse(baseLedgerResponse, "reviewed"));
@@ -799,20 +799,19 @@ describe("LeaseLedgerPage", () => {
     );
 
     expect(await screen.findByText("Credit balance needs allocation review")).toBeInTheDocument();
-    expect(screen.getByText(/aggregate credit balance of -\$8,769.00/i)).toBeInTheDocument();
-    expect(screen.getByText(/but \$2,000.00 remains outstanding on specific obligations/i)).toBeInTheDocument();
-    expect(screen.getByText("Review the obligation rows before resolving overdue decisions.")).toBeInTheDocument();
+    expect(screen.getByText(/a \$2,000.00 rent charge was not yet matched to/i)).toBeInTheDocument();
+    expect(screen.getByText("Review and apply available credit to the rent charge.")).toBeInTheDocument();
     expect(screen.getByText("Review payment allocation")).toBeInTheDocument();
     expect(screen.getAllByText("Allocation review").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Payments exceed charges in aggregate, but one or more obligations remain unmatched.").length).toBeGreaterThan(0);
-    expect(screen.getByText("Review and allocate unmatched payments before taking any overdue-rent action.")).toBeInTheDocument();
+    expect(screen.getAllByText("A rent charge was not yet matched to the tenant's available credit.").length).toBeGreaterThan(0);
+    expect(screen.getByText("Review and apply available credit to the rent charge before resolving this item.")).toBeInTheDocument();
     expect(screen.getByText("Recommended next action")).toBeInTheDocument();
     expect(screen.queryByText("Resolved outcome")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Resolve" })).toBeInTheDocument();
     expect(screen.queryByText("Review / resolve")).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Mark reviewed:/ })).not.toBeInTheDocument();
-    expect(screen.getAllByText("Payments exceed charges in aggregate, but this obligation remains unmatched.").length).toBeGreaterThan(0);
-    expect(screen.getByText("Obligation remains unmatched after due date")).toBeInTheDocument();
+    expect(screen.getAllByText("A rent charge was not yet matched to the tenant's available credit.").length).toBeGreaterThan(0);
+    expect(screen.getByText("Rent charge was not yet matched to available credit")).toBeInTheDocument();
     expect(screen.queryByText("obligation_pending_after_due_date")).not.toBeInTheDocument();
     expect(screen.getAllByText("Reviewed").length).toBeGreaterThan(0);
     expect(screen.getByText(/reviewed or resolved status does not mark rent paid/i)).toBeInTheDocument();
@@ -836,13 +835,13 @@ describe("LeaseLedgerPage", () => {
 
     await screen.findByRole("heading", { name: "Allocate available lease credit" });
     await waitFor(() => expect(mocks.fetchCreditAllocationPreview).toHaveBeenCalledWith("lease-1"));
-    expect(screen.getByText("This lease has available credit, but one or more obligations remain unmatched. Review the suggested allocation before applying credit to the obligation.")).toBeInTheDocument();
+    expect(screen.getByText("This lease has available credit, but a rent charge was not yet matched to that credit. Review and apply available credit to the rent charge.")).toBeInTheDocument();
     expect(screen.getByText("Available credit")).toBeInTheDocument();
     expect(screen.getAllByText("$8,769.00").length).toBeGreaterThan(0);
-    expect(screen.getByText("Outstanding obligation")).toBeInTheDocument();
+    expect(screen.getAllByText("Rent charge outstanding").length).toBeGreaterThan(0);
     expect(screen.getAllByText("$2,000.00").length).toBeGreaterThan(0);
-    expect(screen.getByText("Suggested allocation")).toBeInTheDocument();
-    expect(screen.getByText("Remaining credit after allocation")).toBeInTheDocument();
+    expect(screen.getByText("Suggested credit to apply")).toBeInTheDocument();
+    expect(screen.getByText("Available credit after allocation")).toBeInTheDocument();
     expect(screen.getByText("$6,769.00")).toBeInTheDocument();
     expect(screen.getByText("Existing lease credit available for operator-reviewed allocation")).toBeInTheDocument();
     expect(screen.queryByText(/collection resolved/i)).not.toBeInTheDocument();
@@ -864,16 +863,19 @@ describe("LeaseLedgerPage", () => {
     );
 
     expect(await screen.findByText("Remaining lease credit available")).toBeInTheDocument();
-    expect(screen.getByText(/unallocated credit remaining after applying \$2,000.00 to the unmatched obligation/i)).toBeInTheDocument();
-    expect(screen.getByText(/aggregate ledger balance remains -\$8,769.00/i)).toBeInTheDocument();
-    expect(screen.getByText(/Obligation outstanding after allocation: \$0.00/i)).toBeInTheDocument();
+    expect(screen.getByText(/available credit remaining after \$2,000.00 was applied to the rent charge/i)).toBeInTheDocument();
+    expect(screen.getByText(/ledger balance remains -\$8,769.00/i)).toBeInTheDocument();
+    expect(screen.getByText(/Rent charge outstanding after allocation: \$0.00/i)).toBeInTheDocument();
+    expect(screen.getAllByText("Ledger balance").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Credit applied").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Available credit after allocation").length).toBeGreaterThan(0);
     expect(screen.queryByText(/but \$2,000.00 remains outstanding on specific obligations/i)).not.toBeInTheDocument();
     expect(screen.getByText("Active allocation history")).toBeInTheDocument();
     expect(screen.getAllByText("$0.00 after allocation").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Allocated from credit: $2,000.00").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Original outstanding: $2,000.00").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Credit allocation recorded").length).toBeGreaterThan(0);
-    expect(screen.getAllByText(/Existing lease credit covers this obligation/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Existing lease credit covers this rent charge/i).length).toBeGreaterThan(0);
   });
 
   it("keeps apply disabled until confirmation and sends the current preview fingerprint", async () => {
@@ -892,7 +894,7 @@ describe("LeaseLedgerPage", () => {
     const applyButton = await screen.findByRole("button", { name: "Apply credit allocation" });
     expect(applyButton).toBeDisabled();
 
-    fireEvent.click(screen.getByLabelText("I have reviewed the credit balance and obligation details."));
+    fireEvent.click(screen.getByLabelText("I have reviewed the credit balance and rent charge details."));
     expect(applyButton).not.toBeDisabled();
     fireEvent.click(applyButton);
 
@@ -921,16 +923,16 @@ describe("LeaseLedgerPage", () => {
       </MemoryRouter>
     );
 
-    fireEvent.click(await screen.findByLabelText("I have reviewed the credit balance and obligation details."));
+    fireEvent.click(await screen.findByLabelText("I have reviewed the credit balance and rent charge details."));
     fireEvent.click(screen.getByRole("button", { name: "Apply credit allocation" }));
 
     expect((await screen.findAllByText("Credit allocation recorded")).length).toBeGreaterThan(0);
-    expect(screen.getByText("Existing lease credit was applied to this obligation.")).toBeInTheDocument();
+    expect(screen.getByText("Credit was applied to the rent charge.")).toBeInTheDocument();
     expect(screen.getByText("Historical payment records were not edited.")).toBeInTheDocument();
     expect(screen.getAllByText("allocation-1").length).toBeGreaterThan(0);
     expect(screen.getAllByText("$6,769.00").length).toBeGreaterThan(0);
     expect(screen.getAllByText("$0.00").length).toBeGreaterThan(0);
-    expect(screen.getByText("This allocation records how existing lease credit was applied to an obligation. It does not edit historical payment records.")).toBeInTheDocument();
+    expect(screen.getByText("This allocation records how existing lease credit was applied to a rent charge. It does not edit historical payment records.")).toBeInTheDocument();
     await waitFor(() => expect(mocks.fetchLeaseLedger).toHaveBeenCalledTimes(2));
   });
 
@@ -948,7 +950,7 @@ describe("LeaseLedgerPage", () => {
       </MemoryRouter>
     );
 
-    fireEvent.click(await screen.findByLabelText("I have reviewed the credit balance and obligation details."));
+    fireEvent.click(await screen.findByLabelText("I have reviewed the credit balance and rent charge details."));
     fireEvent.click(screen.getByRole("button", { name: "Apply credit allocation" }));
 
     expect(await screen.findByText("Ledger changed since this preview was generated. Refresh the allocation preview and try again.")).toBeInTheDocument();
@@ -969,7 +971,7 @@ describe("LeaseLedgerPage", () => {
       </MemoryRouter>
     );
 
-    fireEvent.click(await screen.findByLabelText("I have reviewed the credit balance and obligation details."));
+    fireEvent.click(await screen.findByLabelText("I have reviewed the credit balance and rent charge details."));
     fireEvent.click(screen.getByRole("button", { name: "Apply credit allocation" }));
 
     expect(await screen.findByText("Credit allocation could not be recorded. No ledger records were changed.")).toBeInTheDocument();
@@ -1020,9 +1022,9 @@ describe("LeaseLedgerPage", () => {
     expect(screen.getByText("Review payment allocation")).toBeInTheDocument();
     expect(screen.getAllByText("Allocation review").length).toBeGreaterThan(0);
     expect(screen.getByText("Resolved outcome")).toBeInTheDocument();
-    expect(screen.getByText("Marked resolved as an allocation-review item. No rent-collection action should be taken until unmatched payments are reviewed.")).toBeInTheDocument();
+    expect(screen.getByText("Marked resolved as an allocation-review item. Review available credit before taking further action.")).toBeInTheDocument();
     expect(screen.queryByText("Recommended next action")).not.toBeInTheDocument();
-    expect(screen.queryByText("Review and allocate unmatched payments before taking any overdue-rent action.")).not.toBeInTheDocument();
+    expect(screen.queryByText("Review and apply available credit to the rent charge before resolving this item.")).not.toBeInTheDocument();
     expect(screen.getAllByText("Already resolved").length).toBeGreaterThan(0);
     expect(screen.getByText("Last action: Resolved")).toBeInTheDocument();
     expect(screen.queryByText("Review / resolve")).not.toBeInTheDocument();
@@ -1310,15 +1312,15 @@ describe("LeaseLedgerPage", () => {
       const printDecisionText = printRoot?.querySelector(".lease-ledger-print-decision")?.textContent || "";
       expect(printText).toContain("Review payment allocation");
       expect(printText).toContain("Allocation review");
-      expect(printText).toContain("Payments exceed charges in aggregate, but one or more obligations remain unmatched.");
+      expect(printText).toContain("A rent charge was not yet matched to the tenant's available credit.");
       expect(printText).not.toContain("Allocate available lease credit");
       expect(printText).not.toContain("Apply credit allocation");
-      expect(printText).not.toContain("I have reviewed the credit balance and obligation details.");
+      expect(printText).not.toContain("I have reviewed the credit balance and rent charge details.");
       expect(printDecisionText).toContain("Resolved outcome");
-      expect(printDecisionText).toContain("Marked resolved as an allocation-review item. No rent-collection action should be taken until unmatched payments are reviewed.");
+      expect(printDecisionText).toContain("Marked resolved as an allocation-review item. Review available credit before taking further action.");
       expect(printDecisionText).not.toContain("Recommended next action");
-      expect(printDecisionText).not.toContain("Review and allocate unmatched payments before taking any overdue-rent action.");
-      expect(printText).toContain("Signal reason: Obligation remains unmatched after due date");
+      expect(printDecisionText).not.toContain("Review and apply available credit to the rent charge before resolving this item.");
+      expect(printText).toContain("Signal reason: Rent charge was not yet matched to available credit");
       expect(printText).not.toContain("obligation_pending_after_due_date");
       window.dispatchEvent(new Event("afterprint"));
     });

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
@@ -3,7 +3,13 @@ import { Link, useParams } from "react-router-dom";
 import {
   addLeaseCharge,
   addLeasePayment,
+  applyCreditAllocation,
+  fetchCreditAllocationPreview,
+  type ApplyCreditAllocationResponse,
   fetchLeaseLedger,
+  type LeaseCreditAllocationPreview,
+  type LeaseCreditAllocationPreviewObligation,
+  type LeaseCreditAllocationSummary,
   type DelinquencySignalType,
   type LeaseObligationLedgerRow,
   type LeaseObligationLedgerSummary,
@@ -52,6 +58,27 @@ type PaymentMethod = "cash" | "etransfer" | "cheque" | "bank" | "card" | "other"
 function errorMessage(error: unknown, fallback: string) {
   if (error instanceof Error && error.message) return error.message;
   return fallback;
+}
+
+function creditAllocationErrorMessage(error: unknown): string {
+  const code =
+    typeof error === "object" && error && "code" in error
+      ? String((error as { code?: unknown }).code || "")
+      : error instanceof Error
+        ? error.message
+        : "";
+  switch (code) {
+    case "CREDIT_ALLOCATION_STATE_STALE":
+      return "Ledger changed since this preview was generated. Refresh the allocation preview and try again.";
+    case "CREDIT_ALLOCATION_AMOUNT_EXCEEDS_CREDIT":
+      return "The allocation amount exceeds the available credit.";
+    case "CREDIT_ALLOCATION_AMOUNT_EXCEEDS_OUTSTANDING":
+      return "The allocation amount exceeds the obligation outstanding amount.";
+    case "CREDIT_ALLOCATION_IDEMPOTENCY_CONFLICT":
+      return "This allocation request conflicts with a previous submission. Refresh and try again.";
+    default:
+      return "Credit allocation could not be recorded. No ledger records were changed.";
+  }
 }
 
 function centsFromInput(input: string): number | null {
@@ -105,6 +132,14 @@ function prettyLeaseStatus(value: string | null | undefined) {
 }
 
 function formatPeriod(row: LeaseObligationLedgerRow): string {
+  const start = formatDate(row.periodStart);
+  const end = formatDate(row.periodEnd);
+  if (start === "—" && end === "—") return "—";
+  if (start !== "—" && end !== "—") return `${start} - ${end}`;
+  return start !== "—" ? start : end;
+}
+
+function formatAllocationPeriod(row: Pick<LeaseCreditAllocationPreviewObligation, "periodStart" | "periodEnd">): string {
   const start = formatDate(row.periodStart);
   const end = formatDate(row.periodEnd);
   if (start === "—" && end === "—") return "—";
@@ -1239,6 +1274,209 @@ const modalCard: React.CSSProperties = {
   padding: 18,
 };
 
+function createAllocationIdempotencyKey(leaseId: string, obligationRowId: string): string {
+  const random =
+    typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  return `lease-credit-allocation:${leaseId}:${obligationRowId}:${random}`;
+}
+
+function CreditAllocationMetric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="lease-credit-allocation-metric">
+      <span>{label}</span>
+      <strong>{value}</strong>
+    </div>
+  );
+}
+
+function ActiveAllocationSummary({ allocation }: { allocation: LeaseCreditAllocationSummary }) {
+  return (
+    <article className="lease-credit-allocation-history-item">
+      <div>
+        <span>Allocation ID</span>
+        <strong>{allocation.allocationId}</strong>
+      </div>
+      <div>
+        <span>Amount allocated</span>
+        <strong>{formatCurrencyCents(allocation.allocationAmountCents)}</strong>
+      </div>
+      <div>
+        <span>Remaining credit after allocation</span>
+        <strong>{formatCurrencyCents(allocation.afterAvailableCreditCents)}</strong>
+      </div>
+      <div>
+        <span>Obligation outstanding after allocation</span>
+        <strong>{formatCurrencyCents(allocation.afterOutstandingAmountCents)}</strong>
+      </div>
+    </article>
+  );
+}
+
+function LeaseCreditAllocationPanel({
+  preview,
+  loading,
+  error,
+  reviewed,
+  submitting,
+  success,
+  successObligation,
+  onReviewedChange,
+  onApply,
+  onRefresh,
+}: {
+  preview: LeaseCreditAllocationPreview | null;
+  loading: boolean;
+  error: string | null;
+  reviewed: boolean;
+  submitting: boolean;
+  success: ApplyCreditAllocationResponse | null;
+  successObligation: LeaseCreditAllocationPreviewObligation | null;
+  onReviewedChange: (checked: boolean) => void;
+  onApply: (obligation: LeaseCreditAllocationPreviewObligation) => void;
+  onRefresh: () => void;
+}) {
+  if (loading && !preview) {
+    return (
+      <section className="lease-credit-allocation-panel lease-ledger-no-print" aria-label="Credit allocation review">
+        <h2>Allocate available lease credit</h2>
+        <p>Loading allocation preview…</p>
+      </section>
+    );
+  }
+
+  const suggestion = preview?.suggestedAllocations?.[0] || null;
+  const obligation = suggestion
+    ? preview?.eligibleObligations?.find((item) => item.obligationRowId === suggestion.obligationRowId) || preview?.eligibleObligations?.[0] || null
+    : preview?.eligibleObligations?.[0] || null;
+  const activeAllocations = preview?.existingActiveAllocations || [];
+  const shouldRender = Boolean(success || (preview?.allowed && suggestion && obligation) || activeAllocations.length > 0);
+  if (!shouldRender) return null;
+
+  const allocationAmountCents = suggestion?.allocationAmountCents || obligation?.suggestedAllocationAmountCents || 0;
+  const remainingCreditCents = suggestion?.afterAvailableCreditCents ?? obligation?.afterAvailableCreditCents ?? preview?.remainingAvailableCreditCents ?? 0;
+  const outstandingAfterCents =
+    suggestion?.afterOutstandingAmountCents ?? obligation?.obligationOutstandingAfterCents ?? Math.max(0, Number(obligation?.outstandingAmountCents || 0) - allocationAmountCents);
+  const applyDisabled = !reviewed || submitting || !preview?.previewFingerprint || !obligation || allocationAmountCents <= 0;
+
+  return (
+    <section className="lease-credit-allocation-panel lease-ledger-no-print" aria-label="Credit allocation review">
+      <div className="lease-credit-allocation-header">
+        <div>
+          <h2>Allocate available lease credit</h2>
+          <p>
+            This lease has available credit, but one or more obligations remain unmatched. Review the suggested allocation before applying
+            credit to the obligation.
+          </p>
+        </div>
+        <button type="button" onClick={onRefresh} disabled={loading || submitting}>
+          {loading ? "Refreshing…" : "Refresh preview"}
+        </button>
+      </div>
+
+      {success ? (
+        <div className="lease-credit-allocation-success" role="status">
+          <strong>Credit allocation recorded</strong>
+          <span>Existing lease credit was applied to this obligation.</span>
+          <span>Historical payment records were not edited.</span>
+          <div className="lease-credit-allocation-metrics">
+            <CreditAllocationMetric label="Allocation ID" value={success.allocation.allocationId} />
+            <CreditAllocationMetric label="Amount allocated" value={formatCurrencyCents(success.allocation.allocationAmountCents)} />
+            <CreditAllocationMetric label="Obligation period" value={formatAllocationPeriod({
+              periodStart: successObligation?.periodStart || obligation?.periodStart || null,
+              periodEnd: successObligation?.periodEnd || obligation?.periodEnd || null,
+            })} />
+            <CreditAllocationMetric label="Obligation due date" value={formatDate(successObligation?.dueDate || obligation?.dueDate || null)} />
+            <CreditAllocationMetric label="Remaining credit after allocation" value={formatCurrencyCents(success.allocation.afterAvailableCreditCents)} />
+            <CreditAllocationMetric label="Obligation outstanding after allocation" value={formatCurrencyCents(success.allocation.afterOutstandingAmountCents)} />
+          </div>
+          <p className="lease-credit-allocation-note">
+            This allocation records how existing lease credit was applied to an obligation. It does not edit historical payment records.
+          </p>
+        </div>
+      ) : null}
+
+      {preview && obligation && suggestion ? (
+        <>
+          <div className="lease-credit-allocation-metrics">
+            <CreditAllocationMetric label="Available credit" value={formatCurrencyCents(preview.availableCreditCents)} />
+            <CreditAllocationMetric label="Outstanding obligation" value={formatCurrencyCents(obligation.outstandingAmountCents)} />
+            <CreditAllocationMetric label="Suggested allocation" value={formatCurrencyCents(allocationAmountCents)} />
+            <CreditAllocationMetric label="Remaining credit after allocation" value={formatCurrencyCents(remainingCreditCents)} />
+          </div>
+
+          <div className="lease-credit-allocation-obligation">
+            <div>
+              <span>Period</span>
+              <strong>{formatAllocationPeriod(obligation)}</strong>
+            </div>
+            <div>
+              <span>Due date</span>
+              <strong>{formatDate(obligation.dueDate)}</strong>
+            </div>
+            <div>
+              <span>Expected</span>
+              <strong>{formatCurrencyCents(obligation.expectedAmountCents)}</strong>
+            </div>
+            <div>
+              <span>Paid</span>
+              <strong>{formatCurrencyCents(obligation.paidAmountCents)}</strong>
+            </div>
+            <div>
+              <span>Outstanding</span>
+              <strong>{formatCurrencyCents(obligation.outstandingAmountCents)}</strong>
+            </div>
+            <div>
+              <span>Status</span>
+              <strong>Allocation review</strong>
+            </div>
+            <div>
+              <span>Evidence</span>
+              <strong>Existing lease credit available for operator-reviewed allocation</strong>
+            </div>
+            <div>
+              <span>Obligation outstanding after allocation</span>
+              <strong>{formatCurrencyCents(outstandingAfterCents)}</strong>
+            </div>
+          </div>
+
+          <label className="lease-credit-allocation-confirmation">
+            <input
+              type="checkbox"
+              checked={reviewed}
+              onChange={(event) => onReviewedChange(event.target.checked)}
+              disabled={submitting}
+            />
+            <span>I have reviewed the credit balance and obligation details.</span>
+          </label>
+          <p className="lease-credit-allocation-note">
+            This records an allocation review and does not edit historical payment records.
+          </p>
+
+          {error ? <div className="lease-credit-allocation-error" role="alert">{error}</div> : null}
+
+          <div className="lease-credit-allocation-actions">
+            <button type="button" onClick={() => onApply(obligation)} disabled={applyDisabled}>
+              {submitting ? "Recording allocation…" : "Apply credit allocation"}
+            </button>
+          </div>
+        </>
+      ) : null}
+
+      {activeAllocations.length > 0 ? (
+        <div className="lease-credit-allocation-history">
+          <h3>Active allocation history</h3>
+          <p>These records show operator-reviewed allocations. Reversal controls are deferred to a follow-up workflow.</p>
+          {activeAllocations.map((allocation) => (
+            <ActiveAllocationSummary key={allocation.allocationId} allocation={allocation} />
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
 export default function LeaseLedgerPage() {
   const { leaseId = "" } = useParams();
   const printSourceRef = React.useRef<HTMLDivElement | null>(null);
@@ -1265,6 +1503,14 @@ export default function LeaseLedgerPage() {
   const [noteText, setNoteText] = useState("");
   const [isCsvImportOpen, setIsCsvImportOpen] = useState(false);
   const [isPrintExportMounted, setIsPrintExportMounted] = useState(false);
+  const [creditAllocationPreview, setCreditAllocationPreview] = useState<LeaseCreditAllocationPreview | null>(null);
+  const [creditAllocationLoading, setCreditAllocationLoading] = useState(false);
+  const [creditAllocationError, setCreditAllocationError] = useState<string | null>(null);
+  const [creditAllocationReviewed, setCreditAllocationReviewed] = useState(false);
+  const [creditAllocationSubmitting, setCreditAllocationSubmitting] = useState(false);
+  const [creditAllocationSuccess, setCreditAllocationSuccess] = useState<ApplyCreditAllocationResponse | null>(null);
+  const [creditAllocationSuccessObligation, setCreditAllocationSuccessObligation] =
+    useState<LeaseCreditAllocationPreviewObligation | null>(null);
 
   const [chargeDate, setChargeDate] = useState(todayIso());
   const [chargeType, setChargeType] = useState<ChargeType>("rent");
@@ -1310,6 +1556,22 @@ export default function LeaseLedgerPage() {
     }
   };
 
+  const loadCreditAllocationPreview = async () => {
+    if (!leaseId) return;
+    setCreditAllocationLoading(true);
+    setCreditAllocationError(null);
+    try {
+      const preview = await fetchCreditAllocationPreview(leaseId);
+      setCreditAllocationPreview(preview);
+      setCreditAllocationReviewed(false);
+    } catch (err: unknown) {
+      setCreditAllocationPreview(null);
+      setCreditAllocationError(creditAllocationErrorMessage(err));
+    } finally {
+      setCreditAllocationLoading(false);
+    }
+  };
+
   const handleDecisionAction = async (decision: DecisionItem, actionType: DecisionActionType) => {
     if (!leaseId) return;
     if (!decisionActionChangesStatus(decision, actionType)) return;
@@ -1352,6 +1614,49 @@ export default function LeaseLedgerPage() {
     void loadLeaseMeta();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [leaseId]);
+
+  useEffect(() => {
+    if (!leaseId || !hasUnallocatedCreditNotice) {
+      setCreditAllocationPreview(null);
+      setCreditAllocationError(null);
+      setCreditAllocationReviewed(false);
+      setCreditAllocationSuccess(null);
+      setCreditAllocationSuccessObligation(null);
+      return;
+    }
+    void loadCreditAllocationPreview();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [leaseId, hasUnallocatedCreditNotice, totals.balanceCents, outstandingObligationCents]);
+
+  async function submitCreditAllocation(obligation: LeaseCreditAllocationPreviewObligation) {
+    if (!leaseId || !creditAllocationPreview) return;
+    const suggestion = creditAllocationPreview.suggestedAllocations.find((item) => item.obligationRowId === obligation.obligationRowId);
+    const allocationAmountCents = suggestion?.allocationAmountCents || obligation.suggestedAllocationAmountCents;
+    if (!creditAllocationReviewed || !creditAllocationPreview.previewFingerprint || !allocationAmountCents) return;
+    setCreditAllocationSubmitting(true);
+    setCreditAllocationError(null);
+    try {
+      const result = await applyCreditAllocation(leaseId, {
+        obligationRowId: obligation.obligationRowId,
+        allocationAmountCents,
+        previewFingerprint: creditAllocationPreview.previewFingerprint,
+        idempotencyKey: createAllocationIdempotencyKey(leaseId, obligation.obligationRowId),
+      });
+      setCreditAllocationSuccess(result);
+      setCreditAllocationSuccessObligation(obligation);
+      setCreditAllocationPreview(result.preview);
+      setCreditAllocationReviewed(false);
+      await loadLedger({ showLoading: false });
+    } catch (err: unknown) {
+      setCreditAllocationError(creditAllocationErrorMessage(err));
+      if (typeof err === "object" && err && "preview" in err) {
+        const preview = (err as { preview?: LeaseCreditAllocationPreview }).preview;
+        if (preview) setCreditAllocationPreview(preview);
+      }
+    } finally {
+      setCreditAllocationSubmitting(false);
+    }
+  }
 
   async function submitNote() {
     const note = noteText.trim();
@@ -1633,6 +1938,21 @@ export default function LeaseLedgerPage() {
           </span>
           <span>Review the obligation rows before resolving overdue decisions.</span>
         </div>
+      ) : null}
+
+      {hasUnallocatedCreditNotice ? (
+        <LeaseCreditAllocationPanel
+          preview={creditAllocationPreview}
+          loading={creditAllocationLoading}
+          error={creditAllocationError}
+          reviewed={creditAllocationReviewed}
+          submitting={creditAllocationSubmitting}
+          success={creditAllocationSuccess}
+          successObligation={creditAllocationSuccessObligation}
+          onReviewedChange={setCreditAllocationReviewed}
+          onApply={(obligation) => void submitCreditAllocation(obligation)}
+          onRefresh={() => void loadCreditAllocationPreview()}
+        />
       ) : null}
 
       <section className="lease-ledger-csv-card">

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
@@ -666,12 +666,35 @@ function DelinquencyIndicators({
   row,
   signals,
   allocationReviewRequired = false,
+  allocationAdjustment,
 }: {
   row: LeaseObligationLedgerRow;
   signals: LeaseDelinquencySignal[];
   allocationReviewRequired?: boolean;
+  allocationAdjustment?: ObligationAllocationAdjustment | null;
 }) {
   const matchingSignals = signals.filter((signal) => signalMatchesRow(signal, row));
+  if (allocationAdjustment) {
+    if (allocationAdjustment.outstandingAfterAllocationCents === 0) {
+      return (
+        <div style={{ display: "grid", gap: 4 }}>
+          <span style={{ color: "#166534", fontWeight: 800 }}>Credit allocation recorded</span>
+          <span style={{ color: "#475569", fontSize: 12 }}>
+            Existing lease credit covers this obligation. Historical payment records were not edited.
+          </span>
+        </div>
+      );
+    }
+    return (
+      <div style={{ display: "grid", gap: 4 }}>
+        <span style={{ color: "#854d0e", fontWeight: 800 }}>Allocation review</span>
+        <span style={{ color: "#475569", fontSize: 12 }}>
+          Existing lease credit allocation reduced this obligation. Remaining outstanding after allocation:{" "}
+          {formatCurrencyCents(allocationAdjustment.outstandingAfterAllocationCents)}.
+        </span>
+      </div>
+    );
+  }
   if (allocationReviewRequired && matchingSignals.length > 0) {
     return (
       <div style={{ display: "grid", gap: 4 }}>
@@ -712,10 +735,12 @@ function ObligationMobileCard({
   row,
   signals,
   allocationReviewRequired,
+  allocationAdjustment,
 }: {
   row: LeaseObligationLedgerRow;
   signals: LeaseDelinquencySignal[];
   allocationReviewRequired: boolean;
+  allocationAdjustment?: ObligationAllocationAdjustment | null;
 }) {
   return (
     <article className="lease-ledger-obligation-card">
@@ -741,12 +766,29 @@ function ObligationMobileCard({
         </div>
         <div>
           <span>Outstanding</span>
-          <strong>{formatCurrencyCents(obligationOutstandingCents(row))}</strong>
+          {allocationAdjustment ? (
+            <strong>
+              {formatCurrencyCents(allocationAdjustment.outstandingAfterAllocationCents)} after allocation
+            </strong>
+          ) : (
+            <strong>{formatCurrencyCents(obligationOutstandingCents(row))}</strong>
+          )}
         </div>
       </div>
+      {allocationAdjustment ? (
+        <div className="lease-ledger-obligation-card-section">
+          <span>Allocated from credit</span>
+          <strong>{formatCurrencyCents(allocationAdjustment.allocatedCents)}</strong>
+        </div>
+      ) : null}
       <div className="lease-ledger-obligation-card-section">
         <span>Financial signal</span>
-        <DelinquencyIndicators row={row} signals={signals} allocationReviewRequired={allocationReviewRequired} />
+        <DelinquencyIndicators
+          row={row}
+          signals={signals}
+          allocationReviewRequired={allocationReviewRequired}
+          allocationAdjustment={allocationAdjustment}
+        />
       </div>
       <div className="lease-ledger-obligation-card-section">
         <span>Evidence</span>
@@ -816,9 +858,18 @@ function leasePropertyUnitLabel(lease: LandlordActiveLease | null): string {
 function printFinancialSignalText(
   row: LeaseObligationLedgerRow,
   signals: LeaseDelinquencySignal[],
-  allocationReviewRequired: boolean
+  allocationReviewRequired: boolean,
+  allocationAdjustment?: ObligationAllocationAdjustment | null
 ): string {
   const matchingSignals = signals.filter((signal) => signalMatchesRow(signal, row));
+  if (allocationAdjustment) {
+    if (allocationAdjustment.outstandingAfterAllocationCents === 0) {
+      return "Credit allocation recorded — Existing lease credit covers this obligation. Historical payment records were not edited.";
+    }
+    return `Allocation review — Existing lease credit allocation reduced this obligation. Remaining outstanding after allocation: ${formatCurrencyCents(
+      allocationAdjustment.outstandingAfterAllocationCents
+    )}.`;
+  }
   if (allocationReviewRequired && matchingSignals.length > 0) {
     return "Allocation review — Payments exceed charges in aggregate, but this obligation remains unmatched.";
   }
@@ -865,6 +916,7 @@ function LeaseLedgerPrintExport({
   obligationSummary,
   outstandingObligationCents,
   hasUnallocatedCreditNotice,
+  creditAllocationPreview,
   delinquencySignals,
   delinquencySummary,
   decisions,
@@ -879,6 +931,7 @@ function LeaseLedgerPrintExport({
   obligationSummary: LeaseObligationLedgerSummary | null;
   outstandingObligationCents: number;
   hasUnallocatedCreditNotice: boolean;
+  creditAllocationPreview: LeaseCreditAllocationPreview | null;
   delinquencySignals: LeaseDelinquencySignal[];
   delinquencySummary: LeaseDelinquencySummary | null;
   decisions: DecisionItem[];
@@ -889,6 +942,11 @@ function LeaseLedgerPrintExport({
   const propertyUnitLabel = leasePropertyUnitLabel(lease);
   const tenantLabel = lease?.tenantName || "Tenant not linked";
   const singleObligationRow = obligationRows.length === 1 ? obligationRows[0] : null;
+  const singleObligationAllocationAdjustment = singleObligationRow
+    ? allocationAdjustmentForObligation(singleObligationRow, creditAllocationPreview)
+    : null;
+  const creditAllocationPresentation = buildCreditAllocationPresentation(creditAllocationPreview, totals, outstandingObligationCents);
+  const creditAllocationNotice = creditAllocationNoticeCopy(creditAllocationPresentation, totals.balanceCents);
   return (
     <div className="lease-ledger-print-export">
       <div className="lease-ledger-print-page lease-ledger-print-page-summary">
@@ -946,14 +1004,23 @@ function LeaseLedgerPrintExport({
               <strong>{delinquencySummary?.manualReviewCount || 0}</strong>
             </div>
           </div>
-          {hasUnallocatedCreditNotice ? (
+          {hasUnallocatedCreditNotice || creditAllocationPresentation.hasActiveAllocations ? (
             <div className="lease-ledger-print-warning">
-              <strong>Credit balance needs allocation review</strong>
-              <span>
-                This lease has an aggregate credit balance of {formatCurrencyCents(totals.balanceCents)}, but{" "}
-                {formatCurrencyCents(outstandingObligationCents)} remains outstanding on specific obligations because payments have not been matched or allocated.
-              </span>
-              <span>Review and allocate unmatched payments before taking any overdue-rent action.</span>
+              <strong>{creditAllocationNotice.title}</strong>
+              {creditAllocationPresentation.hasActiveAllocations ? (
+                <>
+                  <span>{creditAllocationNotice.body}</span>
+                  <span>{creditAllocationNotice.detail}</span>
+                </>
+              ) : (
+                <>
+                  <span>
+                    This lease has an aggregate credit balance of {formatCurrencyCents(totals.balanceCents)}, but{" "}
+                    {formatCurrencyCents(outstandingObligationCents)} remains outstanding on specific obligations because payments have not been matched or allocated.
+                  </span>
+                  <span>Review and allocate unmatched payments before taking any overdue-rent action.</span>
+                </>
+              )}
             </div>
           ) : null}
         </section>
@@ -1097,7 +1164,13 @@ function LeaseLedgerPrintExport({
               </div>
               <div>
                 <span>Outstanding</span>
-                <strong>{formatCurrencyCents(obligationOutstandingCents(singleObligationRow))}</strong>
+                {singleObligationAllocationAdjustment ? (
+                  <strong>
+                    {formatCurrencyCents(singleObligationAllocationAdjustment.outstandingAfterAllocationCents)} after allocation
+                  </strong>
+                ) : (
+                  <strong>{formatCurrencyCents(obligationOutstandingCents(singleObligationRow))}</strong>
+                )}
               </div>
               <div>
                 <span>Status</span>
@@ -1105,7 +1178,14 @@ function LeaseLedgerPrintExport({
               </div>
               <div className="lease-ledger-print-obligation-card-wide">
                 <span>Financial signal</span>
-                <strong>{printFinancialSignalText(singleObligationRow, delinquencySignals, hasUnallocatedCreditNotice)}</strong>
+                <strong>
+                  {printFinancialSignalText(
+                    singleObligationRow,
+                    delinquencySignals,
+                    hasUnallocatedCreditNotice,
+                    singleObligationAllocationAdjustment
+                  )}
+                </strong>
               </div>
               <div className="lease-ledger-print-obligation-card-wide">
                 <span>Evidence</span>
@@ -1128,18 +1208,25 @@ function LeaseLedgerPrintExport({
                   </tr>
                 </thead>
                 <tbody>
-                  {obligationRows.map((row) => (
-                    <tr key={row.rowId}>
-                      <td>{formatPeriod(row)}</td>
-                      <td>{formatDate(row.dueDate)}</td>
-                      <td>{formatCurrencyCents(row.expectedAmountCents)}</td>
-                      <td>{formatCurrencyCents(row.paidAmountCents)}</td>
-                      <td>{formatCurrencyCents(obligationOutstandingCents(row))}</td>
-                      <td>{obligationStatusCopy[row.obligationStatus || "unknown"]?.label || obligationStatusCopy.unknown.label}</td>
-                      <td>{printFinancialSignalText(row, delinquencySignals, hasUnallocatedCreditNotice)}</td>
-                      <td>{printEvidenceText(row, delinquencySignals)}</td>
-                    </tr>
-                  ))}
+                  {obligationRows.map((row) => {
+                    const allocationAdjustment = allocationAdjustmentForObligation(row, creditAllocationPreview);
+                    return (
+                      <tr key={row.rowId}>
+                        <td>{formatPeriod(row)}</td>
+                        <td>{formatDate(row.dueDate)}</td>
+                        <td>{formatCurrencyCents(row.expectedAmountCents)}</td>
+                        <td>{formatCurrencyCents(row.paidAmountCents)}</td>
+                        <td>
+                          {allocationAdjustment
+                            ? `${formatCurrencyCents(allocationAdjustment.outstandingAfterAllocationCents)} after allocation`
+                            : formatCurrencyCents(obligationOutstandingCents(row))}
+                        </td>
+                        <td>{obligationStatusCopy[row.obligationStatus || "unknown"]?.label || obligationStatusCopy.unknown.label}</td>
+                        <td>{printFinancialSignalText(row, delinquencySignals, hasUnallocatedCreditNotice, allocationAdjustment)}</td>
+                        <td>{printEvidenceText(row, delinquencySignals)}</td>
+                      </tr>
+                    );
+                  })}
                 </tbody>
               </table>
             </div>
@@ -1280,6 +1367,103 @@ function createAllocationIdempotencyKey(leaseId: string, obligationRowId: string
       ? crypto.randomUUID()
       : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
   return `lease-credit-allocation:${leaseId}:${obligationRowId}:${random}`;
+}
+
+type CreditAllocationPresentation = {
+  hasActiveAllocations: boolean;
+  activeAllocatedCents: number;
+  remainingCreditCents: number;
+  adjustedOutstandingCents: number;
+};
+
+type ObligationAllocationAdjustment = {
+  allocationIds: string[];
+  allocatedCents: number;
+  outstandingAfterAllocationCents: number;
+};
+
+function sumAllocationAmountCents(allocations: LeaseCreditAllocationSummary[]): number {
+  return allocations.reduce((total, allocation) => total + Math.max(0, Number(allocation.allocationAmountCents || 0)), 0);
+}
+
+function buildCreditAllocationPresentation(
+  preview: LeaseCreditAllocationPreview | null,
+  totals: { balanceCents: number },
+  outstandingObligationCents: number
+): CreditAllocationPresentation {
+  const activeAllocations = preview?.existingActiveAllocations || [];
+  const activeAllocatedCents =
+    Number(preview?.activeAllocationAmountCents || 0) || sumAllocationAmountCents(activeAllocations);
+  const grossCreditCents = Math.max(0, Number(preview?.grossAvailableCreditCents ?? Math.abs(Math.min(0, totals.balanceCents))));
+  const remainingCreditCents = Math.max(
+    0,
+    Number(preview?.availableCreditCents ?? preview?.remainingAvailableCreditCents ?? grossCreditCents - activeAllocatedCents)
+  );
+  const adjustedOutstandingCents = Math.max(
+    0,
+    Number(preview?.totalOutstandingAmountCents ?? outstandingObligationCents - activeAllocatedCents)
+  );
+  return {
+    hasActiveAllocations: activeAllocations.length > 0 || activeAllocatedCents > 0,
+    activeAllocatedCents,
+    remainingCreditCents,
+    adjustedOutstandingCents,
+  };
+}
+
+function allocationAdjustmentForObligation(
+  row: LeaseObligationLedgerRow,
+  preview: LeaseCreditAllocationPreview | null
+): ObligationAllocationAdjustment | null {
+  const matchingAllocations = (preview?.existingActiveAllocations || []).filter(
+    (allocation) => allocation.obligationRowId === row.rowId
+  );
+  if (matchingAllocations.length === 0) return null;
+  const allocatedCents = sumAllocationAmountCents(matchingAllocations);
+  const latestAllocation = [...matchingAllocations].sort((a, b) => String(b.createdAt || "").localeCompare(String(a.createdAt || "")))[0];
+  const outstandingAfterAllocationCents = Math.max(
+    0,
+    Number(latestAllocation?.afterOutstandingAmountCents ?? obligationOutstandingCents(row) - allocatedCents)
+  );
+  return {
+    allocationIds: matchingAllocations.map((allocation) => allocation.allocationId),
+    allocatedCents,
+    outstandingAfterAllocationCents,
+  };
+}
+
+function creditAllocationNoticeCopy(
+  presentation: CreditAllocationPresentation,
+  aggregateBalanceCents: number
+): { title: string; body: string; detail: string } {
+  if (!presentation.hasActiveAllocations) {
+    return {
+      title: "Credit balance needs allocation review",
+      body: "",
+      detail: "",
+    };
+  }
+  if (presentation.remainingCreditCents > 0) {
+    return {
+      title: "Remaining lease credit available",
+      body: `This lease has ${formatCurrencyCents(
+        presentation.remainingCreditCents
+      )} of unallocated credit remaining after applying ${formatCurrencyCents(
+        presentation.activeAllocatedCents
+      )} to the unmatched obligation.`,
+      detail: `The aggregate ledger balance remains ${formatCurrencyCents(
+        aggregateBalanceCents
+      )} because historical payment records were not edited. Obligation outstanding after allocation: ${formatCurrencyCents(
+        presentation.adjustedOutstandingCents
+      )}.`,
+    };
+  }
+  return {
+    title: "Credit allocation recorded",
+    body:
+      "Existing lease credit has been allocated to the previously unmatched obligation. The aggregate ledger balance remains a credit because historical payment records were not edited.",
+    detail: `Obligation outstanding after allocation: ${formatCurrencyCents(presentation.adjustedOutstandingCents)}.`,
+  };
 }
 
 function CreditAllocationMetric({ label, value }: { label: string; value: string }) {
@@ -1528,7 +1712,13 @@ export default function LeaseLedgerPage() {
     () => totalOutstandingObligationCents(obligationRows, obligationSummary),
     [obligationRows, obligationSummary]
   );
+  const hasLeaseCreditBalance = totals.balanceCents < 0;
   const hasUnallocatedCreditNotice = hasCreditBalanceAllocationReview(totals.balanceCents, outstandingObligationCents);
+  const creditAllocationPresentation = useMemo(
+    () => buildCreditAllocationPresentation(creditAllocationPreview, totals, outstandingObligationCents),
+    [creditAllocationPreview, totals, outstandingObligationCents]
+  );
+  const creditAllocationNotice = creditAllocationNoticeCopy(creditAllocationPresentation, totals.balanceCents);
 
   const monthlyRows = useMemo(() => {
     return Object.entries(monthlyTotals).sort((a, b) => (a[0] < b[0] ? 1 : -1));
@@ -1616,7 +1806,7 @@ export default function LeaseLedgerPage() {
   }, [leaseId]);
 
   useEffect(() => {
-    if (!leaseId || !hasUnallocatedCreditNotice) {
+    if (!leaseId || !hasLeaseCreditBalance) {
       setCreditAllocationPreview(null);
       setCreditAllocationError(null);
       setCreditAllocationReviewed(false);
@@ -1626,7 +1816,7 @@ export default function LeaseLedgerPage() {
     }
     void loadCreditAllocationPreview();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [leaseId, hasUnallocatedCreditNotice, totals.balanceCents, outstandingObligationCents]);
+  }, [leaseId, hasLeaseCreditBalance, totals.balanceCents, outstandingObligationCents]);
 
   async function submitCreditAllocation(obligation: LeaseCreditAllocationPreviewObligation) {
     if (!leaseId || !creditAllocationPreview) return;
@@ -1857,6 +2047,7 @@ export default function LeaseLedgerPage() {
             obligationSummary={obligationSummary}
             outstandingObligationCents={outstandingObligationCents}
             hasUnallocatedCreditNotice={hasUnallocatedCreditNotice}
+            creditAllocationPreview={creditAllocationPreview}
             delinquencySignals={delinquencySignals}
             delinquencySummary={delinquencySummary}
             decisions={decisions}
@@ -1928,19 +2119,28 @@ export default function LeaseLedgerPage() {
           <strong>{formatCurrencyCents(totals.balanceCents)}</strong>
         </div>
       </div>
-      {hasUnallocatedCreditNotice ? (
+      {hasUnallocatedCreditNotice || creditAllocationPresentation.hasActiveAllocations ? (
         <div style={{ border: "1px solid #fde68a", borderRadius: 12, padding: 12, background: "#fffbeb", color: "#713f12", display: "grid", gap: 4 }}>
-          <strong>Credit balance needs allocation review</strong>
-          <span>
-            This lease has an aggregate credit balance of {formatCurrencyCents(totals.balanceCents)}, but{" "}
-            {formatCurrencyCents(outstandingObligationCents)} remains outstanding on specific obligations because payments have not been
-            matched or allocated to those obligations.
-          </span>
-          <span>Review the obligation rows before resolving overdue decisions.</span>
+          <strong>{creditAllocationNotice.title}</strong>
+          {creditAllocationPresentation.hasActiveAllocations ? (
+            <>
+              <span>{creditAllocationNotice.body}</span>
+              <span>{creditAllocationNotice.detail}</span>
+            </>
+          ) : (
+            <>
+              <span>
+                This lease has an aggregate credit balance of {formatCurrencyCents(totals.balanceCents)}, but{" "}
+                {formatCurrencyCents(outstandingObligationCents)} remains outstanding on specific obligations because payments have not been
+                matched or allocated to those obligations.
+              </span>
+              <span>Review the obligation rows before resolving overdue decisions.</span>
+            </>
+          )}
         </div>
       ) : null}
 
-      {hasUnallocatedCreditNotice ? (
+      {hasLeaseCreditBalance ? (
         <LeaseCreditAllocationPanel
           preview={creditAllocationPreview}
           loading={creditAllocationLoading}
@@ -2121,22 +2321,40 @@ export default function LeaseLedgerPage() {
                 </tr>
               </thead>
               <tbody>
-                {obligationRows.map((row) => (
-                  <tr key={row.rowId}>
-                    <td style={{ padding: 10, borderBottom: "1px solid rgba(91,70,48,0.12)" }}>{formatPeriod(row)}</td>
-                    <td style={{ padding: 10, borderBottom: "1px solid rgba(91,70,48,0.12)" }}>{formatDate(row.dueDate)}</td>
-                    <td style={{ padding: 10, borderBottom: "1px solid rgba(91,70,48,0.12)" }}>{formatCurrencyCents(row.expectedAmountCents)}</td>
-                    <td style={{ padding: 10, borderBottom: "1px solid rgba(91,70,48,0.12)" }}>{formatCurrencyCents(row.paidAmountCents)}</td>
-                    <td style={{ padding: 10, borderBottom: "1px solid rgba(91,70,48,0.12)" }}>{formatCurrencyCents(obligationOutstandingCents(row))}</td>
-                    <td style={{ padding: 10, borderBottom: "1px solid rgba(91,70,48,0.12)" }}>
-                      <ObligationStatusBadge status={row.obligationStatus || "unknown"} />
-                    </td>
-                    <td style={{ padding: 10, borderBottom: "1px solid rgba(91,70,48,0.12)", minWidth: 220 }}>
-                      <DelinquencyIndicators row={row} signals={delinquencySignals} allocationReviewRequired={hasUnallocatedCreditNotice} />
-                    </td>
-                    <td style={{ padding: 10, borderBottom: "1px solid rgba(91,70,48,0.12)", color: "#3f382f" }}>{prettyEvidenceStatus(row)}</td>
-                  </tr>
-                ))}
+                {obligationRows.map((row) => {
+                  const allocationAdjustment = allocationAdjustmentForObligation(row, creditAllocationPreview);
+                  return (
+                    <tr key={row.rowId}>
+                      <td style={{ padding: 10, borderBottom: "1px solid rgba(91,70,48,0.12)" }}>{formatPeriod(row)}</td>
+                      <td style={{ padding: 10, borderBottom: "1px solid rgba(91,70,48,0.12)" }}>{formatDate(row.dueDate)}</td>
+                      <td style={{ padding: 10, borderBottom: "1px solid rgba(91,70,48,0.12)" }}>{formatCurrencyCents(row.expectedAmountCents)}</td>
+                      <td style={{ padding: 10, borderBottom: "1px solid rgba(91,70,48,0.12)" }}>{formatCurrencyCents(row.paidAmountCents)}</td>
+                      <td style={{ padding: 10, borderBottom: "1px solid rgba(91,70,48,0.12)" }}>
+                        {allocationAdjustment ? (
+                          <div className="lease-ledger-obligation-allocation-cell">
+                            <strong>{formatCurrencyCents(allocationAdjustment.outstandingAfterAllocationCents)} after allocation</strong>
+                            <span>Allocated from credit: {formatCurrencyCents(allocationAdjustment.allocatedCents)}</span>
+                            <span>Original outstanding: {formatCurrencyCents(obligationOutstandingCents(row))}</span>
+                          </div>
+                        ) : (
+                          formatCurrencyCents(obligationOutstandingCents(row))
+                        )}
+                      </td>
+                      <td style={{ padding: 10, borderBottom: "1px solid rgba(91,70,48,0.12)" }}>
+                        <ObligationStatusBadge status={row.obligationStatus || "unknown"} />
+                      </td>
+                      <td style={{ padding: 10, borderBottom: "1px solid rgba(91,70,48,0.12)", minWidth: 220 }}>
+                        <DelinquencyIndicators
+                          row={row}
+                          signals={delinquencySignals}
+                          allocationReviewRequired={hasUnallocatedCreditNotice}
+                          allocationAdjustment={allocationAdjustment}
+                        />
+                      </td>
+                      <td style={{ padding: 10, borderBottom: "1px solid rgba(91,70,48,0.12)", color: "#3f382f" }}>{prettyEvidenceStatus(row)}</td>
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           </div>
@@ -2147,6 +2365,7 @@ export default function LeaseLedgerPage() {
                 row={row}
                 signals={delinquencySignals}
                 allocationReviewRequired={hasUnallocatedCreditNotice}
+                allocationAdjustment={allocationAdjustmentForObligation(row, creditAllocationPreview)}
               />
             ))}
           </div>

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
@@ -429,7 +429,7 @@ function recommendedDecisionAction(decision: DecisionItem): { label: string; cta
 
 function allocationReviewRecommendedAction(): { label: string; cta: "resolve"; helper: string } {
   return {
-    label: "Review and allocate unmatched payments before taking any overdue-rent action.",
+    label: "Review and apply available credit to the rent charge before resolving this item.",
     cta: "resolve",
     helper: "Marks the operational review item resolved only after allocation review is complete.",
   };
@@ -443,7 +443,7 @@ function decisionActionDisplay(
     return {
       heading: "Resolved outcome",
       label:
-        "Marked resolved as an allocation-review item. No rent-collection action should be taken until unmatched payments are reviewed.",
+        "Marked resolved as an allocation-review item. Review available credit before taking further action.",
       cta: action.cta,
       helper: action.helper,
     };
@@ -457,7 +457,7 @@ function decisionActionDisplay(
 function allocationReviewDecision(decision: DecisionItem): DecisionItem {
   return {
     ...decision,
-    reason: "Payments exceed charges in aggregate, but one or more obligations remain unmatched.",
+    reason: "A rent charge was not yet matched to the tenant's available credit.",
     metadata: {
       ...(decision.metadata || {}),
       signalType: "allocation_review",
@@ -680,7 +680,7 @@ function DelinquencyIndicators({
         <div style={{ display: "grid", gap: 4 }}>
           <span style={{ color: "#166534", fontWeight: 800 }}>Credit allocation recorded</span>
           <span style={{ color: "#475569", fontSize: 12 }}>
-            Existing lease credit covers this obligation. Historical payment records were not edited.
+            Existing lease credit covers this rent charge. Historical payment records were not edited.
           </span>
         </div>
       );
@@ -689,7 +689,7 @@ function DelinquencyIndicators({
       <div style={{ display: "grid", gap: 4 }}>
         <span style={{ color: "#854d0e", fontWeight: 800 }}>Allocation review</span>
         <span style={{ color: "#475569", fontSize: 12 }}>
-          Existing lease credit allocation reduced this obligation. Remaining outstanding after allocation:{" "}
+          Existing lease credit allocation reduced this rent charge. Rent charge outstanding after allocation:{" "}
           {formatCurrencyCents(allocationAdjustment.outstandingAfterAllocationCents)}.
         </span>
       </div>
@@ -700,7 +700,7 @@ function DelinquencyIndicators({
       <div style={{ display: "grid", gap: 4 }}>
         <span style={{ color: "#854d0e", fontWeight: 800 }}>Allocation review</span>
         <span style={{ color: "#475569", fontSize: 12 }}>
-          Payments exceed charges in aggregate, but this obligation remains unmatched.
+          A rent charge was not yet matched to the tenant's available credit.
         </span>
       </div>
     );
@@ -864,14 +864,14 @@ function printFinancialSignalText(
   const matchingSignals = signals.filter((signal) => signalMatchesRow(signal, row));
   if (allocationAdjustment) {
     if (allocationAdjustment.outstandingAfterAllocationCents === 0) {
-      return "Credit allocation recorded — Existing lease credit covers this obligation. Historical payment records were not edited.";
+      return "Credit allocation recorded — Existing lease credit covers this rent charge. Historical payment records were not edited.";
     }
-    return `Allocation review — Existing lease credit allocation reduced this obligation. Remaining outstanding after allocation: ${formatCurrencyCents(
+    return `Allocation review — Existing lease credit allocation reduced this rent charge. Rent charge outstanding after allocation: ${formatCurrencyCents(
       allocationAdjustment.outstandingAfterAllocationCents
     )}.`;
   }
   if (allocationReviewRequired && matchingSignals.length > 0) {
-    return "Allocation review — Payments exceed charges in aggregate, but this obligation remains unmatched.";
+    return "Allocation review — A rent charge was not yet matched to the tenant's available credit.";
   }
   if (matchingSignals.length === 0) {
     const status = row.obligationStatus || "unknown";
@@ -988,11 +988,23 @@ function LeaseLedgerPrintExport({
               <strong>{formatCurrencyCents(totals.paymentsCents)}</strong>
             </div>
             <div>
-              <span>Balance</span>
+              <span>Ledger balance</span>
               <strong>{formatCurrencyCents(totals.balanceCents)}</strong>
             </div>
+            {creditAllocationPresentation.hasActiveAllocations ? (
+              <>
+                <div>
+                  <span>Credit applied</span>
+                  <strong>{formatCurrencyCents(creditAllocationPresentation.activeAllocatedCents)}</strong>
+                </div>
+                <div>
+                  <span>Available credit after allocation</span>
+                  <strong>{formatCurrencyCents(creditAllocationPresentation.remainingCreditCents)}</strong>
+                </div>
+              </>
+            ) : null}
             <div>
-              <span>Outstanding obligations</span>
+              <span>{creditAllocationPresentation.hasActiveAllocations ? "Rent charges before allocation" : "Outstanding rent charges"}</span>
               <strong>{formatCurrencyCents(outstandingObligationCents)}</strong>
             </div>
             <div>
@@ -1015,10 +1027,10 @@ function LeaseLedgerPrintExport({
               ) : (
                 <>
                   <span>
-                    This lease has an aggregate credit balance of {formatCurrencyCents(totals.balanceCents)}, but{" "}
-                    {formatCurrencyCents(outstandingObligationCents)} remains outstanding on specific obligations because payments have not been matched or allocated.
+                    This lease has available credit, but a {formatCurrencyCents(outstandingObligationCents)} rent charge was not yet matched
+                    to the tenant's available credit.
                   </span>
-                  <span>Review and allocate unmatched payments before taking any overdue-rent action.</span>
+                  <span>Review and apply available credit to the rent charge.</span>
                 </>
               )}
             </div>
@@ -1448,12 +1460,12 @@ function creditAllocationNoticeCopy(
       title: "Remaining lease credit available",
       body: `This lease has ${formatCurrencyCents(
         presentation.remainingCreditCents
-      )} of unallocated credit remaining after applying ${formatCurrencyCents(
+      )} of available credit remaining after ${formatCurrencyCents(
         presentation.activeAllocatedCents
-      )} to the unmatched obligation.`,
-      detail: `The aggregate ledger balance remains ${formatCurrencyCents(
+      )} was applied to the rent charge.`,
+      detail: `The ledger balance remains ${formatCurrencyCents(
         aggregateBalanceCents
-      )} because historical payment records were not edited. Obligation outstanding after allocation: ${formatCurrencyCents(
+      )} because historical payment records were not edited. Rent charge outstanding after allocation: ${formatCurrencyCents(
         presentation.adjustedOutstandingCents
       )}.`,
     };
@@ -1461,8 +1473,8 @@ function creditAllocationNoticeCopy(
   return {
     title: "Credit allocation recorded",
     body:
-      "Existing lease credit has been allocated to the previously unmatched obligation. The aggregate ledger balance remains a credit because historical payment records were not edited.",
-    detail: `Obligation outstanding after allocation: ${formatCurrencyCents(presentation.adjustedOutstandingCents)}.`,
+      "Existing lease credit was applied to the rent charge. The ledger balance remains a credit because historical payment records were not edited.",
+    detail: `Rent charge outstanding after allocation: ${formatCurrencyCents(presentation.adjustedOutstandingCents)}.`,
   };
 }
 
@@ -1483,15 +1495,15 @@ function ActiveAllocationSummary({ allocation }: { allocation: LeaseCreditAlloca
         <strong>{allocation.allocationId}</strong>
       </div>
       <div>
-        <span>Amount allocated</span>
+        <span>Credit applied</span>
         <strong>{formatCurrencyCents(allocation.allocationAmountCents)}</strong>
       </div>
       <div>
-        <span>Remaining credit after allocation</span>
+        <span>Available credit after allocation</span>
         <strong>{formatCurrencyCents(allocation.afterAvailableCreditCents)}</strong>
       </div>
       <div>
-        <span>Obligation outstanding after allocation</span>
+        <span>Rent charge outstanding after allocation</span>
         <strong>{formatCurrencyCents(allocation.afterOutstandingAmountCents)}</strong>
       </div>
     </article>
@@ -1550,8 +1562,8 @@ function LeaseCreditAllocationPanel({
         <div>
           <h2>Allocate available lease credit</h2>
           <p>
-            This lease has available credit, but one or more obligations remain unmatched. Review the suggested allocation before applying
-            credit to the obligation.
+            This lease has available credit, but a rent charge was not yet matched to that credit. Review and apply available credit to the
+            rent charge.
           </p>
         </div>
         <button type="button" onClick={onRefresh} disabled={loading || submitting}>
@@ -1562,21 +1574,21 @@ function LeaseCreditAllocationPanel({
       {success ? (
         <div className="lease-credit-allocation-success" role="status">
           <strong>Credit allocation recorded</strong>
-          <span>Existing lease credit was applied to this obligation.</span>
+          <span>Credit was applied to the rent charge.</span>
           <span>Historical payment records were not edited.</span>
           <div className="lease-credit-allocation-metrics">
             <CreditAllocationMetric label="Allocation ID" value={success.allocation.allocationId} />
-            <CreditAllocationMetric label="Amount allocated" value={formatCurrencyCents(success.allocation.allocationAmountCents)} />
-            <CreditAllocationMetric label="Obligation period" value={formatAllocationPeriod({
+            <CreditAllocationMetric label="Credit applied" value={formatCurrencyCents(success.allocation.allocationAmountCents)} />
+            <CreditAllocationMetric label="Rent charge period" value={formatAllocationPeriod({
               periodStart: successObligation?.periodStart || obligation?.periodStart || null,
               periodEnd: successObligation?.periodEnd || obligation?.periodEnd || null,
             })} />
-            <CreditAllocationMetric label="Obligation due date" value={formatDate(successObligation?.dueDate || obligation?.dueDate || null)} />
-            <CreditAllocationMetric label="Remaining credit after allocation" value={formatCurrencyCents(success.allocation.afterAvailableCreditCents)} />
-            <CreditAllocationMetric label="Obligation outstanding after allocation" value={formatCurrencyCents(success.allocation.afterOutstandingAmountCents)} />
+            <CreditAllocationMetric label="Rent charge due date" value={formatDate(successObligation?.dueDate || obligation?.dueDate || null)} />
+            <CreditAllocationMetric label="Available credit after allocation" value={formatCurrencyCents(success.allocation.afterAvailableCreditCents)} />
+            <CreditAllocationMetric label="Rent charge outstanding after allocation" value={formatCurrencyCents(success.allocation.afterOutstandingAmountCents)} />
           </div>
           <p className="lease-credit-allocation-note">
-            This allocation records how existing lease credit was applied to an obligation. It does not edit historical payment records.
+            This allocation records how existing lease credit was applied to a rent charge. It does not edit historical payment records.
           </p>
         </div>
       ) : null}
@@ -1585,9 +1597,9 @@ function LeaseCreditAllocationPanel({
         <>
           <div className="lease-credit-allocation-metrics">
             <CreditAllocationMetric label="Available credit" value={formatCurrencyCents(preview.availableCreditCents)} />
-            <CreditAllocationMetric label="Outstanding obligation" value={formatCurrencyCents(obligation.outstandingAmountCents)} />
-            <CreditAllocationMetric label="Suggested allocation" value={formatCurrencyCents(allocationAmountCents)} />
-            <CreditAllocationMetric label="Remaining credit after allocation" value={formatCurrencyCents(remainingCreditCents)} />
+            <CreditAllocationMetric label="Rent charge outstanding" value={formatCurrencyCents(obligation.outstandingAmountCents)} />
+            <CreditAllocationMetric label="Suggested credit to apply" value={formatCurrencyCents(allocationAmountCents)} />
+            <CreditAllocationMetric label="Available credit after allocation" value={formatCurrencyCents(remainingCreditCents)} />
           </div>
 
           <div className="lease-credit-allocation-obligation">
@@ -1608,7 +1620,7 @@ function LeaseCreditAllocationPanel({
               <strong>{formatCurrencyCents(obligation.paidAmountCents)}</strong>
             </div>
             <div>
-              <span>Outstanding</span>
+              <span>Rent charge outstanding</span>
               <strong>{formatCurrencyCents(obligation.outstandingAmountCents)}</strong>
             </div>
             <div>
@@ -1620,7 +1632,7 @@ function LeaseCreditAllocationPanel({
               <strong>Existing lease credit available for operator-reviewed allocation</strong>
             </div>
             <div>
-              <span>Obligation outstanding after allocation</span>
+              <span>Rent charge outstanding after allocation</span>
               <strong>{formatCurrencyCents(outstandingAfterCents)}</strong>
             </div>
           </div>
@@ -1632,7 +1644,7 @@ function LeaseCreditAllocationPanel({
               onChange={(event) => onReviewedChange(event.target.checked)}
               disabled={submitting}
             />
-            <span>I have reviewed the credit balance and obligation details.</span>
+            <span>I have reviewed the credit balance and rent charge details.</span>
           </label>
           <p className="lease-credit-allocation-note">
             This records an allocation review and does not edit historical payment records.
@@ -2115,9 +2127,21 @@ export default function LeaseLedgerPage() {
           <strong>{formatCurrencyCents(totals.paymentsCents)}</strong>
         </div>
         <div style={{ border: "1px solid rgba(91,70,48,0.16)", borderRadius: 10, padding: 10, background: "#fff6e8", boxShadow: "0 10px 24px rgba(59,44,28,0.08)" }}>
-          <div style={{ fontSize: 12, color: "#63594d" }}>Balance</div>
+          <div style={{ fontSize: 12, color: "#63594d" }}>Ledger balance</div>
           <strong>{formatCurrencyCents(totals.balanceCents)}</strong>
         </div>
+        {creditAllocationPresentation.hasActiveAllocations ? (
+          <>
+            <div style={{ border: "1px solid rgba(91,70,48,0.16)", borderRadius: 10, padding: 10, background: "#fff6e8", boxShadow: "0 10px 24px rgba(59,44,28,0.08)" }}>
+              <div style={{ fontSize: 12, color: "#63594d" }}>Credit applied</div>
+              <strong>{formatCurrencyCents(creditAllocationPresentation.activeAllocatedCents)}</strong>
+            </div>
+            <div style={{ border: "1px solid rgba(91,70,48,0.16)", borderRadius: 10, padding: 10, background: "#fff6e8", boxShadow: "0 10px 24px rgba(59,44,28,0.08)" }}>
+              <div style={{ fontSize: 12, color: "#63594d" }}>Available credit after allocation</div>
+              <strong>{formatCurrencyCents(creditAllocationPresentation.remainingCreditCents)}</strong>
+            </div>
+          </>
+        ) : null}
       </div>
       {hasUnallocatedCreditNotice || creditAllocationPresentation.hasActiveAllocations ? (
         <div style={{ border: "1px solid #fde68a", borderRadius: 12, padding: 12, background: "#fffbeb", color: "#713f12", display: "grid", gap: 4 }}>
@@ -2130,11 +2154,10 @@ export default function LeaseLedgerPage() {
           ) : (
             <>
               <span>
-                This lease has an aggregate credit balance of {formatCurrencyCents(totals.balanceCents)}, but{" "}
-                {formatCurrencyCents(outstandingObligationCents)} remains outstanding on specific obligations because payments have not been
-                matched or allocated to those obligations.
+                This lease has available credit, but a {formatCurrencyCents(outstandingObligationCents)} rent charge was not yet matched to
+                the tenant's available credit.
               </span>
-              <span>Review the obligation rows before resolving overdue decisions.</span>
+              <span>Review and apply available credit to the rent charge.</span>
             </>
           )}
         </div>

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
@@ -1549,6 +1549,13 @@ function LeaseCreditAllocationPanel({
   const activeAllocations = preview?.existingActiveAllocations || [];
   const shouldRender = Boolean(success || (preview?.allowed && suggestion && obligation) || activeAllocations.length > 0);
   if (!shouldRender) return null;
+  const hasCompletedActiveAllocation = activeAllocations.some(
+    (allocation) => Number(allocation.afterOutstandingAmountCents || 0) === 0
+  );
+  const panelTitle = hasCompletedActiveAllocation ? "Lease credit allocation recorded" : "Allocate available lease credit";
+  const panelCopy = hasCompletedActiveAllocation
+    ? "Available credit has been applied to this rent charge. These records show operator-reviewed allocations and do not edit historical payment records."
+    : "This lease has available credit, but a rent charge was not yet matched to that credit. Review and apply available credit to the rent charge.";
 
   const allocationAmountCents = suggestion?.allocationAmountCents || obligation?.suggestedAllocationAmountCents || 0;
   const remainingCreditCents = suggestion?.afterAvailableCreditCents ?? obligation?.afterAvailableCreditCents ?? preview?.remainingAvailableCreditCents ?? 0;
@@ -1560,11 +1567,8 @@ function LeaseCreditAllocationPanel({
     <section className="lease-credit-allocation-panel lease-ledger-no-print" aria-label="Credit allocation review">
       <div className="lease-credit-allocation-header">
         <div>
-          <h2>Allocate available lease credit</h2>
-          <p>
-            This lease has available credit, but a rent charge was not yet matched to that credit. Review and apply available credit to the
-            rent charge.
-          </p>
+          <h2>{panelTitle}</h2>
+          <p>{panelCopy}</p>
         </div>
         <button type="button" onClick={onRefresh} disabled={loading || submitting}>
           {loading ? "Refreshing…" : "Refresh preview"}


### PR DESCRIPTION
## Summary

Adds the operator-facing lease credit allocation review panel to the lease ledger page. The panel appears near the existing credit-balance allocation-review warning when the landlord-scoped allocation preview API reports an available suggested allocation.

## What changed

- Added typed frontend helpers for credit allocation preview, apply, and reverse endpoints.
- Added an allocation review panel on `/leases/:leaseId/ledger` with available credit, obligation details, suggested allocation, remaining credit, and confirmation guardrails.
- Disabled `Apply credit allocation` until the operator confirms review of the credit balance and obligation details.
- On apply, sends `obligationRowId`, `allocationAmountCents`, `previewFingerprint`, and an idempotency key to the backend API.
- Shows allocation success details including allocation ID, amount, obligation period/due date, remaining credit, and obligation outstanding after allocation.
- Keeps the existing credit-balance warning visible.
- Keeps interactive allocation controls out of the print/PDF export path.

## Guardrails

- No auto-allocation added.
- No payment edit added.
- No ledger entry mutation added.
- No payment math changes added in the frontend.
- No collection, legal, compliance, or lease lifecycle claim added.
- Reversal UI is deferred to a follow-up workflow.

## Validation

- `npm run test -- LeaseLedgerPage` passed, 19 tests.
- `npm run test -- LeaseLedgerPage leaseLedgerApi` passed, 23 tests.
- `npm run build` passed under Node 20.20.2.
- `git diff --check` passed.
- `git diff --cached --check` passed.

## Manual QA

Manual browser QA was not completed in this session because an authenticated landlord/admin browser session was not available here.

Controlled apply QA was not performed. Applying against the known Bailey Blinkers lease would create a real allocation record, so it should only be done with explicit production-data mutation approval.

## Follow-up

If the existing ledger obligation derivation does not immediately reflect allocation records after apply, carry this into `feat/ledger-credit-allocation-ledger-integration-v1`.

Reversal controls remain deferred to `feat/ledger-credit-allocation-reversal-ui-v1`.