### PR TITLE
feat: persist scheduling day notes

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -161,6 +161,7 @@ import landlordInboxRoutes from "./routes/landlordInboxRoutes";
 import landlordDecisionInboxRoutes from "./routes/landlordDecisionInboxRoutes";
 import landlordDecisionQueueRoutes from "./routes/landlordDecisionQueueRoutes";
 import landlordLeaseCreditAllocationRoutes from "./routes/landlordLeaseCreditAllocationRoutes";
+import landlordSchedulingDayNotesRoutes from "./routes/landlordSchedulingDayNotesRoutes";
 import delegatedAccessInvitationRoutes, { delegatedAccessSelfRoutes } from "./routes/delegatedAccessInvitationRoutes";
 import propertyManagerCompanyRelationshipRoutes, {
   propertyManagerCompanyRoutes,
@@ -531,6 +532,8 @@ app.use("/api/landlord", routeSource("landlordDecisionQueueRoutes.ts"), landlord
 console.log("[route-mount] landlordDecisionQueueRoutes mounted at /api/landlord");
 app.use("/api/landlord", routeSource("landlordLeaseCreditAllocationRoutes.ts"), landlordLeaseCreditAllocationRoutes);
 console.log("[route-mount] landlordLeaseCreditAllocationRoutes mounted at /api/landlord");
+app.use("/api/landlord", routeSource("landlordSchedulingDayNotesRoutes.ts"), landlordSchedulingDayNotesRoutes);
+console.log("[route-mount] landlordSchedulingDayNotesRoutes mounted at /api/landlord");
 app.use("/api/delegated-access", routeSource("delegatedAccessInvitationRoutes.ts:self"), delegatedAccessSelfRoutes);
 console.log("[route-mount] delegatedAccessSelfRoutes mounted at /api/delegated-access");
 app.use("/api/landlord", routeSource("delegatedAccessInvitationRoutes.ts"), delegatedAccessInvitationRoutes);

--- a/rentchain-api/src/routes/__tests__/landlordSchedulingDayNotesRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordSchedulingDayNotesRoutes.test.ts
@@ -1,0 +1,314 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fakeDb, listDocs, resetFakeDb, seedDoc } = vi.hoisted(() => {
+  const store = new Map<string, Map<string, any>>();
+  let idSeq = 0;
+
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  }
+
+  function matches(doc: any, filters: Array<{ field: string; op: string; value: any }>) {
+    return filters.every(({ field, op, value }) => {
+      const actual = doc?.data?.[field];
+      if (op === "==") return actual === value;
+      return false;
+    });
+  }
+
+  function makeQuery(name: string, filters: Array<{ field: string; op: string; value: any }> = []) {
+    return {
+      where: (field: string, op: string, value: any) => makeQuery(name, [...filters, { field, op, value }]),
+      get: async () => {
+        const col = ensureCollection(name);
+        const docs = Array.from(col.values())
+          .filter((doc) => matches(doc, filters))
+          .map((doc) => ({ id: doc.id, exists: true, data: () => doc.data }));
+        return { docs, empty: docs.length === 0, size: docs.length };
+      },
+      doc: (id?: string) => makeDoc(name, id),
+    };
+  }
+
+  function makeDoc(name: string, id?: string) {
+    const actualId = id || `doc_${++idSeq}`;
+    const col = ensureCollection(name);
+    return {
+      id: actualId,
+      set: async (value: any, options?: { merge?: boolean }) => {
+        const current = col.get(actualId)?.data || {};
+        col.set(actualId, { id: actualId, data: options?.merge ? { ...current, ...value } : value });
+      },
+      get: async () => {
+        const entry = col.get(actualId);
+        return { id: actualId, exists: Boolean(entry), data: () => entry?.data };
+      },
+    };
+  }
+
+  return {
+    resetFakeDb: () => {
+      store.clear();
+      idSeq = 0;
+    },
+    seedDoc: (name: string, id: string, data: any) => ensureCollection(name).set(id, { id, data }),
+    listDocs: (name: string) => Array.from(ensureCollection(name).values()).map((doc) => ({ id: doc.id, data: doc.data })),
+    fakeDb: {
+      collection: (name: string) => ({
+        where: (field: string, op: string, value: any) => makeQuery(name, [{ field, op, value }]),
+        get: async () => makeQuery(name).get(),
+        doc: (id?: string) => makeDoc(name, id),
+      }),
+    },
+  };
+});
+
+vi.mock("../../firebase", () => ({
+  db: fakeDb,
+}));
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (req.headers?.["x-no-auth"] === "1") {
+      return res.status(401).json({ ok: false, error: "unauthenticated" });
+    }
+    req.user ||= { id: "landlord-1", landlordId: "landlord-1", role: "landlord", email: "ll@example.com" };
+    next();
+  },
+}));
+
+vi.mock("../../middleware/requireLandlord", () => ({
+  requireLandlord: (req: any, res: any, next: any) => {
+    const header = String(req.headers?.["x-test-user"] || "").trim();
+    req.user = header
+      ? JSON.parse(header)
+      : req.user || { id: "landlord-1", landlordId: "landlord-1", role: "landlord", email: "ll@example.com" };
+    if (req.user.role !== "landlord" && req.user.role !== "admin") {
+      return res.status(403).json({ ok: false, error: "Forbidden" });
+    }
+    req.user.landlordId = req.user.landlordId || req.user.id;
+    next();
+  },
+}));
+
+async function invokeRouter(router: any, options: {
+  method: string;
+  url: string;
+  body?: any;
+  headers?: Record<string, string>;
+}) {
+  return await new Promise<{ status: number; body: any; headers: Record<string, any> }>((resolve, reject) => {
+    const headers: Record<string, any> = {};
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path: options.url,
+      body: options.body ?? {},
+      headers: options.headers ?? {},
+      query: {},
+      params: {},
+    };
+    const queryIndex = options.url.indexOf("?");
+    if (queryIndex >= 0) {
+      const query = new URLSearchParams(options.url.slice(queryIndex + 1));
+      query.forEach((value, key) => {
+        req.query[key] = value;
+      });
+      req.url = options.url.slice(0, queryIndex);
+      req.path = req.url;
+    }
+    const res: any = {
+      statusCode: 200,
+      setHeader: (key: string, value: any) => {
+        headers[key.toLowerCase()] = value;
+      },
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload, headers });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload, headers });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+      else resolve({ status: 404, body: { ok: false, error: "not_found" }, headers });
+    });
+  });
+}
+
+describe("landlordSchedulingDayNotesRoutes", () => {
+  beforeEach(() => {
+    resetFakeDb();
+  });
+
+  it("creates, updates, and reads landlord-scoped scheduling day notes", async () => {
+    const router = (await import("../landlordSchedulingDayNotesRoutes")).default;
+
+    const create = await invokeRouter(router, {
+      method: "POST",
+      url: "/scheduling/day-notes/2026-07-15",
+      body: { noteText: "1pm viewing", source: "scheduling" },
+    });
+
+    expect(create.status).toBe(201);
+    expect(create.body.note).toEqual(
+      expect.objectContaining({
+        landlordId: "landlord-1",
+        date: "2026-07-15",
+        noteText: "1pm viewing",
+        source: "scheduling",
+        status: "active",
+        createdBy: "landlord-1",
+        createdByEmail: "ll@example.com",
+      })
+    );
+
+    const update = await invokeRouter(router, {
+      method: "PATCH",
+      url: `/scheduling/day-notes/2026-07-15/${create.body.note.noteId}`,
+      body: { noteText: "3pm plumber", source: "dashboard" },
+    });
+    expect(update.status).toBe(200);
+    expect(update.body.note.noteText).toBe("3pm plumber");
+    expect(update.body.note.source).toBe("dashboard");
+
+    const single = await invokeRouter(router, { method: "GET", url: "/scheduling/day-notes/2026-07-15" });
+    expect(single.status).toBe(200);
+    expect(single.body.notes).toEqual([expect.objectContaining({ noteText: "3pm plumber" })]);
+  });
+
+  it("reads an active date range grouped by date", async () => {
+    seedDoc("schedulingDayNotes", "note-1", {
+      noteId: "note-1",
+      landlordId: "landlord-1",
+      date: "2026-07-15",
+      noteText: "1pm viewing",
+      status: "active",
+      source: "scheduling",
+      createdAt: "2026-07-15T12:00:00.000Z",
+      updatedAt: "2026-07-15T12:00:00.000Z",
+    });
+    seedDoc("schedulingDayNotes", "note-2", {
+      noteId: "note-2",
+      landlordId: "landlord-1",
+      date: "2026-07-16",
+      noteText: "Call contractor",
+      status: "active",
+      source: "scheduling",
+      createdAt: "2026-07-16T12:00:00.000Z",
+      updatedAt: "2026-07-16T12:00:00.000Z",
+    });
+    seedDoc("schedulingDayNotes", "note-deleted", {
+      noteId: "note-deleted",
+      landlordId: "landlord-1",
+      date: "2026-07-15",
+      noteText: "Deleted note",
+      status: "deleted",
+      source: "scheduling",
+    });
+    const router = (await import("../landlordSchedulingDayNotesRoutes")).default;
+
+    const range = await invokeRouter(router, {
+      method: "GET",
+      url: "/scheduling/day-notes?startDate=2026-07-15&endDate=2026-07-16",
+    });
+
+    expect(range.status).toBe(200);
+    expect(range.body.notes).toHaveLength(2);
+    expect(range.body.notesByDate).toEqual({
+      "2026-07-15": [expect.objectContaining({ noteText: "1pm viewing" })],
+      "2026-07-16": [expect.objectContaining({ noteText: "Call contractor" })],
+    });
+  });
+
+  it("soft-deletes notes and excludes them from future reads", async () => {
+    const router = (await import("../landlordSchedulingDayNotesRoutes")).default;
+    const create = await invokeRouter(router, {
+      method: "POST",
+      url: "/scheduling/day-notes/2026-07-15",
+      body: { noteText: "Delete this note" },
+    });
+
+    const deleted = await invokeRouter(router, {
+      method: "DELETE",
+      url: `/scheduling/day-notes/2026-07-15/${create.body.note.noteId}`,
+    });
+
+    expect(deleted.status).toBe(200);
+    expect(deleted.body.note.status).toBe("deleted");
+    expect(listDocs("schedulingDayNotes")[0].data.status).toBe("deleted");
+
+    const single = await invokeRouter(router, { method: "GET", url: "/scheduling/day-notes/2026-07-15" });
+    expect(single.status).toBe(200);
+    expect(single.body.notes).toEqual([]);
+  });
+
+  it("blocks cross-landlord reads and note mutations", async () => {
+    const router = (await import("../landlordSchedulingDayNotesRoutes")).default;
+    const create = await invokeRouter(router, {
+      method: "POST",
+      url: "/scheduling/day-notes/2026-07-15",
+      body: { noteText: "Landlord one note" },
+    });
+    const otherUser = JSON.stringify({ id: "landlord-2", landlordId: "landlord-2", role: "landlord", email: "other@example.com" });
+
+    const otherRead = await invokeRouter(router, {
+      method: "GET",
+      url: "/scheduling/day-notes/2026-07-15",
+      headers: { "x-test-user": otherUser },
+    });
+    expect(otherRead.status).toBe(200);
+    expect(otherRead.body.notes).toEqual([]);
+
+    const otherUpdate = await invokeRouter(router, {
+      method: "PATCH",
+      url: `/scheduling/day-notes/2026-07-15/${create.body.note.noteId}`,
+      body: { noteText: "Should not update" },
+      headers: { "x-test-user": otherUser },
+    });
+    expect(otherUpdate.status).toBe(404);
+    expect(otherUpdate.body.code).toBe("SCHEDULING_DAY_NOTE_NOT_FOUND");
+  });
+
+  it("rejects unauthenticated, non-landlord, invalid-date, and overlong requests", async () => {
+    const router = (await import("../landlordSchedulingDayNotesRoutes")).default;
+
+    const unauth = await invokeRouter(router, {
+      method: "GET",
+      url: "/scheduling/day-notes/2026-07-15",
+      headers: { "x-no-auth": "1" },
+    });
+    expect(unauth.status).toBe(401);
+
+    const tenant = await invokeRouter(router, {
+      method: "GET",
+      url: "/scheduling/day-notes/2026-07-15",
+      headers: { "x-test-user": JSON.stringify({ id: "tenant-1", role: "tenant", email: "tenant@example.com" }) },
+    });
+    expect(tenant.status).toBe(403);
+
+    const invalidDate = await invokeRouter(router, {
+      method: "POST",
+      url: "/scheduling/day-notes/not-a-date",
+      body: { noteText: "Invalid date" },
+    });
+    expect(invalidDate.status).toBe(400);
+    expect(invalidDate.body.code).toBe("SCHEDULING_DAY_NOTE_INVALID_DATE");
+
+    const tooLong = await invokeRouter(router, {
+      method: "POST",
+      url: "/scheduling/day-notes/2026-07-15",
+      body: { noteText: "x".repeat(2001) },
+    });
+    expect(tooLong.status).toBe(400);
+    expect(tooLong.body.code).toBe("SCHEDULING_DAY_NOTE_TEXT_TOO_LONG");
+  });
+});

--- a/rentchain-api/src/routes/__tests__/landlordSchedulingDayNotesRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordSchedulingDayNotesRoutes.test.ts
@@ -229,6 +229,27 @@ describe("landlordSchedulingDayNotesRoutes", () => {
     });
   });
 
+  it("supports multiple active notes on the same date", async () => {
+    const router = (await import("../landlordSchedulingDayNotesRoutes")).default;
+
+    await invokeRouter(router, {
+      method: "POST",
+      url: "/scheduling/day-notes/2026-07-15",
+      body: { noteText: "1pm viewing" },
+    });
+    await invokeRouter(router, {
+      method: "POST",
+      url: "/scheduling/day-notes/2026-07-15",
+      body: { noteText: "3pm plumber" },
+    });
+
+    const single = await invokeRouter(router, { method: "GET", url: "/scheduling/day-notes/2026-07-15" });
+
+    expect(single.status).toBe(200);
+    expect(single.body.notes).toHaveLength(2);
+    expect(single.body.notes.map((note: any) => note.noteText)).toEqual(["1pm viewing", "3pm plumber"]);
+  });
+
   it("soft-deletes notes and excludes them from future reads", async () => {
     const router = (await import("../landlordSchedulingDayNotesRoutes")).default;
     const create = await invokeRouter(router, {

--- a/rentchain-api/src/routes/landlordSchedulingDayNotesRoutes.ts
+++ b/rentchain-api/src/routes/landlordSchedulingDayNotesRoutes.ts
@@ -1,0 +1,117 @@
+import { Router, Response } from "express";
+import { requireAuth } from "../middleware/requireAuth";
+import { requireLandlord } from "../middleware/requireLandlord";
+import {
+  createSchedulingDayNote,
+  deleteSchedulingDayNote,
+  groupSchedulingDayNotesByDate,
+  listSchedulingDayNotesForLandlord,
+  SchedulingDayNotesValidationError,
+  updateSchedulingDayNote,
+} from "../services/schedulingDayNotesService";
+
+const router = Router();
+
+function actorFromRequest(req: any, landlordId: string) {
+  return {
+    id: String(req.user?.id || req.user?.uid || landlordId),
+    email: typeof req.user?.email === "string" ? req.user.email : null,
+  };
+}
+
+function routeError(res: Response, error: unknown) {
+  if (error instanceof SchedulingDayNotesValidationError) {
+    return res.status(error.status).json({
+      ok: false,
+      error: error.code,
+      code: error.code,
+      message: error.message,
+    });
+  }
+  return res.status(500).json({
+    ok: false,
+    error: "SCHEDULING_DAY_NOTE_REQUEST_FAILED",
+    code: "SCHEDULING_DAY_NOTE_REQUEST_FAILED",
+  });
+}
+
+router.get("/scheduling/day-notes", requireAuth, requireLandlord, async (req: any, res: Response) => {
+  try {
+    const landlordId = String(req.user?.landlordId || req.user?.id || "");
+    const startDate = String(req.query?.startDate || "");
+    const endDate = String(req.query?.endDate || startDate);
+    const notes = await listSchedulingDayNotesForLandlord({ landlordId, startDate, endDate });
+    return res.json({
+      ok: true,
+      notes,
+      notesByDate: groupSchedulingDayNotesByDate(notes),
+    });
+  } catch (error) {
+    return routeError(res, error);
+  }
+});
+
+router.get("/scheduling/day-notes/:date", requireAuth, requireLandlord, async (req: any, res: Response) => {
+  try {
+    const landlordId = String(req.user?.landlordId || req.user?.id || "");
+    const date = String(req.params.date || "");
+    const notes = await listSchedulingDayNotesForLandlord({ landlordId, startDate: date, endDate: date });
+    return res.json({
+      ok: true,
+      date,
+      notes,
+    });
+  } catch (error) {
+    return routeError(res, error);
+  }
+});
+
+router.post("/scheduling/day-notes/:date", requireAuth, requireLandlord, async (req: any, res: Response) => {
+  try {
+    const landlordId = String(req.user?.landlordId || req.user?.id || "");
+    const note = await createSchedulingDayNote({
+      landlordId,
+      date: String(req.params.date || ""),
+      noteText: req.body?.noteText,
+      source: req.body?.source || "scheduling",
+      actor: actorFromRequest(req, landlordId),
+    });
+    return res.status(201).json({ ok: true, note });
+  } catch (error) {
+    return routeError(res, error);
+  }
+});
+
+router.patch("/scheduling/day-notes/:date/:noteId", requireAuth, requireLandlord, async (req: any, res: Response) => {
+  try {
+    const landlordId = String(req.user?.landlordId || req.user?.id || "");
+    const note = await updateSchedulingDayNote({
+      landlordId,
+      date: String(req.params.date || ""),
+      noteId: String(req.params.noteId || ""),
+      noteText: req.body?.noteText,
+      source: req.body?.source || "scheduling",
+      actor: actorFromRequest(req, landlordId),
+    });
+    return res.json({ ok: true, note });
+  } catch (error) {
+    return routeError(res, error);
+  }
+});
+
+router.delete("/scheduling/day-notes/:date/:noteId", requireAuth, requireLandlord, async (req: any, res: Response) => {
+  try {
+    const landlordId = String(req.user?.landlordId || req.user?.id || "");
+    const note = await deleteSchedulingDayNote({
+      landlordId,
+      date: String(req.params.date || ""),
+      noteId: String(req.params.noteId || ""),
+      actor: actorFromRequest(req, landlordId),
+    });
+    return res.json({ ok: true, note });
+  } catch (error) {
+    return routeError(res, error);
+  }
+});
+
+export default router;

--- a/rentchain-api/src/services/schedulingDayNotesService.ts
+++ b/rentchain-api/src/services/schedulingDayNotesService.ts
@@ -1,0 +1,277 @@
+import { randomUUID } from "crypto";
+import { db } from "../firebase";
+
+export const SCHEDULING_DAY_NOTES_COLLECTION = "schedulingDayNotes";
+
+export type SchedulingDayNoteStatus = "active" | "deleted";
+export type SchedulingDayNoteSource = "dashboard" | "scheduling" | "manual";
+
+export type SchedulingDayNoteActor = {
+  id: string;
+  email?: string | null;
+};
+
+export type SchedulingDayNoteRecord = {
+  noteId: string;
+  landlordId: string;
+  date: string;
+  noteText: string;
+  source: SchedulingDayNoteSource;
+  status: SchedulingDayNoteStatus;
+  createdAt: string;
+  createdBy: string;
+  createdByEmail?: string | null;
+  updatedAt: string;
+  updatedBy: string;
+  updatedByEmail?: string | null;
+  deletedAt?: string | null;
+  deletedBy?: string | null;
+  deletedByEmail?: string | null;
+};
+
+export type SchedulingDayNotesByDate = Record<string, SchedulingDayNoteRecord[]>;
+
+export class SchedulingDayNotesValidationError extends Error {
+  code: string;
+  status: number;
+
+  constructor(code: string, message: string, status = 400) {
+    super(message);
+    this.code = code;
+    this.status = status;
+  }
+}
+
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const MAX_NOTE_TEXT_LENGTH = 2000;
+const MAX_RANGE_DAYS = 62;
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function cleanString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function parseDateKey(value: string): Date | null {
+  if (!DATE_PATTERN.test(value)) return null;
+  const [year, month, day] = value.split("-").map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return date.getUTCFullYear() === year && date.getUTCMonth() === month - 1 && date.getUTCDate() === day
+    ? date
+    : null;
+}
+
+export function assertSchedulingDate(value: unknown, fieldName = "date"): string {
+  const date = cleanString(value, 32);
+  if (!parseDateKey(date)) {
+    throw new SchedulingDayNotesValidationError("SCHEDULING_DAY_NOTE_INVALID_DATE", `${fieldName} must be YYYY-MM-DD`);
+  }
+  return date;
+}
+
+export function assertSchedulingDateRange(startDateValue: unknown, endDateValue: unknown) {
+  const startDate = assertSchedulingDate(startDateValue, "startDate");
+  const endDate = assertSchedulingDate(endDateValue, "endDate");
+  const start = parseDateKey(startDate)!;
+  const end = parseDateKey(endDate)!;
+  const days = Math.round((end.getTime() - start.getTime()) / 86_400_000);
+  if (days < 0) {
+    throw new SchedulingDayNotesValidationError(
+      "SCHEDULING_DAY_NOTE_INVALID_DATE_RANGE",
+      "endDate must be on or after startDate"
+    );
+  }
+  if (days > MAX_RANGE_DAYS) {
+    throw new SchedulingDayNotesValidationError(
+      "SCHEDULING_DAY_NOTE_DATE_RANGE_TOO_LARGE",
+      `Date range must be ${MAX_RANGE_DAYS} days or less`
+    );
+  }
+  return { startDate, endDate };
+}
+
+export function normalizeSchedulingDayNoteText(value: unknown): string {
+  const text = cleanString(value, MAX_NOTE_TEXT_LENGTH + 1);
+  if (!text) {
+    throw new SchedulingDayNotesValidationError("SCHEDULING_DAY_NOTE_TEXT_REQUIRED", "noteText is required");
+  }
+  if (text.length > MAX_NOTE_TEXT_LENGTH) {
+    throw new SchedulingDayNotesValidationError(
+      "SCHEDULING_DAY_NOTE_TEXT_TOO_LONG",
+      `noteText must be ${MAX_NOTE_TEXT_LENGTH} characters or less`
+    );
+  }
+  return text;
+}
+
+export function normalizeSchedulingDayNoteSource(value: unknown): SchedulingDayNoteSource {
+  const source = cleanString(value, 40).toLowerCase();
+  return source === "dashboard" || source === "manual" || source === "scheduling" ? source : "scheduling";
+}
+
+function serializeNote(doc: any): SchedulingDayNoteRecord | null {
+  const data = (typeof doc?.data === "function" ? doc.data() : doc?.data) || {};
+  const landlordId = cleanString(data.landlordId, 240);
+  const date = cleanString(data.date, 32);
+  const noteText = cleanString(data.noteText, MAX_NOTE_TEXT_LENGTH);
+  const status = cleanString(data.status, 40) === "deleted" ? "deleted" : "active";
+  if (!landlordId || !parseDateKey(date) || !noteText) return null;
+  return {
+    noteId: cleanString(data.noteId, 240) || cleanString(doc?.id, 240),
+    landlordId,
+    date,
+    noteText,
+    source: normalizeSchedulingDayNoteSource(data.source),
+    status,
+    createdAt: cleanString(data.createdAt, 80),
+    createdBy: cleanString(data.createdBy, 240),
+    createdByEmail: cleanString(data.createdByEmail, 320) || null,
+    updatedAt: cleanString(data.updatedAt, 80),
+    updatedBy: cleanString(data.updatedBy, 240),
+    updatedByEmail: cleanString(data.updatedByEmail, 320) || null,
+    deletedAt: cleanString(data.deletedAt, 80) || null,
+    deletedBy: cleanString(data.deletedBy, 240) || null,
+    deletedByEmail: cleanString(data.deletedByEmail, 320) || null,
+  };
+}
+
+function sortNotes(left: SchedulingDayNoteRecord, right: SchedulingDayNoteRecord): number {
+  return (
+    left.date.localeCompare(right.date) ||
+    left.createdAt.localeCompare(right.createdAt) ||
+    left.noteId.localeCompare(right.noteId)
+  );
+}
+
+export function groupSchedulingDayNotesByDate(notes: SchedulingDayNoteRecord[]): SchedulingDayNotesByDate {
+  return notes.reduce<SchedulingDayNotesByDate>((result, note) => {
+    result[note.date] = [...(result[note.date] || []), note];
+    return result;
+  }, {});
+}
+
+export async function listSchedulingDayNotesForLandlord(params: {
+  landlordId: string;
+  startDate: string;
+  endDate: string;
+}): Promise<SchedulingDayNoteRecord[]> {
+  const landlordId = cleanString(params.landlordId, 240);
+  if (!landlordId) {
+    throw new SchedulingDayNotesValidationError("SCHEDULING_DAY_NOTE_LANDLORD_REQUIRED", "landlordId is required", 401);
+  }
+  const { startDate, endDate } = assertSchedulingDateRange(params.startDate, params.endDate);
+  const snap = await db.collection(SCHEDULING_DAY_NOTES_COLLECTION).where("landlordId", "==", landlordId).get();
+  return (snap.docs || [])
+    .map(serializeNote)
+    .filter((note): note is SchedulingDayNoteRecord => {
+      return Boolean(note && note.status === "active" && note.date >= startDate && note.date <= endDate);
+    })
+    .sort(sortNotes);
+}
+
+export async function createSchedulingDayNote(params: {
+  landlordId: string;
+  date: string;
+  noteText: string;
+  source?: SchedulingDayNoteSource | string | null;
+  actor: SchedulingDayNoteActor;
+}): Promise<SchedulingDayNoteRecord> {
+  const landlordId = cleanString(params.landlordId, 240);
+  if (!landlordId) {
+    throw new SchedulingDayNotesValidationError("SCHEDULING_DAY_NOTE_LANDLORD_REQUIRED", "landlordId is required", 401);
+  }
+  const date = assertSchedulingDate(params.date);
+  const noteText = normalizeSchedulingDayNoteText(params.noteText);
+  const source = normalizeSchedulingDayNoteSource(params.source);
+  const noteId = randomUUID();
+  const timestamp = nowIso();
+  const actorId = cleanString(params.actor?.id, 240) || landlordId;
+  const actorEmail = cleanString(params.actor?.email, 320) || null;
+  const record: SchedulingDayNoteRecord = {
+    noteId,
+    landlordId,
+    date,
+    noteText,
+    source,
+    status: "active",
+    createdAt: timestamp,
+    createdBy: actorId,
+    createdByEmail: actorEmail,
+    updatedAt: timestamp,
+    updatedBy: actorId,
+    updatedByEmail: actorEmail,
+  };
+  await db.collection(SCHEDULING_DAY_NOTES_COLLECTION).doc(noteId).set(record);
+  return record;
+}
+
+async function loadOwnedNote(params: {
+  landlordId: string;
+  date: string;
+  noteId: string;
+}): Promise<SchedulingDayNoteRecord> {
+  const landlordId = cleanString(params.landlordId, 240);
+  const date = assertSchedulingDate(params.date);
+  const noteId = cleanString(params.noteId, 240);
+  if (!noteId) {
+    throw new SchedulingDayNotesValidationError("SCHEDULING_DAY_NOTE_ID_REQUIRED", "noteId is required");
+  }
+  const snap = await db.collection(SCHEDULING_DAY_NOTES_COLLECTION).doc(noteId).get();
+  const note = snap.exists ? serializeNote({ id: snap.id, data: snap.data }) : null;
+  if (!note || note.landlordId !== landlordId || note.date !== date || note.status !== "active") {
+    throw new SchedulingDayNotesValidationError("SCHEDULING_DAY_NOTE_NOT_FOUND", "Scheduling day note not found", 404);
+  }
+  return note;
+}
+
+export async function updateSchedulingDayNote(params: {
+  landlordId: string;
+  date: string;
+  noteId: string;
+  noteText: string;
+  source?: SchedulingDayNoteSource | string | null;
+  actor: SchedulingDayNoteActor;
+}): Promise<SchedulingDayNoteRecord> {
+  const current = await loadOwnedNote(params);
+  const noteText = normalizeSchedulingDayNoteText(params.noteText);
+  const source = normalizeSchedulingDayNoteSource(params.source || current.source);
+  const timestamp = nowIso();
+  const actorId = cleanString(params.actor?.id, 240) || params.landlordId;
+  const actorEmail = cleanString(params.actor?.email, 320) || null;
+  const next: SchedulingDayNoteRecord = {
+    ...current,
+    noteText,
+    source,
+    updatedAt: timestamp,
+    updatedBy: actorId,
+    updatedByEmail: actorEmail,
+  };
+  await db.collection(SCHEDULING_DAY_NOTES_COLLECTION).doc(current.noteId).set(next, { merge: true });
+  return next;
+}
+
+export async function deleteSchedulingDayNote(params: {
+  landlordId: string;
+  date: string;
+  noteId: string;
+  actor: SchedulingDayNoteActor;
+}): Promise<SchedulingDayNoteRecord> {
+  const current = await loadOwnedNote(params);
+  const timestamp = nowIso();
+  const actorId = cleanString(params.actor?.id, 240) || params.landlordId;
+  const actorEmail = cleanString(params.actor?.email, 320) || null;
+  const next: SchedulingDayNoteRecord = {
+    ...current,
+    status: "deleted",
+    updatedAt: timestamp,
+    updatedBy: actorId,
+    updatedByEmail: actorEmail,
+    deletedAt: timestamp,
+    deletedBy: actorId,
+    deletedByEmail: actorEmail,
+  };
+  await db.collection(SCHEDULING_DAY_NOTES_COLLECTION).doc(current.noteId).set(next, { merge: true });
+  return next;
+}

--- a/rentchain-frontend/src/api/schedulingDayNotesApi.ts
+++ b/rentchain-frontend/src/api/schedulingDayNotesApi.ts
@@ -1,0 +1,123 @@
+import { apiFetch } from "./apiFetch";
+import type { SchedulingDayNote, SchedulingDayNotesByDate } from "../lib/schedulingDayNotes";
+
+type ApiSchedulingDayNote = {
+  noteId?: string;
+  id?: string;
+  date?: string;
+  noteText?: string;
+  text?: string;
+  source?: "dashboard" | "scheduling" | "manual";
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+type SchedulingDayNotesRangeResponse = {
+  ok: true;
+  notes?: ApiSchedulingDayNote[];
+  notesByDate?: Record<string, ApiSchedulingDayNote[]>;
+};
+
+type SchedulingDayNotesSingleResponse = {
+  ok: true;
+  date: string;
+  notes: ApiSchedulingDayNote[];
+};
+
+type SchedulingDayNoteMutationResponse = {
+  ok: true;
+  note: ApiSchedulingDayNote;
+};
+
+function normalizeNote(raw: ApiSchedulingDayNote): SchedulingDayNote | null {
+  const text = String(raw.noteText ?? raw.text ?? "").trim();
+  const id = String(raw.noteId ?? raw.id ?? "").trim();
+  if (!text || !id) return null;
+  return {
+    id,
+    text,
+    date: raw.date,
+    source: raw.source,
+    createdAt: raw.createdAt,
+    updatedAt: raw.updatedAt,
+  };
+}
+
+function normalizeNotesByDate(value: Record<string, ApiSchedulingDayNote[]> | undefined): SchedulingDayNotesByDate {
+  if (!value || typeof value !== "object") return {};
+  return Object.entries(value).reduce<SchedulingDayNotesByDate>((result, [date, notes]) => {
+    const normalized = Array.isArray(notes)
+      ? notes.map(normalizeNote).filter((note): note is SchedulingDayNote => Boolean(note))
+      : [];
+    if (normalized.length) result[date] = normalized;
+    return result;
+  }, {});
+}
+
+function groupNotesByDate(notes: ApiSchedulingDayNote[] | undefined): SchedulingDayNotesByDate {
+  if (!Array.isArray(notes)) return {};
+  return notes.reduce<SchedulingDayNotesByDate>((result, raw) => {
+    const note = normalizeNote(raw);
+    const date = String(raw.date || note?.date || "").trim();
+    if (!note || !date) return result;
+    result[date] = [...(result[date] || []), note];
+    return result;
+  }, {});
+}
+
+export async function fetchSchedulingDayNotesRange(params: {
+  startDate: string;
+  endDate: string;
+}): Promise<SchedulingDayNotesByDate> {
+  const search = new URLSearchParams({
+    startDate: params.startDate,
+    endDate: params.endDate,
+  });
+  const response = await apiFetch<SchedulingDayNotesRangeResponse>(`/landlord/scheduling/day-notes?${search.toString()}`);
+  const grouped = normalizeNotesByDate(response.notesByDate);
+  return Object.keys(grouped).length ? grouped : groupNotesByDate(response.notes);
+}
+
+export async function fetchSchedulingDayNotesForDate(date: string): Promise<SchedulingDayNote[]> {
+  const response = await apiFetch<SchedulingDayNotesSingleResponse>(`/landlord/scheduling/day-notes/${date}`);
+  return response.notes.map(normalizeNote).filter((note): note is SchedulingDayNote => Boolean(note));
+}
+
+export async function createSchedulingDayNote(
+  date: string,
+  payload: { noteText: string; source?: "dashboard" | "scheduling" | "manual" }
+): Promise<SchedulingDayNote> {
+  const response = await apiFetch<SchedulingDayNoteMutationResponse>(`/landlord/scheduling/day-notes/${date}`, {
+    method: "POST",
+    body: payload,
+  });
+  const note = normalizeNote(response.note);
+  if (!note) throw new Error("Scheduling note response was invalid");
+  return note;
+}
+
+export async function updateSchedulingDayNote(
+  date: string,
+  noteId: string,
+  payload: { noteText: string; source?: "dashboard" | "scheduling" | "manual" }
+): Promise<SchedulingDayNote> {
+  const response = await apiFetch<SchedulingDayNoteMutationResponse>(
+    `/landlord/scheduling/day-notes/${date}/${encodeURIComponent(noteId)}`,
+    {
+      method: "PATCH",
+      body: payload,
+    }
+  );
+  const note = normalizeNote(response.note);
+  if (!note) throw new Error("Scheduling note response was invalid");
+  return note;
+}
+
+export async function deleteSchedulingDayNote(date: string, noteId: string): Promise<void> {
+  await apiFetch<SchedulingDayNoteMutationResponse>(
+    `/landlord/scheduling/day-notes/${date}/${encodeURIComponent(noteId)}`,
+    {
+      method: "DELETE",
+    }
+  );
+}

--- a/rentchain-frontend/src/lib/schedulingDayNotes.test.ts
+++ b/rentchain-frontend/src/lib/schedulingDayNotes.test.ts
@@ -1,46 +1,7 @@
-import { beforeEach, describe, expect, it } from "vitest";
-import {
-  dateKeyFromLocalDate,
-  getSchedulingDayNotes,
-  parseSchedulingNoteTime,
-  readSchedulingDayNotes,
-  schedulingDayNotesStorageKey,
-  writeSchedulingDayNotes,
-} from "./schedulingDayNotes";
-
-const scope = {
-  landlordId: "landlord-1",
-  userId: "user-1",
-  email: "landlord@example.com",
-};
+import { describe, expect, it } from "vitest";
+import { dateKeyFromLocalDate, parseSchedulingNoteTime } from "./schedulingDayNotes";
 
 describe("schedulingDayNotes", () => {
-  beforeEach(() => {
-    window.localStorage.clear();
-  });
-
-  it("persists browser-saved notes by account and selected date", () => {
-    writeSchedulingDayNotes(scope, {
-      "2026-07-15": [{ id: "note-1", text: "Confirm viewing window" }],
-      "2026-07-16": [{ id: "note-2", text: "Call contractor" }],
-    });
-
-    expect(getSchedulingDayNotes(scope, "2026-07-15")).toEqual([
-      { id: "note-1", text: "Confirm viewing window" },
-    ]);
-    expect(getSchedulingDayNotes(scope, "2026-07-16")).toEqual([
-      { id: "note-2", text: "Call contractor" },
-    ]);
-    expect(getSchedulingDayNotes({ ...scope, userId: "user-2" }, "2026-07-15")).toEqual([]);
-  });
-
-  it("returns a safe empty state for malformed local storage", () => {
-    window.localStorage.setItem(schedulingDayNotesStorageKey(scope), "{not-json");
-
-    expect(readSchedulingDayNotes(scope)).toEqual({});
-    expect(getSchedulingDayNotes(scope, "2026-07-15")).toEqual([]);
-  });
-
   it("uses local calendar date keys", () => {
     expect(dateKeyFromLocalDate(new Date(2026, 6, 15, 23, 59))).toBe("2026-07-15");
   });

--- a/rentchain-frontend/src/lib/schedulingDayNotes.ts
+++ b/rentchain-frontend/src/lib/schedulingDayNotes.ts
@@ -1,6 +1,10 @@
 export type SchedulingDayNote = {
   id: string;
   text: string;
+  date?: string;
+  source?: "dashboard" | "scheduling" | "manual";
+  createdAt?: string;
+  updatedAt?: string;
 };
 
 export type SchedulingDayNotesByDate = Record<string, SchedulingDayNote[]>;
@@ -10,106 +14,14 @@ export type SchedulingNoteParsedTime = {
   minute: number;
 };
 
-export type SchedulingDayNotesScope = {
-  landlordId?: string | null;
-  actorLandlordId?: string | null;
-  userId?: string | null;
-  id?: string | null;
-  email?: string | null;
-};
-
-const STORAGE_PREFIX = "rentchain.schedulingDayNotes.v1";
 const MERIDIEM_TIME_PATTERN = /\b(1[0-2]|0?[1-9])(?::([0-5]\d))?\s*(a\.?m\.?|p\.?m\.?)\b/i;
 const TWENTY_FOUR_HOUR_TIME_PATTERN = /\b([01]?\d|2[0-3]):([0-5]\d)\b/;
-
-function cleanPart(value: string | null | undefined): string {
-  return String(value || "").trim().toLowerCase();
-}
-
-function storageAvailable(): boolean {
-  return typeof window !== "undefined" && typeof window.localStorage !== "undefined";
-}
 
 export function dateKeyFromLocalDate(date: Date): string {
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, "0");
   const day = String(date.getDate()).padStart(2, "0");
   return `${year}-${month}-${day}`;
-}
-
-export function schedulingDayNotesStorageKey(scope: SchedulingDayNotesScope | null | undefined): string {
-  const landlord = cleanPart(scope?.actorLandlordId) || cleanPart(scope?.landlordId) || "landlord-unknown";
-  const user = cleanPart(scope?.userId) || cleanPart(scope?.id) || cleanPart(scope?.email) || "user-unknown";
-  return `${STORAGE_PREFIX}:${encodeURIComponent(landlord)}:${encodeURIComponent(user)}`;
-}
-
-function normalizeNotesByDate(value: unknown): SchedulingDayNotesByDate {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return {};
-  }
-
-  return Object.entries(value as Record<string, unknown>).reduce<SchedulingDayNotesByDate>((result, [dateKey, rawNotes]) => {
-    if (!/^\d{4}-\d{2}-\d{2}$/.test(dateKey) || !Array.isArray(rawNotes)) {
-      return result;
-    }
-
-    const notes = rawNotes
-      .map((note, index): SchedulingDayNote | null => {
-        if (!note || typeof note !== "object" || Array.isArray(note)) {
-          return null;
-        }
-        const raw = note as Record<string, unknown>;
-        const text = typeof raw.text === "string" ? raw.text.trim() : "";
-        if (!text) {
-          return null;
-        }
-        const id = typeof raw.id === "string" && raw.id.trim() ? raw.id.trim() : `note-${dateKey}-${index}`;
-        return { id, text };
-      })
-      .filter((note): note is SchedulingDayNote => Boolean(note));
-
-    if (notes.length) {
-      result[dateKey] = notes;
-    }
-
-    return result;
-  }, {});
-}
-
-export function readSchedulingDayNotes(scope: SchedulingDayNotesScope | null | undefined): SchedulingDayNotesByDate {
-  if (!storageAvailable()) {
-    return {};
-  }
-
-  try {
-    const raw = window.localStorage.getItem(schedulingDayNotesStorageKey(scope));
-    return raw ? normalizeNotesByDate(JSON.parse(raw)) : {};
-  } catch {
-    return {};
-  }
-}
-
-export function writeSchedulingDayNotes(
-  scope: SchedulingDayNotesScope | null | undefined,
-  notesByDate: SchedulingDayNotesByDate
-): void {
-  if (!storageAvailable()) {
-    return;
-  }
-
-  try {
-    const normalized = normalizeNotesByDate(notesByDate);
-    window.localStorage.setItem(schedulingDayNotesStorageKey(scope), JSON.stringify(normalized));
-  } catch {
-    // Local browser storage is best-effort; scheduling note edits remain visible in page state.
-  }
-}
-
-export function getSchedulingDayNotes(
-  scope: SchedulingDayNotesScope | null | undefined,
-  dateKey: string
-): SchedulingDayNote[] {
-  return readSchedulingDayNotes(scope)[dateKey] || [];
 }
 
 export function parseSchedulingNoteTime(text: string): SchedulingNoteParsedTime | null {

--- a/rentchain-frontend/src/pages/DashboardPage.test.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.test.tsx
@@ -5,7 +5,7 @@ import { MemoryRouter } from "react-router-dom";
 import DashboardPage from "./DashboardPage";
 import type { LandlordDecisionQueueResponse } from "@/api/landlordDecisionQueueApi";
 import type { LandlordPortfolioStatusFinancialResponse } from "@/api/landlordPortfolioStatusFinancialApi";
-import { dateKeyFromLocalDate, writeSchedulingDayNotes } from "../lib/schedulingDayNotes";
+import { dateKeyFromLocalDate } from "../lib/schedulingDayNotes";
 
 const mocks = vi.hoisted(() => ({
   fetchLandlordDecisionQueueMock: vi.fn(),
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
   fetchUnifiedInboxMock: vi.fn(),
   listWorkOrdersMock: vi.fn(),
   listLandlordMaintenanceMock: vi.fn(),
+  fetchSchedulingDayNotesRangeMock: vi.fn(),
   useAuthMock: vi.fn(),
 }));
 
@@ -44,6 +45,10 @@ vi.mock("@/api/workOrdersApi", () => ({
 
 vi.mock("@/api/maintenanceWorkflowApi", () => ({
   listLandlordMaintenance: mocks.listLandlordMaintenanceMock,
+}));
+
+vi.mock("../api/schedulingDayNotesApi", () => ({
+  fetchSchedulingDayNotesRange: mocks.fetchSchedulingDayNotesRangeMock,
 }));
 
 vi.mock("../context/useAuth", () => ({
@@ -257,6 +262,7 @@ describe("DashboardPage", () => {
       ],
     });
     mocks.fetchUnifiedInboxMock.mockResolvedValue({ ok: true, role: "landlord", items: [], records: [], total: 4, limit: 50, offset: 0 });
+    mocks.fetchSchedulingDayNotesRangeMock.mockResolvedValue({});
     mocks.useAuthMock.mockReturnValue({
       user: {
         id: "user-1",
@@ -264,7 +270,6 @@ describe("DashboardPage", () => {
         landlordId: "landlord-1",
       },
     });
-    window.localStorage.clear();
   });
 
   it("renders Dashboard 2.0 sections from the portfolio and decision queue contracts", async () => {
@@ -382,9 +387,9 @@ describe("DashboardPage", () => {
     const detail = screen.getByTestId("selected-day-detail-panel");
     expect(within(detail).getByRole("heading", { name: selectedDateLabel })).toBeInTheDocument();
     expect(within(detail).getByText("Day notes")).toBeInTheDocument();
-    expect(within(detail).getByText("No saved scheduling notes for this day. Browser-saved notes from the Scheduling page will appear here for this account.")).toBeInTheDocument();
+    expect(within(detail).getByText("No saved scheduling notes for this day. Workspace notes from the Scheduling page will appear here for this landlord account.")).toBeInTheDocument();
     expect(within(detail).getByText("Scheduling summary")).toBeInTheDocument();
-    expect(within(detail).getByText(/combines dated Operations queue items with browser-saved notes for this account/i)).toBeInTheDocument();
+    expect(within(detail).getByText(/combines dated Operations queue items with saved workspace scheduling notes for this landlord account/i)).toBeInTheDocument();
     expect(within(detail).getByText("Scheduled items")).toBeInTheDocument();
     expect(within(detail).getByRole("link", { name: /View full day schedule/i })).toHaveAttribute(
       "href",
@@ -396,7 +401,7 @@ describe("DashboardPage", () => {
     expect(within(detail).getByText("1 Operations item from the Operations queue is scheduled for this day.")).toBeInTheDocument();
   });
 
-  it("counts browser-saved notes and shows timed notes in selected-day scheduled items", async () => {
+  it("counts backend workspace notes and shows timed notes in selected-day scheduled items", async () => {
     const selectedDate = new Date();
     selectedDate.setDate(selectedDate.getDate() + 1);
     selectedDate.setHours(12, 0, 0, 0);
@@ -407,25 +412,18 @@ describe("DashboardPage", () => {
       year: "numeric",
     }).format(selectedDate);
 
-    writeSchedulingDayNotes(
-      {
-        landlordId: "landlord-1",
-        userId: "user-1",
-        email: "landlord@example.com",
-      },
-      {
-        [dateKeyFromLocalDate(selectedDate)]: [
-          { id: "note-viewing", text: "1pm viewing" },
-          { id: "note-plumber", text: "3pm plumber" },
-          { id: "note-untimed", text: "Confirm inspection window" },
-        ],
-      }
-    );
+    mocks.fetchSchedulingDayNotesRangeMock.mockResolvedValue({
+      [dateKeyFromLocalDate(selectedDate)]: [
+        { id: "note-viewing", text: "1pm viewing" },
+        { id: "note-plumber", text: "3pm plumber" },
+        { id: "note-untimed", text: "Confirm inspection window" },
+      ],
+    });
 
     renderDashboard();
 
     await screen.findByTestId("calendar-preview-section");
-    fireEvent.click(screen.getByRole("button", { name: `Select ${selectedDateLabel}, 0 scheduled items` }));
+    fireEvent.click(await screen.findByRole("button", { name: `Select ${selectedDateLabel}, 3 scheduled items` }));
 
     const detail = screen.getByTestId("selected-day-detail-panel");
     expect(within(detail).getByText("3 items")).toBeInTheDocument();
@@ -436,6 +434,7 @@ describe("DashboardPage", () => {
     expect(within(detail).getByText("Unscheduled notes stay here until a clear time is added.")).toBeInTheDocument();
     expect(within(detail).getByText("1 PM - viewing")).toBeInTheDocument();
     expect(within(detail).getByText("3 PM - plumber")).toBeInTheDocument();
+    expect(within(detail).getAllByText("Workspace scheduling note")).toHaveLength(2);
     expect(within(detail).queryByText("No scheduled notes or actions for this day.")).not.toBeInTheDocument();
     expect(within(detail).getByText("No Operations queue reminders are scheduled for this day.")).toBeInTheDocument();
     expect(within(detail).getByRole("link", { name: /View full day schedule/i })).toHaveAttribute(
@@ -731,7 +730,7 @@ describe("DashboardPage", () => {
 
     expect(await screen.findByText("No open decisions. New operational decisions will appear here before routing to their owning workspace.")).toBeInTheDocument();
     expect(screen.getByText("No upcoming dated actions are due right now. Reviewable work may still appear in Decision Queue Preview or the Operations review queue.")).toBeInTheDocument();
-    expect(screen.getByText("No dated schedule items are visible for this week. Upcoming dated decisions will appear here.")).toBeInTheDocument();
+    expect(screen.getByText("No dated schedule items are visible for this week. Upcoming dated decisions and saved scheduling notes will appear here.")).toBeInTheDocument();
     expect(screen.getByTestId("selected-day-detail-panel")).toHaveTextContent("No scheduled notes or actions for this day.");
     expect(screen.getByTestId("selected-day-detail-panel")).toHaveTextContent("No saved scheduling notes for this day.");
   });

--- a/rentchain-frontend/src/pages/DashboardPage.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.tsx
@@ -19,8 +19,8 @@ import {
 } from "lucide-react";
 import { MacShell } from "../components/layout/MacShell";
 import { Card, SkeletonBlock } from "../components/ui/Ui";
-import { useAuth } from "../context/useAuth";
-import { dateKeyFromLocalDate, getSchedulingDayNotes, parseSchedulingNoteTime } from "../lib/schedulingDayNotes";
+import { fetchSchedulingDayNotesRange } from "../api/schedulingDayNotesApi";
+import { dateKeyFromLocalDate, parseSchedulingNoteTime, type SchedulingDayNotesByDate } from "../lib/schedulingDayNotes";
 import { colors, layout, spacing, text } from "../styles/tokens";
 import {
   fetchLandlordDecisionQueue,
@@ -361,6 +361,10 @@ function isSameCalendarDay(left: Date, right: Date): boolean {
 
 function isSameCalendarMonth(left: Date, right: Date): boolean {
   return left.getFullYear() === right.getFullYear() && left.getMonth() === right.getMonth();
+}
+
+function dateKeysFromDays(days: Date[]): string[] {
+  return days.map((day) => dateKeyFromLocalDate(day));
 }
 
 function pluralize(count: number, singular: string, plural = `${singular}s`): string {
@@ -852,7 +856,6 @@ function UpcomingActions({ queue }: { queue: LandlordDecisionQueueResponse | nul
 }
 
 function CalendarPreviewPanel({ queue }: { queue: LandlordDecisionQueueResponse | null }) {
-  const { user } = useAuth();
   const [view, setView] = React.useState<"week" | "month">("week");
   const today = React.useMemo(() => startOfDay(new Date()), []);
   const [selectedDay, setSelectedDay] = React.useState<Date>(today);
@@ -879,19 +882,11 @@ function CalendarPreviewPanel({ queue }: { queue: LandlordDecisionQueueResponse 
       : isSameCalendarMonth(date, today)
   );
   const selectedDayItems = datedItems.filter(({ date }) => isSameCalendarDay(date, selectedDay));
-  const notesScope = React.useMemo(
-    () => ({
-      actorLandlordId: user?.actorLandlordId,
-      landlordId: user?.landlordId,
-      userId: user?.id,
-      email: user?.email,
-    }),
-    [user?.actorLandlordId, user?.landlordId, user?.id, user?.email]
-  );
-  const selectedDayNotes = React.useMemo(
-    () => getSchedulingDayNotes(notesScope, dateKeyFromLocalDate(selectedDay)),
-    [notesScope, selectedDay]
-  );
+  const [notesByDate, setNotesByDate] = React.useState<SchedulingDayNotesByDate>({});
+  const [notesLoading, setNotesLoading] = React.useState(false);
+  const [notesError, setNotesError] = React.useState<string | null>(null);
+  const visibleNoteCount = days.reduce((total, day) => total + (notesByDate[dateKeyFromLocalDate(day)]?.length || 0), 0);
+  const selectedDayNotes = notesByDate[dateKeyFromLocalDate(selectedDay)] || [];
   const selectedScheduledNotes = React.useMemo(
     () =>
       selectedDayNotes
@@ -915,6 +910,35 @@ function CalendarPreviewPanel({ queue }: { queue: LandlordDecisionQueueResponse 
   const selectedDayLabel = formatFullDate(selectedDay);
   const selectedItemSummary = pluralize(selectedTotalItemCount, "item");
   const selectedOperationsSummary = pluralize(selectedDayItems.length, "Operations item");
+
+  React.useEffect(() => {
+    let active = true;
+    const startDate = dateKeyFromLocalDate(days[0]);
+    const endDate = dateKeyFromLocalDate(days[days.length - 1]);
+    setNotesLoading(true);
+    setNotesError(null);
+    fetchSchedulingDayNotesRange({ startDate, endDate })
+      .then((nextNotes) => {
+        if (!active) return;
+        setNotesByDate((current) => {
+          const next = { ...current };
+          dateKeysFromDays(days).forEach((dateKey) => {
+            delete next[dateKey];
+          });
+          return { ...next, ...nextNotes };
+        });
+      })
+      .catch(() => {
+        if (!active) return;
+        setNotesError("Saved scheduling notes could not be loaded.");
+      })
+      .finally(() => {
+        if (active) setNotesLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [days]);
 
   return (
     <Card style={sectionCard} data-testid="calendar-preview-section">
@@ -959,6 +983,8 @@ function CalendarPreviewPanel({ queue }: { queue: LandlordDecisionQueueResponse 
         {days.map((day) => {
           const dayItems = datedItems.filter(({ date }) => isSameCalendarDay(date, day)).slice(0, view === "week" ? 2 : 1);
           const allDayItems = datedItems.filter(({ date }) => isSameCalendarDay(date, day));
+          const dayNotes = notesByDate[dateKeyFromLocalDate(day)] || [];
+          const dayTotalItems = allDayItems.length + dayNotes.length;
           const isSelected = isSameCalendarDay(day, selectedDay);
           return (
             <button
@@ -966,7 +992,7 @@ function CalendarPreviewPanel({ queue }: { queue: LandlordDecisionQueueResponse 
               type="button"
               onClick={() => setSelectedDay(startOfDay(day))}
               aria-pressed={isSelected}
-              aria-label={`Select ${formatFullDate(day)}, ${pluralize(allDayItems.length, "scheduled item")}`}
+              aria-label={`Select ${formatFullDate(day)}, ${pluralize(dayTotalItems, "scheduled item")}`}
               style={{
                 display: "grid",
                 gap: 6,
@@ -1012,6 +1038,18 @@ function CalendarPreviewPanel({ queue }: { queue: LandlordDecisionQueueResponse 
                   {item.title || "Review item"}
                 </span>
               ))}
+              {dayItems.length === 0 && dayNotes.length > 0 ? (
+                <span
+                  style={{
+                    color: dashboardTheme.pine,
+                    fontSize: 12,
+                    fontWeight: 800,
+                    lineHeight: 1.25,
+                  }}
+                >
+                  {pluralize(dayNotes.length, "note")}
+                </span>
+              ) : null}
               {view === "month" && dayItems.length > 0 ? (
                 <span aria-hidden="true" style={{ width: 6, height: 6, borderRadius: 99, background: dashboardTheme.pine }} />
               ) : null}
@@ -1019,9 +1057,9 @@ function CalendarPreviewPanel({ queue }: { queue: LandlordDecisionQueueResponse 
           );
         })}
       </div>
-      {visibleItems.length === 0 ? (
+      {visibleItems.length === 0 && visibleNoteCount === 0 ? (
         <div style={{ border: `1px solid ${colors.border}`, borderRadius: 8, padding: 12, color: text.muted }}>
-          No dated schedule items are visible for this {view === "week" ? "week" : "month"}. Upcoming dated decisions will appear here.
+          No dated schedule items are visible for this {view === "week" ? "week" : "month"}. Upcoming dated decisions and saved scheduling notes will appear here.
         </div>
       ) : null}
       <div
@@ -1075,14 +1113,16 @@ function CalendarPreviewPanel({ queue }: { queue: LandlordDecisionQueueResponse 
               </div>
             ) : (
               <div style={{ color: text.muted, fontSize: 13, lineHeight: 1.45 }}>
-                No saved scheduling notes for this day. Browser-saved notes from the Scheduling page will appear here for this account.
+                No saved scheduling notes for this day. Workspace notes from the Scheduling page will appear here for this landlord account.
               </div>
             )}
+            {notesLoading ? <div style={{ color: text.muted, fontSize: 13, lineHeight: 1.45 }}>Loading saved scheduling notes.</div> : null}
+            {notesError ? <div style={{ color: text.muted, fontSize: 13, lineHeight: 1.45 }} role="alert">{notesError}</div> : null}
           </div>
           <div style={{ display: "grid", gap: 6, minWidth: 0 }}>
             <div style={{ fontWeight: 850 }}>Scheduling summary</div>
             <div style={{ color: text.muted, fontSize: 13, lineHeight: 1.45 }}>
-              This dashboard summary combines dated Operations queue items with browser-saved notes for this account. Team-shared scheduling notes are not enabled yet.
+              This dashboard summary combines dated Operations queue items with saved workspace scheduling notes for this landlord account.
             </div>
           </div>
         </div>
@@ -1118,7 +1158,7 @@ function CalendarPreviewPanel({ queue }: { queue: LandlordDecisionQueueResponse 
                       {formatHourMinute(parsedTime.hour, parsedTime.minute)} - {noteDetail}
                     </div>
                     <div style={{ color: text.muted, fontSize: 13, lineHeight: 1.4, overflowWrap: "anywhere" }}>
-                      Browser-saved scheduling note
+                      Workspace scheduling note
                     </div>
                   </div>
                 );

--- a/rentchain-frontend/src/pages/SchedulingWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/SchedulingWorkspacePage.test.tsx
@@ -1,8 +1,16 @@
 import React from "react";
-import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import SchedulingWorkspacePage from "./SchedulingWorkspacePage";
+import { dateKeyFromLocalDate } from "../lib/schedulingDayNotes";
+
+const mocks = vi.hoisted(() => ({
+  fetchSchedulingDayNotesRangeMock: vi.fn(),
+  createSchedulingDayNoteMock: vi.fn(),
+  updateSchedulingDayNoteMock: vi.fn(),
+  deleteSchedulingDayNoteMock: vi.fn(),
+}));
 
 vi.mock("../context/useAuth", () => ({
   useAuth: () => ({
@@ -14,9 +22,29 @@ vi.mock("../context/useAuth", () => ({
   }),
 }));
 
+vi.mock("../api/schedulingDayNotesApi", () => ({
+  fetchSchedulingDayNotesRange: mocks.fetchSchedulingDayNotesRangeMock,
+  createSchedulingDayNote: mocks.createSchedulingDayNoteMock,
+  updateSchedulingDayNote: mocks.updateSchedulingDayNoteMock,
+  deleteSchedulingDayNote: mocks.deleteSchedulingDayNoteMock,
+}));
+
+beforeEach(() => {
+  mocks.fetchSchedulingDayNotesRangeMock.mockResolvedValue({});
+  mocks.createSchedulingDayNoteMock.mockImplementation(async (_date: string, payload: { noteText: string }) => ({
+    id: `note-${payload.noteText.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`,
+    text: payload.noteText,
+  }));
+  mocks.updateSchedulingDayNoteMock.mockImplementation(async (_date: string, noteId: string, payload: { noteText: string }) => ({
+    id: noteId,
+    text: payload.noteText,
+  }));
+  mocks.deleteSchedulingDayNoteMock.mockResolvedValue(undefined);
+});
+
 afterEach(() => {
   cleanup();
-  window.localStorage.clear();
+  vi.clearAllMocks();
 });
 
 function renderPage(initialEntries: string[] = ["/scheduling"]) {
@@ -61,14 +89,16 @@ describe("SchedulingWorkspacePage", () => {
     expect(screen.getByLabelText("30-day scheduling overview")).toBeInTheDocument();
   });
 
-  it("lets landlords add, edit, and delete multiple selected-day notes", () => {
+  it("lets landlords add, edit, and delete multiple selected-day notes", async () => {
     renderPage();
 
     const noteInput = screen.getByLabelText("New schedule note");
     fireEvent.change(noteInput, { target: { value: "Call tenant before viewing" } });
     fireEvent.click(screen.getByRole("button", { name: "Add note" }));
+    await screen.findByDisplayValue("Call tenant before viewing");
     fireEvent.change(noteInput, { target: { value: "Confirm maintenance access" } });
     fireEvent.click(screen.getByRole("button", { name: "Add note" }));
+    await screen.findByDisplayValue("Confirm maintenance access");
 
     fireEvent.click(screen.getByRole("button", { name: "30 days" }));
     const selectedDay = screen.getByRole("button", { pressed: true });
@@ -77,26 +107,32 @@ describe("SchedulingWorkspacePage", () => {
     expect(screen.getByDisplayValue("Confirm maintenance access")).toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText("Edit note 1"), { target: { value: "Call tenant at noon" } });
+    fireEvent.click(screen.getAllByRole("button", { name: "Save" })[0]);
 
     expect(screen.getByDisplayValue("Call tenant at noon")).toBeInTheDocument();
+    await waitFor(() => expect(mocks.updateSchedulingDayNoteMock).toHaveBeenCalled());
 
     fireEvent.click(screen.getAllByRole("button", { name: "Delete" })[0]);
 
+    await waitFor(() => expect(mocks.deleteSchedulingDayNoteMock).toHaveBeenCalled());
     expect(within(selectedDay).getByText("1 note")).toBeInTheDocument();
     expect(screen.queryByDisplayValue("Call tenant at noon")).not.toBeInTheDocument();
     expect(screen.getByDisplayValue("Confirm maintenance access")).toBeInTheDocument();
   });
 
-  it("places notes with clear times into day schedule slots and keeps vague notes unscheduled", () => {
+  it("places notes with clear times into day schedule slots and keeps vague notes unscheduled", async () => {
     renderPage();
 
     const noteInput = screen.getByLabelText("New schedule note");
     fireEvent.change(noteInput, { target: { value: "9am inspection" } });
     fireEvent.click(screen.getByRole("button", { name: "Add note" }));
+    await screen.findByDisplayValue("9am inspection");
     fireEvent.change(noteInput, { target: { value: "14:00 contractor" } });
     fireEvent.click(screen.getByRole("button", { name: "Add note" }));
+    await screen.findByDisplayValue("14:00 contractor");
     fireEvent.change(noteInput, { target: { value: "Call tenant tomorrow" } });
     fireEvent.click(screen.getByRole("button", { name: "Add note" }));
+    await screen.findByDisplayValue("Call tenant tomorrow");
 
     expect(within(screen.getByLabelText("Schedule slot 9 AM")).getByText("9am inspection")).toBeInTheDocument();
     expect(within(screen.getByLabelText("Schedule slot 2 PM")).getByText("14:00 contractor")).toBeInTheDocument();
@@ -111,20 +147,30 @@ describe("SchedulingWorkspacePage", () => {
     expect(screen.getByLabelText("7 AM-10 PM schedule")).toBeInTheDocument();
   });
 
-  it("persists selected-day notes after the scheduling page remounts", () => {
+  it("loads selected-day notes from backend after the scheduling page remounts", async () => {
+    const todayKey = dateKeyFromLocalDate(new Date());
+    mocks.fetchSchedulingDayNotesRangeMock
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({
+        [todayKey]: [{ id: "note-elevator", text: "Confirm elevator booking" }],
+      });
     const { unmount } = renderPage();
 
     const noteInput = screen.getByLabelText("New schedule note");
     fireEvent.change(noteInput, { target: { value: "Confirm elevator booking" } });
     fireEvent.click(screen.getByRole("button", { name: "Add note" }));
 
-    expect(screen.getByDisplayValue("Confirm elevator booking")).toBeInTheDocument();
+    expect(await screen.findByDisplayValue("Confirm elevator booking")).toBeInTheDocument();
+    await waitFor(() => expect(mocks.createSchedulingDayNoteMock).toHaveBeenCalledWith(todayKey, {
+      noteText: "Confirm elevator booking",
+      source: "scheduling",
+    }));
 
     unmount();
     renderPage();
 
-    expect(screen.getByDisplayValue("Confirm elevator booking")).toBeInTheDocument();
-    expect(screen.getByText(/Notes are saved in this browser for your account/i)).toBeInTheDocument();
+    expect(await screen.findByDisplayValue("Confirm elevator booking")).toBeInTheDocument();
+    expect(screen.getByText(/Notes are saved as workspace notes for this landlord account/i)).toBeInTheDocument();
   });
 
   it("keeps scheduling review recommendations read-only", () => {

--- a/rentchain-frontend/src/pages/SchedulingWorkspacePage.tsx
+++ b/rentchain-frontend/src/pages/SchedulingWorkspacePage.tsx
@@ -11,12 +11,15 @@ import {
   Wrench,
 } from "lucide-react";
 import { Button, Card, Input } from "../components/ui/Ui";
-import { useAuth } from "../context/useAuth";
+import {
+  createSchedulingDayNote,
+  deleteSchedulingDayNote,
+  fetchSchedulingDayNotesRange,
+  updateSchedulingDayNote,
+} from "../api/schedulingDayNotesApi";
 import {
   dateKeyFromLocalDate,
   parseSchedulingNoteTime,
-  readSchedulingDayNotes,
-  writeSchedulingDayNotes,
   type SchedulingDayNote,
   type SchedulingDayNotesByDate,
 } from "../lib/schedulingDayNotes";
@@ -141,6 +144,19 @@ function buildWeekDays(date: Date) {
   });
 }
 
+function dateKeysInRange(startDate: string, endDate: string) {
+  const start = parseDateKey(startDate);
+  const end = parseDateKey(endDate);
+  if (!start || !end) return [];
+  const keys: string[] = [];
+  const cursor = new Date(start);
+  while (cursor <= end) {
+    keys.push(dayKey(cursor));
+    cursor.setDate(cursor.getDate() + 1);
+  }
+  return keys;
+}
+
 function SectionHeader({
   icon: Icon,
   title,
@@ -199,30 +215,40 @@ function WorkspaceList({
 }
 
 export default function SchedulingWorkspacePage() {
-  const { user } = useAuth();
   const [searchParams, setSearchParams] = useSearchParams();
   const today = React.useMemo(() => new Date(), []);
   const requestedDate = React.useMemo(() => parseDateKey(searchParams.get("date")), [searchParams]);
   const initialSelectedDate = requestedDate || new Date(today.getFullYear(), today.getMonth(), today.getDate());
-  const notesScope = React.useMemo(
-    () => ({
-      actorLandlordId: user?.actorLandlordId,
-      landlordId: user?.landlordId,
-      userId: user?.id,
-      email: user?.email,
-    }),
-    [user?.actorLandlordId, user?.landlordId, user?.id, user?.email]
-  );
   const [calendarView, setCalendarView] = React.useState<CalendarView>(() => viewFromParam(searchParams.get("view")));
   const [activeMonth, setActiveMonth] = React.useState(() => new Date(initialSelectedDate.getFullYear(), initialSelectedDate.getMonth(), 1));
   const [selectedDate, setSelectedDate] = React.useState(() => initialSelectedDate);
-  const [notesByDate, setNotesByDate] = React.useState<SchedulingDayNotesByDate>(() => readSchedulingDayNotes(notesScope));
+  const [notesByDate, setNotesByDate] = React.useState<SchedulingDayNotesByDate>({});
   const [noteDraft, setNoteDraft] = React.useState("");
+  const [notesLoading, setNotesLoading] = React.useState(false);
+  const [notesError, setNotesError] = React.useState<string | null>(null);
+  const [notesStatus, setNotesStatus] = React.useState<string | null>(null);
+  const [draftSaving, setDraftSaving] = React.useState(false);
+  const [savingNoteIds, setSavingNoteIds] = React.useState<Record<string, boolean>>({});
 
   const selectedKey = dayKey(selectedDate);
   const selectedNotes = notesByDate[selectedKey] || [];
   const weekDays = React.useMemo(() => buildWeekDays(selectedDate), [selectedDate]);
   const monthDays = React.useMemo(() => buildMonthDays(activeMonth), [activeMonth]);
+  const visibleRange = React.useMemo(() => {
+    if (calendarView === "week") {
+      return {
+        startDate: dayKey(weekDays[0]),
+        endDate: dayKey(weekDays[weekDays.length - 1]),
+      };
+    }
+    if (calendarView === "month") {
+      return {
+        startDate: dayKey(monthDays[0]),
+        endDate: dayKey(monthDays[monthDays.length - 1]),
+      };
+    }
+    return { startDate: selectedKey, endDate: selectedKey };
+  }, [calendarView, monthDays, selectedKey, weekDays]);
   const selectedNotesByTime = React.useMemo(() => {
     const grouped = scheduleHours.reduce<Record<number, SchedulingDayNote[]>>((result, hour) => {
       result[hour] = [];
@@ -241,10 +267,6 @@ export default function SchedulingWorkspacePage() {
   }, [selectedNotes]);
 
   React.useEffect(() => {
-    setNotesByDate(readSchedulingDayNotes(notesScope));
-  }, [notesScope]);
-
-  React.useEffect(() => {
     const nextDate = parseDateKey(searchParams.get("date"));
     const nextView = viewFromParam(searchParams.get("view"));
     if (nextDate) {
@@ -261,16 +283,41 @@ export default function SchedulingWorkspacePage() {
     [setSearchParams]
   );
 
-  const updateStoredNotes = React.useCallback(
-    (updater: (current: SchedulingDayNotesByDate) => SchedulingDayNotesByDate) => {
-      setNotesByDate((current) => {
-        const next = updater(current);
-        writeSchedulingDayNotes(notesScope, next);
-        return next;
+  React.useEffect(() => {
+    let active = true;
+    setNotesLoading(true);
+    setNotesError(null);
+    fetchSchedulingDayNotesRange(visibleRange)
+      .then((nextNotes) => {
+        if (!active) return;
+        setNotesByDate((current) => {
+          const next = { ...current };
+          dateKeysInRange(visibleRange.startDate, visibleRange.endDate).forEach((dateKey) => {
+            delete next[dateKey];
+          });
+          return { ...next, ...nextNotes };
+        });
+      })
+      .catch(() => {
+        if (!active) return;
+        setNotesError("Scheduling notes could not be loaded. Try refreshing this view.");
+      })
+      .finally(() => {
+        if (active) setNotesLoading(false);
       });
-    },
-    [notesScope]
-  );
+    return () => {
+      active = false;
+    };
+  }, [visibleRange]);
+
+  const replaceNotesForDate = React.useCallback((dateKey: string, notes: SchedulingDayNote[]) => {
+    setNotesByDate((current) => {
+      const next = { ...current };
+      if (notes.length) next[dateKey] = notes;
+      else delete next[dateKey];
+      return next;
+    });
+  }, []);
 
   const selectDate = (date: Date, nextView: CalendarView = "day") => {
     const next = new Date(date.getFullYear(), date.getMonth(), date.getDate());
@@ -286,42 +333,72 @@ export default function SchedulingWorkspacePage() {
     syncRoute(nextView, selectedDate);
   };
 
-  const addNote = () => {
+  const addNote = async () => {
     const text = noteDraft.trim();
     if (!text) {
       return;
     }
-    const note: SchedulingDayNote = {
-      id: `note-${Date.now()}-${Math.random().toString(16).slice(2)}`,
-      text,
-    };
-    updateStoredNotes((current) => {
-      const currentNotes = current[selectedKey] || [];
-      return { ...current, [selectedKey]: [...currentNotes, note] };
-    });
-    setNoteDraft("");
+    setDraftSaving(true);
+    setNotesError(null);
+    setNotesStatus(null);
+    try {
+      const note = await createSchedulingDayNote(selectedKey, { noteText: text, source: "scheduling" });
+      replaceNotesForDate(selectedKey, [...selectedNotes, note]);
+      setNoteDraft("");
+      setNotesStatus("Workspace note saved.");
+    } catch {
+      setNotesError("Scheduling note could not be saved. No notification or calendar event was created.");
+    } finally {
+      setDraftSaving(false);
+    }
   };
 
   const updateNote = (noteId: string, value: string) => {
-    updateStoredNotes((current) => {
-      const nextNotes = (current[selectedKey] || []).map((note) =>
-        note.id === noteId ? { ...note, text: value } : note
-      );
-      return { ...current, [selectedKey]: nextNotes };
-    });
+    replaceNotesForDate(
+      selectedKey,
+      selectedNotes.map((note) => (note.id === noteId ? { ...note, text: value } : note))
+    );
   };
 
-  const deleteNote = (noteId: string) => {
-    updateStoredNotes((current) => {
-      const nextNotes = (current[selectedKey] || []).filter((note) => note.id !== noteId);
-      const next = { ...current };
-      if (nextNotes.length) {
-        next[selectedKey] = nextNotes;
-      } else {
-        delete next[selectedKey];
-      }
-      return next;
-    });
+  const saveNote = async (note: SchedulingDayNote) => {
+    const text = note.text.trim();
+    if (!text) {
+      setNotesError("Scheduling note text is required. Delete the note if it is no longer needed.");
+      return;
+    }
+    setSavingNoteIds((current) => ({ ...current, [note.id]: true }));
+    setNotesError(null);
+    setNotesStatus(null);
+    try {
+      const saved = await updateSchedulingDayNote(selectedKey, note.id, { noteText: text, source: "scheduling" });
+      replaceNotesForDate(
+        selectedKey,
+        selectedNotes.map((current) => (current.id === saved.id ? saved : current))
+      );
+      setNotesStatus("Workspace note saved.");
+    } catch {
+      setNotesError("Scheduling note could not be saved. Refresh this view and try again.");
+    } finally {
+      setSavingNoteIds((current) => ({ ...current, [note.id]: false }));
+    }
+  };
+
+  const deleteNote = async (noteId: string) => {
+    setSavingNoteIds((current) => ({ ...current, [noteId]: true }));
+    setNotesError(null);
+    setNotesStatus(null);
+    try {
+      await deleteSchedulingDayNote(selectedKey, noteId);
+      replaceNotesForDate(
+        selectedKey,
+        selectedNotes.filter((note) => note.id !== noteId)
+      );
+      setNotesStatus("Workspace note deleted.");
+    } catch {
+      setNotesError("Scheduling note could not be deleted. Refresh this view and try again.");
+    } finally {
+      setSavingNoteIds((current) => ({ ...current, [noteId]: false }));
+    }
   };
 
   const moveMonth = (offset: number) => {
@@ -767,8 +844,9 @@ export default function SchedulingWorkspacePage() {
             {calendarView === "day" ? (
               <div className="scheduling-day-summary" aria-label="Selected day schedule">
                 <div className="scheduling-local-note">
-                  7 AM-10 PM schedule. Notes with clear times are placed into hourly slots; other notes stay unscheduled.
+                  7 AM-10 PM schedule. Workspace notes with clear times are placed into hourly slots; other notes stay unscheduled.
                 </div>
+                {notesLoading ? <div className="scheduling-local-note">Loading saved scheduling notes.</div> : null}
                 {selectedNotes.length === 0 ? (
                   <div className="scheduling-local-note">No saved notes for this day.</div>
                 ) : null}
@@ -866,8 +944,10 @@ export default function SchedulingWorkspacePage() {
             <div style={{ display: "grid", gap: spacing.sm }}>
               <strong>{formatDay(selectedDate)}</strong>
               <div className="scheduling-local-note">
-                Notes are saved in this browser for your account. Team-shared scheduling notes need backend persistence.
+                Notes are saved as workspace notes for this landlord account.
               </div>
+              {notesError ? <div className="scheduling-local-note" role="alert">{notesError}</div> : null}
+              {notesStatus ? <div className="scheduling-local-note">{notesStatus}</div> : null}
               {selectedNotes.length ? (
                 <div className="scheduling-note-list" aria-label="Saved schedule notes">
                   {selectedNotes.map((note, index) => (
@@ -878,11 +958,11 @@ export default function SchedulingWorkspacePage() {
                         onChange={(event) => updateNote(note.id, event.target.value)}
                         placeholder="Note text"
                       />
-                      <Button type="button" variant="secondary" onClick={() => updateNote(note.id, note.text)}>
-                        Save
+                      <Button type="button" variant="secondary" onClick={() => saveNote(note)} disabled={Boolean(savingNoteIds[note.id])}>
+                        {savingNoteIds[note.id] ? "Saving" : "Save"}
                       </Button>
-                      <Button type="button" variant="ghost" onClick={() => deleteNote(note.id)}>
-                        Delete
+                      <Button type="button" variant="ghost" onClick={() => deleteNote(note.id)} disabled={Boolean(savingNoteIds[note.id])}>
+                        {savingNoteIds[note.id] ? "Deleting" : "Delete"}
                       </Button>
                     </div>
                   ))}
@@ -894,16 +974,16 @@ export default function SchedulingWorkspacePage() {
                 aria-label="New schedule note"
                 value={noteDraft}
                 onChange={(event) => setNoteDraft(event.target.value)}
-                placeholder="Add a browser-saved note for this day"
+                placeholder="Add a workspace note for this day"
               />
               <div className="scheduling-note-actions">
-                <Button type="button" className="scheduling-primary-action" onClick={addNote} aria-label="Add note">
+                <Button type="button" className="scheduling-primary-action" onClick={addNote} aria-label="Add note" disabled={draftSaving}>
                   <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
                     <Plus size={16} aria-hidden="true" />
-                    Add note
+                    {draftSaving ? "Saving" : "Add note"}
                   </span>
                 </Button>
-                <Button type="button" variant="ghost" onClick={() => setNoteDraft("")} disabled={!noteDraft}>
+                <Button type="button" variant="ghost" onClick={() => setNoteDraft("")} disabled={!noteDraft || draftSaving}>
                   Clear draft
                 </Button>
               </div>


### PR DESCRIPTION
## Summary

Adds backend-persisted, landlord-scoped scheduling day notes and wires the dashboard and scheduling workspace to use backend notes instead of browser-local storage.

## What changed

- Added a `schedulingDayNotes` Firestore-backed service with one record per note.
- Added landlord-scoped scheduling note routes under `/api/landlord/scheduling/day-notes`:
  - `GET /api/landlord/scheduling/day-notes?startDate=YYYY-MM-DD&endDate=YYYY-MM-DD`
  - `GET /api/landlord/scheduling/day-notes/:date`
  - `POST /api/landlord/scheduling/day-notes/:date`
  - `PATCH /api/landlord/scheduling/day-notes/:date/:noteId`
  - `DELETE /api/landlord/scheduling/day-notes/:date/:noteId`
- Updated `/scheduling` to load notes for the visible range and save/add/delete notes through the backend.
- Updated `/dashboard` selected-day detail to load backend workspace notes, count them with Operations items, and keep timed notes in scheduled items.
- Kept deterministic frontend time parsing for display only.
- Removed scheduling note localStorage as the source of truth. No automatic localStorage migration is included in this PR.
- Added backend test coverage for multiple active notes on the same date.

## Data and auth model

- Collection: `schedulingDayNotes`.
- Scope: server-derived landlord ID from authenticated landlord/admin context.
- Active notes are returned for date/day-range reads.
- Deletes are soft deletes with `status: deleted` and deletion actor metadata.
- Tenant/contractor/public access is not added.

## Validation

- `cd rentchain-api && npm run test -- landlordSchedulingDayNotesRoutes` passed, 6 tests.
- `cd rentchain-api && npm run build` passed.
- `cd rentchain-frontend && npm run test -- DashboardPage TopNav SchedulingWorkspacePage schedulingDayNotes` passed, 28 tests, using Node 20.20.2.
- `cd rentchain-frontend && npm run build` passed with the existing Vite chunk-size warning.
- `git diff --check` passed.
- `git diff --cached --check` passed.

## QA/review summary

Posted here: https://github.com/rentchaincanada/rentchain/pull/1377#issuecomment-4981050389

## Guardrails

This PR does not add notifications, calendar event creation, Google Calendar integration, AI/LLM parsing, decision/action mutation, payment behavior, lease lifecycle behavior, legal/compliance behavior, or tenant communication behavior.

## Follow-up

Browser-local notes from PR #1376 are not automatically uploaded. If migration is desired, handle it separately in `polish/scheduling-local-notes-migration-v1`.