### PR TITLE
Migrate browser-saved scheduling notes

### DIFF
--- a/rentchain-frontend/src/lib/schedulingDayNotes.test.ts
+++ b/rentchain-frontend/src/lib/schedulingDayNotes.test.ts
@@ -1,5 +1,17 @@
-import { describe, expect, it } from "vitest";
-import { dateKeyFromLocalDate, parseSchedulingNoteTime } from "./schedulingDayNotes";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  clearMigratedLegacySchedulingDayNotes,
+  dateKeyFromLocalDate,
+  legacySchedulingDayNoteFingerprint,
+  legacySchedulingDayNotesStorageKey,
+  markLegacySchedulingDayNotesMigrated,
+  parseSchedulingNoteTime,
+  readLegacySchedulingDayNotes,
+} from "./schedulingDayNotes";
+
+const scope = { landlordId: "Landlord 1", userId: "User@example.com" };
+
+beforeEach(() => window.localStorage.clear());
 
 describe("schedulingDayNotes", () => {
   it("uses local calendar date keys", () => {
@@ -13,5 +25,37 @@ describe("schedulingDayNotes", () => {
     expect(parseSchedulingNoteTime("14:00 contractor")).toEqual({ hour: 14, minute: 0 });
     expect(parseSchedulingNoteTime("7 PM follow up")).toEqual({ hour: 19, minute: 0 });
     expect(parseSchedulingNoteTime("Unit 14 contractor follow up tomorrow")).toBeNull();
+  });
+
+  it("reads only the exact account-scoped legacy localStorage payload", () => {
+    expect(legacySchedulingDayNotesStorageKey(scope)).toBe(
+      "rentchain.schedulingDayNotes.v1:landlord%201:user%40example.com"
+    );
+    window.localStorage.setItem(
+      legacySchedulingDayNotesStorageKey(scope),
+      JSON.stringify({ "2026-07-14": [{ id: "legacy-1", text: "  9am inspection  " }] })
+    );
+    window.localStorage.setItem(
+      legacySchedulingDayNotesStorageKey({ landlordId: "other", userId: "other" }),
+      JSON.stringify({ "2026-07-15": [{ id: "wrong-account", text: "Do not read" }] })
+    );
+
+    expect(readLegacySchedulingDayNotes(scope)).toEqual({
+      "2026-07-14": [{ id: "legacy-1", text: "9am inspection" }],
+    });
+  });
+
+  it("keeps legacy storage intact while hiding completed notes from retry, then clears it after success", () => {
+    const note = { id: "legacy-1", text: "9am inspection" };
+    const key = legacySchedulingDayNotesStorageKey(scope);
+    window.localStorage.setItem(key, JSON.stringify({ "2026-07-14": [note] }));
+
+    markLegacySchedulingDayNotesMigrated(scope, [legacySchedulingDayNoteFingerprint("2026-07-14", note)]);
+
+    expect(window.localStorage.getItem(key)).not.toBeNull();
+    expect(readLegacySchedulingDayNotes(scope)).toEqual({});
+
+    clearMigratedLegacySchedulingDayNotes(scope);
+    expect(window.localStorage.getItem(key)).toBeNull();
   });
 });

--- a/rentchain-frontend/src/lib/schedulingDayNotes.ts
+++ b/rentchain-frontend/src/lib/schedulingDayNotes.ts
@@ -14,8 +14,120 @@ export type SchedulingNoteParsedTime = {
   minute: number;
 };
 
+export type LegacySchedulingDayNotesScope = {
+  landlordId?: string | null;
+  actorLandlordId?: string | null;
+  userId?: string | null;
+  id?: string | null;
+  email?: string | null;
+};
+
+const LEGACY_STORAGE_PREFIX = "rentchain.schedulingDayNotes.v1";
+const LEGACY_MIGRATION_STATE_PREFIX = "rentchain.schedulingDayNotesMigration.v1";
+
 const MERIDIEM_TIME_PATTERN = /\b(1[0-2]|0?[1-9])(?::([0-5]\d))?\s*(a\.?m\.?|p\.?m\.?)\b/i;
 const TWENTY_FOUR_HOUR_TIME_PATTERN = /\b([01]?\d|2[0-3]):([0-5]\d)\b/;
+
+function cleanLegacyScopePart(value: string | null | undefined): string {
+  return String(value || "").trim().toLowerCase();
+}
+
+function legacyStorageAvailable(): boolean {
+  return typeof window !== "undefined" && typeof window.localStorage !== "undefined";
+}
+
+function legacyScopeSuffix(scope: LegacySchedulingDayNotesScope | null | undefined): string {
+  const landlord =
+    cleanLegacyScopePart(scope?.actorLandlordId) || cleanLegacyScopePart(scope?.landlordId) || "landlord-unknown";
+  const user =
+    cleanLegacyScopePart(scope?.userId) ||
+    cleanLegacyScopePart(scope?.id) ||
+    cleanLegacyScopePart(scope?.email) ||
+    "user-unknown";
+  return `${encodeURIComponent(landlord)}:${encodeURIComponent(user)}`;
+}
+
+export function legacySchedulingDayNotesStorageKey(
+  scope: LegacySchedulingDayNotesScope | null | undefined
+): string {
+  return `${LEGACY_STORAGE_PREFIX}:${legacyScopeSuffix(scope)}`;
+}
+
+function legacyMigrationStateStorageKey(scope: LegacySchedulingDayNotesScope | null | undefined): string {
+  return `${LEGACY_MIGRATION_STATE_PREFIX}:${legacyScopeSuffix(scope)}`;
+}
+
+function normalizeLegacySchedulingDayNotes(value: unknown): SchedulingDayNotesByDate {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  return Object.entries(value as Record<string, unknown>).reduce<SchedulingDayNotesByDate>((result, [date, value]) => {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(date) || !Array.isArray(value)) return result;
+    const notes = value
+      .map((note, index): SchedulingDayNote | null => {
+        if (!note || typeof note !== "object" || Array.isArray(note)) return null;
+        const raw = note as Record<string, unknown>;
+        const text = typeof raw.text === "string" ? raw.text.trim() : "";
+        if (!text) return null;
+        const id = typeof raw.id === "string" && raw.id.trim() ? raw.id.trim() : `note-${date}-${index}`;
+        return { id, text };
+      })
+      .filter((note): note is SchedulingDayNote => Boolean(note));
+    if (notes.length) result[date] = notes;
+    return result;
+  }, {});
+}
+
+export function legacySchedulingDayNoteFingerprint(date: string, note: SchedulingDayNote): string {
+  return JSON.stringify([date, note.id, note.text]);
+}
+
+function readMigratedLegacySchedulingDayNoteFingerprints(
+  scope: LegacySchedulingDayNotesScope | null | undefined
+): Set<string> {
+  if (!legacyStorageAvailable()) return new Set();
+  try {
+    const raw = window.localStorage.getItem(legacyMigrationStateStorageKey(scope));
+    const value = raw ? JSON.parse(raw) : [];
+    return new Set(Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : []);
+  } catch {
+    return new Set();
+  }
+}
+
+export function readLegacySchedulingDayNotes(
+  scope: LegacySchedulingDayNotesScope | null | undefined
+): SchedulingDayNotesByDate {
+  if (!legacyStorageAvailable()) return {};
+  try {
+    const raw = window.localStorage.getItem(legacySchedulingDayNotesStorageKey(scope));
+    const notes = raw ? normalizeLegacySchedulingDayNotes(JSON.parse(raw)) : {};
+    const migrated = readMigratedLegacySchedulingDayNoteFingerprints(scope);
+    return Object.entries(notes).reduce<SchedulingDayNotesByDate>((result, [date, dateNotes]) => {
+      const pending = dateNotes.filter((note) => !migrated.has(legacySchedulingDayNoteFingerprint(date, note)));
+      if (pending.length) result[date] = pending;
+      return result;
+    }, {});
+  } catch {
+    return {};
+  }
+}
+
+export function markLegacySchedulingDayNotesMigrated(
+  scope: LegacySchedulingDayNotesScope | null | undefined,
+  fingerprints: string[]
+): void {
+  if (!legacyStorageAvailable() || !fingerprints.length) return;
+  const migrated = readMigratedLegacySchedulingDayNoteFingerprints(scope);
+  fingerprints.forEach((fingerprint) => migrated.add(fingerprint));
+  window.localStorage.setItem(legacyMigrationStateStorageKey(scope), JSON.stringify([...migrated]));
+}
+
+export function clearMigratedLegacySchedulingDayNotes(
+  scope: LegacySchedulingDayNotesScope | null | undefined
+): void {
+  if (!legacyStorageAvailable()) return;
+  window.localStorage.removeItem(legacySchedulingDayNotesStorageKey(scope));
+  window.localStorage.removeItem(legacyMigrationStateStorageKey(scope));
+}
 
 export function dateKeyFromLocalDate(date: Date): string {
   const year = date.getFullYear();

--- a/rentchain-frontend/src/pages/SchedulingWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/SchedulingWorkspacePage.test.tsx
@@ -30,6 +30,7 @@ vi.mock("../api/schedulingDayNotesApi", () => ({
 }));
 
 beforeEach(() => {
+  window.localStorage.clear();
   mocks.fetchSchedulingDayNotesRangeMock.mockResolvedValue({});
   mocks.createSchedulingDayNoteMock.mockImplementation(async (_date: string, payload: { noteText: string }) => ({
     id: `note-${payload.noteText.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`,
@@ -56,6 +57,91 @@ function renderPage(initialEntries: string[] = ["/scheduling"]) {
 }
 
 describe("SchedulingWorkspacePage", () => {
+  const legacyStorageKey = "rentchain.schedulingDayNotes.v1:landlord-1:user-1";
+
+  it("does not show a migration notice or upload automatically when no browser-saved notes exist", () => {
+    renderPage();
+
+    expect(screen.queryByText("Browser-saved notes found")).not.toBeInTheDocument();
+    expect(mocks.createSchedulingDayNoteMock).not.toHaveBeenCalled();
+  });
+
+  it("lets the landlord review browser-saved notes before explicitly moving them without overwriting workspace notes", async () => {
+    window.localStorage.setItem(
+      legacyStorageKey,
+      JSON.stringify({ "2026-07-14": [{ id: "legacy-1", text: "9am legacy inspection" }] })
+    );
+    mocks.fetchSchedulingDayNotesRangeMock.mockResolvedValue({
+      "2026-07-14": [{ id: "workspace-1", text: "Existing workspace note" }],
+    });
+    renderPage(["/scheduling?view=day&date=2026-07-14"]);
+
+    expect(await screen.findByText("Browser-saved notes found")).toBeInTheDocument();
+    expect(mocks.createSchedulingDayNoteMock).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "Review notes" }));
+    const review = screen.getByLabelText("Browser-saved notes review");
+    expect(within(review).getByText("9am legacy inspection")).toBeInTheDocument();
+    expect(within(review).getByText(/Existing workspace notes for this date will not be changed/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Move to workspace notes" }));
+
+    await waitFor(() =>
+      expect(mocks.createSchedulingDayNoteMock).toHaveBeenCalledWith("2026-07-14", {
+        noteText: "9am legacy inspection",
+        source: "scheduling",
+      })
+    );
+    expect(mocks.updateSchedulingDayNoteMock).not.toHaveBeenCalled();
+    await waitFor(() => expect(window.localStorage.getItem(legacyStorageKey)).toBeNull());
+    expect(screen.queryByText("Browser-saved notes found")).not.toBeInTheDocument();
+    expect(await screen.findByDisplayValue("9am legacy inspection")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Existing workspace note")).toBeInTheDocument();
+  });
+
+  it("keeps the legacy payload on failure and does not duplicate notes already created on retry", async () => {
+    window.localStorage.setItem(
+      legacyStorageKey,
+      JSON.stringify({
+        "2026-07-14": [
+          { id: "legacy-1", text: "First legacy note" },
+          { id: "legacy-2", text: "Second legacy note" },
+        ],
+      })
+    );
+    mocks.createSchedulingDayNoteMock
+      .mockResolvedValueOnce({ id: "created-1", text: "First legacy note" })
+      .mockRejectedValueOnce(new Error("request failed"))
+      .mockResolvedValueOnce({ id: "created-2", text: "Second legacy note" });
+    renderPage();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Move to workspace notes" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent(/original browser data was kept/i);
+    expect(window.localStorage.getItem(legacyStorageKey)).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Move to workspace notes" }));
+    await waitFor(() => expect(mocks.createSchedulingDayNoteMock).toHaveBeenCalledTimes(3));
+    expect(mocks.createSchedulingDayNoteMock.mock.calls.map((call) => call[1].noteText)).toEqual([
+      "First legacy note",
+      "Second legacy note",
+      "Second legacy note",
+    ]);
+    await waitFor(() => expect(window.localStorage.getItem(legacyStorageKey)).toBeNull());
+  });
+
+  it("dismisses the migration notice without uploading or deleting browser-saved notes", async () => {
+    window.localStorage.setItem(
+      legacyStorageKey,
+      JSON.stringify({ "2026-07-14": [{ id: "legacy-1", text: "Legacy note" }] })
+    );
+    renderPage();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Not now" }));
+
+    expect(screen.queryByText("Browser-saved notes found")).not.toBeInTheDocument();
+    expect(mocks.createSchedulingDayNoteMock).not.toHaveBeenCalled();
+    expect(window.localStorage.getItem(legacyStorageKey)).not.toBeNull();
+  });
+
   it("renders a calendar-centric scheduling workspace with operational sections", () => {
     renderPage();
 

--- a/rentchain-frontend/src/pages/SchedulingWorkspacePage.tsx
+++ b/rentchain-frontend/src/pages/SchedulingWorkspacePage.tsx
@@ -11,6 +11,7 @@ import {
   Wrench,
 } from "lucide-react";
 import { Button, Card, Input } from "../components/ui/Ui";
+import { useAuth } from "../context/useAuth";
 import {
   createSchedulingDayNote,
   deleteSchedulingDayNote,
@@ -18,8 +19,12 @@ import {
   updateSchedulingDayNote,
 } from "../api/schedulingDayNotesApi";
 import {
+  clearMigratedLegacySchedulingDayNotes,
   dateKeyFromLocalDate,
+  legacySchedulingDayNoteFingerprint,
+  markLegacySchedulingDayNotesMigrated,
   parseSchedulingNoteTime,
+  readLegacySchedulingDayNotes,
   type SchedulingDayNote,
   type SchedulingDayNotesByDate,
 } from "../lib/schedulingDayNotes";
@@ -215,6 +220,7 @@ function WorkspaceList({
 }
 
 export default function SchedulingWorkspacePage() {
+  const { user } = useAuth();
   const [searchParams, setSearchParams] = useSearchParams();
   const today = React.useMemo(() => new Date(), []);
   const requestedDate = React.useMemo(() => parseDateKey(searchParams.get("date")), [searchParams]);
@@ -229,6 +235,20 @@ export default function SchedulingWorkspacePage() {
   const [notesStatus, setNotesStatus] = React.useState<string | null>(null);
   const [draftSaving, setDraftSaving] = React.useState(false);
   const [savingNoteIds, setSavingNoteIds] = React.useState<Record<string, boolean>>({});
+  const legacyNotesScope = React.useMemo(
+    () => ({
+      actorLandlordId: user?.actorLandlordId,
+      landlordId: user?.landlordId,
+      userId: user?.id,
+      email: user?.email,
+    }),
+    [user?.actorLandlordId, user?.email, user?.id, user?.landlordId]
+  );
+  const [legacyNotesByDate, setLegacyNotesByDate] = React.useState<SchedulingDayNotesByDate>({});
+  const [legacyReviewOpen, setLegacyReviewOpen] = React.useState(false);
+  const [legacyNoticeDismissed, setLegacyNoticeDismissed] = React.useState(false);
+  const [legacyMigrationRunning, setLegacyMigrationRunning] = React.useState(false);
+  const [legacyMigrationError, setLegacyMigrationError] = React.useState<string | null>(null);
 
   const selectedKey = dayKey(selectedDate);
   const selectedNotes = notesByDate[selectedKey] || [];
@@ -265,6 +285,19 @@ export default function SchedulingWorkspacePage() {
     });
     return { grouped, unscheduled };
   }, [selectedNotes]);
+  const legacyNotes = React.useMemo(
+    () =>
+      Object.entries(legacyNotesByDate).flatMap(([date, notes]) =>
+        notes.map((note) => ({ date, note, fingerprint: legacySchedulingDayNoteFingerprint(date, note) }))
+      ),
+    [legacyNotesByDate]
+  );
+
+  React.useEffect(() => {
+    setLegacyNotesByDate(readLegacySchedulingDayNotes(legacyNotesScope));
+    setLegacyNoticeDismissed(false);
+    setLegacyMigrationError(null);
+  }, [legacyNotesScope]);
 
   React.useEffect(() => {
     const nextDate = parseDateKey(searchParams.get("date"));
@@ -401,6 +434,40 @@ export default function SchedulingWorkspacePage() {
     }
   };
 
+  const migrateLegacyNotes = async () => {
+    setLegacyMigrationRunning(true);
+    setLegacyMigrationError(null);
+    const createdByDate: SchedulingDayNotesByDate = {};
+    try {
+      for (const legacy of legacyNotes) {
+        const created = await createSchedulingDayNote(legacy.date, {
+          noteText: legacy.note.text,
+          source: "scheduling",
+        });
+        markLegacySchedulingDayNotesMigrated(legacyNotesScope, [legacy.fingerprint]);
+        createdByDate[legacy.date] = [...(createdByDate[legacy.date] || []), created];
+      }
+      clearMigratedLegacySchedulingDayNotes(legacyNotesScope);
+      setLegacyNotesByDate({});
+      setLegacyReviewOpen(false);
+      setNotesByDate((current) => {
+        const next = { ...current };
+        Object.entries(createdByDate).forEach(([date, notes]) => {
+          next[date] = [...(next[date] || []), ...notes];
+        });
+        return next;
+      });
+      setNotesStatus(`${legacyNotes.length} browser-saved ${legacyNotes.length === 1 ? "note" : "notes"} moved to workspace notes.`);
+    } catch {
+      setLegacyNotesByDate(readLegacySchedulingDayNotes(legacyNotesScope));
+      setLegacyMigrationError(
+        "Some browser-saved notes could not be moved. Your original browser data was kept; retry to move the remaining notes."
+      );
+    } finally {
+      setLegacyMigrationRunning(false);
+    }
+  };
+
   const moveMonth = (offset: number) => {
     setActiveMonth((current) => new Date(current.getFullYear(), current.getMonth() + offset, 1));
   };
@@ -435,6 +502,37 @@ export default function SchedulingWorkspacePage() {
           background: var(--schedule-card) !important;
           border-color: var(--schedule-border) !important;
           box-shadow: var(--schedule-shadow) !important;
+        }
+        .scheduling-migration-card {
+          display: grid;
+          gap: ${spacing.sm};
+          border-color: rgba(36, 88, 66, 0.38) !important;
+          background: var(--schedule-panel) !important;
+        }
+        .scheduling-migration-card h2,
+        .scheduling-migration-card p {
+          margin: 0;
+        }
+        .scheduling-migration-card p,
+        .scheduling-migration-list small {
+          color: var(--schedule-muted);
+          line-height: 1.5;
+        }
+        .scheduling-migration-list {
+          display: grid;
+          gap: 8px;
+          margin: 0;
+          padding: 0;
+          list-style: none;
+        }
+        .scheduling-migration-list li {
+          display: grid;
+          gap: 3px;
+          padding: 10px 12px;
+          border: 1px solid var(--schedule-border);
+          border-radius: ${radius.md};
+          background: var(--schedule-card);
+          overflow-wrap: anywhere;
         }
         .scheduling-workspace input {
           background: var(--schedule-card) !important;
@@ -778,6 +876,45 @@ export default function SchedulingWorkspacePage() {
           Back to Dashboard
         </Link>
       </Card>
+
+      {legacyNotes.length && !legacyNoticeDismissed ? (
+        <Card className="scheduling-card scheduling-migration-card" aria-label="Browser-saved notes migration">
+          <h2>Browser-saved notes found</h2>
+          <p>
+            These {legacyNotes.length} {legacyNotes.length === 1 ? "note was" : "notes were"} saved on this browser before
+            workspace notes were enabled. You can move {legacyNotes.length === 1 ? "it" : "them"} into workspace notes so
+            {legacyNotes.length === 1 ? " it is" : " they are"} available across devices for this landlord account.
+          </p>
+          {legacyReviewOpen ? (
+            <ul className="scheduling-migration-list" aria-label="Browser-saved notes review">
+              {legacyNotes.map(({ date, note, fingerprint }) => (
+                <li key={fingerprint}>
+                  <strong>{date}</strong>
+                  <span>{note.text}</span>
+                  <small>A new workspace note will be created. Existing workspace notes for this date will not be changed.</small>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+          {legacyMigrationError ? <div role="alert">{legacyMigrationError}</div> : null}
+          <div className="scheduling-note-actions">
+            <Button type="button" onClick={() => setLegacyReviewOpen((open) => !open)} disabled={legacyMigrationRunning}>
+              {legacyReviewOpen ? "Hide review" : "Review notes"}
+            </Button>
+            <Button
+              type="button"
+              className="scheduling-primary-action"
+              onClick={migrateLegacyNotes}
+              disabled={legacyMigrationRunning}
+            >
+              {legacyMigrationRunning ? "Moving notes..." : "Move to workspace notes"}
+            </Button>
+            <Button type="button" onClick={() => setLegacyNoticeDismissed(true)} disabled={legacyMigrationRunning}>
+              Not now
+            </Button>
+          </div>
+        </Card>
+      ) : null}
 
       <div className="scheduling-layout">
         <div className="scheduling-left">


### PR DESCRIPTION
## Summary

- detect PR #1376 browser-saved scheduling notes using the original landlord/user-scoped localStorage key
- offer an explicit review, move, or not-now migration card on `/scheduling`
- create a separate backend workspace note for every migrated legacy note without changing existing same-date notes
- retain the original legacy payload on partial failure and track completed item fingerprints to avoid duplicate retries
- clear the legacy payload and migration state only after all pending notes migrate successfully

## Scope

- frontend-only
- no backend route, schema, notification, decision/action, payment, lease lifecycle, legal/compliance, tenant communication, Google Calendar, or AI/LLM changes

## Validation

- `npm run test -- SchedulingWorkspacePage schedulingDayNotes DashboardPage TopNav` (34 tests passed)
- `npm run build` under Node 20.11.1 (passed; Vite minimum-version and existing chunk-size warnings emitted)
- `git diff --check`
- `git diff --cached --check`

## QA

- Draft pending manual preview QA of the migration card, review state, success state, failure/retry behavior, and cross-view workspace-note visibility.
