### PR TITLE
Add advisory scheduling note parser

### DIFF
--- a/rentchain-frontend/src/lib/schedulingNoteParser.test.ts
+++ b/rentchain-frontend/src/lib/schedulingNoteParser.test.ts
@@ -12,6 +12,9 @@ describe("schedulingNoteParser", () => {
     ["2pm lease review", 14 * 60, "2 PM", "lease review"],
     ["14:00 contractor", 14 * 60, "2 PM", "contractor"],
     ["7 PM follow up", 19 * 60, "7 PM", "follow up"],
+    ["230pm contractor", 14 * 60 + 30, "2:30 PM", "contractor"],
+    ["0230pm contractor", 14 * 60 + 30, "2:30 PM", "contractor"],
+    ["1030am inspection", 10 * 60 + 30, "10:30 AM", "inspection"],
   ])("parses exact time in %s", (text, timeMinutes, timeLabel, cleanedTitle) => {
     expect(parse(text)).toMatchObject({
       placementType: "exact_time",
@@ -60,6 +63,10 @@ describe("schedulingNoteParser", () => {
     "Visit 123 Main Street",
     "Review lease 7842",
     "Confirm 3 tenants",
+    "Unit 230",
+    "$230 repair estimate",
+    "230 dollars",
+    "230 days",
   ])(
     "does not treat %s as an exact time",
     (text) => {
@@ -68,6 +75,16 @@ describe("schedulingNoteParser", () => {
       expect(result).not.toHaveProperty("timeMinutes");
     }
   );
+
+  it("places a note at its first explicit time and flags multiple time cues for review", () => {
+    expect(parse("1pm painter and 4pm landscaper")).toMatchObject({
+      placementType: "exact_time",
+      timeMinutes: 13 * 60,
+      timeLabel: "1 PM",
+      needsReview: true,
+      reason: "Multiple explicit time cues were detected. The first time is shown; review the original note before acting.",
+    });
+  });
 
   it("keeps an ambiguous temporal note in needs review", () => {
     expect(parse("remind me to review application tomorrow")).toMatchObject({

--- a/rentchain-frontend/src/lib/schedulingNoteParser.test.ts
+++ b/rentchain-frontend/src/lib/schedulingNoteParser.test.ts
@@ -45,11 +45,22 @@ describe("schedulingNoteParser", () => {
     ["review application by noon", 12 * 60, "Deadline cue: 12 PM"],
     ["send update before 5pm", 17 * 60, "Deadline cue: 5 PM"],
     ["send update by end of day", 17 * 60, "Deadline cue: end of day"],
+    ["finish inspection before close", 17 * 60, "Deadline cue: before close"],
   ])("treats %s as a deadline rather than a confirmed appointment", (text, timeMinutes, timeLabel) => {
     expect(parse(text)).toMatchObject({ placementType: "deadline", timeMinutes, timeLabel, needsReview: true });
   });
 
-  it.each(["Unit 3 leak", "$300 repair estimate", "24 hours notice", "7 days remaining", "30 day notice"])(
+  it.each([
+    "Unit 3 leak",
+    "$300 repair estimate",
+    "24 hours notice",
+    "7 days remaining",
+    "30 day notice",
+    "Call 902-555-0134",
+    "Visit 123 Main Street",
+    "Review lease 7842",
+    "Confirm 3 tenants",
+  ])(
     "does not treat %s as an exact time",
     (text) => {
       const result = parse(text);

--- a/rentchain-frontend/src/lib/schedulingNoteParser.test.ts
+++ b/rentchain-frontend/src/lib/schedulingNoteParser.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { parseSchedulingNote } from "./schedulingNoteParser";
+
+function parse(text: string) {
+  return parseSchedulingNote({ noteId: "note-1", text, date: "2026-07-22" });
+}
+
+describe("schedulingNoteParser", () => {
+  it.each([
+    ["9am inspection", 9 * 60, "9 AM", "inspection"],
+    ["9:30 AM call plumber", 9 * 60 + 30, "9:30 AM", "call plumber"],
+    ["2pm lease review", 14 * 60, "2 PM", "lease review"],
+    ["14:00 contractor", 14 * 60, "2 PM", "contractor"],
+    ["7 PM follow up", 19 * 60, "7 PM", "follow up"],
+  ])("parses exact time in %s", (text, timeMinutes, timeLabel, cleanedTitle) => {
+    expect(parse(text)).toMatchObject({
+      placementType: "exact_time",
+      timeMinutes,
+      timeLabel,
+      cleanedTitle,
+      confidence: "high",
+      parserMode: "deterministic",
+      needsReview: false,
+    });
+  });
+
+  it.each([
+    ["follow up first thing", "early_morning", "Early morning"],
+    ["follow up with contractor in the morning", "morning", "Morning"],
+    ["call tenant after lunch", "midday", "After lunch"],
+    ["review application in the afternoon", "afternoon", "Afternoon"],
+    ["check messages this evening", "evening", "Evening"],
+  ])("derives advisory daypart for %s", (text, daypart, timeLabel) => {
+    expect(parse(text)).toMatchObject({
+      placementType: "daypart",
+      daypart,
+      timeLabel,
+      confidence: "medium",
+      parserMode: "ai_suggested_ready",
+    });
+  });
+
+  it.each([
+    ["check Unit 3 leak before 5", 17 * 60, "Deadline cue: 5 PM"],
+    ["review application by noon", 12 * 60, "Deadline cue: 12 PM"],
+    ["send update before 5pm", 17 * 60, "Deadline cue: 5 PM"],
+    ["send update by end of day", 17 * 60, "Deadline cue: end of day"],
+  ])("treats %s as a deadline rather than a confirmed appointment", (text, timeMinutes, timeLabel) => {
+    expect(parse(text)).toMatchObject({ placementType: "deadline", timeMinutes, timeLabel, needsReview: true });
+  });
+
+  it.each(["Unit 3 leak", "$300 repair estimate", "24 hours notice", "7 days remaining", "30 day notice"])(
+    "does not treat %s as an exact time",
+    (text) => {
+      const result = parse(text);
+      expect(result.placementType).toBe("unscheduled");
+      expect(result).not.toHaveProperty("timeMinutes");
+    }
+  );
+
+  it("keeps an ambiguous temporal note in needs review", () => {
+    expect(parse("remind me to review application tomorrow")).toMatchObject({
+      placementType: "unscheduled",
+      confidence: "low",
+      needsReview: true,
+    });
+  });
+
+  it("keeps empty and cue-free notes unscheduled", () => {
+    expect(parse("")).toMatchObject({ placementType: "unscheduled", needsReview: false });
+    expect(parse("Call contractor")).toMatchObject({ placementType: "unscheduled", needsReview: false });
+  });
+});

--- a/rentchain-frontend/src/lib/schedulingNoteParser.test.ts
+++ b/rentchain-frontend/src/lib/schedulingNoteParser.test.ts
@@ -15,6 +15,11 @@ describe("schedulingNoteParser", () => {
     ["230pm contractor", 14 * 60 + 30, "2:30 PM", "contractor"],
     ["0230pm contractor", 14 * 60 + 30, "2:30 PM", "contractor"],
     ["1030am inspection", 10 * 60 + 30, "10:30 AM", "inspection"],
+    ["630pm meeting", 18 * 60 + 30, "6:30 PM", "meeting"],
+    ["0630pm meeting", 18 * 60 + 30, "6:30 PM", "meeting"],
+    ["6:30pm meeting", 18 * 60 + 30, "6:30 PM", "meeting"],
+    ["1230pm meeting", 12 * 60 + 30, "12:30 PM", "meeting"],
+    ["1205pm meeting", 12 * 60 + 5, "12:05 PM", "meeting"],
   ])("parses exact time in %s", (text, timeMinutes, timeLabel, cleanedTitle) => {
     expect(parse(text)).toMatchObject({
       placementType: "exact_time",
@@ -67,6 +72,9 @@ describe("schedulingNoteParser", () => {
     "$230 repair estimate",
     "230 dollars",
     "230 days",
+    "Unit 630",
+    "$630 repair estimate",
+    "630 days",
   ])(
     "does not treat %s as an exact time",
     (text) => {

--- a/rentchain-frontend/src/lib/schedulingNoteParser.ts
+++ b/rentchain-frontend/src/lib/schedulingNoteParser.ts
@@ -139,6 +139,20 @@ export function parseSchedulingNote(input: SchedulingNoteParserInput): Schedulin
     };
   }
 
+  if (/\bbefore close\b/i.test(originalText)) {
+    return {
+      ...base,
+      placementType: "deadline",
+      timeMinutes: 17 * 60,
+      timeLabel: "Deadline cue: before close",
+      daypart: "afternoon",
+      confidence: "medium",
+      reason: "The note contains a before-close deadline cue, not a confirmed appointment time.",
+      parserMode: "ai_suggested_ready",
+      needsReview: true,
+    };
+  }
+
   const deadlineMatch = originalText.match(DEADLINE_PATTERN);
   if (deadlineMatch) {
     const timeMinutes = deadlineMinutes(deadlineMatch);

--- a/rentchain-frontend/src/lib/schedulingNoteParser.ts
+++ b/rentchain-frontend/src/lib/schedulingNoteParser.ts
@@ -27,7 +27,9 @@ type SchedulingNoteParserInput = {
   date: string;
 };
 
-const EXACT_TIME_TEXT_PATTERN = /\b(?:1[0-2]|0?[1-9])(?::[0-5]\d)?\s*(?:a\.?m\.?|p\.?m\.?)\b|\b(?:[01]?\d|2[0-3]):[0-5]\d\b/i;
+const EXACT_TIME_PATTERN_SOURCE = String.raw`\b(?:1[0-2]|0?[1-9])(?::[0-5]\d)?\s*(?:a\.?m\.?|p\.?m\.?)\b|\b(?:0?[1-9]|1[0-2])[0-5]\d\s*(?:a\.?m\.?|p\.?m\.?)\b|\b(?:[01]?\d|2[0-3]):[0-5]\d\b`;
+const EXACT_TIME_TEXT_PATTERN = new RegExp(EXACT_TIME_PATTERN_SOURCE, "i");
+const COMPACT_MERIDIEM_TIME_PATTERN = /\b(0?[1-9]|1[0-2])([0-5]\d)\s*(a\.?m\.?|p\.?m\.?)\b/i;
 const DEADLINE_PATTERN = /\b(before|by)\s+(noon|midnight|(?:1[0-2]|0?[1-9])(?::([0-5]\d))?\s*(?:a\.?m\.?|p\.?m\.?)?)\b/i;
 const AMBIGUOUS_TEMPORAL_CUE_PATTERN = /\b(tomorrow|later|soon|after|before|by|around|sometime|tonight|today)\b/i;
 
@@ -91,6 +93,25 @@ function formatTimeMinutes(timeMinutes: number): string {
 
 function cleanExactTimeTitle(text: string): string {
   return text.replace(EXACT_TIME_TEXT_PATTERN, "").replace(/^[\s,:;\-]+|[\s,:;\-]+$/g, "").replace(/\s{2,}/g, " ") || text;
+}
+
+function parseCompactMeridiemTime(text: string): { hour: number; minute: number } | null {
+  const match = text.match(COMPACT_MERIDIEM_TIME_PATTERN);
+  if (!match) return null;
+  const hourInput = Number(match[1]);
+  const minute = Number(match[2]);
+  const meridiem = match[3].toLowerCase();
+  const hour =
+    meridiem.startsWith("p") && hourInput !== 12
+      ? hourInput + 12
+      : meridiem.startsWith("a") && hourInput === 12
+        ? 0
+        : hourInput;
+  return { hour, minute };
+}
+
+function explicitTimeCueCount(text: string): number {
+  return text.match(new RegExp(EXACT_TIME_PATTERN_SOURCE, "gi"))?.length || 0;
 }
 
 function deadlineMinutes(match: RegExpMatchArray): number | null {
@@ -171,9 +192,10 @@ export function parseSchedulingNote(input: SchedulingNoteParserInput): Schedulin
     }
   }
 
-  const exactTime = parseSchedulingNoteTime(originalText);
+  const exactTime = parseSchedulingNoteTime(originalText) || parseCompactMeridiemTime(originalText);
   if (exactTime) {
     const timeMinutes = exactTime.hour * 60 + exactTime.minute;
+    const hasMultipleTimeCues = explicitTimeCueCount(originalText) > 1;
     return {
       ...base,
       cleanedTitle: cleanExactTimeTitle(originalText),
@@ -181,9 +203,11 @@ export function parseSchedulingNote(input: SchedulingNoteParserInput): Schedulin
       timeMinutes,
       timeLabel: formatTimeMinutes(timeMinutes),
       confidence: "high",
-      reason: "The note contains an explicit time.",
+      reason: hasMultipleTimeCues
+        ? "Multiple explicit time cues were detected. The first time is shown; review the original note before acting."
+        : "The note contains an explicit time.",
       parserMode: "deterministic",
-      needsReview: false,
+      needsReview: hasMultipleTimeCues,
     };
   }
 

--- a/rentchain-frontend/src/lib/schedulingNoteParser.ts
+++ b/rentchain-frontend/src/lib/schedulingNoteParser.ts
@@ -1,0 +1,202 @@
+import { parseSchedulingNoteTime } from "./schedulingDayNotes";
+
+export type SchedulingNotePlacementType = "exact_time" | "daypart" | "deadline" | "unscheduled";
+export type SchedulingNoteDaypart = "early_morning" | "morning" | "midday" | "afternoon" | "evening";
+export type SchedulingNoteConfidence = "high" | "medium" | "low";
+export type SchedulingNoteParserMode = "deterministic" | "ai_suggested_ready";
+
+export type SchedulingNoteParseResult = {
+  noteId: string;
+  originalText: string;
+  cleanedTitle: string;
+  date: string;
+  placementType: SchedulingNotePlacementType;
+  timeMinutes?: number;
+  timeLabel?: string;
+  daypart?: SchedulingNoteDaypart;
+  confidence: SchedulingNoteConfidence;
+  reason: string;
+  source: "deterministic";
+  parserMode: SchedulingNoteParserMode;
+  needsReview: boolean;
+};
+
+type SchedulingNoteParserInput = {
+  noteId: string;
+  text: string;
+  date: string;
+};
+
+const EXACT_TIME_TEXT_PATTERN = /\b(?:1[0-2]|0?[1-9])(?::[0-5]\d)?\s*(?:a\.?m\.?|p\.?m\.?)\b|\b(?:[01]?\d|2[0-3]):[0-5]\d\b/i;
+const DEADLINE_PATTERN = /\b(before|by)\s+(noon|midnight|(?:1[0-2]|0?[1-9])(?::([0-5]\d))?\s*(?:a\.?m\.?|p\.?m\.?)?)\b/i;
+const AMBIGUOUS_TEMPORAL_CUE_PATTERN = /\b(tomorrow|later|soon|after|before|by|around|sometime|tonight|today)\b/i;
+
+const DAYPART_RULES: Array<{
+  pattern: RegExp;
+  daypart: SchedulingNoteDaypart;
+  timeMinutes: number;
+  timeLabel: string;
+  reason: string;
+}> = [
+  {
+    pattern: /\b(first thing|early morning)\b/i,
+    daypart: "early_morning",
+    timeMinutes: 8 * 60,
+    timeLabel: "Early morning",
+    reason: "The note contains an early-morning cue.",
+  },
+  {
+    pattern: /\b(after lunch)\b/i,
+    daypart: "midday",
+    timeMinutes: 13 * 60,
+    timeLabel: "After lunch",
+    reason: "The note contains an after-lunch cue.",
+  },
+  {
+    pattern: /\b(morning)\b/i,
+    daypart: "morning",
+    timeMinutes: 9 * 60,
+    timeLabel: "Morning",
+    reason: "The note contains a morning cue.",
+  },
+  {
+    pattern: /\b(noon|midday)\b/i,
+    daypart: "midday",
+    timeMinutes: 12 * 60,
+    timeLabel: "Midday",
+    reason: "The note contains a midday cue.",
+  },
+  {
+    pattern: /\b(afternoon)\b/i,
+    daypart: "afternoon",
+    timeMinutes: 14 * 60,
+    timeLabel: "Afternoon",
+    reason: "The note contains an afternoon cue.",
+  },
+  {
+    pattern: /\b(evening|end of day)\b/i,
+    daypart: "evening",
+    timeMinutes: 18 * 60,
+    timeLabel: "Evening",
+    reason: "The note contains an evening cue.",
+  },
+];
+
+function formatTimeMinutes(timeMinutes: number): string {
+  const hour = Math.floor(timeMinutes / 60);
+  const minute = timeMinutes % 60;
+  const displayHour = hour % 12 || 12;
+  return `${displayHour}${minute ? `:${String(minute).padStart(2, "0")}` : ""} ${hour >= 12 ? "PM" : "AM"}`;
+}
+
+function cleanExactTimeTitle(text: string): string {
+  return text.replace(EXACT_TIME_TEXT_PATTERN, "").replace(/^[\s,:;\-]+|[\s,:;\-]+$/g, "").replace(/\s{2,}/g, " ") || text;
+}
+
+function deadlineMinutes(match: RegExpMatchArray): number | null {
+  const value = match[2].toLowerCase().replace(/\./g, "").trim();
+  if (value === "noon") return 12 * 60;
+  if (value === "midnight") return 0;
+  const time = parseSchedulingNoteTime(value);
+  if (time) return time.hour * 60 + time.minute;
+  const hour = Number(value);
+  if (!Number.isInteger(hour) || hour < 1 || hour > 12) return null;
+  return (hour === 12 ? 12 : hour + 12) * 60;
+}
+
+export function parseSchedulingNote(input: SchedulingNoteParserInput): SchedulingNoteParseResult {
+  const originalText = String(input.text || "").trim();
+  const base = {
+    noteId: input.noteId,
+    originalText,
+    cleanedTitle: originalText,
+    date: input.date,
+    source: "deterministic" as const,
+  };
+
+  if (!originalText) {
+    return {
+      ...base,
+      placementType: "unscheduled",
+      confidence: "low",
+      reason: "The note is empty.",
+      parserMode: "deterministic",
+      needsReview: false,
+    };
+  }
+
+  if (/\bend of day\b/i.test(originalText)) {
+    return {
+      ...base,
+      placementType: "deadline",
+      timeMinutes: 17 * 60,
+      timeLabel: "Deadline cue: end of day",
+      daypart: "afternoon",
+      confidence: "medium",
+      reason: "The note contains an end-of-day deadline cue, not a confirmed appointment time.",
+      parserMode: "ai_suggested_ready",
+      needsReview: true,
+    };
+  }
+
+  const deadlineMatch = originalText.match(DEADLINE_PATTERN);
+  if (deadlineMatch) {
+    const timeMinutes = deadlineMinutes(deadlineMatch);
+    if (timeMinutes !== null) {
+      return {
+        ...base,
+        placementType: "deadline",
+        timeMinutes,
+        timeLabel: `Deadline cue: ${formatTimeMinutes(timeMinutes)}`,
+        daypart: timeMinutes <= 12 * 60 ? "midday" : "afternoon",
+        confidence: "medium",
+        reason: "The note contains a deadline cue, not a confirmed appointment time.",
+        parserMode: "ai_suggested_ready",
+        needsReview: true,
+      };
+    }
+  }
+
+  const exactTime = parseSchedulingNoteTime(originalText);
+  if (exactTime) {
+    const timeMinutes = exactTime.hour * 60 + exactTime.minute;
+    return {
+      ...base,
+      cleanedTitle: cleanExactTimeTitle(originalText),
+      placementType: "exact_time",
+      timeMinutes,
+      timeLabel: formatTimeMinutes(timeMinutes),
+      confidence: "high",
+      reason: "The note contains an explicit time.",
+      parserMode: "deterministic",
+      needsReview: false,
+    };
+  }
+
+  const daypartRule = DAYPART_RULES.find((rule) => rule.pattern.test(originalText));
+  if (daypartRule) {
+    return {
+      ...base,
+      placementType: "daypart",
+      timeMinutes: daypartRule.timeMinutes,
+      timeLabel: daypartRule.timeLabel,
+      daypart: daypartRule.daypart,
+      confidence: "medium",
+      reason: daypartRule.reason,
+      parserMode: "ai_suggested_ready",
+      needsReview: false,
+    };
+  }
+
+  const needsReview = AMBIGUOUS_TEMPORAL_CUE_PATTERN.test(originalText);
+  return {
+    ...base,
+    placementType: "unscheduled",
+    confidence: "low",
+    reason: needsReview
+      ? "The note contains an ambiguous timing cue that needs review."
+      : "The note does not contain a recognized time or daypart cue.",
+    parserMode: needsReview ? "ai_suggested_ready" : "deterministic",
+    needsReview,
+  };
+}

--- a/rentchain-frontend/src/pages/DashboardPage.test.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.test.tsx
@@ -431,7 +431,7 @@ describe("DashboardPage", () => {
     expect(within(detail).getByText("1pm viewing")).toBeInTheDocument();
     expect(within(detail).getByText("3pm plumber")).toBeInTheDocument();
     expect(within(detail).getByText("Confirm inspection window")).toBeInTheDocument();
-    expect(within(detail).getByText("Unscheduled notes stay here until a clear time is added.")).toBeInTheDocument();
+    expect(within(detail).getByText(/Notes without exact times stay under Day notes/i)).toBeInTheDocument();
     expect(within(detail).getByText("1 PM - viewing")).toBeInTheDocument();
     expect(within(detail).getByText("3 PM - plumber")).toBeInTheDocument();
     expect(within(detail).getAllByText("Workspace scheduling note")).toHaveLength(2);
@@ -442,6 +442,38 @@ describe("DashboardPage", () => {
       `/scheduling?view=day&date=${dateKeyFromLocalDate(selectedDate)}`
     );
     expect(within(detail).queryByText(/No saved scheduling notes for this day/i)).not.toBeInTheDocument();
+  });
+
+  it("uses the shared parser for advisory daypart and deadline notes without double-counting", async () => {
+    const selectedDate = new Date();
+    const selectedDateLabel = selectedDate.toLocaleDateString(undefined, {
+      weekday: "long",
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    });
+    const selectedKey = dateKeyFromLocalDate(selectedDate);
+    mocks.fetchSchedulingDayNotesRangeMock.mockResolvedValue({
+      [selectedKey]: [
+        { id: "note-afternoon", text: "Review application in the afternoon" },
+        { id: "note-deadline", text: "Check Unit 3 leak before 5" },
+        { id: "note-plain", text: "Confirm access details" },
+      ],
+    });
+
+    renderDashboard();
+
+    await screen.findByTestId("calendar-preview-section");
+    fireEvent.click(await screen.findByRole("button", { name: `Select ${selectedDateLabel}, 3 scheduled items` }));
+    const detail = screen.getByTestId("selected-day-detail-panel");
+    expect(within(detail).getByText("3 items")).toBeInTheDocument();
+    expect(within(detail).getByText("Suggested plan")).toBeInTheDocument();
+    expect(within(detail).getByText("Afternoon")).toBeInTheDocument();
+    expect(within(detail).getByText("Deadline cue: 5 PM")).toBeInTheDocument();
+    expect(within(detail).getByText(/AI-assisted scheduling is advisory; no calendar event has been created/i)).toBeInTheDocument();
+    expect(within(detail).getAllByText("Review application in the afternoon")).toHaveLength(2);
+    expect(within(detail).getAllByText("Check Unit 3 leak before 5")).toHaveLength(2);
+    expect(within(detail).queryByText("3 PM - application")).not.toBeInTheDocument();
   });
 
   it("uses specific Dashboard decision destination labels for common RC1 cards", async () => {

--- a/rentchain-frontend/src/pages/DashboardPage.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.tsx
@@ -20,7 +20,8 @@ import {
 import { MacShell } from "../components/layout/MacShell";
 import { Card, SkeletonBlock } from "../components/ui/Ui";
 import { fetchSchedulingDayNotesRange } from "../api/schedulingDayNotesApi";
-import { dateKeyFromLocalDate, parseSchedulingNoteTime, type SchedulingDayNotesByDate } from "../lib/schedulingDayNotes";
+import { dateKeyFromLocalDate, type SchedulingDayNotesByDate } from "../lib/schedulingDayNotes";
+import { parseSchedulingNote } from "../lib/schedulingNoteParser";
 import { colors, layout, spacing, text } from "../styles/tokens";
 import {
   fetchLandlordDecisionQueue,
@@ -887,24 +888,32 @@ function CalendarPreviewPanel({ queue }: { queue: LandlordDecisionQueueResponse 
   const [notesError, setNotesError] = React.useState<string | null>(null);
   const visibleNoteCount = days.reduce((total, day) => total + (notesByDate[dateKeyFromLocalDate(day)]?.length || 0), 0);
   const selectedDayNotes = notesByDate[dateKeyFromLocalDate(selectedDay)] || [];
+  const selectedParsedNotes = React.useMemo(
+    () =>
+      selectedDayNotes.map((note) => ({
+        note,
+        parsed: parseSchedulingNote({ noteId: note.id, text: note.text, date: dateKeyFromLocalDate(selectedDay) }),
+      })),
+    [selectedDay, selectedDayNotes]
+  );
   const selectedScheduledNotes = React.useMemo(
     () =>
-      selectedDayNotes
-        .map((note) => ({ note, parsedTime: parseSchedulingNoteTime(note.text) }))
-        .filter(
-          (
-            entry
-          ): entry is {
-            note: (typeof selectedDayNotes)[number];
-            parsedTime: Exclude<ReturnType<typeof parseSchedulingNoteTime>, null>;
-          } => entry.parsedTime !== null
-        )
-        .sort((left, right) => left.parsedTime.hour - right.parsedTime.hour || left.parsedTime.minute - right.parsedTime.minute),
-    [selectedDayNotes]
+      selectedParsedNotes
+        .filter((entry) => entry.parsed.placementType === "exact_time" && entry.parsed.timeMinutes !== undefined)
+        .sort((left, right) => (left.parsed.timeMinutes || 0) - (right.parsed.timeMinutes || 0)),
+    [selectedParsedNotes]
+  );
+  const selectedSuggestedNotes = React.useMemo(
+    () => selectedParsedNotes.filter((entry) => entry.parsed.placementType === "daypart"),
+    [selectedParsedNotes]
+  );
+  const selectedReviewNotes = React.useMemo(
+    () => selectedParsedNotes.filter((entry) => entry.parsed.needsReview),
+    [selectedParsedNotes]
   );
   const selectedUnscheduledNotes = React.useMemo(
-    () => selectedDayNotes.filter((note) => !parseSchedulingNoteTime(note.text)),
-    [selectedDayNotes]
+    () => selectedParsedNotes.filter((entry) => entry.parsed.placementType === "unscheduled" && !entry.parsed.needsReview),
+    [selectedParsedNotes]
   );
   const selectedTotalItemCount = selectedDayItems.length + selectedDayNotes.length;
   const selectedDayLabel = formatFullDate(selectedDay);
@@ -1105,9 +1114,9 @@ function CalendarPreviewPanel({ queue }: { queue: LandlordDecisionQueueResponse 
                     <li key={note.id}>{note.text}</li>
                   ))}
                 </ul>
-                {selectedUnscheduledNotes.length ? (
+                {selectedUnscheduledNotes.length || selectedReviewNotes.length ? (
                   <div style={{ color: text.muted, fontSize: 13, lineHeight: 1.45 }}>
-                    Unscheduled notes stay here until a clear time is added.
+                    Notes without exact times stay under Day notes or the advisory Suggested plan until reviewed.
                   </div>
                 ) : null}
               </div>
@@ -1128,6 +1137,39 @@ function CalendarPreviewPanel({ queue }: { queue: LandlordDecisionQueueResponse 
         </div>
 
         <div style={{ display: "grid", gap: 8, minWidth: 0 }}>
+          <div style={{ fontWeight: 850 }}>Suggested plan</div>
+          <div style={{ color: text.muted, fontSize: 13, lineHeight: 1.45 }}>
+            Suggested from note text. AI-assisted scheduling is advisory; no calendar event has been created.
+          </div>
+          {selectedSuggestedNotes.length || selectedReviewNotes.length ? (
+            <div style={{ display: "grid", gap: 8 }}>
+              {[...selectedSuggestedNotes, ...selectedReviewNotes].map(({ note, parsed }) => (
+                <div
+                  key={note.id}
+                  style={{
+                    display: "grid",
+                    gap: 5,
+                    padding: 12,
+                    borderRadius: 8,
+                    border: `1px solid ${dashboardTheme.border}`,
+                    background: dashboardTheme.card,
+                    color: dashboardTheme.text,
+                  }}
+                >
+                  <div style={{ fontWeight: 850 }}>{parsed.timeLabel || "Needs review"}</div>
+                  <div style={{ overflowWrap: "anywhere" }}>{note.text}</div>
+                  <div style={{ color: text.muted, fontSize: 13, lineHeight: 1.4 }}>
+                    {parsed.needsReview ? "Needs review" : "Suggested by note parser"} · Workspace scheduling note
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div style={{ color: text.muted, fontSize: 13 }}>No advisory note placements for this day.</div>
+          )}
+        </div>
+
+        <div style={{ display: "grid", gap: 8, minWidth: 0 }}>
           <div style={{ fontWeight: 850 }}>Scheduled items</div>
           <Link to={`/scheduling?view=day&date=${dateKeyFromLocalDate(selectedDay)}`} style={{ ...compactButton, width: "fit-content" }}>
             View full day schedule <ArrowRight size={16} />
@@ -1138,8 +1180,9 @@ function CalendarPreviewPanel({ queue }: { queue: LandlordDecisionQueueResponse 
             </div>
           ) : (
             <div style={{ display: "grid", gap: 8 }}>
-              {selectedScheduledNotes.map(({ note, parsedTime }) => {
+              {selectedScheduledNotes.map(({ note, parsed }) => {
                 const noteDetail = noteTextWithoutTime(note.text) || note.text;
+                const timeMinutes = parsed.timeMinutes || 0;
                 return (
                   <div
                     key={note.id}
@@ -1155,7 +1198,7 @@ function CalendarPreviewPanel({ queue }: { queue: LandlordDecisionQueueResponse 
                     }}
                   >
                     <div style={{ fontWeight: 850, overflowWrap: "anywhere" }}>
-                      {formatHourMinute(parsedTime.hour, parsedTime.minute)} - {noteDetail}
+                      {formatHourMinute(Math.floor(timeMinutes / 60), timeMinutes % 60)} - {noteDetail}
                     </div>
                     <div style={{ color: text.muted, fontSize: 13, lineHeight: 1.4, overflowWrap: "anywhere" }}>
                       Workspace scheduling note
@@ -1191,9 +1234,9 @@ function CalendarPreviewPanel({ queue }: { queue: LandlordDecisionQueueResponse 
                   </div>
                 </Link>
               ))}
-              {selectedScheduledNotes.length === 0 && selectedDayItems.length === 0 && selectedUnscheduledNotes.length > 0 ? (
+              {selectedScheduledNotes.length === 0 && selectedDayItems.length === 0 && selectedDayNotes.length > 0 ? (
                 <div style={{ border: `1px solid ${colors.border}`, borderRadius: 8, padding: 12, color: text.muted }}>
-                  Saved notes for this day do not include clear times. They are listed under Day notes.
+                  Saved notes for this day do not include confirmed exact times. Review Day notes and the advisory Suggested plan.
                 </div>
               ) : null}
             </div>

--- a/rentchain-frontend/src/pages/SchedulingWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/SchedulingWorkspacePage.test.tsx
@@ -226,6 +226,22 @@ describe("SchedulingWorkspacePage", () => {
     expect(within(screen.getByLabelText("7 AM-10 PM schedule")).queryByText("Call tenant tomorrow")).not.toBeInTheDocument();
   });
 
+  it("places compact times and warns when an exact note contains multiple time cues", async () => {
+    mocks.fetchSchedulingDayNotesRangeMock.mockResolvedValue({
+      "2026-07-23": [
+        { id: "note-compact", text: "230pm contractor" },
+        { id: "note-multiple", text: "1pm painter and 4pm landscaper" },
+      ],
+    });
+    renderPage(["/scheduling?view=day&date=2026-07-23"]);
+
+    expect(within(await screen.findByLabelText("Schedule slot 2 PM")).getByText("230pm contractor")).toBeInTheDocument();
+    const firstTimeSlot = screen.getByLabelText("Schedule slot 1 PM");
+    expect(within(firstTimeSlot).getByText("1pm painter and 4pm landscaper")).toBeInTheDocument();
+    expect(within(firstTimeSlot).getByText(/Needs review · Multiple explicit time cues were detected/i)).toBeInTheDocument();
+    expect(within(screen.getByLabelText("Schedule slot 4 PM")).queryByText("1pm painter and 4pm landscaper")).not.toBeInTheDocument();
+  });
+
   it("shows daypart suggestions and deadline cues as advisory rather than confirmed scheduled notes", async () => {
     mocks.fetchSchedulingDayNotesRangeMock.mockResolvedValue({
       "2026-07-22": [

--- a/rentchain-frontend/src/pages/SchedulingWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/SchedulingWorkspacePage.test.tsx
@@ -158,6 +158,9 @@ describe("SchedulingWorkspacePage", () => {
     expect(screen.getByRole("heading", { name: "Maintenance Requests" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Work Orders" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Screening Activities" })).toBeInTheDocument();
+    expect(screen.queryByText("No upcoming viewing conflicts detected.")).not.toBeInTheDocument();
+    expect(screen.getByText("Connected conflict detection is not enabled yet.")).toBeInTheDocument();
+    expect(screen.getByText("Parser suggestions are advisory. No calendar event or reminder has been created.")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Connect Screening Provider" })).toHaveAttribute("href", "/screening");
     expect(screen.getByRole("link", { name: "Screen Manually" })).toHaveAttribute("href", "/screening/manual");
   });
@@ -342,6 +345,26 @@ describe("SchedulingWorkspacePage", () => {
     expect(within(screen.getByLabelText("Schedule slot 4 PM")).queryByText("1pm painter and 4pm landscaper")).not.toBeInTheDocument();
   });
 
+  it("flags same-time workspace notes for advisory review without creating duplicates", async () => {
+    mocks.fetchSchedulingDayNotesRangeMock.mockResolvedValue({
+      "2026-07-23": [
+        { id: "note-same-time-1", text: "630pm meeting" },
+        { id: "note-same-time-2", text: "630pm contractor follow-up" },
+      ],
+    });
+    renderPage(["/scheduling?view=day&date=2026-07-23"]);
+
+    const timeSlot = await screen.findByLabelText("Schedule slot 6 PM");
+    expect(within(timeSlot).getByText("630pm meeting")).toBeInTheDocument();
+    expect(within(timeSlot).getByText("630pm contractor follow-up")).toBeInTheDocument();
+    expect(
+      within(screen.getByLabelText("Read-only scheduling recommendations")).getByText(
+        "Multiple workspace notes share the same time. Review before confirming the schedule."
+      )
+    ).toBeInTheDocument();
+    expect(mocks.createSchedulingDayNoteMock).not.toHaveBeenCalled();
+  });
+
   it("shows daypart suggestions and deadline cues as advisory rather than confirmed scheduled notes", async () => {
     mocks.fetchSchedulingDayNotesRangeMock.mockResolvedValue({
       "2026-07-22": [
@@ -406,7 +429,7 @@ describe("SchedulingWorkspacePage", () => {
     renderPage();
 
     const review = screen.getByLabelText("Read-only scheduling recommendations");
-    expect(within(review).getAllByRole("listitem")).toHaveLength(4);
+    expect(within(review).getAllByRole("listitem")).toHaveLength(3);
     expect(within(review).queryByRole("button")).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/pages/SchedulingWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/SchedulingWorkspacePage.test.tsx
@@ -206,7 +206,7 @@ describe("SchedulingWorkspacePage", () => {
     expect(screen.getByDisplayValue("Confirm maintenance access")).toBeInTheDocument();
   });
 
-  it("places notes with clear times into day schedule slots and keeps vague notes unscheduled", async () => {
+  it("places exact notes into slots and keeps ambiguous notes in needs review without duplication", async () => {
     renderPage();
 
     const noteInput = screen.getByLabelText("New schedule note");
@@ -222,7 +222,34 @@ describe("SchedulingWorkspacePage", () => {
 
     expect(within(screen.getByLabelText("Schedule slot 9 AM")).getByText("9am inspection")).toBeInTheDocument();
     expect(within(screen.getByLabelText("Schedule slot 2 PM")).getByText("14:00 contractor")).toBeInTheDocument();
-    expect(within(screen.getByLabelText("Unscheduled notes")).getByText("Call tenant tomorrow")).toBeInTheDocument();
+    expect(within(screen.getByLabelText("Notes needing review")).getByText("Call tenant tomorrow")).toBeInTheDocument();
+    expect(within(screen.getByLabelText("7 AM-10 PM schedule")).queryByText("Call tenant tomorrow")).not.toBeInTheDocument();
+  });
+
+  it("shows daypart suggestions and deadline cues as advisory rather than confirmed scheduled notes", async () => {
+    mocks.fetchSchedulingDayNotesRangeMock.mockResolvedValue({
+      "2026-07-22": [
+        { id: "note-morning", text: "Follow up with contractor in the morning" },
+        { id: "note-lunch", text: "Call tenant after lunch" },
+        { id: "note-deadline", text: "Check Unit 3 leak before 5" },
+        { id: "note-plain", text: "Confirm access details" },
+      ],
+    });
+    renderPage(["/scheduling?view=day&date=2026-07-22"]);
+
+    const suggestions = await screen.findByLabelText("Suggested day plan");
+    expect(within(suggestions).getByText("Follow up with contractor in the morning")).toBeInTheDocument();
+    expect(within(suggestions).getByText("Call tenant after lunch")).toBeInTheDocument();
+    expect(within(suggestions).getByText("Morning")).toBeInTheDocument();
+    expect(within(suggestions).getByText("After lunch")).toBeInTheDocument();
+    expect(screen.getByText(/AI-assisted scheduling is advisory; no calendar event has been created/i)).toBeInTheDocument();
+
+    const review = screen.getByLabelText("Notes needing review");
+    expect(within(review).getByText("Check Unit 3 leak before 5")).toBeInTheDocument();
+    expect(within(review).getByText("Deadline cue: 5 PM")).toBeInTheDocument();
+    expect(within(screen.getByLabelText("Unscheduled notes")).getByText("Confirm access details")).toBeInTheDocument();
+    expect(screen.getAllByText("Call tenant after lunch")).toHaveLength(1);
+    expect(screen.getByDisplayValue("Call tenant after lunch")).toBeInTheDocument();
   });
 
   it("opens a requested day from scheduling query params", () => {

--- a/rentchain-frontend/src/pages/SchedulingWorkspacePage.tsx
+++ b/rentchain-frontend/src/pages/SchedulingWorkspacePage.tsx
@@ -76,10 +76,9 @@ const screeningActivities: WorkspaceItem[] = [
 ];
 
 const reviewItems = [
-  "No upcoming viewing conflicts detected.",
-  "No maintenance windows are scheduled for the selected day.",
-  "Work order sequencing is ready for review from the Work Orders workspace.",
-  "Suggested scheduling windows will appear as calendar data becomes available.",
+  "Review same-time notes, viewing appointments, maintenance windows, and work orders before confirming the day plan.",
+  "Parser suggestions are advisory. No calendar event or reminder has been created.",
+  "Connected conflict detection is not enabled yet.",
 ];
 
 const scheduleHours = Array.from({ length: 16 }, (_, index) => index + 7);
@@ -376,6 +375,14 @@ export default function SchedulingWorkspacePage() {
       }
     });
     return { grouped, suggestions, needsReview, unscheduled };
+  }, [selectedParsedNotes]);
+  const hasSameTimeWorkspaceNotes = React.useMemo(() => {
+    const noteCountByTime = new Map<number, number>();
+    selectedParsedNotes.forEach(({ parsed }) => {
+      if (parsed.placementType !== "exact_time" || parsed.timeMinutes === undefined) return;
+      noteCountByTime.set(parsed.timeMinutes, (noteCountByTime.get(parsed.timeMinutes) || 0) + 1);
+    });
+    return [...noteCountByTime.values()].some((count) => count > 1);
   }, [selectedParsedNotes]);
   const legacyNotes = React.useMemo(
     () =>
@@ -1314,6 +1321,9 @@ export default function SchedulingWorkspacePage() {
           <Card className="scheduling-card" style={{ display: "grid", gap: spacing.md }}>
             <SectionHeader icon={ListChecks} title="Scheduling Review" />
             <ul className="scheduling-review-list" aria-label="Read-only scheduling recommendations">
+              {hasSameTimeWorkspaceNotes ? (
+                <li>Multiple workspace notes share the same time. Review before confirming the schedule.</li>
+              ) : null}
               {reviewItems.map((item) => (
                 <li key={item}>{item}</li>
               ))}

--- a/rentchain-frontend/src/pages/SchedulingWorkspacePage.tsx
+++ b/rentchain-frontend/src/pages/SchedulingWorkspacePage.tsx
@@ -23,11 +23,11 @@ import {
   dateKeyFromLocalDate,
   legacySchedulingDayNoteFingerprint,
   markLegacySchedulingDayNotesMigrated,
-  parseSchedulingNoteTime,
   readLegacySchedulingDayNotes,
   type SchedulingDayNote,
   type SchedulingDayNotesByDate,
 } from "../lib/schedulingDayNotes";
+import { parseSchedulingNote, type SchedulingNoteParseResult } from "../lib/schedulingNoteParser";
 import { radius, spacing, text } from "../styles/tokens";
 
 type CalendarView = "day" | "week" | "month";
@@ -114,10 +114,6 @@ function formatMonth(date: Date) {
 function formatHour(hour: number) {
   const value = hour % 12 || 12;
   return `${value} ${hour >= 12 ? "PM" : "AM"}`;
-}
-
-function formatNoteTime(hour: number, minute: number) {
-  return minute ? `${formatHour(hour).replace(" ", `:${String(minute).padStart(2, "0")} `)}` : formatHour(hour);
 }
 
 function startOfMonthGrid(date: Date) {
@@ -269,22 +265,32 @@ export default function SchedulingWorkspacePage() {
     }
     return { startDate: selectedKey, endDate: selectedKey };
   }, [calendarView, monthDays, selectedKey, weekDays]);
-  const selectedNotesByTime = React.useMemo(() => {
-    const grouped = scheduleHours.reduce<Record<number, SchedulingDayNote[]>>((result, hour) => {
+  const selectedParsedNotes = React.useMemo(
+    () => selectedNotes.map((note) => ({ note, parsed: parseSchedulingNote({ noteId: note.id, text: note.text, date: selectedKey }) })),
+    [selectedKey, selectedNotes]
+  );
+  const selectedNotePlan = React.useMemo(() => {
+    const grouped = scheduleHours.reduce<Record<number, Array<{ note: SchedulingDayNote; parsed: SchedulingNoteParseResult }>>>((result, hour) => {
       result[hour] = [];
       return result;
     }, {});
-    const unscheduled: SchedulingDayNote[] = [];
-    selectedNotes.forEach((note) => {
-      const parsed = parseSchedulingNoteTime(note.text);
-      if (parsed && parsed.hour >= 7 && parsed.hour <= 22) {
-        grouped[parsed.hour].push(note);
+    const suggestions: Array<{ note: SchedulingDayNote; parsed: SchedulingNoteParseResult }> = [];
+    const needsReview: Array<{ note: SchedulingDayNote; parsed: SchedulingNoteParseResult }> = [];
+    const unscheduled: Array<{ note: SchedulingDayNote; parsed: SchedulingNoteParseResult }> = [];
+    selectedParsedNotes.forEach((entry) => {
+      const hour = entry.parsed.timeMinutes === undefined ? null : Math.floor(entry.parsed.timeMinutes / 60);
+      if (entry.parsed.placementType === "exact_time" && hour !== null && hour >= 7 && hour <= 22) {
+        grouped[hour].push(entry);
+      } else if (entry.parsed.placementType === "daypart") {
+        suggestions.push(entry);
+      } else if (entry.parsed.needsReview) {
+        needsReview.push(entry);
       } else {
-        unscheduled.push(note);
+        unscheduled.push(entry);
       }
     });
-    return { grouped, unscheduled };
-  }, [selectedNotes]);
+    return { grouped, suggestions, needsReview, unscheduled };
+  }, [selectedParsedNotes]);
   const legacyNotes = React.useMemo(
     () =>
       Object.entries(legacyNotesByDate).flatMap(([date, notes]) =>
@@ -989,17 +995,16 @@ export default function SchedulingWorkspacePage() {
                 ) : null}
                 <div className="scheduling-hour-list" aria-label="7 AM-10 PM schedule">
                   {scheduleHours.map((hour) => {
-                    const notes = selectedNotesByTime.grouped[hour] || [];
+                    const notes = selectedNotePlan.grouped[hour] || [];
                     return (
                       <div key={hour} className="scheduling-hour-row" aria-label={`Schedule slot ${formatHour(hour)}`}>
                         <div className="scheduling-hour-label">{formatHour(hour)}</div>
                         <div className="scheduling-slot-notes">
                           {notes.length ? (
-                            notes.map((note) => {
-                              const parsed = parseSchedulingNoteTime(note.text);
+                            notes.map(({ note, parsed }) => {
                               return (
                                 <div key={note.id} className="scheduling-slot-note">
-                                  <strong>{parsed ? formatNoteTime(parsed.hour, parsed.minute) : formatHour(hour)}</strong>
+                                  <strong>{parsed.timeLabel || formatHour(hour)}</strong>
                                   <div>{note.text}</div>
                                 </div>
                               );
@@ -1013,10 +1018,45 @@ export default function SchedulingWorkspacePage() {
                   })}
                 </div>
                 <div style={{ display: "grid", gap: spacing.sm }}>
+                  <strong>Suggested day plan</strong>
+                  <div className="scheduling-local-note">
+                    Suggested from note text. AI-assisted scheduling is advisory; no calendar event has been created.
+                  </div>
+                  {selectedNotePlan.suggestions.length ? (
+                    <div className="scheduling-note-list" aria-label="Suggested day plan">
+                      {selectedNotePlan.suggestions.map(({ note, parsed }) => (
+                        <div key={note.id} className="scheduling-slot-note">
+                          <strong>{parsed.timeLabel}</strong>
+                          <div>{note.text}</div>
+                          <small className="scheduling-local-note">Suggested by note parser · {parsed.reason}</small>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <div className="scheduling-local-note">No daypart suggestions for this day.</div>
+                  )}
+                </div>
+                <div style={{ display: "grid", gap: spacing.sm }}>
+                  <strong>Needs review</strong>
+                  {selectedNotePlan.needsReview.length ? (
+                    <div className="scheduling-note-list" aria-label="Notes needing review">
+                      {selectedNotePlan.needsReview.map(({ note, parsed }) => (
+                        <div key={note.id} className="scheduling-slot-note">
+                          {parsed.timeLabel ? <strong>{parsed.timeLabel}</strong> : null}
+                          <div>{note.text}</div>
+                          <small className="scheduling-local-note">Needs review · {parsed.reason}</small>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <div className="scheduling-local-note">No ambiguous timing cues need review.</div>
+                  )}
+                </div>
+                <div style={{ display: "grid", gap: spacing.sm }}>
                   <strong>Unscheduled notes</strong>
-                  {selectedNotesByTime.unscheduled.length ? (
+                  {selectedNotePlan.unscheduled.length ? (
                     <div className="scheduling-note-list" aria-label="Unscheduled notes">
-                      {selectedNotesByTime.unscheduled.map((note) => (
+                      {selectedNotePlan.unscheduled.map(({ note }) => (
                         <div key={note.id} className="scheduling-slot-note">
                           {note.text}
                         </div>

--- a/rentchain-frontend/src/pages/SchedulingWorkspacePage.tsx
+++ b/rentchain-frontend/src/pages/SchedulingWorkspacePage.tsx
@@ -1006,6 +1006,9 @@ export default function SchedulingWorkspacePage() {
                                 <div key={note.id} className="scheduling-slot-note">
                                   <strong>{parsed.timeLabel || formatHour(hour)}</strong>
                                   <div>{note.text}</div>
+                                  {parsed.needsReview ? (
+                                    <small className="scheduling-local-note">Needs review · {parsed.reason}</small>
+                                  ) : null}
                                 </div>
                               );
                             })


### PR DESCRIPTION
## Summary

- add a pure render-time `schedulingNoteParser` abstraction shared by `/scheduling` and `/dashboard`
- preserve exact deterministic time placement while deriving advisory daypart and deadline cues
- separate ambiguous timing language into Needs review and keep cue-free notes Unscheduled
- retain original workspace note text and count each backend note once
- add false-positive protections for unit numbers, currency, durations, day counts, and notices

## Architecture and safety

- frontend-only; no backend endpoint or schema changes
- no parse-result persistence or cache
- no external AI/LLM provider call and no note content transmission
- parser output includes deterministic source plus `deterministic` / `ai_suggested_ready` mode metadata
- suggestions are explicitly advisory and do not create calendar events, notifications, reminders, actions, or other mutations

Provider-backed parsing is intentionally deferred to #1379, subject to explicit privacy, configuration, and supervision gates.

## Validation

- `npm run test -- SchedulingWorkspacePage schedulingDayNotes schedulingNoteParser DashboardPage TopNav` — 62 tests passed
- `npm run build` under Node 20.20.2 — passed with the existing chunk-size warning
- `git diff --check`
- `git diff --cached --check`

## QA

Draft pending manual preview QA of exact-time slots, Suggested day plan, Needs review, Unscheduled notes, dashboard consistency, responsive rendering, and advisory copy.
