### PR TITLE
test: stabilize Operations command center fixtures

### DIFF
--- a/rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx
+++ b/rentchain-frontend/src/pages/OperationalCommandCenterPage.test.tsx
@@ -21,6 +21,12 @@ const mocks = vi.hoisted(() => ({
   useEntitlements: vi.fn(),
 }));
 
+const TEST_NOW = new Date("2026-06-15T12:00:00.000Z");
+
+beforeEach(() => {
+  vi.setSystemTime(TEST_NOW);
+});
+
 vi.mock("@/api/decisionInboxApi", async () => {
   const actual = await vi.importActual<any>("@/api/decisionInboxApi");
   return {
@@ -75,6 +81,7 @@ vi.mock("@/components/billing/LockedFeature", () => ({
 
 afterEach(() => {
   cleanup();
+  vi.useRealTimers();
 });
 
 function decision(overrides: Record<string, any> = {}) {


### PR DESCRIPTION
## Summary

- freeze `OperationalCommandCenterPage` tests to their existing June 2026 fixture timeline
- restore deterministic lease-renewal signals and dependent queue/count assertions
- keep the repair test-only with no Operations product behavior changes

## Root cause

The shared lease fixture ends on July 15, 2026. Tests that call production signal derivation without an explicit `now` began using the real clock, so the fixture moved outside the supported current-to-90-day renewal window. The missing `Lease ending soon` signal then cascaded into stale queue counts and search/view assertions on clean `main` and unrelated PRs.

## Validation

- `VITE_API_BASE_URL=http://localhost:3001 npm run test -- OperationalCommandCenterPage` — 19 passed
- `git diff --check`
- `git diff --cached --check`

## Scope

One frontend test file only. No production code, backend, workflow, notification, payment, lease mutation, or tenant/contractor communication behavior changes.
