### PR TITLE
Add scheduling note delete confirmation

### DIFF
--- a/rentchain-frontend/src/pages/SchedulingWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/SchedulingWorkspacePage.test.tsx
@@ -199,11 +199,66 @@ describe("SchedulingWorkspacePage", () => {
     await waitFor(() => expect(mocks.updateSchedulingDayNoteMock).toHaveBeenCalled());
 
     fireEvent.click(screen.getAllByRole("button", { name: "Delete" })[0]);
+    const confirmation = screen.getByRole("alertdialog", { name: "Delete note?" });
+    expect(within(confirmation).getByText("This will remove this workspace scheduling note from the selected day.")).toBeInTheDocument();
+    expect(mocks.deleteSchedulingDayNoteMock).not.toHaveBeenCalled();
+    fireEvent.click(within(confirmation).getByRole("button", { name: "Delete note" }));
 
     await waitFor(() => expect(mocks.deleteSchedulingDayNoteMock).toHaveBeenCalled());
     expect(within(selectedDay).getByText("1 note")).toBeInTheDocument();
     expect(screen.queryByDisplayValue("Call tenant at noon")).not.toBeInTheDocument();
     expect(screen.getByDisplayValue("Confirm maintenance access")).toBeInTheDocument();
+    expect(screen.getByText("Workspace note deleted.")).toBeInTheDocument();
+  });
+
+  it("cancels scheduling note deletion without calling the API", async () => {
+    mocks.fetchSchedulingDayNotesRangeMock.mockResolvedValue({
+      "2026-07-15": [{ id: "note-cancel", text: "Keep this note" }],
+    });
+    renderPage(["/scheduling?view=day&date=2026-07-15"]);
+
+    await screen.findByDisplayValue("Keep this note");
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    const confirmation = screen.getByRole("alertdialog", { name: "Delete note?" });
+    expect(within(confirmation).getByRole("button", { name: "Delete note" })).toHaveFocus();
+
+    fireEvent.click(within(confirmation).getByRole("button", { name: "Cancel" }));
+
+    expect(screen.queryByRole("alertdialog", { name: "Delete note?" })).not.toBeInTheDocument();
+    expect(mocks.deleteSchedulingDayNoteMock).not.toHaveBeenCalled();
+    expect(screen.getByDisplayValue("Keep this note")).toBeInTheDocument();
+  });
+
+  it("closes scheduling note deletion confirmation with Escape", async () => {
+    mocks.fetchSchedulingDayNotesRangeMock.mockResolvedValue({
+      "2026-07-15": [{ id: "note-escape", text: "Keep this note too" }],
+    });
+    renderPage(["/scheduling?view=day&date=2026-07-15"]);
+
+    await screen.findByDisplayValue("Keep this note too");
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    fireEvent.keyDown(screen.getByRole("alertdialog", { name: "Delete note?" }), { key: "Escape" });
+
+    expect(screen.queryByRole("alertdialog", { name: "Delete note?" })).not.toBeInTheDocument();
+    expect(mocks.deleteSchedulingDayNoteMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps a scheduling note visible when confirmed deletion fails", async () => {
+    mocks.fetchSchedulingDayNotesRangeMock.mockResolvedValue({
+      "2026-07-15": [{ id: "note-failure", text: "Do not lose this note" }],
+    });
+    mocks.deleteSchedulingDayNoteMock.mockRejectedValueOnce(new Error("delete failed"));
+    renderPage(["/scheduling?view=day&date=2026-07-15"]);
+
+    await screen.findByDisplayValue("Do not lose this note");
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    fireEvent.click(screen.getByRole("button", { name: "Delete note" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Scheduling note could not be deleted. Refresh this view and try again."
+    );
+    expect(mocks.deleteSchedulingDayNoteMock).toHaveBeenCalledWith("2026-07-15", "note-failure");
+    expect(screen.getByDisplayValue("Do not lose this note")).toBeInTheDocument();
   });
 
   it("places notes with clear times into day schedule slots and keeps vague notes unscheduled", async () => {

--- a/rentchain-frontend/src/pages/SchedulingWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/SchedulingWorkspacePage.test.tsx
@@ -46,6 +46,7 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  Object.defineProperty(window, "innerWidth", { configurable: true, value: 1024 });
 });
 
 function renderPage(initialEntries: string[] = ["/scheduling"]) {
@@ -202,7 +203,9 @@ describe("SchedulingWorkspacePage", () => {
     const confirmation = screen.getByRole("alertdialog", { name: "Delete note?" });
     expect(within(confirmation).getByText("This will remove this workspace scheduling note from the selected day.")).toBeInTheDocument();
     expect(mocks.deleteSchedulingDayNoteMock).not.toHaveBeenCalled();
-    fireEvent.click(within(confirmation).getByRole("button", { name: "Delete note" }));
+    const confirmButton = within(confirmation).getByRole("button", { name: "Delete note" });
+    await waitFor(() => expect(confirmButton).toBeEnabled());
+    fireEvent.click(confirmButton);
 
     await waitFor(() => expect(mocks.deleteSchedulingDayNoteMock).toHaveBeenCalled());
     expect(within(selectedDay).getByText("1 note")).toBeInTheDocument();
@@ -220,7 +223,7 @@ describe("SchedulingWorkspacePage", () => {
     await screen.findByDisplayValue("Keep this note");
     fireEvent.click(screen.getByRole("button", { name: "Delete" }));
     const confirmation = screen.getByRole("alertdialog", { name: "Delete note?" });
-    expect(within(confirmation).getByRole("button", { name: "Delete note" })).toHaveFocus();
+    await waitFor(() => expect(within(confirmation).getByRole("button", { name: "Delete note" })).toHaveFocus());
 
     fireEvent.click(within(confirmation).getByRole("button", { name: "Cancel" }));
 
@@ -252,13 +255,55 @@ describe("SchedulingWorkspacePage", () => {
 
     await screen.findByDisplayValue("Do not lose this note");
     fireEvent.click(screen.getByRole("button", { name: "Delete" }));
-    fireEvent.click(screen.getByRole("button", { name: "Delete note" }));
+    const confirmButton = screen.getByRole("button", { name: "Delete note" });
+    await waitFor(() => expect(confirmButton).toBeEnabled());
+    fireEvent.click(confirmButton);
 
     expect(await screen.findByRole("alert")).toHaveTextContent(
       "Scheduling note could not be deleted. Refresh this view and try again."
     );
     expect(mocks.deleteSchedulingDayNoteMock).toHaveBeenCalledWith("2026-07-15", "note-failure");
     expect(screen.getByDisplayValue("Do not lose this note")).toBeInTheDocument();
+  });
+
+  it("routes exact-time and unscheduled mobile delete controls through confirmation", async () => {
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 390 });
+    fireEvent(window, new Event("resize"));
+    mocks.fetchSchedulingDayNotesRangeMock.mockResolvedValue({
+      "2026-07-15": [
+        { id: "note-mobile-timed", text: "9am mobile inspection" },
+        { id: "note-mobile-unscheduled", text: "Mobile follow-up" },
+      ],
+    });
+    renderPage(["/scheduling?view=day&date=2026-07-15"]);
+
+    const timedInput = await screen.findByDisplayValue("9am mobile inspection");
+    const timedRow = timedInput.closest(".scheduling-note-row");
+    expect(timedRow).not.toBeNull();
+    fireEvent.click(within(timedRow as HTMLElement).getByRole("button", { name: "Delete" }));
+
+    const timedConfirmation = screen.getByRole("alertdialog", { name: "Delete note?" });
+    expect(mocks.deleteSchedulingDayNoteMock).not.toHaveBeenCalled();
+    fireEvent.click(within(timedConfirmation).getByRole("button", { name: "Cancel" }));
+    expect(screen.getByDisplayValue("9am mobile inspection")).toBeInTheDocument();
+    expect(mocks.deleteSchedulingDayNoteMock).not.toHaveBeenCalled();
+
+    const unscheduledInput = screen.getByDisplayValue("Mobile follow-up");
+    const unscheduledRow = unscheduledInput.closest(".scheduling-note-row");
+    expect(unscheduledRow).not.toBeNull();
+    fireEvent.click(within(unscheduledRow as HTMLElement).getByRole("button", { name: "Delete" }));
+
+    const unscheduledConfirmation = screen.getByRole("alertdialog", { name: "Delete note?" });
+    expect(mocks.deleteSchedulingDayNoteMock).not.toHaveBeenCalled();
+    const confirmButton = within(unscheduledConfirmation).getByRole("button", { name: "Delete note" });
+    await waitFor(() => expect(confirmButton).toBeEnabled());
+    fireEvent.click(confirmButton);
+
+    await waitFor(() =>
+      expect(mocks.deleteSchedulingDayNoteMock).toHaveBeenCalledWith("2026-07-15", "note-mobile-unscheduled")
+    );
+    expect(screen.getByDisplayValue("9am mobile inspection")).toBeInTheDocument();
+    expect(screen.queryByDisplayValue("Mobile follow-up")).not.toBeInTheDocument();
   });
 
   it("places notes with clear times into day schedule slots and keeps vague notes unscheduled", async () => {

--- a/rentchain-frontend/src/pages/SchedulingWorkspacePage.tsx
+++ b/rentchain-frontend/src/pages/SchedulingWorkspacePage.tsx
@@ -228,6 +228,22 @@ function DeleteNoteDialog({
   onCancel: () => void;
   onConfirm: () => void;
 }) {
+  const dialogRef = React.useRef<HTMLDivElement | null>(null);
+  const [confirmationReady, setConfirmationReady] = React.useState(false);
+
+  React.useEffect(() => {
+    const timer = window.setTimeout(() => {
+      setConfirmationReady(true);
+    }, 250);
+    return () => window.clearTimeout(timer);
+  }, []);
+
+  React.useEffect(() => {
+    if (confirmationReady) {
+      dialogRef.current?.querySelector<HTMLButtonElement>("[data-confirm-delete-note]")?.focus();
+    }
+  }, [confirmationReady]);
+
   return (
     <div
       role="presentation"
@@ -242,6 +258,7 @@ function DeleteNoteDialog({
       }}
     >
       <div
+        ref={dialogRef}
         role="alertdialog"
         aria-modal="true"
         aria-labelledby="delete-scheduling-note-title"
@@ -274,9 +291,9 @@ function DeleteNoteDialog({
           </Button>
           <Button
             type="button"
-            autoFocus
+            data-confirm-delete-note
             onClick={onConfirm}
-            disabled={busy}
+            disabled={busy || !confirmationReady}
             style={{ background: "#b91c1c", color: "#fff" }}
           >
             {busy ? "Deleting" : "Delete note"}
@@ -303,7 +320,7 @@ export default function SchedulingWorkspacePage() {
   const [notesStatus, setNotesStatus] = React.useState<string | null>(null);
   const [draftSaving, setDraftSaving] = React.useState(false);
   const [savingNoteIds, setSavingNoteIds] = React.useState<Record<string, boolean>>({});
-  const [pendingDeleteNoteId, setPendingDeleteNoteId] = React.useState<string | null>(null);
+  const [pendingDeleteNote, setPendingDeleteNote] = React.useState<SchedulingDayNote | null>(null);
   const legacyNotesScope = React.useMemo(
     () => ({
       actorLandlordId: user?.actorLandlordId,
@@ -485,7 +502,9 @@ export default function SchedulingWorkspacePage() {
     }
   };
 
-  const deleteNote = async (noteId: string) => {
+  const confirmDeleteNote = async () => {
+    if (!pendingDeleteNote) return;
+    const noteId = pendingDeleteNote.id;
     setSavingNoteIds((current) => ({ ...current, [noteId]: true }));
     setNotesError(null);
     setNotesStatus(null);
@@ -495,13 +514,17 @@ export default function SchedulingWorkspacePage() {
         selectedKey,
         selectedNotes.filter((note) => note.id !== noteId)
       );
-      setPendingDeleteNoteId(null);
+      setPendingDeleteNote(null);
       setNotesStatus("Workspace note deleted.");
     } catch {
       setNotesError("Scheduling note could not be deleted. Refresh this view and try again.");
     } finally {
       setSavingNoteIds((current) => ({ ...current, [noteId]: false }));
     }
+  };
+
+  const openDeleteConfirmation = (note: SchedulingDayNote) => {
+    setPendingDeleteNote(note);
   };
 
   const migrateLegacyNotes = async () => {
@@ -1171,7 +1194,7 @@ export default function SchedulingWorkspacePage() {
                       <Button
                         type="button"
                         variant="ghost"
-                        onClick={() => setPendingDeleteNoteId(note.id)}
+                        onClick={() => openDeleteConfirmation(note)}
                         disabled={Boolean(savingNoteIds[note.id])}
                       >
                         {savingNoteIds[note.id] ? "Deleting" : "Delete"}
@@ -1255,12 +1278,12 @@ export default function SchedulingWorkspacePage() {
           </Card>
         </div>
       </div>
-      {pendingDeleteNoteId ? (
+      {pendingDeleteNote ? (
         <DeleteNoteDialog
-          busy={Boolean(savingNoteIds[pendingDeleteNoteId])}
-          onCancel={() => setPendingDeleteNoteId(null)}
+          busy={Boolean(savingNoteIds[pendingDeleteNote.id])}
+          onCancel={() => setPendingDeleteNote(null)}
           onConfirm={() => {
-            void deleteNote(pendingDeleteNoteId);
+            void confirmDeleteNote();
           }}
         />
       ) : null}

--- a/rentchain-frontend/src/pages/SchedulingWorkspacePage.tsx
+++ b/rentchain-frontend/src/pages/SchedulingWorkspacePage.tsx
@@ -219,6 +219,74 @@ function WorkspaceList({
   );
 }
 
+function DeleteNoteDialog({
+  busy,
+  onCancel,
+  onConfirm,
+}: {
+  busy: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  return (
+    <div
+      role="presentation"
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 50,
+        display: "grid",
+        placeItems: "center",
+        padding: spacing.md,
+        background: "rgba(15, 23, 42, 0.42)",
+      }}
+    >
+      <div
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby="delete-scheduling-note-title"
+        aria-describedby="delete-scheduling-note-description"
+        aria-busy={busy || undefined}
+        onKeyDown={(event) => {
+          if (event.key === "Escape" && !busy) onCancel();
+        }}
+        style={{
+          width: "min(100%, 420px)",
+          display: "grid",
+          gap: spacing.md,
+          padding: spacing.lg,
+          borderRadius: radius.lg,
+          background: "#fff",
+          boxShadow: "0 24px 60px rgba(15, 23, 42, 0.28)",
+        }}
+      >
+        <div style={{ display: "grid", gap: spacing.xs }}>
+          <h2 id="delete-scheduling-note-title" style={{ margin: 0, fontSize: "1.2rem" }}>
+            Delete note?
+          </h2>
+          <p id="delete-scheduling-note-description" style={{ margin: 0, color: text.secondary, lineHeight: 1.5 }}>
+            This will remove this workspace scheduling note from the selected day.
+          </p>
+        </div>
+        <div style={{ display: "flex", justifyContent: "flex-end", gap: spacing.sm, flexWrap: "wrap" }}>
+          <Button type="button" variant="secondary" onClick={onCancel} disabled={busy}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            autoFocus
+            onClick={onConfirm}
+            disabled={busy}
+            style={{ background: "#b91c1c", color: "#fff" }}
+          >
+            {busy ? "Deleting" : "Delete note"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default function SchedulingWorkspacePage() {
   const { user } = useAuth();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -235,6 +303,7 @@ export default function SchedulingWorkspacePage() {
   const [notesStatus, setNotesStatus] = React.useState<string | null>(null);
   const [draftSaving, setDraftSaving] = React.useState(false);
   const [savingNoteIds, setSavingNoteIds] = React.useState<Record<string, boolean>>({});
+  const [pendingDeleteNoteId, setPendingDeleteNoteId] = React.useState<string | null>(null);
   const legacyNotesScope = React.useMemo(
     () => ({
       actorLandlordId: user?.actorLandlordId,
@@ -426,6 +495,7 @@ export default function SchedulingWorkspacePage() {
         selectedKey,
         selectedNotes.filter((note) => note.id !== noteId)
       );
+      setPendingDeleteNoteId(null);
       setNotesStatus("Workspace note deleted.");
     } catch {
       setNotesError("Scheduling note could not be deleted. Refresh this view and try again.");
@@ -1098,7 +1168,12 @@ export default function SchedulingWorkspacePage() {
                       <Button type="button" variant="secondary" onClick={() => saveNote(note)} disabled={Boolean(savingNoteIds[note.id])}>
                         {savingNoteIds[note.id] ? "Saving" : "Save"}
                       </Button>
-                      <Button type="button" variant="ghost" onClick={() => deleteNote(note.id)} disabled={Boolean(savingNoteIds[note.id])}>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        onClick={() => setPendingDeleteNoteId(note.id)}
+                        disabled={Boolean(savingNoteIds[note.id])}
+                      >
                         {savingNoteIds[note.id] ? "Deleting" : "Delete"}
                       </Button>
                     </div>
@@ -1180,6 +1255,15 @@ export default function SchedulingWorkspacePage() {
           </Card>
         </div>
       </div>
+      {pendingDeleteNoteId ? (
+        <DeleteNoteDialog
+          busy={Boolean(savingNoteIds[pendingDeleteNoteId])}
+          onCancel={() => setPendingDeleteNoteId(null)}
+          onConfirm={() => {
+            void deleteNote(pendingDeleteNoteId);
+          }}
+        />
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- require explicit confirmation before deleting a persisted scheduling workspace note
- present the requested copy in an accessible alert dialog with destructive confirmation styling
- support Cancel and Escape without calling the DELETE API
- preserve the existing success message and failure behavior

## Validation

- `npm run test -- SchedulingWorkspacePage schedulingDayNotes` (18 tests passed under Node 20.20.2)
- `npm run build` (passed under Node 20.20.2; existing chunk-size warning only)
- `git diff --check`
- `git diff --cached --check`

## Scope and safety

Frontend-only polish. No backend or API behavior changes. No notifications, reminders, calendar events, Google Calendar integration, decision/action mutation, payments, lease lifecycle/legal/compliance behavior, tenant communication, contractor assignment, or external AI/LLM behavior.
