### PR TITLE
Fix landing capture/export and signup continuity

### DIFF
--- a/rentchain-frontend/src/App.routes.test.tsx
+++ b/rentchain-frontend/src/App.routes.test.tsx
@@ -327,7 +327,7 @@ describe("Routes: /register", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText(/Create your RentChain account/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Create your housing operations workspace/i)).toBeInTheDocument();
     expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/components/auth/authPageStyles.ts
+++ b/rentchain-frontend/src/components/auth/authPageStyles.ts
@@ -34,6 +34,11 @@ export const authShellStyle: React.CSSProperties = {
   color: authPalette.ink,
 };
 
+export const signupAuthShellStyle: React.CSSProperties = {
+  ...authShellStyle,
+  backgroundImage: "linear-gradient(135deg, #f4efe6 0%, #efe6d7 48%, #f8f3ea 100%)",
+};
+
 export const authCardStyle = (
   width: string = "min(460px, 92vw)"
 ): React.CSSProperties => ({

--- a/rentchain-frontend/src/index.css
+++ b/rentchain-frontend/src/index.css
@@ -354,13 +354,13 @@ button,
     display: block !important;
   }
 
-  body:not([data-print-root-active="true"]) * {
+  body:not([data-print-root-active="true"]):not([data-marketing-print-active="true"]) * {
     visibility: hidden !important;
   }
 
-  body:not([data-print-root-active="true"]) .print-only-summary,
-  body:not([data-print-root-active="true"]) .print-only-lease-renewals,
-  body:not([data-print-root-active="true"]) .print-only-application {
+  body:not([data-print-root-active="true"]):not([data-marketing-print-active="true"]) .print-only-summary,
+  body:not([data-print-root-active="true"]):not([data-marketing-print-active="true"]) .print-only-lease-renewals,
+  body:not([data-print-root-active="true"]):not([data-marketing-print-active="true"]) .print-only-application {
     display: block !important;
     visibility: visible !important;
     position: static !important;
@@ -375,9 +375,9 @@ button,
     transform: none !important;
   }
 
-  body:not([data-print-root-active="true"]) .print-only-summary *,
-  body:not([data-print-root-active="true"]) .print-only-lease-renewals *,
-  body:not([data-print-root-active="true"]) .print-only-application * {
+  body:not([data-print-root-active="true"]):not([data-marketing-print-active="true"]) .print-only-summary *,
+  body:not([data-print-root-active="true"]):not([data-marketing-print-active="true"]) .print-only-lease-renewals *,
+  body:not([data-print-root-active="true"]):not([data-marketing-print-active="true"]) .print-only-application * {
     visibility: visible !important;
   }
 

--- a/rentchain-frontend/src/pages/SignupPage.test.tsx
+++ b/rentchain-frontend/src/pages/SignupPage.test.tsx
@@ -28,6 +28,22 @@ describe("SignupPage", () => {
     mocks.trackAuthEvent.mockReset();
   });
 
+  it("sets conversion-focused workspace expectations without changing the properties destination", () => {
+    render(
+      <MemoryRouter initialEntries={["/signup?next=/properties&intent=registry_readiness"]}>
+        <SignupPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole("heading", { level: 1, name: "Create your housing operations workspace" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 2, name: "What happens next" })).toBeInTheDocument();
+    expect(screen.getByText("Add your first property.")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Go to login" })).toHaveAttribute(
+      "href",
+      "/login?next=%2Fproperties"
+    );
+  });
+
   it("preserves delegated access invite context during account creation", async () => {
     render(
       <MemoryRouter initialEntries={["/signup?next=/delegated-access/accept%3Ftoken%3Dsafe-token"]}>

--- a/rentchain-frontend/src/pages/SignupPage.tsx
+++ b/rentchain-frontend/src/pages/SignupPage.tsx
@@ -17,7 +17,7 @@ import {
   authMutedLinkStyle,
   authPalette,
   authPrimaryButtonStyle,
-  authShellStyle,
+  signupAuthShellStyle,
 } from "../components/auth/authPageStyles";
 
 function maskEmail(value: string): string {
@@ -199,17 +199,37 @@ const SignupPage: React.FC = () => {
   };
 
   return (
-    <div style={authShellStyle}>
+    <div style={signupAuthShellStyle}>
       <Card elevated style={authCardStyle("min(520px, 94vw)")}>
         <div style={authEyebrowStyle}>
           RentChain
         </div>
         <h1 style={authHeadingStyle}>
-          Create your RentChain account
+          Create your housing operations workspace
         </h1>
         <p style={authBodyStyle}>
-          Create an account to access your RentChain workspace.
+          Start free with your first property. Build a connected record for leases, payments, maintenance, tenants, documents, and operations.
         </p>
+        <section
+          aria-labelledby="signup-next-steps-title"
+          style={{
+            marginBottom: spacing.md,
+            padding: "14px 16px",
+            border: `1px solid ${authPalette.fieldBorder}`,
+            borderRadius: 12,
+            background: authPalette.beigeSoft,
+          }}
+        >
+          <h2 id="signup-next-steps-title" style={{ margin: "0 0 8px", fontSize: "1rem", color: authPalette.ink }}>
+            What happens next
+          </h2>
+          <ol style={{ margin: 0, paddingLeft: 20, color: authPalette.muted, lineHeight: 1.55 }}>
+            <li>Create your account.</li>
+            <li>Add your first property.</li>
+            <li>Organize units, tenants, leases, and records.</li>
+            <li>Upgrade only when your workflow needs more support.</li>
+          </ol>
+        </section>
         {inviteBanner ? (
           <div style={authBannerStyle("info")}>
             <div style={{ fontWeight: 700, marginBottom: 4 }}>{inviteBanner.title}</div>

--- a/rentchain-frontend/src/pages/marketing/LandingPage.test.tsx
+++ b/rentchain-frontend/src/pages/marketing/LandingPage.test.tsx
@@ -71,6 +71,17 @@ describe("Marketing LandingPage", () => {
       screen.getByRole("heading", { level: 1, name: /Housing operations\. Connected\./i })
     ).toBeInTheDocument();
     expect(screen.getByText(/The operating system for housing/i)).toBeInTheDocument();
+    expect(document.body).toHaveAttribute("data-marketing-print-active", "true");
+    expect(screen.getByLabelText("Sample connected operating record")).toHaveTextContent("Lease terms approved");
+    expect(screen.getByText("One shared record", { selector: ".rc-trust-mobile-connector strong" })).toBeInTheDocument();
+  });
+
+  it("removes the landing-only print marker when the route unmounts", () => {
+    const view = renderLanding("/");
+
+    view.unmount();
+
+    expect(document.body).not.toHaveAttribute("data-marketing-print-active");
   });
 
   it("renders at the /site route", () => {

--- a/rentchain-frontend/src/pages/marketing/LandingPage.tsx
+++ b/rentchain-frontend/src/pages/marketing/LandingPage.tsx
@@ -58,6 +58,10 @@ const LandingPage: React.FC = () => {
   useEffect(() => {
     document.title = "RentChain - Housing operations. Connected.";
     ensureMarketingFonts();
+    document.body.dataset.marketingPrintActive = "true";
+    return () => {
+      delete document.body.dataset.marketingPrintActive;
+    };
   }, []);
 
   const handlePrimaryCta = () => {

--- a/rentchain-frontend/src/pages/marketing/landing/LandingSections.tsx
+++ b/rentchain-frontend/src/pages/marketing/landing/LandingSections.tsx
@@ -276,6 +276,10 @@ export function TrustFlowSection() {
             <path d="M48 18 V102" />
             <path d="M48 60 H116" />
           </svg>
+          <div className="rc-trust-mobile-connector" aria-hidden="true">
+            <span>Connected roles</span>
+            <strong>One shared record</strong>
+          </div>
           <RevealOnScroll className="rc-panel rc-trust-hub">
             <p className="rc-kicker">{trustFlow.hubKicker}</p>
             <h3>{trustFlow.hubTitle}</h3>
@@ -343,7 +347,9 @@ export function AudienceSection() {
 
 export function LifecycleSection() {
   const [active, setActive] = useState(0);
-  const activeStep = lifecycle.steps[active] ?? lifecycle.steps[0];
+  const [printActive, setPrintActive] = useState(false);
+  const displayedIndex = printActive ? 0 : active;
+  const activeStep = lifecycle.steps[displayedIndex] ?? lifecycle.steps[0];
   const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
 
   useEffect(() => {
@@ -352,6 +358,20 @@ export function LifecycleSection() {
       setActive((current) => (current + 1) % lifecycle.steps.length);
     }, lifecycle.autoAdvanceMs);
     return () => window.clearInterval(interval);
+  }, []);
+
+  useEffect(() => {
+    const printMedia = window.matchMedia?.("print");
+    const updatePrintState = () => setPrintActive(Boolean(printMedia?.matches));
+    updatePrintState();
+    printMedia?.addEventListener?.("change", updatePrintState);
+    window.addEventListener("beforeprint", updatePrintState);
+    window.addEventListener("afterprint", updatePrintState);
+    return () => {
+      printMedia?.removeEventListener?.("change", updatePrintState);
+      window.removeEventListener("beforeprint", updatePrintState);
+      window.removeEventListener("afterprint", updatePrintState);
+    };
   }, []);
 
   function focusStep(index: number) {
@@ -400,7 +420,7 @@ export function LifecycleSection() {
                 }}
                 type="button"
                 role="tab"
-                aria-selected={active === index}
+                aria-selected={displayedIndex === index}
                 aria-controls="lifecycle-panel"
                 className="rc-lifecycle-tab"
                 onClick={() => setActive(index)}

--- a/rentchain-frontend/src/pages/marketing/landing/landingPageCss.ts
+++ b/rentchain-frontend/src/pages/marketing/landing/landingPageCss.ts
@@ -415,6 +415,10 @@ export const landingPageCss = `
   stroke-linejoin: round;
 }
 
+.rc-trust-mobile-connector {
+  display: none;
+}
+
 .rc-trust-node {
   position: relative;
 }
@@ -707,9 +711,9 @@ export const landingPageCss = `
 }
 
 .rc-reveal {
-  opacity: 0;
+  opacity: 1;
   transform: translateY(22px);
-  transition: opacity 600ms ease, transform 600ms ease;
+  transition: transform 600ms ease;
 }
 
 .rc-reveal.is-visible {
@@ -752,6 +756,27 @@ export const landingPageCss = `
     display: none;
   }
 
+  .rc-trust-mobile-connector {
+    display: grid;
+    justify-items: center;
+    gap: 4px;
+    padding: 8px 0;
+    color: var(--rc-muted);
+    font-size: 0.82rem;
+    text-align: center;
+  }
+
+  .rc-trust-mobile-connector::after {
+    content: "↓";
+    color: ${colors.pine600};
+    font-size: 1.4rem;
+    line-height: 1;
+  }
+
+  .rc-trust-mobile-connector strong {
+    color: var(--rc-text);
+  }
+
   .rc-trust-role-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -788,7 +813,20 @@ export const landingPageCss = `
   }
 
   .rc-hero-visual {
-    display: none;
+    padding: 12px;
+    border-radius: 18px;
+  }
+
+  .rc-ledger-row {
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: 9px;
+    padding: 11px;
+  }
+
+  .rc-ledger-row > strong:last-child {
+    grid-column: 2;
+    color: ${colors.amber500};
+    font-size: 0.82rem;
   }
 
   .rc-audience-grid,
@@ -826,6 +864,46 @@ export const landingPageCss = `
   .rc-reveal {
     opacity: 1;
     transform: none;
+  }
+}
+
+@media print {
+  @page {
+    margin: 12mm;
+  }
+
+  .rc-landing,
+  .rc-landing * {
+    visibility: visible !important;
+    -webkit-print-color-adjust: exact !important;
+    print-color-adjust: exact !important;
+  }
+
+  .rc-landing {
+    background: var(--rc-paper) !important;
+  }
+
+  .rc-marketing-header {
+    position: static;
+  }
+
+  .rc-reveal {
+    opacity: 1 !important;
+    transform: none !important;
+  }
+
+  .rc-section,
+  .rc-card,
+  .rc-panel,
+  .rc-ledger-row,
+  .rc-footer-grid > div {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  .rc-mobile-toggle,
+  .rc-mobile-menu {
+    display: none !important;
   }
 }
 `;

--- a/rentchain-frontend/src/styles/print.css
+++ b/rentchain-frontend/src/styles/print.css
@@ -1,5 +1,5 @@
 @media print {
-  body * {
+  body:not([data-marketing-print-active="true"]) * {
     visibility: hidden !important;
   }
 

--- a/rentchain-frontend/src/styles/printPdfGuardrails.test.ts
+++ b/rentchain-frontend/src/styles/printPdfGuardrails.test.ts
@@ -29,6 +29,21 @@ describe("print PDF guardrails", () => {
     expect(samplePdfPage).toMatch(/PdfPreviewBoundary/);
   });
 
+  it("allows only the mounted marketing page to bypass report print isolation", () => {
+    const indexCss = readFileSync(resolve(srcRoot, "index.css"), "utf8");
+    const printCss = readFileSync(resolve(srcRoot, "styles/print.css"), "utf8");
+    const landingCss = readFileSync(
+      resolve(srcRoot, "pages/marketing/landing/landingPageCss.ts"),
+      "utf8"
+    );
+
+    expect(indexCss).toMatch(/body:not\(\[data-print-root-active="true"\]\):not\(\[data-marketing-print-active="true"\]\) \*/);
+    expect(printCss).toMatch(/body:not\(\[data-marketing-print-active="true"\]\) \*/);
+    expect(landingCss).toMatch(/@media print/);
+    expect(landingCss).toMatch(/print-color-adjust: exact !important/);
+    expect(landingCss).toMatch(/\.rc-reveal \{[\s\S]*?opacity: 1;/);
+  });
+
   it("keeps application print view from reserving a viewport-height phantom page", () => {
     const source = readFileSync(
       resolve(srcRoot, "components/applications/PrintApplicationView.tsx"),


### PR DESCRIPTION
## Summary

Fixes the existing public landing page so browser screenshots and print/PDF exports retain the full page, while preserving the current design and report-print isolation. It also keeps the operating-record visual and role relationship understandable on mobile and aligns the public signup conversion page with the landing story.

## Root cause

- The global report print guard hid `body *` unless a report print root was active, so the marketing page exported as blank pages.
- Reveal blocks began at `opacity: 0`, allowing full-page captures to record unrevealed sections.
- Responsive rules removed the operating-record visual below 720px and the role connector below 980px.
- The shared signup shell used a radial gradient that some mobile capture paths composited as a large solid gold circle.
- The lifecycle auto-advance state made export output timing-dependent.

## Implementation

- Adds a landing-only body marker while the page is mounted and narrows the global print exclusions around that marker. Existing report roots remain unchanged.
- Adds landing print rules for visible reveal content, exact colors/backgrounds, stable positioning, and practical page-break avoidance.
- Keeps reveal content opaque during normal browsing while preserving the existing translate-in motion and reduced-motion behavior.
- Pins lifecycle export to the first step without changing runtime tab interaction or auto-advance.
- Retains a compact four-row operating record on narrow screens and adds a simple mobile shared-record connector.
- Adds signup-only capture-safe background styling, approved workspace copy, and a four-step “What happens next” panel. Auth logic and `next=/properties` behavior are unchanged.

## QA artifacts

Before audit evidence:
- Full-page captures could omit unrevealed sections.
- Browser PDF output was ten blank pages.
- Supplied mobile signup captures showed the oversized gold radial artifact.

After artifacts were generated locally at `artifacts/qa/landing-capture-export-signup-v1/`:
- `landing-desktop-1440.png`
- `landing-mobile-375.png`
- `landing-mobile-390.png`
- `landing-mobile-430.png`
- `landing-mobile-768.png`
- `signup-mobile-390.png`
- `landing-print.pdf` (15 populated pages)
- `landing-print-page-1.png`

Rendered checks confirmed all 10 landing sections at every requested width, zero hidden reveal blocks, no horizontal overflow, mobile hero/relationship visibility, exact print colors, deterministic “Viewing request” lifecycle export, and no signup radial gradient artifact.

## Validation

- Node 20.20.2
- `npm run test -- LandingPage SignupPage LoginPage printPdfGuardrails` — 32 tests passed
- `npm run build` — passed; existing large-chunk warning only
- `git diff --check` — passed
- `git diff --cached --check` — passed
- Public route smoke checks: login, forgot password, invite, tenant entry, contractor redirect, signup
- Signup login continuation remained `/login?next=%2Fproperties`

## Isolation and scope

Frontend-only. No backend/API changes and no auth-flow logic changes. The report/evidence/package print model remains the default: only a currently mounted landing page opts out of global report hiding, and that marker is removed on unmount. No broader landing redesign or heavy animation dependency is included.