### PR TITLE
docs: enterprise readiness audit and PAD roadmap

### DIFF
--- a/docs/strategy/enterprise-migration-strategy-v1.md
+++ b/docs/strategy/enterprise-migration-strategy-v1.md
@@ -1,0 +1,147 @@
+# Enterprise Migration Strategy v1
+
+Status: planning only; no import implementation or customer-data migration
+
+## Why Transition Risk Matters
+
+For a 3,000-unit operator, switching cost is operational risk: data mapping, accounting continuity, staff training, tenant disruption, integrations, support, close periods and the inability to unwind a failed cutover. RentChain should remove the big-bang decision.
+
+The adoption promise should be:
+
+> Start beside Yardi as a governed workflow, evidence and PAD-readiness layer; expand only after reconciled pilot results.
+
+## Coexistence And Source Of Truth
+
+Before importing data, agree a field-level ownership matrix.
+
+| Domain | Initial authority | RentChain role |
+| --- | --- | --- |
+| Legal entity/accounting books | Existing PMS/accounting system | Reference mapping and governed exports only. |
+| Property/unit master | Existing PMS initially | Imported canonical RentChain records with external IDs as attributes, reconciled changes. |
+| Tenant/lease baseline | Existing PMS at cutover | Workflow context; lease lifecycle becomes authoritative only where explicitly contracted. |
+| Applications/new workflow evidence | RentChain for pilot scope | Primary workflow/evidence record, export summaries back to incumbent process. |
+| Maintenance pilot workflow | Agreed per property group | Operational record with export/reconciliation. |
+| PAD mandate/payment evidence | Processor plus RentChain workflow/reconciliation | Processor is execution evidence; lease/obligation ownership remains explicit. |
+| General ledger and close | Existing accounting system | Export payment/adjustment batches; no native GL claim. |
+
+Never use external identifiers as RentChain primary keys. Preserve them as scoped mapping attributes. Conflicts go to review, not last-write-wins automation.
+
+## Minimum Import Capability
+
+Start with versioned CSV templates and a two-step preview/apply workflow. An API or Yardi-specific adapter can follow after canonical contracts are stable.
+
+### Priority 1: pilot baseline
+
+- organizations/property groups and properties;
+- units with human-readable labels and occupancy status;
+- tenant identities/contact data with minimization and lawful-purpose review;
+- leases, parties, dates, rent, deposit and lifecycle state;
+- starting balances as dated opening entries, never fabricated transaction history;
+- external source/system/record references and import batch provenance.
+
+### Priority 2: continuity context
+
+- payment history summarized or transaction-level where legally and operationally justified;
+- maintenance history, open work and vendor/contractor mapping;
+- documents only after classification, consent/access and storage rules are approved;
+- renewal, notice and move-in/out context.
+
+### Import controls
+
+1. Upload to an isolated, access-controlled staging area.
+2. Parse without mutation; validate encoding, schema, required fields, types and enumerations.
+3. Normalize dates/time zones, currency amounts and addresses deterministically.
+4. Match through explicit external-reference mappings; flag duplicates and ambiguous identities.
+5. Produce row errors, warnings, proposed creates/updates and financial control totals.
+6. Require an authorized operator to approve an immutable preview fingerprint.
+7. Apply idempotently in bounded batches with append-safe audit events.
+8. Produce a signed-off reconciliation report and rejected-row file.
+9. Support correction through superseding imports/reversals, not destructive history rewrites.
+
+## Yardi And Other PMS Inputs
+
+Accept customer-produced CSV/export files first. Do not promise direct Yardi connectivity until the customer edition, licensed interface, credentials, permitted use, field contracts, rate limits and support ownership are known.
+
+Build a provider-neutral canonical import contract before a Yardi adapter. Each adapter should translate external fields, never leak vendor semantics into product identity or authority logic. Store source system, export timestamp, external reference and transformation version for reconciliation.
+
+## Parallel-Run Strategy
+
+```text
+discovery and field ownership
+  -> sanitized sample mapping
+    -> full dry-run and control totals
+      -> bounded property-group import
+        -> 60-90 day parallel workflow
+          -> weekly reconciliation
+            -> expand, hold or exit
+```
+
+During parallel run:
+
+- the incumbent remains authoritative for agreed master/accounting domains;
+- staff avoid double entry through a written operating procedure and assigned reconciliation owner;
+- RentChain exports agreed changes/outcomes on a fixed cadence;
+- exceptions are logged and resolved with actor/reason evidence;
+- no automated bidirectional sync is introduced in the first pilot;
+- a freeze/cutover window is used only if a domain later transfers authority.
+
+## Staged Rollout
+
+1. **Discovery:** inventory systems, data owners, volumes, quality, integrations, close calendar, retention and privacy constraints.
+2. **Sample mapping:** use synthetic or minimized samples; approve mapping and source-of-truth matrix.
+3. **Dry run:** import a production-shaped export into a non-production isolated environment; reconcile counts and totals.
+4. **Pilot group:** select a representative but bounded property group and train named champions.
+5. **Parallel run:** operate selected workflows with weekly data and process reconciliation.
+6. **Controlled expansion:** add property groups only when prior acceptance gates pass; preserve cohort/version tracking.
+7. **Optional domain cutover:** transfer authority one domain at a time with freeze, final delta, sign-off and rollback plan.
+
+## White-Glove Onboarding
+
+Enterprise onboarding is a service, not only an import screen. Assign an implementation lead, customer data owner, security/privacy contact, workflow champion, support owner and executive sponsor.
+
+Checklist:
+
+- contract, DPA/security review and permitted data approved;
+- system/data inventory and field ownership signed;
+- staff roles and least-privilege access approved;
+- import templates, mappings, control totals and rejection policy approved;
+- sandbox/dry-run evidence accepted;
+- training and operating procedures completed;
+- support severity/escalation and communication channels agreed;
+- go-live, reconciliation, rollback/export and deletion responsibilities agreed;
+- weekly pilot review and final outcome review scheduled.
+
+A one-time migration/implementation fee is justified because mapping, cleanup, rehearsal, training and reconciliation are material services. Quote by sources, domains, record volume, data quality, documents/integrations and support—not units alone.
+
+## Fear-Reduction Commitments
+
+- No portfolio-wide commitment before a bounded pilot.
+- No forced replacement of accounting/PMS authority.
+- Preview before mutation and customer-readable rejection reports.
+- Reconciled counts and financial control totals at every batch.
+- Stable exports and a documented exit path.
+- Clear separation of current capability, configured pilot behavior and roadmap.
+- Named human support and no hidden autonomous remediation.
+- Expansion gates based on evidence, not sunk cost.
+
+## Migration Acceptance Gates
+
+- 100% of imported rows accounted for as accepted, warned or rejected.
+- Property, unit, tenant and lease counts reconcile to approved source extracts.
+- Starting-balance totals reconcile by property and in aggregate; opening entries are visibly distinct from transaction history.
+- Duplicate/ambiguous identities are resolved by an authorized reviewer.
+- Role and tenant projection tests show no cross-landlord or cross-tenant leakage.
+- Re-running the same batch is idempotent.
+- Export/rollback procedure is rehearsed.
+- Customer data owner signs off before each rollout cohort.
+
+## Deferred Work
+
+- Automated bidirectional synchronization.
+- Direct write-back to Yardi or accounting systems.
+- Import of every historical document and message.
+- Automatic identity merging.
+- General ledger conversion or historical accounting reconstruction.
+- Big-bang portfolio cutover.
+
+These should remain future integration missions justified by pilot evidence.

--- a/docs/strategy/enterprise-pricing-and-pilot-package-v1.md
+++ b/docs/strategy/enterprise-pricing-and-pilot-package-v1.md
@@ -1,0 +1,110 @@
+# Enterprise Pricing And Pilot Package v1
+
+Status: strategic recommendation only; no approved pricing or entitlement change
+
+## Pricing Conclusion
+
+Current public plans (`Free`, `Starter`, `Pro`, `Elite`) are designed for smaller landlords; the documented maximum public price is `$79/month` or `$790/year`. That structure should remain simple. It is not an appropriate enterprise price once RentChain includes implementation, migration, portfolio governance, PAD operations, reconciliation, security review and premium support.
+
+At `$79/month`, a 3,000-unit operator would pay only `$948/year`, or about `$0.32/unit/year`. That cannot plausibly fund enterprise onboarding, payment exceptions, compliance work and service commitments.
+
+Enterprise should be contract-based and per-unit, with a minimum annual commitment. `$30/unit/year` is a useful reference, not approved public pricing:
+
+```text
+3,000 units x $30/unit/year = $90,000/year
+```
+
+## Packaging Recommendation
+
+| Package | Customer | Commercial model | Scope |
+| --- | --- | --- | --- |
+| Public plans | Small landlords | Simple monthly/annual subscription | Current self-serve capabilities and limits. |
+| Enterprise pilot | One selected property group | Fixed paid pilot fee, credited partly toward annual contract | Implementation, migration subset, workflow wedge, support and success measurement. |
+| Enterprise core | Larger operators | Per-unit annual price with minimum ACV | Applications/lease/maintenance/portals, governance, evidence, exports, onboarding and support. |
+| PAD module | Approved enterprise customers | Add-on or included above a higher floor; processor fees separate/pass-through as contracted | Mandates, schedules, debit lifecycle, reconciliation, receipts and exception operations after release. |
+| Screening | Eligible customers | Usage-based credits/package fees | Provider cost plus platform workflow; consent and report-access controls. |
+
+Do not insert “Enterprise” into legacy plan normalization or publish a number without a separate commercial approval. Safe public copy is `Custom`. `Starting at $30/unit/year` should appear only after margin, scope, minimums, processor economics and sales authority are approved.
+
+## Price Scenarios For 3,000 Units
+
+| Scenario | Unit price | Annual contract value | Use |
+| --- | ---: | ---: | --- |
+| Entry wedge | $20/unit/year | $60,000 | Narrow workflows, limited integrations/support; PAD fees/module extra. |
+| Reference | $30/unit/year | $90,000 | Strong target for governed workflow, onboarding, support and enterprise operations. |
+| Premium | $45/unit/year | $135,000 | PAD included subject to usage bands, advanced support/reporting and greater implementation scope. |
+
+These are planning scenarios, not price commitments. Validate willingness to pay, cost-to-serve, provider fees, payment failure rates, screening economics and required support before selection.
+
+## Recommended Commercial Mechanics
+
+- Annual prepayment or committed annual contract, not casual monthly cancellation.
+- Enterprise minimum ACV: test `$30,000-$50,000` during discovery; approve after pipeline validation.
+- Unit bands with an annual true-up and an explicit definition of billable active/managed units.
+- One-time implementation/migration fee based on complexity, provisionally `$15,000-$50,000+` for a 3,000-unit operator.
+- Premium support priced separately or included only in higher bands, with named hours/severity targets rather than an unsupported 24/7 promise.
+- Processor transaction/return fees separately disclosed; never hide volatile rail cost inside an unbounded flat price.
+- Certn/other screening credits usage-based, with expiry/refund/provider-failure terms and no claim that Certn is currently live.
+
+## PAD Monetization Options
+
+| Option | Advantage | Risk | Recommendation |
+| --- | --- | --- | --- |
+| Included in enterprise core | Simple sales story. | Unbounded usage/support and return costs. | Include only with volume/exception limits at premium pricing. |
+| Annual PAD module add-on | Aligns price with high-value capability. | More procurement complexity. | Best initial production model. |
+| Per-successful-debit platform fee | Aligns with usage. | Variable bills and regulatory/tenancy fee sensitivity. | Consider only after legal review; do not charge tenants by default. |
+| Processor fees plus platform subscription | Transparent cost allocation. | Requires clear reconciliation/invoicing. | Use as baseline contract treatment. |
+
+## Proposed 60-90 Day Pilot
+
+### Objective
+
+Prove that RentChain can reduce workflow friction and create trusted records beside the incumbent PMS without requiring a portfolio-wide switch.
+
+### Scope
+
+- One landlord and one bounded property group, ideally 100-300 units rather than all 3,000.
+- Applications, lease/move-in workflow, tenant portal, maintenance/contractor coordination and evidence/export.
+- A migration subset with reconciliation to the incumbent PMS.
+- PAD only if the beta exit gates are met; otherwise complete provider/design validation and sandbox demonstrations without live tenant debits.
+- Screening only through a confirmed configured path; Certn remains excluded until implemented and approved.
+
+### Delivery
+
+- Weeks 0-2: discovery, data ownership, security/legal review, success baseline and import rehearsal.
+- Weeks 3-4: configuration, training, synthetic/internal acceptance, reconciled production import.
+- Weeks 5-10: live bounded use, weekly operating review, exceptions and measured adoption.
+- Weeks 11-12: reconciliation, user feedback, outcomes, annual proposal and expand/hold/exit decision.
+
+### Success Measures
+
+- Import validation and reconciliation error rate.
+- Application-to-decision and lease/move-in cycle time.
+- Tenant activation and task completion.
+- Maintenance acknowledgment/resolution time and exception aging.
+- Evidence completeness and export success.
+- Support incidents by severity and time to resolution.
+- If PAD is authorized: mandate completion, successful debit, return/NSF, reconciliation and notice-delivery rates, with zero duplicate or unauthorized debits.
+
+Targets must be agreed from the operator's baseline before launch.
+
+### Commercial Structure
+
+- Paid pilot, suggested discovery band `$15,000-$30,000`, based on migration and support scope.
+- Define what portion is creditable toward a 12-month agreement signed within a fixed period.
+- Processor/screening usage passed through or separately itemized.
+- No custom feature promises outside a signed change process.
+- Annual expansion option around the `$90,000/year` reference, adjusted for included modules, unit volume and support.
+
+### Exit Criteria
+
+Proceed to annual rollout only if security/compliance gates, data reconciliation, workflow adoption, support capacity and agreed outcome measures pass. Otherwise export customer data, document gaps and end or extend the pilot without forcing migration.
+
+## Sales Guardrails
+
+- Sell the wedge beside Yardi, not replacement parity.
+- Show current, pilot, beta and roadmap states separately.
+- Do not promise PAD dates before provider/legal design gates.
+- Do not call Certn integrated.
+- Do not promise full accounting, AP, bulk operations or 3,000-unit performance before validation.
+- Attach every price to units, modules, implementation scope, service levels, usage and contract term.

--- a/docs/strategy/enterprise-readiness-audit-v2.md
+++ b/docs/strategy/enterprise-readiness-audit-v2.md
@@ -1,0 +1,138 @@
+# Enterprise Readiness Audit v2
+
+Status: strategic audit only; no runtime or commercial change
+
+Audit date: 2026-07-16
+
+## Executive Summary
+
+RentChain can credibly demonstrate a modern, governed rental-operations layer today. It has useful foundations across applications, screening workflows, leases, maintenance, landlord/tenant/contractor experiences, payments, ledgers, evidence, exports, delegated access, and property-manager-company authority. Those foundations support a narrow, supervised pilot, but they do not yet support a claim of enterprise-suite or 3,000-unit production readiness.
+
+The recommended enterprise wedge is:
+
+> Applications + screening readiness + lease workflow + maintenance coordination + tenant/contractor portals + evidence records + a PAD rent-collection roadmap.
+
+RentChain should coexist with Yardi or another property-management system first. PAD is the most important missing revenue-critical capability. Full property accounting, accounts payable, utility/asset management, property sales, generalized customization, and full PMS replacement should remain outside the near-term build.
+
+## Evidence And Claim Boundaries
+
+This audit reconciles current product code with existing strategy and architecture documents. It does not certify scale, security, compliance, or production readiness.
+
+- Current card-based Stripe rent-payment paths and provider-boundary foundations are not PAD.
+- The existing `papMandates` / PAP scheduler prototype emits attempted-payment events; it does not execute a bank debit, reconcile settlement, handle returns, or satisfy a production mandate lifecycle.
+- Certn appears as a workflow candidate marked `coming_soon` and `live: false`. It is not an active provider integration.
+- TransUnion-oriented and manual screening paths exist, but availability depends on configuration and each workflow still needs enterprise operational validation.
+- Payment-obligation and ledger-readiness models are useful foundations, not an automated receivables or accounting system.
+- No current evidence establishes performance or operating readiness at 3,000 units.
+
+## Readiness Definitions
+
+| Label | Meaning |
+| --- | --- |
+| Demo-ready | Can be shown with curated data and an explicit statement of limitations. |
+| Pilot-ready | Can be used in a narrow, supervised, reversible pilot with named support owners. |
+| Partial | Foundations exist, but scale, workflow completeness, support, or controls are missing. |
+| Missing | No production-ready capability was identified. |
+
+## Category Audit
+
+| Category | Capability | Readiness | Current evidence | Enterprise gap |
+| --- | --- | --- | --- | --- |
+| Management | Properties, units, rooms/amenities | Partial / pilot candidate | Property and unit services and landlord surfaces exist. | Bulk import/edit, hierarchy, portfolio segmentation, scale tests, richer amenity/community model. |
+| Management | Pricing strategies, property sales | Missing | No enterprise-ready native capability identified. | Defer; integrate/export rather than build now. |
+| Management | Workflows/customization | Partial | Governed lifecycle, decision, review, and automation foundations exist. | No safe general workflow builder, templates, or enterprise administration. |
+| Management | Dashboards/reports/unified view | Demo-ready, partial | Dashboard, operations, portfolio, tenant, property, and report surfaces exist. | KPI contracts, pagination, bulk triage, scheduled reports, scale and reconciliation proof. |
+| Finance | Rent ledger and payment records | Demo-ready, partial | Lease ledger, manual payments, card rent-payment execution, reconciliation/read-model foundations. | Automated obligations, PAD, returns, payouts, close/reconciliation controls. |
+| Finance | Property accounting, income/expense | Partial | Narrow ledger/export and maintenance cost/expense links exist. | Chart of accounts, journal/close, bank reconciliation, entity accounting, audit-ready financial reports. |
+| Finance | Vendors and accounts payable | Partial / missing | Contractor and maintenance foundations exist. | Vendor master, invoices, approvals, disbursements, tax and AP controls. |
+| Leasing | Applications and acquisition | Demo-ready / narrow pilot | Public/manual application and review surfaces exist. | Portfolio configuration, bulk operations, SLAs, exception queues, scale testing. |
+| Leasing | Screening | Demo-ready, partial | Consent/status, manual and TransUnion-oriented provider foundations, payment/order primitives. | Certn is not live; provider contracts, end-to-end QA, support and compliance packaging remain. |
+| Leasing | Leases, renewals, move-in/out | Demo-ready, partial | Lease creation/signing/document, lifecycle, notice, renewal and move-in readiness foundations. | High-volume exceptions, reliable renewal-to-vacancy continuity, migration and bulk operations. |
+| Leasing | Rent collection | Card demo only; PAD missing | Stripe-oriented card checkout, rent-payment records, webhook normalization foundations. | Mandates, bank verification, scheduling, ACSS initiation, returns, retry, payout and reconciliation. |
+| Maintenance | Requests and work coordination | Demo-ready / narrow pilot | Landlord, tenant and contractor request/job surfaces; state and cost foundations. | Planning/scheduling, SLA queues, vendor governance, asset/utility programs and scale reporting. |
+| Portals | Landlord/PM portal | Demo-ready / narrow pilot | Landlord operations, delegated access and PM-company relationship/staff foundations. | Enterprise hierarchy, permission templates, bulk administration, support tooling. |
+| Portals | Tenant portal | Demo-ready / narrow pilot | Lease, payment, ledger, message, notice, screening, document and maintenance surfaces. | Mass onboarding/recovery, PAD authorization, accessibility/support and scale proof. |
+| Portals | Contractor portal | Demo-ready / narrow pilot | Invite, profile, dashboard and jobs foundations exist. | Vendor onboarding, insurance/compliance, scheduling, invoicing and SLA reporting. |
+| Portals | Community manager portal | Future | Adjacent PM/delegate patterns could support it later. | Do not create another role model until real customer authority needs are validated. |
+
+## What RentChain Can Demo Today
+
+Use seeded or explicitly approved demo data to show one coherent path:
+
+1. Set up a property/unit and review the portfolio workspace.
+2. Receive and review an application.
+3. Explain consent-preserving screening options; show only a configured live path or manual fallback, and label Certn as future.
+4. Create/review a lease and move-in readiness context.
+5. Show tenant portal records, messages/notices, documents, ledger/payment visibility, and maintenance intake.
+6. Route maintenance work to a contractor surface.
+7. Show evidence/audit/export posture and role-governed access.
+8. Present PAD as the next designed module, never as live functionality.
+
+## What Is Pilot-Ready
+
+A pilot should be limited to a selected property group, named users, capped record volumes, supervised onboarding, manual exception handling, and a documented rollback/export path. Reasonable pilot candidates are applications, lease workflow, tenant/contractor coordination, maintenance, and evidence records after environment-specific QA. Card payment or screening flows may join only when provider configuration, consent, support ownership, and end-to-end testing are confirmed.
+
+PAD, 3,000-unit portfolio-wide migration, full accounting, and unattended automation are not pilot-ready.
+
+## Minimum Enterprise Wedge At $30 Per Unit Per Year
+
+At a reference price of `$30/unit/year`, the minimum credible annual package should solve an operating problem, not merely unlock existing screens. It should include:
+
+- governed applications-to-lease workflow;
+- tenant and contractor participation;
+- maintenance coordination and exception visibility;
+- evidence/audit records and practical exports;
+- enterprise onboarding, roles, and named support;
+- a contracted PAD delivery path or a production PAD module once released;
+- integration-friendly exports so the existing PMS remains authoritative where required.
+
+Before PAD is live, `$30/unit/year` is most defensible as a negotiated pilot-to-production price tied to explicit milestones, not a blanket public claim.
+
+## What Must Be Built Next
+
+For a serious 3,000-unit conversation, the next work should be:
+
+1. Pilot packaging, demo script, success measures, data-processing boundaries, support model, and architecture questionnaire.
+2. PAD provider selection and legal/compliance design.
+3. A narrow PAD beta: mandate to scheduled obligation to debit evidence to receipt/failed-payment record.
+4. Portfolio-scale import previews, validation, idempotent apply, and reconciliation reports.
+5. Bulk/exception operations, pagination and measured scale tests on the chosen pilot workflows.
+6. Screening packaging with a proven provider path; Certn only after an authorized integration mission.
+
+## Do Not Build Yet
+
+- A full Yardi/RIOO clone or general ledger.
+- Native accounts payable, payroll, procurement, property sales, or utility billing.
+- A generic no-code workflow engine.
+- Direct funds custody or an internal payment rail.
+- Autonomous collections, eviction, screening decisions, or retry logic.
+- A new community-manager role before authority requirements are validated.
+- One-off Yardi coupling before a canonical import/export contract exists.
+
+## Prefer Integration Over Native Scope
+
+Keep general ledger/accounting, AP, payroll, tax, utility metering, property sales, bank connectivity, background/credit data, electronic signature, and mature PMS recordkeeping behind governed provider or export/import boundaries. RentChain should own workflow context, authorization, evidence, projections, exceptions, and reconciliation—not recreate every upstream system.
+
+## Advantages RentChain Already Has
+
+- Modern tenant-facing and cross-role workflow direction.
+- Server-side authority and projection-safe design principles.
+- Append-safe evidence, review, canonical-event, and export foundations.
+- Provider boundaries and manual-review posture rather than hidden automation.
+- A coexistence-friendly architecture that can add value without a big-bang PMS replacement.
+
+## Risks And Dependencies
+
+| Risk | Consequence | Control |
+| --- | --- | --- |
+| Full-suite ambition | Years of accounting and operational scope before revenue proof. | Sell a bounded wedge beside the incumbent PMS. |
+| Prototype overclaim | A demo artifact is mistaken for payment capability. | Maintain explicit current/partial/future labels. |
+| Unproven scale | Slow queries, unusable single-record workflows, export failures. | Benchmark realistic volumes; add pagination, bulk controls and SLOs. |
+| Split source of truth | Rent, lease or tenant status conflicts across systems. | Declare field ownership and reconciliation rules per integration. |
+| Payment/compliance error | Unauthorized debits, poor notices, regulatory exposure. | Processor-led flow, counsel review, fail-closed states and immutable evidence. |
+| Migration failure | Buyer cannot reconcile imported data or safely roll back. | Preview, validation, idempotency, parallel run and signed reconciliation. |
+| Support underinvestment | Operational exceptions overwhelm a small team. | Named pilot support, severity model, runbooks and capacity limits. |
+
+## Strategic Answer
+
+RentChain should not replace Yardi first. It should become the modern workflow, screening-readiness, maintenance, tenant/contractor, evidence, and PAD layer beside it. Success is a low-friction, measurable enterprise pilot that preserves the incumbent source of truth while proving a revenue-critical workflow.

--- a/docs/strategy/pad-roadmap-v1.md
+++ b/docs/strategy/pad-roadmap-v1.md
@@ -1,0 +1,195 @@
+# Canadian PAD Rent Collection Roadmap v1
+
+Status: planning only; PAD is not implemented
+
+Architecture posture: processor-led, no direct funds custody
+
+## Strategic Importance
+
+PAD is the most important missing revenue-critical enterprise feature identified for RentChain. It turns payment readiness into a recurring rent-collection workflow while strengthening the usefulness of leases, tenant records, ledgers, notifications, reconciliation and evidence. It must not be treated as a payment-method toggle.
+
+An old PAP mandate/scheduler prototype currently emits `RentPaymentAttempted` events. It does not initiate debits, receive provider settlement evidence, handle returns, reconcile payouts, or establish production compliance. Existing Stripe card rent payments and provider-neutral reconciliation seams are reusable foundations, not PAD completion.
+
+## Recommended Funds Flow
+
+Use a Canadian PAD/ACSS-capable processor first, with Stripe ACSS debit as a provider candidate rather than a final selection. Stripe documents hosted bank-account collection, mandate handling, instant verification with micro-deposit fallback, and Canadian ACSS debit support. Payments Canada Rule H1 governs PAD authorization and related requirements.
+
+```text
+tenant bank account
+  -> regulated processor / financial institution
+    -> landlord-designated settlement destination
+
+RentChain
+  -> captures workflow context and provider references
+  -> schedules authorized debit requests
+  -> consumes verified provider events
+  -> records reconciliation, notices and audit evidence
+  -> does not hold tenant or landlord funds
+```
+
+Provider selection must validate Canadian availability, account model, landlord onboarding/KYC, settlement routing, mandate responsibility, verification, return codes/timing, dispute handling, webhooks, reporting, data residency/privacy, pricing, support and RPAA status. Do not select on API ergonomics alone.
+
+## Tenant Authorization Flow
+
+1. Landlord proposes PAD for an eligible active/signed-future lease; no debit is created.
+2. Tenant sees payee identity, lease/property context, fixed or variable terms, amount/schedule basis, notice rules, cancellation method, contact details, privacy terms and processor disclosure.
+3. Tenant enters bank details only through the processor-hosted/tokenized surface.
+4. Processor verifies the bank account and returns opaque references/status; RentChain stores no raw account number.
+5. Tenant affirmatively accepts the PAD agreement. Record agreement version, presented terms, timestamps, actor, IP/device evidence only if approved, provider mandate reference, lease context, and consent evidence.
+6. Mandate remains `pending_verification` until provider confirmation; never schedule from client-only state.
+7. Tenant and landlord receive a durable confirmation record.
+8. Tenant can view status and submit cancellation. Cancellation stops future initiation after applicable cutoffs but does not erase rent obligations or history.
+
+Suggested mandate states:
+
+`draft -> pending_authorization -> pending_verification -> active -> suspended | cancellation_pending -> cancelled | expired | failed_review`
+
+Fixed and variable PADs must be distinct. Counsel and the processor must approve agreement language, pre-notification/waiver behavior, change notices and cancellation timing before implementation.
+
+## Rent Schedule And Obligation Model
+
+Lease lifecycle remains the authority for whether an obligation should exist. A versioned schedule generator should produce immutable obligation versions, not silently rewrite history.
+
+Each obligation should contain canonical lease/tenant/property references, rental period, due date/time zone, expected amount/currency, proration basis, source lease version, adjustment lineage, collection eligibility, mandate reference and status.
+
+Rules must be explicit for:
+
+- monthly due dates, weekends/holidays and time zone;
+- partial first/last periods and approved proration method;
+- move-in, move-out, termination and possession-date changes;
+- rent increases and renewals, with future-effective versions;
+- credits, concessions, manual adjustments and starting balances;
+- arrears kept separate from the current-period obligation;
+- multiple tenants and whether payment responsibility is joint or allocated;
+- a freeze window after which changes require operator review.
+
+Never infer a debit amount from an editable client display. Generate a preview, require operator confirmation where policy demands it, and record the exact obligation version used.
+
+## Payment Lifecycle
+
+Suggested attempt states:
+
+`scheduled -> notice_pending -> notice_sent -> initiation_queued -> initiated -> pending -> succeeded | failed | returned | cancelled | manual_review_required`
+
+- A worker queues eligible attempts using deterministic idempotency keys based on mandate, obligation version and attempt number.
+- Only the provider can confirm initiation, success, failure or return evidence.
+- Webhook receipt is authenticated, durably deduplicated and stored before state projection.
+- Unknown, contradictory, duplicate, missing-subject, amount-mismatch and currency-mismatch events fail to manual review.
+- `pending` is not paid. A successful initiation is not final settlement.
+- Return/NSF codes use a normalized internal taxonomy while preserving a restricted provider reference.
+- Retry is opt-in policy, capped, notice-aware, and never autonomous when mandate, amount, lease or account state is ambiguous.
+- Manual override means “record a reviewed decision,” not “force success.” Actor, reason and evidence are mandatory.
+
+Landlords see obligation/attempt status, next action, reconciliation and restricted failure reason. Tenants see their amount, due date, mandate, notices, receipt/failure state and support/cancellation path without internal IDs or provider payloads.
+
+## Ledger, Reconciliation And Payout View
+
+Preserve the existing source hierarchy:
+
+```text
+lease lifecycle = obligation authority
+scheduled obligation = amount due
+payment attempt = execution
+provider event = external evidence
+reconciliation = comparison result
+ledger = append-safe financial history
+```
+
+Write append-safe entries for obligation creation/change, notice, initiation, pending, success, failure/return, retry decision, receipt, cancellation and reconciliation. Corrections reverse or supersede; they do not rewrite prior evidence.
+
+The landlord reconciliation view should compare obligation, collected amount, fees, provider settlement/payout evidence, expected/actual dates, exceptions and export batch. It must not label a landlord “paid out” without provider evidence. Export CSV/PDF records need stable public references, period, amount, status, timestamps and adjustment lineage, without raw bank details or internal Firestore IDs as labels.
+
+## Notifications
+
+| Notification | Recipient | Trigger / evidence |
+| --- | --- | --- |
+| Upcoming debit | Tenant | Approved pre-notification rule; exact amount/date/mandate context and immutable delivery record. |
+| Debit initiated/pending | Tenant, optional landlord | Verified provider initiation; clearly not a receipt. |
+| Successful payment | Tenant and landlord | Provider success plus reconciliation; receipt reference. |
+| Failed/returned payment | Tenant and landlord | Normalized provider event; privacy-safe reason and next step. |
+| Retry notice | Tenant; landlord visibility | Reviewed/capped retry decision and new date/amount. |
+| Mandate cancellation | Tenant and landlord | Effective date, future-attempt impact and remaining lease obligation disclaimer. |
+| Exception alert | Authorized operator/admin | Mismatch, duplicate, unknown event, missed webhook or reconciliation failure. |
+
+Delivery failure must be visible and retryable; it must not change payment truth.
+
+## Compliance And Legal Gate
+
+This roadmap is not legal advice. Canadian payments/privacy counsel must approve the final funds flow and tenant documents before beta.
+
+- Payments Canada Rule H1: PAD agreement class and content, electronic authorization, confirmation, fixed/variable treatment, pre-notification and waiver, change notices, cancellation/revocation, reimbursement/recourse, records and sponsorship/processor allocation.
+- Consumer/tenancy law by launch province: rent-payment method constraints, consent, fees, NSF terms, receipts, notices, arrears and lease-language interaction.
+- Privacy: processor disclosures, consent, minimization, token/reference storage, access, retention/deletion, incident response, cross-border processing, privacy policy and vendor terms.
+- Contracting: terms of use, PAD agreement, landlord agreement, processor terms, prohibited use, support/dispute allocation and service levels.
+- RPAA: counsel must determine whether RentChain performs an in-scope payment function even without custody. Since September 8, 2025, in-scope PSPs face registration and operational-risk, incident, safeguarding (if applicable) and reporting obligations.
+- FINTRAC/MSB: obtain a written activities/funds-flow analysis; do not assume processor use or no custody automatically resolves it.
+- Insurance: confirm cyber, technology E&O, crime, payment/funds-transfer and regulatory coverage and exclusions.
+- Evidence: approve authorization, notice, webhook, decision and cancellation retention periods, legal holds, access controls and export procedure.
+
+Primary references for design review:
+
+- [Stripe ACSS debit documentation](https://docs.stripe.com/payments/acss-debit)
+- [Payments Canada Rule H1](https://www.payments.ca/sites/default/files/h1eng.pdf)
+- [Bank of Canada retail payments supervision](https://www.bankofcanada.ca/regulatory-oversight/retail-payments/)
+- [Bank of Canada PSP registration criteria](https://www.bankofcanada.ca/regulatory-oversight/retail-payments/supervisory-framework/)
+
+## Technical Architecture Outline
+
+Names below are conceptual and require a later design mission.
+
+### Frontend surfaces
+
+- Tenant: PAD offer/terms, hosted bank verification, authorization confirmation, mandate details/cancellation, schedule, payment timeline, receipt/failure and support.
+- Landlord/PM: enablement/readiness, lease-linked mandate status, schedule preview/approval, attempt exceptions, retry/manual decision, reconciliation, exports and alerts.
+- Support/admin: restricted exception inspection, webhook/reconciliation evidence, mandate history and audited remediation—never raw bank credentials.
+
+### API/service boundaries
+
+- Mandate offer, authorization-session, status and cancellation routes.
+- Obligation schedule preview/apply and adjustment routes.
+- Debit initiation orchestration and provider adapter.
+- Authenticated webhook ingestion, receipt store and replay-safe projector.
+- Reconciliation, notification, receipt/export and support-review services.
+- Server-side landlord/PM/tenant authority on every read and action.
+
+### Likely Firestore entities
+
+- `padMandates`: opaque provider references, agreement/version evidence, lease context and status.
+- `rentObligations`: immutable/versioned amounts and due dates.
+- `paymentAttempts`: provider-neutral execution state and idempotency key.
+- `paymentProviderEventReceipts`: deduplicated restricted evidence.
+- `paymentReconciliations`: derived comparison and manual-review status.
+- `paymentNotices` / `paymentReceipts`: content version and delivery evidence.
+- canonical audit events for all material state transitions.
+
+Do not store raw bank-account data. Tenant projections must be explicit whitelists. Provider payloads and internal identifiers remain restricted.
+
+## Test And Sandbox Strategy
+
+- Pure tests: schedule generation, proration, state machines, authorization eligibility, retry policy, idempotency and reconciliation.
+- Contract tests: provider request/response mapping and signature verification against versioned fixtures.
+- Route/auth tests: tenant/landlord/PM/support separation and fail-closed ownership.
+- Webhook tests: duplicate, reordered, delayed, missing, forged, unknown, amount/currency mismatch and replay.
+- Scenario tests: fixed/variable mandate, verification delay, cancellation near cutoff, rent change, renewal, partial month, NSF/return, capped retry, manual adjustment and payout mismatch.
+- Projection/privacy tests: no bank credentials, provider payloads, storage paths or raw IDs leak.
+- Load/recovery tests: 3,000-unit schedule generation, queue backpressure, outage recovery and reconciliation rerun.
+- Sandbox isolation: separate provider credentials/accounts, webhook endpoints and Firestore environment; synthetic identities only; no production replay into sandbox.
+- Operational exercises: processor outage, notification outage, duplicate debit allegation, tenant cancellation, incident escalation and reconciliation close.
+
+## Phased Delivery
+
+1. **Enterprise audit and pilot packaging:** this documentation, demo script and readiness matrix.
+2. **PAD technical design:** provider RFP/spike, funds-flow decision, data/state design, threat model, counsel-approved terms and go/no-go gates.
+3. **PAD beta:** one provider and one province; tenant authorization -> rent obligation -> debit attempt -> ledger/reconciliation -> receipt/failure audit. No custody, autonomous retry or bulk rollout.
+4. **Screening integration:** consent -> provider invite/status -> restricted report access -> usage credits. Certn requires a separate authorized integration mission.
+5. **Migration/import:** properties, units, tenants, leases and starting balances with preview/apply/reconciliation.
+6. **Enterprise pilot:** one landlord/property group for 60–90 days, capped scope, weekly review, support owner and exit/export plan.
+
+## Beta Exit Gates
+
+- Provider, legal, privacy, security and insurance approvals recorded.
+- Mandate, notice, cancellation and return scenarios pass.
+- No unresolved high-severity auth, privacy, duplicate-debit or reconciliation defects.
+- End-to-end sandbox evidence and recovery drill complete.
+- Pilot support/on-call, incident and reconciliation runbooks staffed.
+- Pilot landlord accepts source-of-truth, responsibilities, limits and rollback/export plan.


### PR DESCRIPTION
## Summary

- adds an evidence-based enterprise readiness audit across management, finance, leasing, maintenance, and portal categories
- recommends a focused wedge beside Yardi: applications, screening readiness, lease workflow, maintenance, tenant/contractor portals, evidence, and PAD readiness
- defines a processor-led Canadian PAD roadmap covering mandates, schedules, debit lifecycle, returns, reconciliation, notices, compliance gates, architecture, testing, and staged rollout
- proposes enterprise per-unit pricing around the $30/unit/year reference, a $90,000/year 3,000-unit scenario, and a bounded paid 60-90 day pilot
- defines a CSV-first, preview/apply, parallel-run migration strategy with reconciliation and white-glove onboarding

## Key findings

- RentChain has credible demo and narrow pilot foundations, but 3,000-unit scale and enterprise-suite readiness are not proven.
- PAD is the most important missing revenue-critical enterprise feature.
- The existing PAP event prototype and Stripe card flow are not production PAD.
- Certn is currently a coming-soon provider candidate, not a live integration.
- RentChain should coexist with an incumbent PMS before considering deeper system-of-record expansion.

## Validation

- `git diff --cached --check` — passed before commit
- documentation lint — not configured in the repository
- build/manual QA — not required for docs-only changes

## Scope confirmation

- docs only
- no backend/API changes
- no frontend runtime changes
- no auth, routing, database schema, payment, Stripe, Certn, or entitlement changes
- no PAD implementation included