### PR TITLE
docs: PAD technical design and beta plan

### DIFF
--- a/docs/architecture/pad-compliance-and-risk-gates-v1.md
+++ b/docs/architecture/pad-compliance-and-risk-gates-v1.md
@@ -1,0 +1,136 @@
+# PAD Compliance And Risk Gates v1
+
+Status: implementation checklist for qualified review; not legal advice or compliance certification
+
+## Gate Ownership
+
+No single engineering approval is sufficient. The launch record must name owners and evidence for product, payments operations, Canadian payments/privacy counsel, security, privacy, finance/reconciliation, support and the pilot landlord. Unknown or conditional findings keep the gate closed.
+
+## Legal And Counsel Review
+
+- Identify the payee, processor, sponsor/financial institution, merchant/connected account, statement descriptor and landlord/tenant responsibilities for the exact funds flow.
+- Approve the PAD agreement class and language, electronic authorization, agreement delivery/confirmation and evidence standard.
+- Map fixed, variable, sporadic/interval/combined and rent-change scenarios to approved mandate terms.
+- Approve advance/pre-notification, waiver and change-notice requirements and delivery evidence.
+- Approve cancellation/revocation rights, effective cutoffs and effect on already-submitted debits and underlying lease obligations.
+- Approve NSF/returned-payment language, any fee treatment, retry eligibility/caps and landlord/tenant communications.
+- Approve refund, reversal, adjustment, dispute/reimbursement and unauthorized-debit processes.
+- Review applicable provincial tenancy/consumer rules for requiring/offering payment methods, receipts, fees, rent changes and arrears handling.
+- Approve Terms of Use, privacy policy, PAD agreement, landlord/pilot agreement, support terms and processor-contract alignment before production.
+- Approve audit, agreement, notice, receipt, dispute and payment-record retention and legal-hold procedure.
+
+## Regulatory Review
+
+- Document the processor-led ACSS/PAD flow and confirm RentChain does not hold funds under the approved architecture.
+- Obtain written RPAA scope analysis for every payment function RentChain performs; no-custody alone is not treated as an exemption.
+- Obtain written FINTRAC/MSB scope analysis for the final activities and funds flow.
+- Verify provider/partner registration, sponsorship and contractual responsibilities where applicable; a registry entry is not an endorsement.
+- Review funds safeguarding only if any design change causes RentChain or its agent to hold end-user funds; that change requires a new architecture approval.
+- Review cyber, technology E&O, crime/funds-transfer, regulatory and payment/dispute insurance coverage and exclusions.
+- Record provincial launch scope. Expanding to another province requires a delta review.
+
+## Provider And Commercial Gate
+
+- Sandbox and live product eligibility confirmed in writing.
+- Payee/merchant account ownership, onboarding/KYC, negative-balance and return liability approved.
+- Settlement destination, timing, reserves/holds, fees, limits, statement descriptors and reporting documented.
+- Mandate ownership, portability, cancellation and provider-exit/export documented.
+- Webhook types, status/return codes, retry behavior, rate limits, idempotency and support escalation documented.
+- Data processing, subprocessors, residency/transfer, incident notice, retention/deletion and audit rights approved.
+- Sandbox behavior and test fixtures are sufficient to exercise delayed failures/returns and disputes.
+
+## Security And Privacy Gate
+
+### Data minimization
+
+- Bank details are collected only on a provider-controlled/tokenized surface.
+- RentChain stores provider tokens/references and approved masked display data only.
+- Raw bank, transit, institution, login, verification and micro-deposit data are prohibited from product records, logs, analytics and support tools.
+- Raw provider payload storage is prohibited unless a separate encrypted forensic store, access policy and retention decision are approved.
+
+### Access and secrets
+
+- Tenant, landlord/PM and support projections are explicit allowlists with cross-tenant/landlord negative tests.
+- Every mutation resolves server-side authority and requires the minimum role permission.
+- Use provider restricted API keys with minimum endpoint permissions where supported, separate per service/environment.
+- Store keys and webhook secrets in the platform secrets manager; never source control, client code or logged environment dumps.
+- Apply provider-supported IP restrictions and strong dashboard access controls; require phishing-resistant 2FA where practical.
+
+### Webhooks and jobs
+
+- Verify webhook signatures against the raw body before parsing/processing.
+- Deduplicate durable provider-event receipts atomically.
+- Bound request size, validate schema, reject unknown account context and rate limit abuse.
+- Separate sandbox/staging/production endpoints, secrets, accounts, data and queues.
+- Scheduler/worker entry points use authenticated service identity, least privilege, bounded batches and replay-safe locks.
+- Controlled replay requires allowlisted event types, dry-run, reason, actor, expected state/version and audit record.
+
+### Incident readiness
+
+- Threat model covers duplicate/unauthorized debit, account takeover, cross-tenant leakage, compromised key/webhook, provider outage, incorrect schedule, insider misuse and reconciliation drift.
+- Runbooks cover key rotation, webhook compromise, duplicate-debit allegation, unauthorized debit/dispute, privacy incident, provider outage and queue/reconciliation recovery.
+- Alerts avoid sensitive payloads and include safe correlation references.
+
+## Data And Financial Integrity Gate
+
+- Lease-to-obligation source-of-truth and multi-tenant responsibility are approved.
+- Obligation preview/apply is deterministic, versioned and stale-safe.
+- Attempt idempotency survives timeouts, retries, worker restarts and duplicate jobs.
+- Provider receipt and reconciliation precede ledger/receipt success projection.
+- Manual/card/external payments prevent duplicate PAD collection through allocation checks.
+- Returns reverse allocations append-safely and reopen balances correctly.
+- Settlement/payee reconciliation and exports balance to provider reports for the pilot scope.
+- No destructive correction or last-write-wins financial history exists.
+
+## Product And Accessibility Gate
+
+- Tenant understands payee, amount/schedule basis, mandate status, cancellation and support path.
+- Pending, succeeded, failed and returned language is distinct and user tested.
+- Consent is affirmative, versioned and accessible; no prechecked or coercive control.
+- Notifications are accessible, privacy-safe and retain delivery evidence.
+- Landlord views expose actionable exceptions without raw banking/provider data.
+- English/French and accessibility obligations are assessed for the launch scope.
+
+## Operational Gate
+
+- Named payment operations and support owners exist with severity/escalation targets.
+- Daily exception/reconciliation queue, ownership and aging controls are rehearsed.
+- Support cannot fabricate payment success, activate mandates or bypass authorization.
+- Provider escalation and tenant/landlord communication templates are approved.
+- Pilot volume, debit limits, retry rules, rollout cohorts, stop switch and rollback/export path are documented.
+- Business continuity covers provider, email and RentChain outages around due dates.
+
+## Go / No-Go Checklist
+
+Production remains **no-go** until all are evidenced:
+
+1. Provider and funds-flow decision approved; sandbox account/onboarding complete.
+2. Counsel signs off on PAD authorization, notices, cancellation, failure/return, dispute and provincial launch language.
+3. RPAA and FINTRAC/MSB analyses are written and approved.
+4. Privacy policy, terms, agreements and data-processing records are updated outside this design PR.
+5. Security/threat model and privacy assessment pass; secrets and environment separation verified.
+6. Mandate, obligation and attempt state-machine tests pass.
+7. Signed-webhook, duplicate, out-of-order, delayed, missing and replay tests pass.
+8. NSF, closed account, cancellation race, rent change, partial period, manual payment and later-return scenarios pass.
+9. Ledger allocation, receipt reversal, provider settlement and export reconciliation pass.
+10. Load/recovery tests pass at production-shaped 3,000-unit volume with documented SLOs.
+11. Support, incident, reconciliation and provider-outage playbooks are exercised.
+12. Pilot landlord agreement, data ownership, limits, success criteria and exit plan are signed.
+13. Final production readiness review records named approval from every gate owner.
+
+Any material funds-flow, provider, province, mandate, retry, settlement or data-retention change reopens the applicable gates.
+
+## Evidence Register Template
+
+| Gate | Owner | Evidence link/reference | Status | Conditions/expiry | Approved at |
+| --- | --- | --- | --- | --- | --- |
+| Provider/funds flow | Payments lead | Future | Open | — | — |
+| Legal/Rule H1 | Counsel | Future | Open | — | — |
+| RPAA/FINTRAC | Counsel | Future | Open | — | — |
+| Privacy/data | Privacy owner | Future | Open | — | — |
+| Security | Security owner | Future | Open | — | — |
+| Financial reconciliation | Finance/ops | Future | Open | — | — |
+| Support/incident | Support owner | Future | Open | — | — |
+| Pilot acceptance | Customer owner | Future | Open | — | — |
+
+This template intentionally begins open. Documentation completion is not gate approval.

--- a/docs/architecture/pad-data-model-v1.md
+++ b/docs/architecture/pad-data-model-v1.md
@@ -1,0 +1,222 @@
+# PAD Data Model v1
+
+Status: conceptual Firestore design only; no collections, migrations or indexes are implemented
+
+## Design Rules
+
+- Canonical internal IDs drive authorization and joins; provider and legacy IDs are attributes.
+- All money uses integer cents and ISO currency (`cad` for the first beta).
+- Dates are UTC instants plus explicit local due-date/time-zone context where required.
+- Operational history is append-safe. Corrections supersede or reverse rather than rewrite.
+- Provider payloads are evidence inputs, not product records.
+- Tenant, landlord/PM and support responses are separate whitelist projections.
+- Unknown ownership, authorization, status or reconciliation fails closed.
+
+Collection names are proposals. A build mission must reconcile them with existing `paymentIntents`, `rentPayments`, `paymentProviderEventReceipts`, `paymentReconciliationRecords`, canonical events and ledger entries before writing data.
+
+## Relationship Model
+
+```text
+lease 1 -> many rentObligations
+lease + tenant 1 -> many padMandates (at most one active per approved responsibility context)
+rentObligation 1 -> many paymentAttempts
+paymentAttempt 1 -> many providerEventReceipts
+paymentAttempt 1 -> many reconciliation versions
+successful reconciled paymentAttempt 1 -> zero/one receipt
+all material records -> many canonical audit events
+```
+
+For multi-tenant leases, responsibility must be explicit. Do not assume every lease party authorizes or owes the full amount. A future `paymentResponsibilityId` or allocation record should define who is authorized for which obligation share.
+
+## Payment Mandate
+
+Proposed collection: `padMandates`
+
+| Field | Type | Rule |
+| --- | --- | --- |
+| `id` | string | Canonical opaque mandate ID. |
+| `landlordId`, `tenantId`, `leaseId`, `propertyId`, `unitId` | string | Internal authority/context; never user-facing labels. |
+| `paymentResponsibilityId` | string/null | Required when multiple payors or allocated responsibility exists. |
+| `provider` | enum | `stripe_acss` or approved future adapter key. |
+| `providerAccountContextRef` | string | Opaque payee/connected-account context; restricted. |
+| `providerCustomerId` | string | Opaque restricted reference. |
+| `providerSetupIntentId` | string | Opaque restricted reference. |
+| `providerPaymentMethodId` | string | Opaque restricted reference. |
+| `providerMandateId` | string | Opaque restricted reference. |
+| `status` | enum | State below; never defaults directly to active. |
+| `authorizationType` | enum | `personal`, `business`, or provider/counsel-approved class. |
+| `amountType` | enum | `fixed`, `variable`, `combined` only after counsel/provider mapping. |
+| `authorizedAmountCents` | integer/null | Required only where agreement terms require a fixed/capped amount. |
+| `currency` | string | First beta: `cad`. |
+| `scheduleDescription` | string | Versioned, counsel-approved interval/trigger text. |
+| `agreementVersion`, `agreementDigest` | string | Exact presented agreement identity; no raw document body in broad projections. |
+| `authorizationEvidenceRef` | string | Safe evidence reference, not a public URL. |
+| `authorizedAt`, `verifiedAt` | timestamp/null | Provider-confirmed milestones. |
+| `cancellationRequestedAt`, `cancelledAt`, `effectiveCancellationAt` | timestamp/null | Preserve request and effective timing separately. |
+| `cancellationReasonCode` | enum/null | Allowlisted; free text restricted to reviewed support record. |
+| `createdBy`, `updatedBy` | actor reference | Safe actor/authority context. |
+| `createdAt`, `updatedAt` | timestamp | Server timestamps. |
+| `version` | integer | Optimistic concurrency / transition guard. |
+
+Mandate statuses:
+
+`draft`, `pending_authorization`, `pending_verification`, `active`, `suspended`, `cancellation_pending`, `cancelled`, `revoked`, `expired`, `failed_review`
+
+Only verified provider evidence plus complete authorization evidence may transition a mandate to `active`. `cancelled`, `revoked` and `expired` are terminal for new attempts.
+
+## Rent Obligation
+
+Proposed collection: `rentObligations`
+
+| Field | Type | Rule |
+| --- | --- | --- |
+| `id` | string | Deterministic from lease, responsibility, period and obligation version. |
+| `landlordId`, `leaseId`, `tenantId`, `propertyId`, `unitId` | string | Canonical context. |
+| `paymentResponsibilityId` | string/null | Payor/allocation context. |
+| `periodStart`, `periodEnd` | local date | Non-overlapping rental period under approved policy. |
+| `dueDate`, `dueTimeZone` | date/string | Business due date and zone. |
+| `amountCents` | integer | Positive expected amount; never floating point. |
+| `currency` | string | First beta: `cad`. |
+| `status` | enum | Derived/transitioned state below. |
+| `source` | enum | `lease_schedule`, `renewal`, `manual_adjustment`, `migration_opening_balance`. |
+| `sourceLeaseVersion`, `sourceTermsDigest` | string | Exact terms used to generate it. |
+| `scheduleRunId`, `previewFingerprint` | string | Generation/apply provenance and stale-preview protection. |
+| `adjustments` | array of refs | References to append-safe adjustment records, not mutable inline history. |
+| `supersedesObligationId` | string/null | Version lineage. |
+| `collectionEligibility` | enum | `eligible`, `held`, `manual_only`, `requires_review`. |
+| `createdAt`, `updatedAt` | timestamp | Server timestamps. |
+| `version` | integer | Concurrency guard. |
+
+Obligation statuses:
+
+`scheduled`, `due`, `pending_payment`, `partially_paid`, `paid`, `failed`, `returned`, `overdue`, `waived`, `adjusted`, `cancelled`, `manual_review_required`
+
+`failed` and `returned` do not erase the obligation. Paid amount should be derived from append-safe allocations across PAD, card and manual payments. `waived` requires an authorized adjustment record.
+
+## Obligation Adjustment / Allocation
+
+Use separate append-safe records rather than mutating obligation history:
+
+- `rentObligationAdjustments`: amount delta, reason code, actor, approval, effective date, source and supersession.
+- `paymentAllocations`: payment source/attempt, obligation, allocated cents, status, created/reversed timestamps and actor.
+
+This supports partial payments, manual/offline payments, credits, reversals and one payment covering multiple obligations without representing non-PAD money as PAD.
+
+## Payment Attempt
+
+Proposed collection: `paymentAttempts`
+
+| Field | Type | Rule |
+| --- | --- | --- |
+| `id` | string | Canonical attempt ID. |
+| `rentObligationId`, `mandateId` | string | Required execution context. |
+| `landlordId`, `tenantId`, `leaseId`, `propertyId` | string | Denormalized for scoped queries; validated from authority. |
+| `provider`, `providerAccountContextRef` | enum/string | Restricted provider context. |
+| `providerPaymentIntentId` | string/null | Opaque execution reference or equivalent provider ID. |
+| `status` | enum | Lifecycle below. |
+| `amountCents`, `currency` | integer/string | Must match approved obligation/adjustment. |
+| `attemptNumber` | integer | Starts at one; retries create new records. |
+| `retryOfPaymentAttemptId` | string/null | Explicit lineage. |
+| `idempotencyKey` | string | Deterministic and unique for one approved attempt. |
+| `noticeEvidenceRef` | string | Required proof that applicable notice gate passed. |
+| `initiatedAt`, `pendingSettlementAt`, `settledAt`, `failedAt`, `returnedAt`, `cancelledAt` | timestamp/null | Provider-evidenced milestones. |
+| `failureCategory`, `failureCodeRef` | enum/string/null | Normalized category and restricted provider code reference. |
+| `failureMessagePublic` | string/null | Allowlisted tenant-safe copy only; no raw provider message. |
+| `collectionDecisionRef` | string | Approval/policy version that allowed initiation. |
+| `createdAt`, `updatedAt` | timestamp | Server timestamps. |
+| `version` | integer | Concurrency guard. |
+
+Attempt statuses:
+
+`created`, `notice_pending`, `ready`, `initiation_queued`, `processing`, `pending_settlement`, `succeeded`, `failed`, `returned`, `cancelled`, `retry_scheduled`, `manual_review_required`
+
+## Provider Event Receipt
+
+Extend the existing receipt concept rather than store raw webhook bodies in product collections.
+
+| Field | Rule |
+| --- | --- |
+| `receiptId` | Deterministic from provider, account context and provider event ID. |
+| `providerEventId`, `providerEventType` | Restricted references/type. |
+| `signatureVerified` | Must be true before processing. |
+| `receivedAt`, `providerCreatedAt` | Timing and ordering evidence. |
+| `normalizedStatus` | Provider-neutral status or `unknown`. |
+| `subjectType`, `subjectId`, `paymentAttemptId` | Server-resolved links. |
+| `amountCents`, `currency` | Minimal reconciliation facts. |
+| `processingState` | `received`, `matched`, `unmatched`, `duplicate`, `ignored`, `failed`, `manual_review_required`. |
+| `payloadDigest`, `schemaVersion` | Integrity/version metadata; not raw payload. |
+| `processedAt`, `processingErrorCode` | Replay/recovery metadata. |
+
+If forensic raw payload retention is required, counsel/security must approve a separate encrypted, tightly restricted store and retention policy. It must never enter tenant/landlord projections or logs.
+
+## Payment Reconciliation
+
+Extend `paymentReconciliationRecords` with versioned comparison facts:
+
+- obligation/attempt/mandate/provider receipt references;
+- expected vs observed amount/currency/payee context;
+- settlement and return evidence;
+- reconciliation state, reasons and policy version;
+- `requiresManualReview`, `automationEligible` and reviewer decision reference;
+- created/updated timestamps without overwriting prior decision history.
+
+States: `pending`, `reconciled`, `failed`, `mismatch`, `duplicate_risk`, `returned`, `manual_review_required`.
+
+## Payment Event / Audit Event
+
+Use `canonicalEvents`, not an unrestricted mutable event log.
+
+Conceptual fields:
+
+- `eventId`, `eventType`, `occurredAt`, `createdAt`;
+- safe actor and authority references;
+- safe subject/parent references for mandate, obligation or attempt;
+- `source`: tenant, landlord, system, provider, support;
+- safe provider-event reference when applicable;
+- allowlisted metadata summary and policy/version references;
+- append-only/immutable flags.
+
+Never include bank details, secrets, raw provider payloads, agreement bodies, raw internal IDs as visible labels or free-form failure messages.
+
+## Receipt
+
+Proposed collection: `paymentReceipts`
+
+| Field | Rule |
+| --- | --- |
+| `id`, `receiptNumber` | Opaque canonical ID and stable human-safe number. |
+| `paymentAttemptId`, `rentObligationId`, `leaseId`, `tenantId`, `landlordId` | Internal scoped references. |
+| `amountCents`, `currency`, `issuedAt`, `paidPeriod` | Reconciled payment facts. |
+| `status` | `issued`, `superseded`, `reversed`; never issued for pending initiation. |
+| `providerReferencePublic` | Optional safe reference, not raw provider ID. |
+| `documentObjectRef` | Restricted storage reference if a PDF is generated. Never expose raw storage path. |
+| `supersedesReceiptId` | Correction lineage. |
+| `createdAt` | Server timestamp. |
+
+Downloads should use short-lived authorized URLs. A returned payment creates a return/reversal record and superseding receipt status; it does not delete the original receipt.
+
+## Access And Projection Rules
+
+- All reads resolve landlord/PM authority or tenant lease ownership server-side.
+- Landlord projections exclude bank data, tenant agreement bodies and unrestricted provider/support data.
+- Tenant projections include only the tenant's mandate, obligations, attempts, receipts and approved failure/support copy.
+- Support projections are purpose-limited and audited; they do not grant mutation authority.
+- Cross-landlord collection reads and client-supplied authority scopes are prohibited.
+- Exports use safe public references and explicit columns; they never serialize Firestore documents wholesale.
+
+## Sensitive Data That Must Never Be Stored
+
+- Raw bank account, transit or institution numbers in RentChain product records.
+- Online banking credentials, verification answers or micro-deposit values.
+- Secret/restricted API keys, webhook signing secrets or client secrets after their short-lived use.
+- Raw provider webhook/request/response payloads in logs, analytics, canonical events or user records.
+- Unredacted dispute documents or unrelated financial/identity data.
+- Bank information copied from the legacy PAP prototype.
+
+## Retention
+
+Retention is a counsel/privacy/security gate. The existing evidence policy uses a seven-year planning schedule for payment evidence, but this design does not declare that legally sufficient or automatically applicable. Define separate schedules for agreement evidence, provider receipts, payment/reconciliation records, notices, support decisions, exports and any restricted forensic payload store. Legal holds must fail closed and lifecycle changes must be append-safe.
+
+## Index And Scale Planning
+
+Before implementation, enumerate Firestore indexes for landlord/property/lease/tenant scopes, mandate status, obligation due date/eligibility, attempt status, provider event ID and reconciliation exception queues. Test query pagination and bounded worker batches at 3,000-unit and multi-month volumes. No unbounded collection scan or per-item N+1 provider lookup is acceptable.

--- a/docs/architecture/pad-payment-lifecycle-v1.md
+++ b/docs/architecture/pad-payment-lifecycle-v1.md
@@ -1,0 +1,179 @@
+# PAD Payment Lifecycle v1
+
+Status: future-state state-machine design only; no debit execution is implemented
+
+## Lifecycle Principles
+
+- State transitions occur server-side from explicit commands or verified provider evidence.
+- Every command carries an expected version and every provider event has a deterministic receipt.
+- Pending is not paid; initiated is not settled; a later return can reverse earlier success projections.
+- Terminal mandate states prohibit new debit initiation.
+- Retries are new attempts with lineage, not mutations of failed attempts.
+- Unknown or contradictory evidence routes to manual review.
+- Payment transitions never mutate lease truth.
+
+## Mandate Lifecycle
+
+```text
+draft
+  -> pending_authorization
+    -> pending_verification
+      -> active
+        -> suspended -> active
+        -> cancellation_pending -> cancelled
+        -> revoked
+        -> expired
+
+pending_authorization | pending_verification
+  -> failed_review | cancelled
+```
+
+| Transition | Required evidence/control |
+| --- | --- |
+| `draft -> pending_authorization` | Eligible lease/tenant/payee context and versioned agreement invitation. |
+| `pending_authorization -> pending_verification` | Tenant acceptance plus provider setup reference; no client-only activation. |
+| `pending_verification -> active` | Provider-confirmed verification, mandate reference and complete agreement evidence. |
+| `active -> suspended` | Provider restriction or authorized hold; reason and actor required. |
+| `active/suspended -> cancellation_pending` | Tenant/payee request and calculated effective cutoff under approved policy. |
+| `cancellation_pending -> cancelled` | Effective cancellation recorded; queued future attempts cancelled where possible. |
+| `active -> revoked/expired` | Verified provider/legal/term event. |
+
+Activation must never default from request input. Cancellation does not erase rent owed or prior payment history.
+
+## Rent Obligation Lifecycle
+
+```text
+scheduled -> due -> pending_payment -> paid
+              |          |             -> returned -> due | overdue | manual_review_required
+              |          -> partially_paid -> paid | overdue
+              -> overdue
+
+scheduled | due -> adjusted (superseded by new version)
+scheduled | due -> waived | cancelled
+any nonterminal -> manual_review_required
+```
+
+- `scheduled`: approved future obligation version exists.
+- `due`: due date reached and balance remains.
+- `pending_payment`: one or more attempts are processing; outstanding balance remains visible.
+- `partially_paid`: reconciled allocations are less than amount due.
+- `paid`: reconciled allocations equal the obligation balance.
+- `returned`: a prior allocation was reversed by provider evidence.
+- `overdue`: unpaid balance passed the approved grace/aging rule; no autonomous enforcement implied.
+- `adjusted`: prior version is superseded by an append-safe adjustment/new obligation version.
+- `waived`: authorized adjustment reduces balance to zero.
+
+## Payment Attempt Lifecycle
+
+```text
+created
+  -> notice_pending
+    -> ready
+      -> initiation_queued
+        -> processing
+          -> pending_settlement
+            -> succeeded
+              -> returned
+
+created | notice_pending | ready | initiation_queued -> cancelled
+processing | pending_settlement -> failed | manual_review_required
+failed | returned -> retry_scheduled (decision only) -> new created attempt
+```
+
+`succeeded` requires provider success evidence and reconciliation. Because PAD is delayed-notification, product projections and payout views must accommodate later returns. A return creates reversal/allocation evidence and may reopen the obligation.
+
+## Command And Event Rules
+
+| Action | Command authority | Evidence source |
+| --- | --- | --- |
+| Invite authorization | Landlord/PM with explicit permission | Lease/payee policy and audit event. |
+| Accept mandate | Authenticated tenant | Provider-controlled flow plus agreement evidence. |
+| Generate obligations | System preview; authorized apply | Versioned lease terms and preview fingerprint. |
+| Queue debit | Governed scheduler | Active mandate, eligible obligation, notice gate, no conflicting payment. |
+| Mark processing/success/failure/return | System only | Signed provider event plus reconciliation. |
+| Pause/cancel/retry | Authorized tenant/landlord/support role per policy | Reasoned command and audit event; provider response where applicable. |
+| Record manual payment | Authorized landlord workflow | External/manual evidence and explicit allocation; never PAD success. |
+
+## Idempotency
+
+### Command keys
+
+Suggested deterministic forms (hashed before external display):
+
+```text
+mandate_invitation:{leaseId}:{tenantId}:{agreementVersion}
+obligation:{leaseId}:{responsibilityId}:{periodStart}:{periodEnd}:{termsDigest}
+pad_attempt:{obligationId}:{mandateId}:{attemptNumber}:{amountCents}:{currency}
+provider_event:{provider}:{accountContext}:{providerEventId}
+notice:{noticeType}:{mandateOrAttemptId}:{contentVersion}:{effectiveDate}
+receipt:{paymentAttemptId}:{reconciliationVersion}
+```
+
+The attempt key is passed as the provider idempotency key where supported and persisted before the external call. A timeout must cause lookup/reconciliation, not blind re-initiation.
+
+### Duplicate webhooks
+
+1. Verify signature against the raw request body.
+2. Derive receipt ID from provider/account/event ID.
+3. Atomically create or load the receipt.
+4. If already processed, return success without repeating effects.
+5. Normalize minimal facts and resolve the internal subject server-side.
+6. Apply a version-guarded transition only if allowed.
+7. Persist reconciliation and audit event.
+8. Mark the receipt processed; failures remain replayable through a future controlled tool.
+
+Out-of-order events are compared against state precedence and provider timestamps. They must never regress a settled/returned record to processing.
+
+### Retry safety
+
+- Retry policy is counsel/provider/landlord approved, capped and notice-aware.
+- Only retry eligible normalized failure categories.
+- Confirm mandate is active, obligation balance remains, no manual/card payment satisfied it, and lease/payee context is unchanged.
+- Create a new attempt number and idempotency key.
+- Never let the provider's optional automatic retry and RentChain retry run concurrently without one declared owner.
+- Ambiguous timeouts, duplicate risk, disputed debits and cancellation races require manual review.
+
+## Failure Scenarios
+
+| Scenario | Required behavior |
+| --- | --- |
+| NSF / insufficient funds | Normalize as return/failure according to evidence; reopen balance, notify safely, require reviewed retry policy. |
+| Bank account closed/invalid | Fail attempt, suspend mandate pending tenant action; do not retry automatically. |
+| Mandate cancelled/revoked | Block new attempts; cancel queued work; reconcile any already-submitted debit under provider/counsel rules. |
+| Processor outage/timeout | Persist uncertain request state, query by idempotency/reference, and hold retries until resolved. |
+| Webhook delay/missing | Keep pending; scheduled reconciliation polling may fetch status within rate limits; alert after SLA. |
+| Duplicate webhook | Return success from existing receipt; no duplicate ledger, receipt or notice. |
+| Out-of-order webhook | Apply transition precedence; preserve receipt and flag contradictions. |
+| Tenant disputes debit | Freeze automation for mandate/attempt, preserve evidence, use counsel/provider dispute process and restricted support workflow. |
+| Lease ended before debit | Eligibility recheck at queue and immediately before provider call; hold/cancel and audit. |
+| Rent changes after schedule | Freeze applied attempt amount; supersede future obligation versions; ambiguous/late changes require review and possibly new notice. |
+| Partial month/move-out | Use approved deterministic proration; no UI-entered ad hoc debit amount. |
+| Manual/card payment outside PAD | Allocate external payment, reduce balance and cancel unsubmitted attempt; submitted races require reconciliation. |
+| Landlord pauses collection | Stop future queueing at authorized scope; do not represent pause as mandate cancellation or debt waiver. |
+| Amount/currency/payee mismatch | No success projection; manual review and incident alert. |
+| Notification failure | Payment truth is unchanged; retry delivery and expose missing-notice gate before initiation where legally required. |
+| Later return after success | Append reversal, supersede receipt status, reopen obligation balance and notify; never delete original evidence. |
+
+## Audit Taxonomy
+
+Proposed canonical event families:
+
+- `pad.mandate_invited`, `pad.mandate_authorized`, `pad.mandate_verified`, `pad.mandate_suspended`, `pad.mandate_cancellation_requested`, `pad.mandate_cancelled`, `pad.mandate_revoked`, `pad.mandate_expired`;
+- `rent.obligation_previewed`, `rent.obligation_created`, `rent.obligation_adjusted`, `rent.obligation_waived`;
+- `pad.attempt_created`, `pad.attempt_queued`, `pad.attempt_initiated`, `pad.attempt_pending`, `pad.attempt_succeeded`, `pad.attempt_failed`, `pad.attempt_returned`, `pad.attempt_cancelled`, `pad.retry_decided`;
+- `pad.provider_event_received`, `pad.reconciliation_completed`, `pad.reconciliation_manual_review_required`;
+- `pad.notice_sent`, `pad.notice_delivery_failed`, `pad.receipt_issued`, `pad.receipt_reversed`.
+
+Events contain safe references and allowlisted summaries only. Actor, authority, reason, policy/version and source evidence must be attributable.
+
+## Reconciliation Cadence
+
+- Event-driven reconciliation on every verified provider event.
+- Scheduled reconciliation for attempts pending beyond provider-specific thresholds.
+- Daily exception report during beta.
+- Period close/export reconciliation agreed with the pilot landlord.
+- No “paid out” status without provider settlement evidence tied to the approved payee context.
+
+## Lifecycle Test Matrix
+
+Test every allowed and forbidden transition, concurrent commands, stale versions, duplicate/out-of-order events, delayed success/failure/return, cancellation at each cutoff, schedule change races, multi-tenant responsibility, partial/manual payments and projection isolation. State-machine tests must be pure; provider contract tests use versioned fixtures; sandbox E2E tests prove real signature and delayed-status behavior.

--- a/docs/architecture/pad-technical-design-v1.md
+++ b/docs/architecture/pad-technical-design-v1.md
@@ -1,0 +1,183 @@
+# PAD Technical Design v1
+
+Status: future-state design only; PAD is not implemented
+
+## Executive Summary
+
+Canadian pre-authorized debit (PAD) is RentChain's highest-priority missing enterprise capability. At the enterprise reference of `$30/unit/year`, a 3,000-unit operator represents `$90,000/year`; this context justifies careful design, not a shortcut around payment, legal, or operational controls.
+
+The first implementation should be processor-led. RentChain should not hold tenant or landlord funds. RentChain should own lease-linked workflow context, authorization evidence, obligation scheduling, provider orchestration, projections, reconciliation, notifications and audit history. A selected processor should collect and tokenize bank details, manage the payment-method and mandate objects where possible, execute the debit and supply signed status evidence.
+
+PAD must be:
+
+- linked to an authoritative lease and versioned rent obligation;
+- affirmatively authorized by the tenant under counsel-approved terms;
+- initiated only against an active, verified mandate;
+- asynchronous, idempotent and reconciliation-led;
+- visible through separate landlord/property-manager and tenant-safe projections;
+- append-safe and reviewable when evidence is missing or contradictory.
+
+No production debit may occur until provider, legal/compliance, privacy, security, reconciliation, support and pilot gates pass.
+
+## Current-State Findings
+
+### Active foundations to reuse
+
+| Area | Current implementation | Reuse decision |
+| --- | --- | --- |
+| Card rent collection | `rentPaymentService.ts` creates tenant-initiated Stripe Checkout sessions and `rentPayments` records after server-side lease/tenant eligibility checks. | Reuse the service/provider boundary and tenant authority pattern; do not force PAD into card checkout statuses. |
+| Provider boundary | `paymentExecutionService.ts`, provider adapter types and Stripe adapter isolate session creation and event normalization. | Extend through a PAD-specific adapter capability in a future mission, not provider conditionals in routes. |
+| Internal obligations | `paymentIntents` stores provider-neutral rent obligation context, cents, currency, lease links and review state. | Reconcile terminology before build: future `rentObligations` should be schedule truth; provider PaymentIntents should remain execution references, not monthly schedule authority. |
+| Webhook evidence | The shared Stripe webhook verifies the Stripe signature. Rent-provider event receipts and reconciliation records support deterministic receipt IDs, deduplication and manual-review outcomes. | Reuse signature verification and receipt-before-projection patterns. Split a PAD event handler from screening/subscription branches before live use. |
+| Reconciliation | Pure reconciliation detects missing subjects, duplicates, amount/currency mismatch and unknown statuses. | Reuse and extend with delayed settlement, return and mandate comparisons. |
+| Ledger/read models | Lease ledger, tenant ledger, payment-obligation readiness and tenant financial projections combine leases, `paymentIntents`, `rentPayments` and reconciliation evidence. | Add PAD through additive projections; do not rewrite current ledger or mark `pending` as paid. |
+| Audit | Rent payments and PaymentIntent linking emit canonical events; evidence governance excludes bank details and raw provider payloads. | Add a PAD event taxonomy through the canonical event service with safe references and append-safe semantics. |
+| Tenant visibility | Authenticated tenant checkout/history, payment summary and receipt-summary surfaces already use lease ownership and whitelist projections. | Reuse workspace authority and projection builders; add PAD fields only through explicit allowlists. |
+| Landlord visibility | Lease payment-rail enablement and lease payment projections are landlord-scoped. | Replace the generic enablement concept with explicit PAD readiness/mandate policy in a future design-to-build mission. |
+| Notifications | Tenant notification preferences/inbox, structured notifications and email delivery patterns exist. | Reuse delivery infrastructure, but persist PAD notice content/version and delivery evidence separately from payment truth. |
+| Tests | Focused tests cover rent checkout, webhook normalization, PaymentIntent linking, provider receipts, reconciliation, tenant payments and lease ledger. | Extend with mandate, schedule, delayed failure/return, authorization and projection suites. |
+
+### Prototype that must not be extended as production PAD
+
+`papMandateRoutes.ts`, `papMandateService.ts` and `papSchedulerRoutes.ts` are legacy prototypes. Repository search found no application mounting for these routers. The route files have no authentication middleware, accept bank-routing fields from request bodies, default mandates to active, and the scheduler merely emits a `RentPaymentAttempted` event. It does not initiate a processor debit, persist provider evidence, reconcile settlement or handle returns.
+
+Future PAD work should quarantine/deprecate this prototype and create governed service boundaries. It must not expose or migrate prototype bank fields into a production model without a separately approved data-handling review.
+
+### Current limitations
+
+- Current live rent execution is Stripe-oriented card checkout, not PAD.
+- Existing monthly obligation generation is not authoritative or automated.
+- Current receipt UI is a payment summary, not a legally reviewed PAD receipt.
+- No landlord settlement account model or payout ownership decision is approved.
+- No 3,000-unit schedule, queue, webhook or reconciliation load evidence exists.
+- No production PAD terms, tenant authorization, processor contract or counsel approval exists.
+
+## Provider Strategy
+
+### Decision criteria
+
+Phase 0 must compare providers on Canadian PAD eligibility, merchant/payee model, landlord onboarding, settlement destination, mandate ownership, hosted bank collection, verification fallback, fixed/variable schedules, debit notification, failure/return codes and timing, dispute handling, webhook quality, idempotency, sandbox fidelity, reporting/export, data residency/privacy, pricing, support, RPAA status and contract allocation.
+
+### High-level comparison
+
+| Option | Strengths to validate | Material questions | Posture |
+| --- | --- | --- | --- |
+| Stripe ACSS debit | Existing Stripe footprint; SetupIntent/mandate and PaymentIntent primitives; hosted/tokenized collection; signed webhooks; documented sandbox cases. | Which party is payee/merchant; direct vs platform/connected-account flow; landlord onboarding and settlement; mandate portability; delayed failure/return behavior; account eligibility and economics. | Preferred first feasibility track, not a final selection. |
+| VoPay or comparable Canadian EFT/PAD platform | Canadian EFT/PAD focus, tokenized accounts, scheduled payments and digital debit agreement capabilities. | Custody/settlement model, sponsorship, merchant onboarding, mandate responsibility, webhook/status semantics, data handling, pricing and operational support. | Run a structured alternative-provider review to avoid lock-in. |
+| Rotessa or comparable PAD platform | PAD-focused platform and connected-platform model may reduce custom rail work. | API/webhook depth, per-landlord onboarding, authorization evidence, reconciliation/export, scale, commercial and regulatory allocation. | Consider if its operating model fits property-manager portfolios. |
+| Manual/offline PAD recording | Can document payments executed outside RentChain. | Cannot be represented as automated collection or provider-confirmed settlement. | Fallback record only, always labeled external/manual and reviewable. |
+
+Provider marketing or documentation does not establish legal suitability. Procurement, counsel, privacy, security and financial-operations review remain mandatory.
+
+### Stripe-oriented feasibility shape
+
+If Stripe is selected:
+
+- use a Stripe-hosted or Stripe-controlled bank-detail/mandate collection surface where supported;
+- use a SetupIntent to save a verified ACSS debit payment method for future off-session use;
+- store only opaque Customer, PaymentMethod, Mandate and SetupIntent references;
+- create a PaymentIntent for each approved off-session debit against the applicable mandate;
+- configure payment method eligibility through Stripe settings/configuration and required ACSS mandate options rather than copying legacy hard-coded payment-method arrays;
+- treat ACSS as delayed-notification: initiation and processing are not settlement;
+- consume verified webhook events into immutable provider-event receipts before projecting state;
+- use restricted API keys with minimal permissions, separate environment keys and secrets-manager storage;
+- do not choose a Connect charge/funds-flow pattern until payee, statement descriptor, negative-balance liability, fees, onboarding and mandate scoping are approved.
+
+For a new Connect design, evaluate the current Accounts v2/controller-property model and hosted onboarding. Do not inherit legacy account-type assumptions from unrelated billing code.
+
+## Future Architecture
+
+```text
+lease lifecycle and approved rent terms
+  -> versioned rent obligation generator
+    -> eligible obligation + active mandate
+      -> notice evidence and collection approval
+        -> provider adapter creates debit request
+          -> signed provider event receipt
+            -> normalized payment attempt transition
+              -> reconciliation
+                -> ledger projection + receipt/failure record
+                  -> tenant/landlord notification + audit evidence
+```
+
+### End-to-end flow
+
+1. An authorized landlord or property manager enables PAD policy for an eligible property/lease; this creates no debit.
+2. RentChain creates a tenant authorization invitation tied to the lease, tenant, payee context, agreement version and allowed schedule.
+3. The authenticated tenant opens a provider-controlled bank collection and mandate flow and affirmatively authorizes it.
+4. The provider verifies/tokenizes the bank account and returns opaque customer, payment-method, mandate and setup references.
+5. RentChain records a mandate only after server-side provider confirmation and agreement-evidence checks.
+6. A deterministic generator previews versioned monthly rent obligations from the authoritative lease; apply requires appropriate approval and a matching preview fingerprint.
+7. A collection worker selects an eligible obligation, active mandate and satisfied notice gate, then creates one idempotent payment attempt.
+8. The provider initiates the debit. Attempt status moves through queued/processing/pending settlement and only later to succeeded, failed or returned based on verified evidence.
+9. Reconciliation compares the obligation, mandate, attempt, provider event, amount, currency and settlement/payee context.
+10. Ledger projections, receipts/failure records and notifications update from reconciled evidence; append-safe audit history records every material action.
+
+## Component Boundaries
+
+### Future frontend surfaces
+
+- Tenant: PAD invitation, agreement context, hosted authorization, verification status, mandate detail/cancellation, upcoming debit, payment timeline, receipt/failure and support guidance.
+- Landlord/PM: PAD readiness, mandate status, obligation preview, upcoming debit/exception queue, failed/returned workflow, reconciliation and export.
+- Admin/support: restricted event/attempt inspection, safe provider references, mismatch review and future controlled replay. No raw bank details, secrets or unrestricted provider payloads.
+
+### Future backend boundaries
+
+- `padMandateService`: invitation, provider setup reconciliation, status and cancellation.
+- `rentObligationService`: pure preview plus idempotent versioned apply from lease truth.
+- `padPaymentExecutionService`: provider-neutral initiation capability and adapter selection.
+- `padProviderEventService`: signature-verified receipt, normalization and deduplication.
+- `padReconciliationService`: pure comparison plus append-safe persisted outcome.
+- `padNoticeService`: approved templates, notice policy, delivery evidence and retry.
+- `padReceiptService`: tenant-safe receipt metadata after reconciled success.
+- `padSupportReviewService`: role-gated, purpose-limited manual decisions.
+
+Routes should be thin, authenticated and server-authoritative. Scheduled work must use an authenticated job boundary, never a public GET endpoint.
+
+## Role Access
+
+### Landlord / property manager
+
+May view only records within server-resolved authority: mandate readiness/status (not bank details), upcoming obligations/debits, attempt and reconciliation status, privacy-safe failure/return categories, reviewed retry/NSF state, receipts/exports and audit timeline. Enabling policy, approving schedule exceptions, retrying or pausing collection requires a named permission and audit reason.
+
+### Tenant
+
+May authorize only their own lease-linked mandate, view agreement/version/status, upcoming debit amount/date, payment state, receipts and privacy-safe failures, and request cancellation/change under approved policy. Tenant projections must not expose landlord settlement data, processor payloads, internal IDs, other occupants' sensitive data or support notes.
+
+### Admin / support
+
+May inspect safe provider references, receipt/reconciliation state and audit history only under purpose-limited role access. Any replay or manual transition tool is future work and must be allowlisted, reasoned, idempotent and audited. Support cannot activate a mandate, fabricate success or bypass tenant authorization.
+
+## Source Of Truth
+
+```text
+lease = whether and how rent is owed
+rent obligation = versioned amount and due period
+mandate = authorization eligibility
+payment attempt = execution request
+provider receipt = external evidence
+reconciliation = trusted comparison outcome
+ledger/receipt = projected financial history
+```
+
+Provider status never mutates a lease. Notifications never determine payment truth. A manual payment can satisfy an obligation through an explicit allocation/reconciliation record, but it cannot be rewritten as a PAD success.
+
+## Non-Goals
+
+- Production payment or Stripe/ACSS code.
+- Funds custody, wallet balances or a RentChain settlement account.
+- Billing/subscription, pricing, auth or screening changes.
+- Autonomous retries, collections, arrears enforcement or tenant decisions.
+- Full accounting/general-ledger replacement.
+- Direct Yardi write-back or big-bang migration.
+
+## Primary Design References
+
+- [Stripe ACSS debit overview](https://docs.stripe.com/payments/acss-debit)
+- [Stripe saving ACSS details for future payments](https://docs.stripe.com/payments/acss-debit/set-up-payment)
+- [Stripe accepting ACSS debit](https://docs.stripe.com/payments/acss-debit/accept-a-payment)
+- [Payments Canada Rule H1](https://www.payments.ca/sites/default/files/h1eng.pdf)
+- [VoPay digital debit agreement](https://docs.vopay.com/docs/digital-debit-agreement)
+- [Rotessa platform documentation](https://rotessa.com/platform-documentation/)
+
+These references are implementation inputs, not legal approval or a provider decision.

--- a/docs/strategy/pad-beta-implementation-plan-v1.md
+++ b/docs/strategy/pad-beta-implementation-plan-v1.md
@@ -1,0 +1,196 @@
+# PAD Beta Implementation Plan v1
+
+Status: future mission plan only; no PAD, Stripe/ACSS, route, UI, schema or migration implementation is authorized
+
+## Objective
+
+Deliver a processor-led, lease-linked and tenant-authorized Canadian PAD beta for one landlord and a limited property group, with no RentChain funds custody. The narrow proof is:
+
+```text
+tenant authorization
+  -> versioned rent obligation
+    -> one idempotent debit attempt
+      -> verified provider status
+        -> reconciliation
+          -> tenant/landlord record and append-safe evidence
+```
+
+The plan supports the 3,000-unit enterprise conversation and `$30/unit/year` / `$90,000/year` reference, but the beta must start with a bounded cohort. It should run beside the landlord's existing PMS/accounting system under the merged migration/parallel-run strategy.
+
+## Delivery Rules
+
+- Each phase is a separate operator-approved, reviewable mission with acceptance gates.
+- Provider, legal and security decisions precede live debit code.
+- Existing card rent payments and billing/screening flows remain behaviorally isolated.
+- Certn is outside scope.
+- No autonomous retry, collection enforcement or hidden remediation.
+- Every phase preserves an export/exit path and explicit source-of-truth ownership.
+
+## Phase 0 — Discovery And Provider Confirmation
+
+### Work
+
+- Confirm current card checkout, payment provider adapter, receipt, reconciliation, ledger, audit, tenant projection and notification boundaries.
+- Quarantine/deprecation-plan the unmounted PAP prototype; do not migrate its bank fields.
+- Compare Stripe ACSS debit with at least one Canadian PAD alternative using the decision matrix in the technical design.
+- Decide payee/merchant/connected-account model, landlord onboarding, statement descriptor, settlement destination, liability, fees and mandate scope.
+- Confirm SetupIntent/mandate and off-session PaymentIntent feasibility in sandbox if Stripe is selected.
+- Complete counsel, RPAA, FINTRAC/MSB, privacy, security and insurance discovery.
+- Define pilot province, property group, volume, incumbent PMS authority and success baseline.
+
+### Deliverables / exit gate
+
+Provider decision record, signed-off funds-flow diagram, responsibility matrix, data inventory, legal/security question log, sandbox test plan, cost model and explicit go/no-go. No production code.
+
+## Phase 1 — Data Model, State Machines And Audit Contracts
+
+### Work
+
+- Finalize collection/entity names after reconciling existing `paymentIntents`, `rentPayments`, provider receipts and reconciliation records.
+- Implement pure mandate, obligation and attempt state machines first.
+- Define deterministic IDs/idempotency, optimistic concurrency and append-safe adjustment/allocation contracts.
+- Define canonical PAD audit events and tenant/landlord/support projection schemas.
+- Define Firestore query/index plan and retention classifications; do not deploy indexes/rules without explicit scope.
+- Add pure unit tests, property/transition tests and projection-negative tests.
+
+### Exit gate
+
+No provider call or UI. All allowed/forbidden transitions, stale versions, multi-tenant responsibility, money/date normalization and sensitive-field exclusions pass review.
+
+## Phase 2 — Tenant Authorization Prototype
+
+### Work
+
+- Create authenticated, lease-owned authorization invitation/session endpoints.
+- Use provider-hosted/tokenized bank collection and SetupIntent/mandate lifecycle where selected.
+- Store only opaque provider references and approved masked display metadata.
+- Persist agreement version/digest, acceptance and verification evidence.
+- Add tenant mandate status/cancellation-request prototype and landlord readiness/status projection.
+- Consume sandbox setup/verification webhooks into deduplicated receipts.
+
+### Safety boundary
+
+No PaymentIntent/debit initiation. Sandbox only. Legacy PAP routes remain unmounted/quarantined. Provider client uses least-privilege test credentials and verified webhooks.
+
+### Exit gate
+
+Instant and micro-deposit verification, abandoned flow, duplicate/out-of-order webhook, cancellation and cross-tenant/landlord tests pass. Counsel approves the prototype language before any external pilot exposure.
+
+## Phase 3 — Rent Schedule And Obligation Linking
+
+### Work
+
+- Build a pure monthly obligation preview from authoritative lease versions.
+- Support due date/time zone, partial first/last period, move-in/out, rent change, renewal, credits/adjustments, starting balance and multi-tenant responsibility policies.
+- Add preview fingerprint, authorized idempotent apply and supersession history.
+- Add manual/card payment allocation checks and exception queue.
+- Benchmark preview/apply at 3,000-unit, multi-month volume in an isolated environment.
+
+### Exit gate
+
+Control totals and repeat runs are deterministic; stale previews fail; ambiguous lease terms require review; no obligation automatically initiates payment.
+
+## Phase 4 — Payment Attempt Lifecycle
+
+### Work
+
+- Add PAD initiation capability to the provider boundary without changing card checkout behavior.
+- Create one PaymentIntent/equivalent per approved attempt with deterministic provider idempotency.
+- Persist attempt before provider call; handle timeout through lookup/reconciliation.
+- Add signed webhook normalization for processing, success, failure and return.
+- Extend receipt/reconciliation models for mandate, obligation, payee and delayed-return evidence.
+- Implement reviewed/capped retry decision records, not autonomous retry.
+- Issue receipt only after reconciled success and reverse/supersede on later return.
+
+### Exit gate
+
+Sandbox matrix passes success, NSF, closed account, delayed failure, later return, duplicate/out-of-order/missing webhook, timeout, cancellation race, amount/currency mismatch and manual-payment race. No live mode.
+
+## Phase 5 — Landlord And Tenant Visibility
+
+### Work
+
+- Tenant: agreement/mandate status, upcoming debit, attempt timeline, receipt/return, cancellation and support.
+- Landlord/PM: mandate readiness, obligation/debit status, failure/return and reconciliation exception queue, reviewed retry/pause and export.
+- Admin/support: purpose-limited safe references, receipt/reconciliation history and audited review decisions.
+- Notifications: upcoming debit, mandate confirmation/cancellation, success, failure/return and retry with versioned content/delivery evidence.
+- Accessibility, mobile, privacy, error-language and projection isolation QA.
+
+### Exit gate
+
+No raw bank details, provider payloads, internal IDs as labels or cross-scope data leak. User research shows pending/success/return/cancellation are understood. Support runbook is executable.
+
+## Phase 6 — Paid Pilot Rollout
+
+### Shape
+
+- One landlord, one limited property group and named users/tenants.
+- 60–90 days, paid, with weekly operating reviews.
+- Sandbox rehearsal followed by live limited rollout only after every compliance/risk gate passes.
+- Daily reconciliation/exception ownership, provider escalation and a tested stop switch.
+- Parallel run beside the incumbent PMS/accounting system with field ownership, control totals and agreed exports.
+- No entire 3,000-unit portfolio cutover.
+
+### Rollout cohorts
+
+1. Internal synthetic/sandbox tenants.
+2. Staff/friendly test cohort where legally and contractually permitted.
+3. Small live property cohort with conservative debit/volume limits.
+4. Expand within pilot only after a full rent cycle reconciles and the go/no-go group approves.
+
+### Exit/rollback
+
+Stop new initiations, preserve mandate/payment evidence, reconcile in-flight attempts, notify affected parties under approved templates, export records and return payment collection to the agreed incumbent/manual process. Ending the pilot must not strand tenant access to records or erase history.
+
+## Phase 7 — Enterprise Scale
+
+Only after pilot evidence:
+
+- bulk schedule generation and exception operations;
+- portfolio cohort administration and permission templates;
+- migration imports with preview/apply/reconciliation;
+- accounting and settlement exports/adapters;
+- payout/reconciliation reporting and period close;
+- support/replay tooling with strict controls;
+- performance, queue backpressure, disaster recovery and multi-region/provider continuity decisions;
+- contract/pricing refinement and annual rollout.
+
+Do not interpret Phase 7 as authorization for a full Yardi replacement, native general ledger or direct funds custody.
+
+## Pilot Success Metrics
+
+Agree targets against a measured baseline before launch.
+
+| Metric | Definition / guardrail |
+| --- | --- |
+| Authorization completion | Eligible invited tenants reaching verified active mandate; segment abandonment and verification delays. |
+| Debit success | Attempts reconciled succeeded after the provider's delayed-notification window; never count initiation as success. |
+| Return/NSF rate | Attempts failed/returned by normalized category and time-to-resolution. |
+| Failure handling time | From verified failure/return receipt to owned next action and tenant/landlord notice. |
+| Reconciliation effort | Operator minutes and unresolved exceptions per payment cycle versus baseline. |
+| Duplicate/unauthorized debit | Target zero; any case is a severity-one stop-review event. |
+| Notice delivery | Required notices with confirmed delivery evidence before applicable gate. |
+| Evidence completeness | Mandate, obligation, attempt, provider receipt, reconciliation, notice and audit chain complete. |
+| Support burden | Tickets per 100 tenants, severity, repeat contacts and resolution time. |
+| Tenant experience | Confusion, complaints, cancellation success and accessibility issues. |
+| Landlord value | Collection visibility, exception aging, export usefulness and willingness to annualize. |
+| Commercial outcome | Willingness to move to per-unit annual pricing around the approved enterprise package; no public pricing change implied. |
+
+## Dependencies And Risks
+
+| Dependency/risk | Plan response |
+| --- | --- |
+| Provider account/funds-flow ambiguity | Phase 0 blocks implementation until ownership/liability/settlement are explicit. |
+| Legal/regulatory uncertainty | Written counsel gates; no engineering inference presented as legal conclusion. |
+| Legacy PAP prototype | Quarantine; no reuse of unauthenticated routes or bank fields. |
+| Existing payment model overlap | Reconcile obligation vs execution naming before schema work; preserve card behavior. |
+| Delayed failure/returns | Asynchronous state machine, reconciliation and receipt reversal. |
+| Duplicate collection across rails/PMS | Allocation checks, parallel-run ownership and pre-initiation revalidation. |
+| Scale at 3,000 units unproven | Production-shaped schedule/queue/reconciliation load tests before pilot expansion. |
+| Support capacity | Bounded cohort, named owners, daily exceptions and stop switch. |
+| Provider lock-in | Provider-neutral internal contracts and exportable authorization/evidence references where legally portable. |
+| Migration friction | CSV-first preview/apply, signed reconciliation, staged property cohorts and exit export. |
+
+## Immediate Next Mission
+
+Phase 0 provider and funds-flow decision record. It should produce no live payment code and should answer: who is payee, who onboards each landlord, where funds settle, who bears returns/negative balances, how mandates are scoped, what RentChain stores, and which legal/security gates apply.


### PR DESCRIPTION
## Summary

- adds the processor-led Canadian PAD technical architecture and current-state audit
- defines conceptual mandate, rent-obligation, payment-attempt, provider-event, reconciliation, audit, allocation, and receipt models
- specifies mandate, obligation, and payment-attempt lifecycle transitions, idempotency, webhook deduplication, retry safety, and failure handling
- establishes legal, regulatory, provider, security/privacy, financial-integrity, operational, and production go/no-go gates
- sequences a bounded PAD beta from provider/funds-flow discovery through authorization, obligations, sandbox debit lifecycle, visibility, paid pilot, and later enterprise scale

## Current-state findings

- active Stripe card rent checkout already has authenticated tenant/landlord boundaries, provider adapters, signed webhook handling, provider-event receipts, reconciliation records, canonical events, ledger projections, tenant-safe payment views, notifications, and focused tests
- the legacy PAP mandate/service/scheduler files appear unmounted and unauthenticated prototypes; they do not initiate debits or reconcile provider settlement and must not be extended as production PAD
- current `paymentIntents` and payment-obligation read models are reusable foundations but are not authoritative monthly PAD schedules
- no current evidence proves 3,000-unit PAD schedule, queue, webhook, reconciliation, or support readiness

## Provider-led strategy

- Stripe ACSS debit is the preferred first feasibility track, not a final provider decision
- future authorization should use provider-hosted/tokenized collection and SetupIntent/mandate primitives where selected
- each approved off-session debit should use a PaymentIntent or provider equivalent
- landlord/payee onboarding, settlement destination, mandate scope, fees, returns, and negative-balance liability remain explicit Phase 0 decisions
- RentChain must not hold tenant or landlord funds

## Validation

- `git diff --cached --check` — passed before commit
- documentation lint — not configured in the repository
- build/manual QA — not required for docs-only changes

## Scope confirmation

- documentation only: five new Markdown files
- no production PAD or live debit implementation
- no Stripe/ACSS runtime code
- no backend/API routes, database schema/migrations, frontend UI, auth, billing/subscription, Certn/screening, pricing, landing page, terms, or privacy changes