### PR TITLE
docs: PAD Phase 0 feasibility preparation

### DIFF
--- a/docs/operations/pad-counsel-review-brief-v1.md
+++ b/docs/operations/pad-counsel-review-brief-v1.md
@@ -1,0 +1,76 @@
+# PAD Counsel Review Brief v1
+
+## Request
+
+RentChain requests Canadian payments counsel's written advice on a proposed, bounded PAD beta. The immediate goal is feasibility and approved language—not launch approval by implication. PAD is not currently implemented, no live debit is authorized, and no public capability promise should be made.
+
+## Business context
+
+RentChain is rental workflow, evidence, and property intelligence infrastructure. For an enterprise customer, it should enter beside the customer's PMS/Yardi rather than claim to replace it. The proposed 60–90 day paid pilot would use staged properties and a parallel run. The commercial reference is $30 per unit per year, or $90,000 per year for 3,000 units; this is planning context, not public pricing or a commitment to bundle PAD in a cheap flat tier.
+
+## Proposed model for review
+
+- A tenant authorizes bank debits through a provider-managed authorization and bank-verification flow.
+- The provider stores sensitive payment credentials and returns a token/reference and mandate evidence.
+- RentChain records authorization status and evidence references, but does not hold tenant or landlord funds.
+- For each specifically approved rent obligation, RentChain would create an off-session provider debit request using the saved payment method.
+- The provider processes the debit and routes settlement to the approved payee/recipient under the selected provider account model.
+- Signed provider events update an auditable lifecycle, reconciliation, and role-appropriate views.
+- Stripe ACSS is the preferred first feasibility track; provider selection and the exact account/funds-flow model remain open.
+
+The following Phase 0 decisions are intentionally unresolved: payee of record; landlord/property-manager onboarding; settlement routing; responsibility for notices and authorization records; returns, disputes, refunds, fees, reserves, and negative balances; and allocation of regulatory and operational liability.
+
+Legacy PAP route, service, and scheduler files are unmounted, unauthenticated prototypes. They are not production PAD and will not be used as the legal or technical basis for the beta.
+
+## Advice requested
+
+Please provide written conclusions, assumptions, required changes, and blockers for:
+
+1. The legal characterization and responsibilities of RentChain, the payment provider, tenant, property owner/manager, payee, and settlement recipient.
+2. Applicability of the Retail Payment Activities Act and Bank of Canada registration/operational-risk/safeguarding requirements. Please assess the actual activities and do not assume that avoiding custody alone resolves scope.
+3. Applicability of FINTRAC requirements and whether the proposed parties or activities create money-services-business or related obligations.
+4. Applicable Payments Canada PAD rules, including the appropriate PAD category and requirements for authorization, confirmation, pre-notification, waiver/variation, cancellation/revocation, disputes/reimbursement, and evidence retention.
+5. Whether electronic/provider-managed authorization and the proposed evidence record are sufficient, and which party must produce evidence on demand.
+6. Required tenant-facing language for variable rent amounts, debit timing, changes, failed/returned debits, fees, cancellation, complaints, refunds, and support.
+7. Required property-owner/property-manager/payee agreements, representations, allocation of return/dispute liability, reserves/negative balances, and authorization to initiate debits.
+8. Privacy and consent implications, including bank/payment data, provider/subprocessor disclosures, cross-border processing, retention, deletion, access, and incident notice.
+9. Consumer-protection, accessibility, language, electronic-commerce/signature, record-keeping, and provincial considerations for the initial pilot jurisdictions.
+10. Restrictions on product claims, pilot communications, pricing language, or use of terms such as PAD, automated rent, guaranteed, settled, or compliant.
+11. The minimum legal gates and documentary evidence required before the first live debit.
+12. Insurance implications, including appropriate coverage, exclusions, limits, notices, and risk allocation.
+13. Whether a separate payment entity is required or advisable now or after a defined activity/scale threshold.
+
+## Materials counsel should receive
+
+- PAD technical design, data model, lifecycle, compliance gates, beta plan, and this Phase 0 package.
+- Participant/authority diagram and end-to-end funds-flow diagram for each provider option.
+- Provider terms, account/onboarding model, authorization/mandate artifacts, data-processing terms, and return/dispute rules.
+- Draft tenant authorization, confirmation, notice, cancellation, support, and complaint language.
+- Draft landlord/property-manager/payee agreement changes.
+- Requested deliverables: PAD authorization template; terms/privacy change language; cancellation/notice and NSF/return language; RPAA/FINTRAC/MSB memo; recommended funds flow; risk allocation; insurance/entity advice; and pilot agreement terms.
+- Data inventory, retention schedule, privacy/security review, and incident process.
+- Pilot charter, provinces, property/tenant cohort, operating model, and support/escalation plan.
+
+## Required form of response
+
+For each issue, counsel should label the result `APPROVED`, `APPROVED WITH CONDITIONS`, `BLOCKED`, or `OUT OF SCOPE`; state assumptions; cite the governing source where useful; identify the accountable party; provide required language/actions; and state whether it blocks sandbox work, production implementation, enrollment, or the first live debit.
+
+Counsel approval expires if the provider, participant roles, funds flow, jurisdictions, authorization method, settlement routing, liability allocation, or customer-facing language materially changes.
+
+## Draft email request
+
+**Subject:** Counsel review request — RentChain Canadian PAD Phase 0 feasibility
+
+Hello [Counsel name],
+
+RentChain is evaluating a bounded 60–90 day paid pilot for provider-processed Canadian pre-authorized rent debits. PAD is not implemented today, and we are not requesting permission to launch based only on a sandbox test.
+
+Our proposed direction is provider-managed bank verification and authorization, a saved provider payment-method reference, and one off-session debit request per specifically approved rent obligation. The provider would process and settle the debit to the approved payee; RentChain would not hold funds. Stripe ACSS is our preferred first feasibility track, but neither the provider nor the account/funds-flow model has been selected.
+
+Please review the attached brief and designs and advise on participant roles, Payments Canada PAD rules, RPAA/Bank of Canada and FINTRAC applicability, authorization/notice/cancellation language, evidence retention, agreements, privacy, consumer protection, and liability for settlement, returns, disputes, fees, reserves, and negative balances.
+
+We need a written gate decision and approved tenant/customer language before any live debit. Please identify assumptions, blockers, conditions, required documents, and any facts you need from us or a provider.
+
+Regards,
+
+[Executive sponsor / legal owner]

--- a/docs/operations/pad-pilot-readiness-runbook-v1.md
+++ b/docs/operations/pad-pilot-readiness-runbook-v1.md
@@ -1,0 +1,121 @@
+# PAD Pilot Readiness Runbook v1
+
+## Objective and operating boundary
+
+Prepare and operate a bounded, paid 60–90 day PAD beta for named properties and tenants, beside the customer's PMS/Yardi workflow. The PMS remains the system of record for lease/rent obligations unless the signed pilot charter says otherwise. RentChain is the workflow, evidence, and PAD-readiness layer; it is not a full Yardi replacement and does not hold funds.
+
+This runbook becomes executable for live activity only after counsel, RPAA/FINTRAC, privacy/security, reconciliation, operational, provider, and executive approvals. Sandbox success is not launch approval. No live debit may use unapproved authorization or notice language.
+
+## Pilot charter
+
+| Item | Required decision |
+| --- | --- |
+| Executive sponsor / pilot owner | Named individual |
+| Customer and PMS owner | Named individuals |
+| Duration | 60–90 days, with start/end dates |
+| Cohort | Named properties, leases, tenants, jurisdictions |
+| Rollout | Internal test, staff/friendly cohort if lawful, Property 1, then staged properties |
+| Commercial terms | Paid pilot; fees and provider costs documented |
+| Reference economics | $30/unit/year; 3,000 units = $90,000/year |
+| Source of truth | PMS/Yardi for obligations; provider for processing; RentChain for governed workflow/evidence; reconciliation resolves differences |
+| Success and stop criteria | Signed and measurable |
+| Fallback | Manual/offline collection and evidence process |
+| Onboarding | Decide and disclose any paid migration/onboarding service |
+
+Do not advertise the reference economics as public pricing or promise PAD in a cheap flat tier.
+
+## Roles and approvals
+
+| Role | Accountable for |
+| --- | --- |
+| Executive sponsor | Go/no-go, scope, risk acceptance, customer commitment |
+| Product owner | Charter, cohort, workflow, success metrics, change control |
+| Engineering owner | Technical readiness, access, observability, idempotency, pause/rollback |
+| Legal/compliance owner | Counsel, PAD rules, RPAA/FINTRAC, approved language/contracts |
+| Security/privacy owner | Vendor/data-flow review, least privilege, incident readiness |
+| Finance/reconciliation owner | Settlement model, daily reconciliation, exceptions, accounting evidence |
+| Operations/support owner | Enrollment, monitoring, cases, scripts, service levels, complaints |
+| Customer PMS owner | Roster/obligation accuracy, parallel-run controls, operator decisions |
+
+Any domain owner may block live activity for an unresolved critical risk in their domain.
+
+## Entry checklist
+
+- [ ] Phase 0 checklist is signed `GO`; all conditions are satisfied and current.
+- [ ] Provider, payee, onboarding, funds flow, settlement, returns, disputes, and liability are contractually confirmed.
+- [ ] Counsel-approved authorization, confirmation, notice, cancellation, complaint, and support language is deployed exactly as approved.
+- [ ] Privacy/security, reconciliation, and operational approvals are recorded.
+- [ ] Production credentials are least privilege, environment-separated, and protected by an enablement control.
+- [ ] Provider webhook signing, idempotency, replay, delayed events, returns, and reconciliation have passed tests.
+- [ ] Pilot roster and rent obligations are dual-reviewed against PMS/Yardi.
+- [ ] Duplicate-debit controls identify every existing payment schedule or manual process.
+- [ ] Support, finance, operations, engineering, provider, and customer escalations are staffed.
+- [ ] Pause, cancellation, manual fallback, incident, and customer-communication rehearsals pass.
+
+## Migration and parallel-run procedure
+
+Migration friction is a primary enterprise risk, not an onboarding detail.
+
+1. Export the bounded property, lease, tenant, rent-obligation, and existing-payment-schedule roster from the PMS.
+2. Map records to canonical RentChain IDs with an exception queue; never use external identifiers as product primary keys.
+3. Use bounded CSV/import/export only where needed for the pilot; do not make a full platform migration a prerequisite.
+4. Have the customer PMS owner validate ownership, payee, settlement destination, amount, timing, lease status, tenant contact data, and duplicates.
+5. Do not assume an existing bank authorization is portable. Obtain a new provider-managed authorization unless counsel and the provider confirm lawful, evidenced conversion.
+6. Record a cutover state per lease: `MANUAL_ONLY`, `AUTHORIZATION_PENDING`, `PAD_READY`, `PAD_ACTIVE`, `PAUSED`, or `EXITED`.
+7. Before each debit window, compare PMS obligation, RentChain approved instruction, provider state, and any manual/external schedule.
+8. Maintain manual/offline collection until the lease is explicitly active and reconciled; never run both collection paths for the same obligation.
+9. Reconcile outcomes back to the PMS/operator process through approved evidence rather than claiming RentChain replaces the PMS ledger.
+
+## Staged rollout
+
+### Stage 0 — production-safe readiness
+
+Use non-live verification, access review, tabletop incidents, and a final roster dry run. Confirm the production kill switch and that legacy PAP prototypes are not mounted or called.
+
+### Stage 1 — first property
+
+Enroll only the approved small cohort. Require dual approval for every initial debit instruction. Hold expansion until authorization, submission, webhook, support, and daily reconciliation evidence is reviewed.
+
+### Stage 2 — additional properties
+
+Add one property batch at a time. Each batch requires clean roster mapping, no unresolved severe exceptions, capacity confirmation, and a signed expansion decision.
+
+### Stage 3 — pilot completion
+
+Stop new enrollment, finish settlement/return observation, reconcile all instructions, export evidence, collect customer/tenant/support feedback, and decide `EXIT`, `EXTEND`, or `PROPOSE BETA IMPLEMENTATION`. No automatic general availability follows.
+
+## Per-debit operating procedure
+
+1. Confirm current authorization, approved amount/timing, lease/tenant/payee ownership, and absence of another schedule.
+2. Record the operator/user approval and deterministic debit instruction.
+3. Submit exactly once with a durable idempotency key; retain provider request identifiers without sensitive bank data.
+4. Show `submitted/processing`, not paid or settled, until the appropriate provider evidence exists.
+5. Process only signed provider events; tolerate duplicates and out-of-order delivery.
+6. Reconcile provider, instruction, obligation, receipt, ledger projection, and settlement/return state.
+7. Route ambiguous, failed, returned, disputed, cancelled, or mismatched results to review. Do not silently retry.
+8. Notify affected parties using counsel-approved templates and record delivery evidence.
+
+## Daily operations
+
+- Review submissions, processing age, failures, returns, cancellations, disputes, webhook health, reconciliation exceptions, complaints, and support backlog.
+- Verify provider totals against RentChain instructions and approved settlement evidence.
+- Age and assign every exception; require dual review for manual correction or retry.
+- Sample authorization/notice evidence and role-based views for privacy and accuracy.
+- Confirm the PMS/operator record does not schedule or represent a duplicate collection.
+- Produce a daily signed status: `CONTINUE`, `HOLD EXPANSION`, or `PAUSE`.
+- Hold a weekly customer review of metrics, exceptions, tenant/landlord feedback, support load, reconciliation time, pricing feedback, and expansion eligibility.
+
+## Immediate pause conditions
+
+Pause affected debits—and the whole pilot when scope is uncertain—for duplicate or wrong-amount submission, unauthorized debit, compromised credential, webhook verification failure, unexplained reconciliation difference, settlement to the wrong recipient, systemic provider outage, missing approved notice, privacy/security incident, excessive returns/complaints, or loss of operational coverage.
+
+On pause: disable new submission through the approved control; preserve evidence; notify incident owners and provider; assess tenant/customer communications with counsel; continue safe status retrieval/reconciliation; use the manual fallback without duplicating obligations; and require written restart approval.
+
+## Exit and evidence package
+
+- Every instruction has a final or explicitly tracked delayed state.
+- Provider totals, settlement/return evidence, RentChain records, and operator/PMS records reconcile.
+- Authorizations, approvals, notices, provider events, support cases, incidents, exceptions, and decisions are exportable and retained per approved policy.
+- Success/stop metrics and unit economics are reported without overstating production readiness.
+- Customer migration friction, operator time, complaints, failures/returns, and support effort are included.
+- Counsel, security/privacy, finance, operations, product, engineering, and executive owners record follow-up conditions.

--- a/docs/strategy/pad-phase-0-feasibility-checklist-v1.md
+++ b/docs/strategy/pad-phase-0-feasibility-checklist-v1.md
@@ -1,0 +1,110 @@
+# PAD Phase 0 Feasibility Checklist v1
+
+## Purpose and boundary
+
+This checklist governs the decision to begin a bounded PAD beta. It does not authorize production PAD, customer enrollment, or a live debit. PAD is not implemented today, and this package includes no Stripe/ACSS or Certn implementation. Legacy PAP route, service, and scheduler files are unmounted, unauthenticated prototypes and must not become the production PAD path.
+
+RentChain's intended role is a workflow, evidence, and PAD-readiness layer beside an operator's property-management system (PMS), including Yardi. RentChain must not hold tenant or landlord funds. Provider-managed authorization, payment-method storage, debit submission, settlement, and return handling are required design assumptions, subject to counsel and provider confirmation.
+
+Sandbox evidence is not legal, compliance, security, reconciliation, operational, or production approval. No live debit may occur until counsel approves the authorization and notice language and every mandatory gate below is signed.
+
+## Decision record
+
+| Field | Required entry |
+| --- | --- |
+| Decision owner | Executive sponsor |
+| Target decision date | TBD |
+| Proposed provider and funds flow | TBD after provider diligence |
+| Payee of record | TBD |
+| Settlement destination owner | TBD |
+| Liability owner for returns, disputes, fees, and negative balances | TBD |
+| Pilot cohort and properties | TBD |
+| Recommendation | `GO`, `CONDITIONAL GO`, or `NO-GO` |
+| Conditions and expiry | Required for conditional go |
+| Approvers | Executive, product, engineering, legal/compliance, security/privacy, finance/reconciliation, operations/support |
+
+## Gate A — business and commercial feasibility
+
+- [ ] Executive sponsor and single accountable pilot owner are named.
+- [ ] The initial job is limited to approved rent debits, not a general wallet, custody product, or PMS replacement.
+- [ ] Pricing chooses among an enterprise add-on, an annual enterprise-package inclusion, or per-unit pricing plus transaction/provider costs; the pilot validates the choice.
+- [ ] The team explicitly decides whether any per-transaction fee, monthly module fee, or per-unit annual bundle is customer-facing or absorbed.
+- [ ] The paid pilot is bounded to 60–90 days, named properties, a tenant cohort, and explicit exit criteria.
+- [ ] The pilot operates in parallel with the customer's PMS/Yardi process and does not replace the system of record.
+- [ ] The commercial reference is documented: $30 per unit per year implies $90,000 per year for 3,000 units.
+- [ ] Pricing is treated as an enterprise reference, not a public promise or a cheap flat-tier bundle.
+- [ ] Pilot fees, provider fees, return costs, implementation effort, support effort, and liability allocation are modeled.
+- [ ] Paid onboarding and migration support are evaluated separately from recurring PAD pricing.
+- [ ] Success metrics cover adoption, authorization completion, submission success, settlement evidence, reconciliation, returns, support load, and operator time saved.
+- [ ] Pilot and customer owners decide who answers tenant questions and the support coverage commitment.
+- [ ] Stop-loss thresholds are defined for failed/returned debits, reconciliation exceptions, complaints, privacy/security incidents, and support capacity.
+- [ ] No public launch date, provider commitment, or capability promise has been made.
+
+Evidence: approved pilot charter, unit economics model, cohort definition, success/stop criteria, signed commercial owner review.
+
+## Gate B — payment and provider feasibility
+
+- [ ] The provider decision matrix is complete with evidence for Stripe ACSS, at least one Canadian alternative, and a manual/offline fallback.
+- [ ] Stripe ACSS is evaluated as the preferred first feasibility track, not treated as the final provider selection.
+- [ ] Provider eligibility, Canadian availability, account configuration, limits, settlement timing, returns, disputes, and support escalation are confirmed in writing.
+- [ ] Provider-managed authorization and mandate evidence are supported.
+- [ ] A SetupIntent-style flow can save a verified bank payment method and mandate for later use.
+- [ ] An off-session PaymentIntent-style debit can be created for each specifically approved rent debit.
+- [ ] Payment method data and sensitive bank credentials are not stored by RentChain.
+- [ ] Webhook authenticity, idempotency, duplicate delivery, out-of-order events, delayed outcomes, retry safety, and reconciliation exports are tested.
+- [ ] The end-to-end funds flow shows that RentChain does not hold funds.
+- [ ] Payee ownership, landlord/property-manager onboarding, settlement routing, reserves/negative balances, returns, refunds, and liability are explicitly decided.
+- [ ] Production enablement is separate from sandbox credentials and cannot be activated by ordinary application configuration alone.
+
+Evidence: provider responses, architecture diagram, sandbox test record, webhook/reconciliation evidence, approved funds-flow and liability record.
+
+## Gate C — legal, regulatory, privacy, and security
+
+- [ ] Canadian payments counsel has reviewed the exact proposed participant roles and funds flow.
+- [ ] Counsel has provided a documented RPAA/Bank of Canada analysis; no-custody is not assumed by itself to settle regulatory scope.
+- [ ] Counsel has reviewed applicable Payments Canada PAD rules and the authorization, confirmation, pre-notification, cancellation, dispute, and record-retention approach.
+- [ ] Counsel has approved the tenant-facing mandate, debit authorization, variable-amount/timing disclosure, notice, cancellation, and support language.
+- [ ] Counsel has confirmed whether landlord/property-manager agreements require amendments.
+- [ ] Counsel and the insurance broker assess insurance coverage, exclusions, limits, and notification obligations.
+- [ ] Counsel advises whether a separate payments entity is required or advisable now or at a later scale threshold.
+- [ ] Privacy review covers data inventory, purpose, consent, retention, deletion, subprocessors, cross-border processing, and access requests.
+- [ ] Security review covers threat model, least privilege, restricted provider keys, secret storage, environment separation, signed webhooks, audit logs, incident response, and vendor risk.
+- [ ] RentChain's terms and privacy documents are assessed, but no public document is changed in this mission.
+- [ ] No live debit occurs before the preceding reviews are approved.
+
+Evidence: counsel memo, approved language, RPAA/FINTRAC applicability record, privacy impact review, security approval, vendor-risk record.
+
+## Gate D — technical feasibility
+
+- [ ] Current reusable foundations are confirmed: authenticated payment entry points, provider boundary, signed webhook handling, provider receipts, reconciliation, canonical events, ledger projections, tenant payment views, and tests.
+- [ ] Production PAD is isolated from legacy PAP prototypes and uses authenticated, authority-resolved routes.
+- [ ] The canonical data model covers customer/payee configuration, authorization, payment method reference, debit instruction, attempt, provider event, settlement/return, reconciliation exception, and immutable audit evidence.
+- [ ] Lifecycle states and allowed transitions are deterministic and distinguish submitted, processing, succeeded, settled, failed, returned, cancelled, and reconciliation-exception outcomes.
+- [ ] Each debit is traceable to an approved rent obligation, authorization, actor, amount, schedule, provider request, provider event, ledger projection, and settlement result.
+- [ ] Idempotency keys and durable request fingerprints prevent duplicate debit creation.
+- [ ] Webhook processing is signature-verified, replay-safe, order-tolerant, and auditable.
+- [ ] Retry policy never silently creates a second debit and requires operator review where outcome is ambiguous.
+- [ ] Tenant, landlord/property-manager, and admin/support projections expose only role-appropriate information.
+- [ ] Sandbox exit evidence is repeatable and reviewed; it is not represented as production readiness.
+
+Evidence: approved design, threat model, test matrix/results, trace samples, failure/replay tests, engineering sign-off.
+
+## Gate E — operational and pilot readiness
+
+- [ ] Pilot runbook names accountable owners and escalation paths for enrollment, debit approval, monitoring, returns, cancellations, complaints, incidents, reconciliation, and customer communications.
+- [ ] Tenant support can explain authorization, debit timing, cancellation, returns, and escalation without giving legal advice.
+- [ ] Finance approves daily reconciliation, exception aging, evidence retention, and month-end treatment.
+- [ ] Operations approves manual review queues and service levels.
+- [ ] A staged property rollout and rollback/pause mechanism are rehearsed.
+- [ ] The PMS/Yardi parallel-run source-of-truth and double-entry prevention controls are documented.
+- [ ] Migration friction is tracked as a primary enterprise risk, including roster quality, ownership mapping, authorization conversion limits, duplicate schedules, and operator training.
+- [ ] Incident exercises cover duplicate submission, delayed provider event, returned debit, wrong amount, cancellation race, provider outage, compromised credential, and reconciliation mismatch.
+- [ ] A final pre-live review confirms no unresolved critical risks.
+
+Evidence: runbook rehearsal, support scripts, reconciliation sign-off, incident tabletop results, pilot roster, rollback record, operational approval.
+
+## Go/no-go rule
+
+`GO` requires all mandatory gates, named owners, signed approvals, no unresolved critical risk, and a production-enablement control. `CONDITIONAL GO` is allowed only for non-live preparation with explicit conditions, owners, deadlines, and expiry. It never authorizes a live debit. `NO-GO` is required if payee, settlement, liability, counsel, RPAA/FINTRAC, privacy/security, reconciliation, operational, provider, or duplicate-debit controls remain unresolved.
+
+The executive sponsor records the result. Legal/compliance, security/privacy, finance/reconciliation, or operations may independently block live activation within their domain.

--- a/docs/strategy/pad-provider-decision-matrix-v1.md
+++ b/docs/strategy/pad-provider-decision-matrix-v1.md
@@ -1,0 +1,77 @@
+# PAD Provider Decision Matrix v1
+
+## Decision to be made
+
+Select the first provider and funds-flow model for a bounded Canadian PAD beta. Stripe ACSS is the preferred first feasibility track because it aligns with existing Stripe foundations, but it is not the final selection. All capabilities, commercial terms, eligibility, and regulatory responsibilities require current written confirmation from the provider and counsel.
+
+RentChain must not hold funds. The intended model uses provider-managed authorization and payment-method storage, with one off-session debit object per approved rent debit. No option may advance because of sandbox success alone.
+
+## Non-negotiable requirements
+
+- Canadian PAD support for the proposed merchant/payee and property-management model.
+- Provider-hosted or provider-managed bank verification, authorization, and mandate evidence.
+- Tokenized payment method; no bank credentials stored by RentChain.
+- Explicit payee, settlement destination, onboarding, return/dispute, reserve, negative-balance, and liability model.
+- Signed, replay-safe webhooks plus durable provider identifiers and reconciliation evidence.
+- Safe idempotent submission and documented delayed-outcome handling.
+- Separate sandbox and production enablement with least-privilege credentials.
+- Exportable evidence sufficient for operations, audit, counsel, and customer support.
+- Acceptable Canadian data-processing, privacy, security, availability, support, and incident terms.
+
+## Options
+
+| Option | Proposed shape | Advantages to validate | Material questions and risks | Initial disposition |
+| --- | --- | --- | --- | --- |
+| Stripe ACSS Debit | Provider-managed SetupIntent/mandate for future use; one off-session PaymentIntent per approved debit; determine whether Connect/onboarding and settlement routing are required | Reuses existing Stripe/provider, webhook, receipt, reconciliation, and ledger foundations; coherent API lifecycle; sandbox path | Account eligibility; supported merchant/payee structure; Connect account model; delayed outcomes; verification fallback; returns/disputes; settlement routing; reserves and negative balances; pricing and limits | Preferred first feasibility track; not selected |
+| Canadian PAD/EFT provider category, with VoPay or Rotessa as diligence candidates | Provider-managed PAD agreement/token and API-driven debit/schedule; provider-specific payee and settlement model | Canadian specialization may offer onboarding, PAD operations, reporting, or support better aligned to the use case | API and webhook maturity; authorization evidence; idempotency; role model; custody/funds flow; settlement; returns; security; reconciliation; portability; commercial minimums | Required comparison; candidate(s) to be qualified |
+| Manual/offline fallback | Existing operator-approved rent collection outside RentChain; RentChain records workflow status/evidence without initiating a debit | Preserves a safe operational fallback and parallel run; avoids forcing an unapproved integration | Manual work, delayed evidence, reconciliation errors, duplicate scheduling, unclear source of truth, weak scalability | Pilot contingency only; not the target automated model |
+
+Candidate names are prompts for diligence, not endorsements or capability claims.
+
+For every option, the evidence pack must explicitly cover mandate/authorization support, bank verification, Canadian ACSS/PAD fit, webhooks/events, platform/Connect capability, landlord onboarding, settlement clarity, reconciliation, tenant experience, developer experience, compliance burden, support burden, beta feasibility, enterprise scalability, and unknowns. A missing answer remains `unknown` and cannot be inferred from a generic product page.
+
+## Weighted evaluation
+
+Score each criterion 0–5 using linked evidence. A score without evidence is `unknown`, not zero. Mandatory failures cannot be offset by a high weighted total.
+
+| Criterion | Weight | Mandatory? | Evidence required |
+| --- | ---: | --- | --- |
+| Legal/regulatory role clarity | 15 | Yes | Provider role/funds-flow response plus counsel analysis |
+| No-custody settlement model | 10 | Yes | Diagram and contract terms showing funds movement |
+| Payee and landlord/manager onboarding fit | 10 | Yes | Confirmed account/onboarding model |
+| Authorization and mandate evidence | 10 | Yes | API flow, retained evidence, notice/cancellation support |
+| Debit lifecycle, returns, and disputes | 10 | Yes | State/event documentation and sandbox cases |
+| Idempotency, webhooks, and retry safety | 10 | Yes | API guarantees and replay/out-of-order tests |
+| Reconciliation and audit evidence | 10 | Yes | Reports/API/export samples and trace test |
+| Security, privacy, and data residency | 10 | Yes | Security package, DPA, subprocessor/data-flow review |
+| Existing foundation reuse and delivery effort | 5 | No | Engineering estimate and architecture review |
+| Commercial model and 3,000-unit economics | 5 | No | Written pricing, limits, fees, reserves, support costs |
+| Reliability, support, and incident response | 5 | No | SLA/status history/support escalation terms |
+| **Total** | **100** |  |  |
+
+The commercial comparison must show the $30/unit/year enterprise reference ($90,000/year at 3,000 units) alongside provider fees, returns, implementation, paid onboarding, support, reconciliation, and risk costs. PAD is expected to support enterprise positioning more directly than public small-landlord tiers, and it must not be assumed to fit a cheap flat tier.
+
+## Provider diligence questions
+
+1. Who is merchant, payee, payment service provider, settlement recipient, and party liable for returns, disputes, fees, reserves, and negative balances?
+2. Can property owners/managers be onboarded without RentChain taking custody, and which provider account model applies?
+3. What authorization evidence is created, retained, retrievable, and exportable? Who sends confirmation and pre-notification?
+4. How are variable amounts, timing changes, cancellation, revocation, refunds, returns, and disputes represented?
+5. Which outcomes are synchronous versus delayed? What are the settlement and return windows?
+6. What idempotency, webhook signing, event ordering, replay, retry, and status-retrieval guarantees exist?
+7. What sandbox scenarios and production certification are available?
+8. What Canadian eligibility, transaction limits, reserves, underwriting, prohibited-business, and volume requirements apply?
+9. Where is data processed, which subprocessors are used, and what deletion/export/security commitments apply?
+10. What pricing, minimums, onboarding lead time, SLA, escalation, and termination/portability terms apply?
+
+## Decision process
+
+1. Product and engineering document the common use case and required lifecycle without provider-specific assumptions.
+2. Finance and operations document payee, settlement, reconciliation, return, and support needs.
+3. Providers answer the same diligence pack and demonstrate sandbox flows.
+4. Security/privacy review vendor evidence and data flows.
+5. Counsel reviews the actual proposed roles, contracts, and funds flow, including Payments Canada rules and RPAA/FINTRAC applicability.
+6. The team scores evidence, records mandatory failures, and runs total-cost/sensitivity analysis.
+7. Approvers record `SELECT`, `CONDITIONAL`, or `REJECT`, plus assumptions, conditions, expiry, and fallback.
+
+No provider selection authorizes implementation or live debits. Those require a separately approved implementation mission and all Phase 0 gates.

--- a/docs/strategy/pad-sandbox-readiness-plan-v1.md
+++ b/docs/strategy/pad-sandbox-readiness-plan-v1.md
@@ -1,0 +1,103 @@
+# PAD Sandbox Readiness Plan v1
+
+## Purpose
+
+Produce repeatable technical and operational evidence for a provider decision without implementing or enabling production PAD. Stripe ACSS is the preferred first feasibility track, not the final provider selection. A second Canadian PAD/EFT candidate must receive a comparable assessment.
+
+Sandbox work does not constitute legal approval, production readiness, provider eligibility, or authority to debit. RentChain will not hold funds. No public promise, live customer enrollment, real bank credential, real debit, pricing-page change, or production configuration is in scope.
+
+## Preconditions
+
+- Product supplies one provider-neutral use case: provider-managed authorization for later rent debits and one off-session debit per approved obligation.
+- Finance and operations draft payee, onboarding, settlement, reconciliation, return, and liability questions; unresolved items stay visibly open.
+- Counsel identifies prohibited test data and confirms that sandbox artifacts cannot be reused as live authorization.
+- Security approves isolated test accounts, synthetic data, secret handling, least privilege, retention, and access logging.
+- Engineering confirms legacy PAP prototypes remain unmounted and are not reused as the sandbox implementation path.
+- A time-box, owner, evidence repository, decision date, and teardown date are set.
+
+## Workstreams
+
+Before implementation, engineering must confirm current provider documentation; enumerate required environment variables and secrets without recording values; define webhook-signature verification; specify synthetic tenant, landlord, property, lease, authorization, debit, event, and return fixtures; define event replay/status-retrieval tooling; document local, sandbox, staging, and production separation; and obtain approved retention and log-redaction rules.
+
+### 1. Provider/account feasibility
+
+Obtain written confirmation or record `unknown` for Canadian account eligibility, ACSS/PAD enablement, provider account model, payee/settlement recipient, onboarding, limits, delayed outcomes, returns/disputes, reserves/negative balances, support, pricing, and production approval steps.
+
+For a Connect-style model, evaluate the provider's current account/controller model and hosted onboarding; do not base a new design on legacy account-type labels. The chosen model must show that funds do not pass through RentChain custody.
+
+### 2. Authorization feasibility
+
+Demonstrate with synthetic test identities and provider test methods:
+
+- provider-managed bank verification;
+- a SetupIntent-style future-use flow and retrievable mandate/authorization evidence;
+- success, incomplete verification, failure, cancellation, expiry, and replacement;
+- provider-published test bank details/payment methods only, including instant-verification and fallback paths where supported;
+- evidence references sufficient for tenant, operator, support, and audit views;
+- no raw bank credential stored or logged by RentChain.
+
+Capture provider-hosted screens or artifacts only under approved data-handling rules. Counsel must separately approve live language and evidence sufficiency.
+
+### 3. Debit lifecycle feasibility
+
+Demonstrate one off-session PaymentIntent-style object per approved debit and test:
+
+- deterministic request/idempotency identity;
+- submitted/processing behavior without premature paid/settled claims;
+- success and settlement evidence;
+- insufficient funds or equivalent failure;
+- delayed failure/return after an earlier processing or success signal;
+- cancellation race and ambiguous network response;
+- duplicate request suppression and safe operator-directed retry;
+- refund/dispute representation where supported.
+- simulated NSF/return and delayed settlement/return outcomes where supported.
+
+Do not hardcode a provider payment-method list merely to force a sandbox result; use provider account/payment-method configuration consistent with current provider guidance.
+
+### 4. Webhook, event, and reconciliation feasibility
+
+- Verify signatures using isolated secrets.
+- Test duplicates, replays, out-of-order events, missing events, delayed events, unknown objects, and key rotation.
+- Prove processing is idempotent and creates append-safe canonical evidence.
+- Compare API status retrieval, event history, provider report/export, debit instruction, receipt, ledger projection, and settlement/return outcome.
+- Create an exception when sources disagree; never rewrite history to hide the difference.
+- Measure detection and recovery time for a missed event and reconciliation mismatch.
+
+### 5. Role and operational feasibility
+
+Using synthetic data, review least-information projections for:
+
+- tenant: authorization, approved debit, current non-misleading status, notice/cancellation/support evidence;
+- landlord/property manager: authorized cohort, obligation/debit status, settlement/return and actionable exceptions;
+- admin/support: evidence trace, provider identifiers, event/reconciliation state, safe remediation controls.
+
+Run table-top exercises for duplicate debit, wrong amount, returned debit, provider outage, compromised key, unauthorized access, cancellation race, wrong settlement recipient, and customer complaint.
+
+### 6. Comparative provider spike
+
+Run the same evidence checklist against at least one qualified Canadian provider/category. A documentation/API review may replace code when access is unavailable, but all untested claims must remain `unknown`. Compare capability, role clarity, evidence, integration effort, risk, support, and total cost at the $30/unit/year reference ($90,000/year for 3,000 units).
+
+## Test evidence register
+
+| Test | Expected evidence | Owner | Result |
+| --- | --- | --- | --- |
+| Authorization success/failure/replacement | Provider IDs, safe screenshots/logs, mandate evidence reference | Engineering | TBD |
+| Off-session debit success/processing/failure/return | Object/event timeline and application state trace | Engineering | TBD |
+| Duplicate and ambiguous submission | One provider debit and reviewable outcome | Engineering | TBD |
+| Webhook replay/out-of-order/missing | Idempotent event processing and recovery record | Engineering | TBD |
+| Reconciliation match/mismatch | Provider-to-instruction trace and exception | Finance/engineering | TBD |
+| Role projections | Approved tenant/operator/support view review | Product/privacy | TBD |
+| Incident tabletop | Timeline, decisions, communication and restart gates | Operations/security | TBD |
+| Provider/account/funds-flow confirmation | Written provider response and diagram | Product/finance | TBD |
+
+Every artifact records environment, date, provider/API version where applicable, test identifiers, expected/actual result, reviewer, limitations, and linked issue. Do not include secrets, raw bank details, or unrelated personal data.
+
+## Exit criteria
+
+The sandbox phase may recommend `PROCEED TO DESIGN/IMPLEMENTATION APPROVAL`, `CONTINUE DILIGENCE`, or `STOP`. A proceed recommendation requires repeatable evidence for authorization, one-debit-per-approval submission, webhook/idempotency/retry safety, delayed outcomes, reconciliation, role projections, secure environment separation, and a plausible no-custody funds flow.
+
+It also requires provider answers sufficient for counsel and the provider matrix, provider account approval or a documented approval path, an approved payment-flow diagram, a selected pilot landlord, and a defined support escalation path. It does not require or imply a live debit. Unresolved payee, settlement, liability, provider eligibility, counsel, RPAA/FINTRAC, privacy/security, reconciliation, or operational questions must block production enablement.
+
+## Teardown
+
+At the time-box end, revoke unused test credentials, remove unnecessary test access, delete synthetic artifacts according to policy, retain the approved evidence package, record open risks, and verify no production flag, live credential, customer authorization, schedule, or public product claim was created.


### PR DESCRIPTION
## Summary

- adds a Phase 0 go/no-go feasibility checklist
- adds provider decision inputs for Stripe ACSS, a Canadian PAD/EFT alternative category, and a manual fallback
- adds a Canadian payments/privacy counsel review brief and request email
- adds a bounded 60–90 day paid pilot readiness runbook beside PMS/Yardi
- adds a tactical sandbox readiness plan with evidence and exit criteria

## Boundaries

- docs-only: exactly five new Markdown files
- no runtime, backend/API, or frontend product changes
- no payment or PAD implementation
- no Stripe/ACSS implementation
- no Certn implementation
- no pricing, landing page, terms, or privacy changes
- RentChain does not hold funds; provider selection remains open

## Key decisions and gates

- Stripe ACSS remains the preferred first feasibility track, not a final provider selection
- payee ownership, landlord onboarding, settlement routing, returns, reconciliation, and liability require explicit decisions
- counsel, RPAA/FINTRAC, privacy/security, reconciliation, operational, provider, and executive gates block live debits
- sandbox success is not legal or production approval
- the pilot uses staged properties and a parallel run beside the existing PMS/Yardi
- $30/unit/year implies $90,000/year for 3,000 units; final pricing is pilot-validated

## Validation

- git diff --cached --check passed before commit
- no documentation lint command is configured
- build and manual runtime QA are not applicable to this docs-only change