### PR TITLE
docs: PAD external validation package

### DIFF
--- a/docs/operations/pad-counsel-go-no-go-request-v1.md
+++ b/docs/operations/pad-counsel-go-no-go-request-v1.md
@@ -1,0 +1,91 @@
+# PAD Counsel Go/No-Go Request v1
+
+Status: request for qualified Canadian legal advice; not legal advice or launch authorization
+
+## RentChain context
+
+RentChain is a Canadian proptech/SaaS platform for landlords/property managers and tenants, with lease-linked workflow, payment evidence, maintenance, portal, and export foundations. PAD is planned and not implemented. RentChain prefers a processor-led model and does not intend to hold tenant or landlord funds directly.
+
+The proposed beta would be paid, limited to a staged property group, and run for 60–90 days beside Yardi or another existing PMS. No full migration is required. Provider feasibility and all legal conclusions remain open.
+
+## Proposed flow for review
+
+1. A landlord enables PAD for an eligible lease/property.
+2. A tenant receives counsel-approved, versioned authorization language.
+3. The tenant completes provider-managed bank verification and authorization.
+4. The provider stores sensitive payment information and returns mandate/payment references.
+5. RentChain stores approved opaque references, status, agreement metadata, and evidence only.
+6. RentChain creates versioned lease-linked rent obligations.
+7. One approved off-session debit request is sent per obligation under the mandate.
+8. Signed provider events and reconciliation update lifecycle status.
+9. Tenant and landlord receive approved notices, status, receipts, failure/return, cancellation, and support information.
+10. Append-safe evidence covers authorization, notice, debit, return, dispute, reconciliation, and decisions.
+
+## Documents to provide counsel
+
+- PAD technical design, lifecycle, data model, compliance/risk gates, beta plan, and Phase 0 package.
+- This external-validation package and completed provider feasibility response.
+- Participant/responsibility and end-to-end funds-flow diagrams.
+- Proposed mandate model and provider authorization artifacts.
+- Draft tenant authorization, confirmation, notice, cancellation, failure/return, complaint, and privacy copy, if available.
+- Landlord pilot agreement concept, commercial structure, cohort, province, and responsibility matrix.
+- Privacy/data inventory, processing, retention, deletion, access, and incident plan.
+- Support, reconciliation, complaint, dispute, and payment-incident playbooks.
+
+## Questions for counsel
+
+1. Which PAD agreement class and authorization terms apply to the proposed rent flow?
+2. How should fixed, variable, interval, sporadic/combined, rent-change, adjustment, and timing scenarios be treated?
+3. What confirmation, pre-notification, change-notice, delivery-evidence, and waiver requirements apply?
+4. What cancellation/revocation rights, methods, effective cutoffs, and already-submitted-debit treatment apply?
+5. What tenant dispute, reimbursement, unauthorized-debit, refund, and complaint processes are required?
+6. What NSF/returned-payment, fee, retry, rent-obligation, and communication terms are permitted?
+7. What responsibilities must the landlord/payee accept for authority, tenant data, amounts, notices, settlement, returns, disputes, and support?
+8. What responsibilities and liability should remain with RentChain and with the processor/provider?
+9. Which Terms of Use, privacy policy, PAD agreement, landlord agreement, pilot agreement, and support-term changes are required before external or live use?
+10. What authorization, notice, provider, payment, reconciliation, support, audit, and legal-hold records must be retained, by whom, where, and for how long?
+11. Does RentChain perform one or more payment functions within RPAA scope under the actual model? Analyze incidental activity, agent/mandatary, third-party service provider, registration, operational-risk, incident, and safeguarding implications.
+12. Does the final activity/funds flow create FINTRAC/MSB registration, compliance, reporting, recordkeeping, or related exposure?
+13. Does avoiding funds custody change—but not necessarily eliminate—RPAA, FINTRAC, contractual, privacy, or operational duties?
+14. Which cyber, technology E&O, crime/funds-transfer, regulatory, payment/dispute, or other insurance coverage and limits are appropriate?
+15. Is a separate payment entity required or advisable now or after a defined activity, jurisdiction, volume, or risk threshold?
+16. Are electronic authorization/signature, language, accessibility, consumer-protection, tenancy, payment-method-choice, fee, receipt, or provincial requirements triggered?
+17. Are the proposed pilot terms, pricing validation, data exchange, parallel run, rollback, support, indemnity, limitation, and risk allocation appropriate?
+18. What exact conditions constitute legal `GO`, `GO WITH CONDITIONS`, or `NO-GO` for beta implementation and separately for a first live debit?
+
+## Requested counsel deliverables
+
+- PAD authorization template and agreement/evidence requirements.
+- Approved or recommended confirmation, notice, cancellation, change, NSF/return, dispute, complaint, and support language.
+- Terms/privacy and landlord/pilot agreement change recommendations.
+- Short written RPAA and FINTRAC/MSB scope memo with assumptions and re-review triggers.
+- Recommended participant, payee, no-custody funds-flow, responsibility, and risk-allocation structure.
+- Insurance and separate-entity recommendations.
+- A gate table labeling each issue `APPROVED`, `APPROVED WITH CONDITIONS`, `BLOCKED`, or `OUT OF SCOPE`.
+- Go/no-go recommendation for beta implementation and distinct conditions for any live debit.
+
+Counsel approval must expire if provider, roles, funds flow, jurisdiction, authorization model, settlement, liability, data processing, or customer language materially changes.
+
+## Email-ready request
+
+**Subject:** Go/no-go legal review — Canadian PAD beta preparation
+
+Hello [Counsel name],
+
+RentChain is preparing external validation for a possible provider-processed Canadian PAD beta. PAD is planned, not implemented, and no live debit is authorized. Our preferred model uses provider-managed verification and authorization, opaque provider references, and direct settlement to the approved payee; RentChain does not intend to hold funds.
+
+Please review the attached provider response, proposed flow, funds-flow and responsibility diagrams, draft customer language, data plan, and pilot concept. We request written conclusions on PAD rules, authorization/notice/cancellation/returns, agreements, privacy, retention, RPAA, FINTRAC/MSB, insurance, entity structure, and risk allocation, plus an explicit go/no-go recommendation.
+
+We will not treat sandbox success as legal approval or begin live debit testing without approved authorization language and all required gates.
+
+Regards,
+
+[Executive/legal owner]
+
+## Current official references for counsel
+
+- Payments Canada Rule H1: <https://www.payments.ca/sites/default/files/h1eng.pdf>
+- Bank of Canada RPAA supervisory framework: <https://www.bankofcanada.ca/regulatory-oversight/retail-payments/supervisory-framework/>
+- Bank of Canada registration criteria: <https://www.bankofcanada.ca/2026/06/criteria-for-registering-payment-service-providers/>
+
+These links do not replace counsel's current-source review or legal analysis of RentChain's actual activities.

--- a/docs/operations/pad-enterprise-pilot-validation-script-v1.md
+++ b/docs/operations/pad-enterprise-pilot-validation-script-v1.md
@@ -1,0 +1,91 @@
+# PAD Enterprise Pilot Validation Script v1
+
+Status: discovery script only; no PAD capability or commercial commitment
+
+## Interview objective
+
+Determine whether a serious landlord/property manager—including the 3,000-unit opportunity—would participate in a paid 60–90 day validation pilot beside Yardi or another PMS. Validate demand, transition friction, data, operating ownership, support needs, success measures, and price logic before implementation.
+
+## Opening positioning
+
+Suggested language:
+
+> RentChain is not asking you to rip out Yardi. We are evaluating a parallel workflow, evidence, and PAD-readiness layer that could support application/screening workflow, maintenance/evidence, tenant/contractor portals, a processor-led PAD rent-collection roadmap, and operating records/exports. PAD is planned, not live. We want to understand whether a limited paid pilot could solve a measurable problem without forcing a full migration.
+
+Do not claim Certn is live. Describe screening providers only according to verified current availability.
+
+## Current-state discovery
+
+Ask for examples, volumes, time, owners, exceptions, and baseline measures—not only opinions.
+
+1. Which PMS/Yardi modules and other systems own property, lease, tenant, rent, payment, maintenance, screening, renewal, and reporting data?
+2. How are rent obligations generated, approved, collected, posted, reconciled, and exported today?
+3. How are PAD authorizations obtained, changed, retained, cancelled, and proved during a dispute?
+4. What are the most costly PAD/pre-authorized debit pain points?
+5. How are failed, NSF, returned, disputed, duplicated, wrong-amount, or delayed payments handled and communicated?
+6. How much operator time is spent reconciling tenant, bank/provider, ledger, and PMS records each cycle?
+7. How are tenants onboarded, authenticated, supported, and moved between properties or payment methods?
+8. How are maintenance requests, evidence, assignments, contractor updates, cost records, and disputes managed?
+9. Which screening workflow/provider is live, and where do consent, status, evidence, or manual handoffs break down?
+10. How are renewals, rent changes, move-outs, partial periods, arrears, and responsibility changes communicated across systems?
+11. Which reports, exports, evidence packages, or audit responses are hardest to produce?
+12. Where do tenant, landlord, contractor, provider, or internal records disagree during disputes?
+13. What transition risks would make a parallel pilot unsafe—duplicate debits, roster quality, staff training, source-of-truth ambiguity, privacy, or support capacity?
+14. Can you provide bounded CSV or API exports for properties, units, leases, tenants, obligations, payment schedules, and historical reconciliation? Which fields are unreliable?
+15. Who owns business sponsorship, payments, finance/reconciliation, privacy/legal, security, IT/PMS, operations, support, procurement, and final approval?
+16. What annual budget, procurement threshold, contract term, security review, and price sensitivity apply?
+
+## Pilot validation questions
+
+1. Would you test RentChain beside Yardi/existing PMS with explicit field ownership and no full replacement?
+2. Which property group is safest and representative, and how many units/tenants should be included?
+3. Which workflows should enter first: application/lease evidence, maintenance, portals, exports, PAD readiness, or a narrower subset?
+4. What measurable result would make a 60–90 day pilot worth paying for?
+5. What result and risk evidence would justify annualizing?
+6. Is a $30/unit/year enterprise reference reasonable if PAD plus workflow/evidence value is proven? Which provider/transaction costs should be passed through or bundled?
+7. Would you pay separately for white-glove onboarding, migration preparation, training, and reconciliation support?
+8. What data, SSO/security, insurance, legal, provider, integration, accessibility, support, or procurement requirement would block approval?
+9. Which tenant groups should review authorization language, and what language/accessibility needs apply?
+10. Who can authorize a sample export, technical/payment follow-up, pilot negotiation, and final decision?
+
+Do not bundle PAD into low-cost flat monthly tiers without enterprise pricing review. The 3,000-unit reference is $90,000/year at $30/unit/year, not a public price or promise. Final pricing must be validated in the pilot.
+
+## Proposed pilot structure to test
+
+| Element | Proposal for feedback |
+| --- | --- |
+| Duration | Paid 60–90 days |
+| Cohort | One limited, staged property group; no portfolio-wide cutover |
+| Operating model | Parallel run beside Yardi/existing PMS with named field ownership |
+| Migration | No full migration; limited CSV/import/export only where necessary |
+| Onboarding | White-glove setup/training may be a paid service |
+| Cadence | Weekly feedback and operating calls; daily exception ownership if payment activity begins later |
+| Success measures | Authorization comprehension/completion, payment outcomes after delayed-return window, reconciliation effort, evidence completeness, support burden, transition risk, and annualization willingness |
+| Safety | Provider/counsel gates before implementation; no live debit in this validation mission |
+| Exit | Annual proposal, extend validation, pause for risk, or stop with export/transition plan |
+
+## Close and requested next steps
+
+Ask for:
+
+- a redacted/sample bounded export and field dictionary;
+- a follow-up technical/payment workflow call;
+- permission to send a written paid-pilot proposal;
+- a meeting with the economic buyer and legal, finance/payments, IT/security, PMS, operations, and support decision makers;
+- written confirmation of the candidate property group, baseline measures, blockers, and decision date.
+
+## Interview record
+
+| Field | Notes |
+| --- | --- |
+| Customer/date/interviewers | TBD |
+| Participants and roles | TBD |
+| Current systems/source ownership | TBD |
+| Top pain points/baselines | TBD |
+| Candidate cohort/data readiness | TBD |
+| Pilot/value/pricing reaction | TBD |
+| Support/onboarding needs | TBD |
+| Risks/blockers | TBD |
+| Decision makers/process/date | TBD |
+| Evidence received/follow-ups | TBD |
+| Result | `COMMITTED`, `NEGOTIATING`, `MORE VALIDATION`, or `NO DEMAND` |

--- a/docs/operations/pad-provider-feasibility-request-v1.md
+++ b/docs/operations/pad-provider-feasibility-request-v1.md
@@ -1,0 +1,93 @@
+# PAD Provider Feasibility Request v1
+
+Status: provider inquiry only; no provider selected and no PAD implementation authorized
+
+## RentChain context
+
+RentChain is a Canadian proptech/SaaS platform serving landlords/property managers and tenants across lease-linked rental workflows. It is evaluating recurring monthly rent collection using a processor-led Canadian PAD/ACSS model. RentChain does not intend to hold funds and prefers provider-managed bank verification, authorization/mandate evidence, payment-method lifecycle, processing, and settlement.
+
+The initial opportunity is a bounded enterprise pilot, not a public launch. The planning reference is $30/unit/year, or $90,000/year for 3,000 units, with final pricing validated in a paid pilot and provider costs modeled separately.
+
+## Proposed flow to validate
+
+1. Landlord enables PAD for an eligible lease/property.
+2. Tenant receives a versioned authorization link.
+3. Tenant authorizes Canadian bank-account debit through a provider-managed flow.
+4. Provider stores the payment method and mandate and returns opaque references/evidence.
+5. RentChain stores only approved provider references, status, agreement metadata, and audit evidence—never raw bank credentials.
+6. RentChain creates lease-linked, versioned rent obligations.
+7. RentChain initiates one approved off-session debit attempt per obligation using durable idempotency.
+8. Signed provider webhooks and status retrieval update processing, success, failure, return, cancellation/dispute, and settlement evidence.
+9. Landlord and tenant see role-appropriate payment status, receipts, failures, returns, and support paths.
+10. An append-safe audit trail links authorization, obligation, attempt, provider evidence, reconciliation, notices, and receipt/reversal.
+
+This flow is a hypothesis for validation. `Pending` is not paid, and an initial success can still be followed by a return.
+
+## Questions for the provider
+
+### Eligibility and account model
+
+1. Does your Canadian ACSS/PAD product support recurring residential rent for this proposed platform/customer structure?
+2. Who should be payee/merchant of record and settlement recipient?
+3. Should each landlord/property manager have a connected/provider account? If so, which current account configuration and capabilities apply?
+4. Which party collects KYC/verification requirements, pays provider fees, and bears losses, returns, disputes, reserves, and negative balances?
+5. Is a platform/Connect model required, optional, or inappropriate? Please describe responsibilities rather than relying only on legacy account-type labels.
+6. Can settlement route directly to the landlord-designated account without RentChain possessing or controlling funds?
+7. What onboarding/KYC, underwriting, volume, reserve, prohibited-business, and ongoing verification requirements apply to RentChain and each landlord?
+
+### Authorization and debit lifecycle
+
+8. Can a provider-managed SetupIntent or equivalent create a reusable Canadian bank payment-method and mandate reference for future rent debits?
+9. Which payment-method, mandate, customer, account-context, agreement, and verification references should RentChain store or avoid storing?
+10. Which fixed, interval, sporadic, combined, or variable schedule model best fits monthly rent with lawful future rent changes?
+11. Can one off-session PaymentIntent or equivalent be created for each specifically approved debit under the mandate?
+12. Which current events and statuses represent authorization pending/verified, debit processing, succeeded, failed, returned, cancelled, disputed, refunded, and settled?
+13. What are expected verification, submission, settlement, return, and dispute timelines? How late can a return arrive?
+14. Who sends required mandate confirmation and debit notifications, and what evidence is retrievable/exportable?
+
+### Reliability, testing, and operations
+
+15. What idempotency scope and retention apply? How should ambiguous network timeouts be resolved without resubmission?
+16. How are webhook signatures verified, events replayed, duplicates/out-of-order delivery handled, and missed events recovered?
+17. How can NSF, closed account, verification failure, delayed success/failure, return, dispute, cancellation race, and settlement delay be simulated in sandbox?
+18. Which sandbox behavior differs from live mode, and what certification or production approval is required?
+19. What reporting/API/export evidence supports per-attempt and aggregate settlement reconciliation?
+20. What transaction, verification, platform, onboarding, return, dispute, refund, payout, reserve, minimum, support, and currency-conversion fees apply?
+21. What rate/amount/volume limits, availability commitments, escalation paths, response targets, and support exclusions apply?
+22. What data-processing locations, subprocessors, retention/deletion behavior, incident terms, and portability/export options apply?
+23. What restrictions or additional terms apply specifically to rent collection and PAD authorization?
+
+## Requested deliverables
+
+- Written feasibility conclusion with assumptions, restrictions, and expiry.
+- Recommended participant, account, responsibility, and no-custody funds-flow model.
+- Sandbox account/access/setup steps and production eligibility path.
+- Authorization/mandate and bank-verification artifact examples.
+- Test event matrix, current webhook event/status list, return codes, and timelines.
+- Idempotency, replay, status-retrieval, and reconciliation recommendations.
+- Fee schedule, limits, reserves, liability, onboarding/KYC, support, and escalation terms.
+- Explicit unresolved risks, unknowns, and questions for counsel.
+
+## Email-ready request
+
+**Subject:** Canadian ACSS/PAD rent collection feasibility review for RentChain
+
+Hello [Provider contact],
+
+RentChain is a Canadian proptech/SaaS platform evaluating a limited paid beta for provider-processed pre-authorized rent debits. PAD is planned, not implemented. We prefer provider-managed bank verification and mandate/payment-method lifecycle, and RentChain does not intend to hold funds.
+
+Please review the attached proposed flow and answer the account/payee, connected-account, KYC, settlement, mandate, off-session debit, webhook, delayed return, idempotency, sandbox, reconciliation, fee, and support questions. We need written confirmation for the actual rent use case and participant structure, not a generic product-capability statement.
+
+This request does not authorize production use. Provider findings will be reviewed with Canadian payments/privacy/commercial counsel before any implementation or live testing.
+
+Regards,
+
+[Payments/product owner]
+
+## Current official references to confirm
+
+- Stripe Canadian PAD setup/future payments: <https://docs.stripe.com/payments/acss-debit/set-up-payment>
+- Stripe connected-account configuration: <https://docs.stripe.com/connect/accounts-v2/connected-account-configuration>
+- Stripe onboarding options: <https://docs.stripe.com/connect/onboarding>
+
+These references are starting points only. The provider response must confirm current applicability to RentChain's actual account and funds-flow model.

--- a/docs/strategy/pad-external-validation-checklist-v1.md
+++ b/docs/strategy/pad-external-validation-checklist-v1.md
@@ -1,0 +1,89 @@
+# PAD External Validation Checklist v1
+
+Status: external-validation preparation only; PAD is planned and not implemented
+
+## Use and boundaries
+
+This checklist coordinates evidence from a payment provider, Canadian payments/privacy/commercial counsel, a prospective enterprise pilot landlord, tenant-style reviewers, and RentChain's internal decision owners. It does not authorize implementation or live debit testing.
+
+Do not reuse the legacy PAP prototype as production PAD. Do not let RentChain hold funds directly in the first implementation. Provider sandbox success is not legal approval. Do not begin live debit testing without counsel-approved authorization language. Do not publicly promise PAD until provider, legal, and beta readiness are confirmed. Do not claim Certn is live unless the integration is actually live.
+
+Allowed status values: `OPEN`, `IN PROGRESS`, `PASS`, `PASS WITH CONDITIONS`, `BLOCKED`, `NOT APPLICABLE`. Every pass needs linked evidence, an owner, a date, and any expiry or assumptions.
+
+## Provider validation
+
+| Validation item | Owner | Evidence required | Pass condition | Notes/status |
+| --- | --- | --- | --- | --- |
+| Canadian ACSS/PAD eligibility | Payments lead | Written provider confirmation for the actual rent use case, business, volume, and jurisdiction | Sandbox and prospective live eligibility are confirmed with conditions documented | TBD |
+| Landlord/payee model | Payments + finance | Participant and payee-of-record statement | Payee, merchant, tenant, landlord/manager, provider, and RentChain roles are unambiguous | TBD |
+| Account/Connect model | Payments + engineering | Recommended account configuration and responsibility matrix | Account ownership, KYC, fees, losses, requirements collection, and dashboard access are explicit | TBD |
+| No-custody funds flow | Payments + counsel | Provider-confirmed funds-flow diagram | Funds route provider-to-approved payee without RentChain possession or control; counsel separately approves characterization | TBD |
+| Mandate/payment references | Engineering + privacy | Sample safe objects and retention/export description | Provider owns sensitive bank data; RentChain can retain only approved opaque references, status, and evidence metadata | TBD |
+| Off-session debit | Engineering | Written flow and sandbox test plan | One specifically approved debit can reference the applicable mandate and payment method within mandate terms | TBD |
+| Lifecycle/webhooks | Engineering + finance | Event/state matrix | Pending, success, failure, return, cancellation/dispute, and settlement evidence can be represented without premature success claims | TBD |
+| NSF/failed/returned handling | Payments operations | Return-code, timing, retry, notice, and dispute documentation | Delayed returns and liability are understood; no silent or autonomous retry is required | TBD |
+| Sandbox access | Engineering | Account/access/setup instructions | Isolated test access, supported fixtures, and teardown path are available | TBD |
+| Idempotency/replay | Engineering | Provider guarantees plus duplicate, timeout, replay, and out-of-order test cases | Duplicate debit risk is controlled and ambiguous submission requires lookup/reconciliation | TBD |
+| Fees, reserves, limits | Finance | Written fee schedule and commercial terms | Transaction, verification, return, dispute, platform, reserve, minimum, and volume costs are modeled | TBD |
+| Support limitations | Operations | SLA, escalation, incident, and account-support terms | Beta coverage, escalation contacts, response expectations, and unsupported cases are acceptable | TBD |
+
+## Counsel and legal validation
+
+| Validation item | Owner | Evidence required | Pass condition | Notes/status |
+| --- | --- | --- | --- | --- |
+| PAD authorization agreement | Counsel | Approved template and assumptions | Agreement class, parties, authorization evidence, delivery, and retention are approved | TBD |
+| Fixed/variable treatment | Counsel + product | Written classification and approved copy | Rent amount/timing changes, schedule type, and required new authorization or notice are explicit | TBD |
+| Notice requirements | Counsel + operations | Notice matrix and delivery evidence requirements | Pre-notice, change notice, confirmation, and any waiver rules are approved | TBD |
+| Cancellation process | Counsel + product | Approved cutoffs, copy, and operational steps | Tenant can cancel/revoke clearly; submitted versus future debit treatment is defined | TBD |
+| NSF/return language | Counsel + operations | Approved tenant/landlord terms and messages | Fees, retries, obligations, disputes, and support communications are lawful and understandable | TBD |
+| Privacy updates | Privacy counsel | Required change list and data-flow review | Collection, purpose, consent, provider disclosure, transfers, retention, access, and deletion changes are approved | TBD |
+| Terms updates | Commercial counsel | Required Terms of Use and agreement changes | RentChain, landlord, tenant, and provider responsibilities and limitations are aligned | TBD |
+| RPAA analysis | Payments counsel | Written activity-by-activity memo | Registration, exclusion, agency/mandatary, third-party, safeguarding, and operational-risk conclusions are documented | TBD |
+| FINTRAC/MSB analysis | Payments counsel | Written memo | Applicable activities, exemptions, registrations, and controls are documented | TBD |
+| Insurance | Counsel + broker | Coverage/exclusion/limit review | Cyber, E&O, crime/funds-transfer, regulatory, and dispute risks are accepted or remediated | TBD |
+| No-custody review | Counsel | Final provider response, contracts, and funds-flow diagram | Counsel approves the actual roles and flags any regulatory duties that remain despite no custody | TBD |
+
+## Pilot landlord validation
+
+| Validation item | Owner | Evidence required | Pass condition | Notes/status |
+| --- | --- | --- | --- | --- |
+| Candidate and property group | Enterprise lead | Named customer, decision makers, and bounded cohort | Serious candidate and safe limited property group are identified | TBD |
+| Pain points | Product | Interview notes and baseline measures | PAD, reconciliation, evidence, onboarding, and support problems are concrete and prioritized | TBD |
+| Parallel run | Customer sponsor | Written acceptance of field ownership and operating model | Pilot runs beside Yardi/existing PMS with no forced replacement | TBD |
+| Paid pilot | Enterprise lead | Commercial discussion record | 60–90 day paid structure is accepted or under written negotiation | TBD |
+| Annual pricing path | Executive + customer sponsor | Pricing feedback | $30/unit/year reference and provider/transaction costs are discussed without public commitment | TBD |
+| Data availability | Customer technical owner | Sample export and data inventory | Limited CSV/import/export can support the cohort with identified quality gaps | TBD |
+| Support ownership | Operations + customer | Named contacts and coverage | Tenant, landlord, payment, and technical escalation owners are assigned | TBD |
+| Success metrics | Product + customer | Signed metric/exit sheet | Annualization, extension, pause, and stop criteria have measurable baselines | TBD |
+
+## Tenant experience validation
+
+| Validation item | Owner | Evidence required | Pass condition | Notes/status |
+| --- | --- | --- | --- | --- |
+| Authorization copy | Product + counsel | Counsel-approved draft tested with reviewers | Reviewers understand authorization, payee, amount/schedule, data handling, and support | TBD |
+| 3–5 comprehension tests | Research owner | Completed test templates | At least 3–5 uncoached tenant-style reviews are recorded | TBD |
+| Mobile comprehension | Design/research | Mobile-first review notes | Key terms and actions are understandable without desktop context | TBD |
+| Receipt/status language | Product + operations | Review results for pending/success/settled/returned states | Reviewers do not confuse initiation, processing, payment, and settlement | TBD |
+| Failed-payment notice | Counsel + support | Tested approved copy | Reviewer understands what happened, what remains owed, and who to contact | TBD |
+| Cancellation/change flow | Product + counsel | Tested scenario notes | Reviewer understands cancellation timing, rent changes, and future debit impact | TBD |
+
+## Internal operational validation
+
+| Validation item | Owner | Evidence required | Pass condition | Notes/status |
+| --- | --- | --- | --- | --- |
+| Payment incident playbook | Security + operations | Tabletop record | Duplicate/unauthorized debit, provider outage, compromised key, and reconciliation incidents are executable | TBD |
+| Support scripts | Support + counsel | Approved scripts | Tenant/landlord questions, cancellation, failures, and escalation are covered without legal overclaim | TBD |
+| Audit event list | Engineering + compliance | Reviewed taxonomy | Authorization, notices, attempts, provider evidence, returns, decisions, and reconciliation are attributable and append-safe | TBD |
+| Reconciliation workflow | Finance + operations | Daily/period process and exception ownership | Provider, obligation, attempt, ledger, settlement, and PMS evidence can be balanced | TBD |
+| Provider memo | Payments lead | Signed feasibility memo | Provider findings, conditions, costs, risks, and unknowns are complete | TBD |
+| Counsel memo | Counsel owner | Signed go/no-go memo | Required legal deliverables and blockers are complete | TBD |
+| Pilot memo | Enterprise lead | Customer validation summary | Demand, cohort, pricing, data, support, metrics, and commitment are recorded | TBD |
+| Internal meeting | Executive sponsor | Minutes and signed decision table | All critical owners record proceed, extend, or pause decision | TBD |
+
+## Pricing, migration, and final gate
+
+The enterprise reference is $30/unit/year, or $90,000/year for 3,000 units. PAD supports enterprise value more directly than public small-landlord pricing, must not be bundled into low-cost flat monthly tiers without enterprise review, and requires pilot validation of provider costs and willingness to annualize. White-glove onboarding may be paid.
+
+The pilot should use staged property groups beside Yardi/existing PMS, no forced full migration, and limited CSV/import/export only as needed.
+
+**PAD beta implementation cannot begin until provider feasibility, counsel go/no-go, and pilot landlord commitment are complete.**

--- a/docs/strategy/pad-go-no-go-decision-table-v1.md
+++ b/docs/strategy/pad-go-no-go-decision-table-v1.md
@@ -1,0 +1,63 @@
+# PAD Go/No-Go Decision Table v1
+
+Status: executive validation record; all gates begin open
+
+## Decision boundary
+
+This table decides whether RentChain may propose a separately authorized PAD beta implementation mission. It does not approve production release or a live debit. Provider, counsel, pilot, tenant, and internal evidence must describe the same participant roles, funds flow, jurisdiction, authorization model, and cohort.
+
+| Gate | Required status | Evidence | Owner | Actual status/conditions |
+| --- | --- | --- | --- | --- |
+| Provider feasibility memo complete | `PASS` | Written feasibility, restrictions, event/timeline matrix, fees, support, unknowns | Payments lead | `OPEN` |
+| Counsel go/no-go memo complete | `PASS` | Written counsel recommendation and approved/conditional deliverables | Legal owner | `OPEN` |
+| No-custody funds flow confirmed | `PASS` | Provider-confirmed diagram, contracts, responsibility matrix, counsel review | Payments + counsel | `OPEN` |
+| RPAA/FINTRAC/MSB risk reviewed | `PASS` or approved conditions that block live activity only | Activity-by-activity written legal analysis | Counsel + executive | `OPEN` |
+| Pilot landlord selected | `PASS` | Named sponsor, decision makers, written interest/commitment | Enterprise lead | `OPEN` |
+| Paid pilot accepted/negotiating | `PASS` or `PASS WITH CONDITIONS` | 60–90 day structure accepted or written negotiation with deadline | Executive + customer | `OPEN` |
+| Limited property group selected | `PASS` | Property/unit/tenant cohort, province, source ownership, data inventory | Product + customer | `OPEN` |
+| Tenant authorization copy tested | `PASS` | Counsel-reviewed copy and 3–5 comprehension-test results with critical issues closed | Product + counsel | `OPEN` |
+| Sandbox access ready | `PASS` | Isolated provider access, fixtures, event simulations, secrets/teardown plan | Engineering + security | `OPEN` |
+| Support playbook ready | `PASS` | Named owners, scripts, severity/escalation, cancellation/failure/complaint paths | Operations + counsel | `OPEN` |
+| Audit/reconciliation plan ready | `PASS` | Event taxonomy, evidence chain, daily/period reconciliation, exception ownership | Engineering + finance | `OPEN` |
+| Internal go/no-go meeting complete | `PASS` | Signed minutes, risk acceptance, conditions, expiry, next-mission scope | Executive sponsor | `OPEN` |
+
+## Cross-gate commercial and migration facts
+
+- The enterprise planning reference is $30/unit/year; 3,000 units equals $90,000/year.
+- PAD supports enterprise value more directly than public small-landlord pricing and must not be placed in a low-cost flat monthly tier without review.
+- Final pricing, provider costs, paid white-glove onboarding, and annualization willingness are validated in the pilot.
+- The pilot runs beside Yardi/existing PMS, uses staged property groups, avoids forced full migration, and uses limited CSV/import/export only as needed.
+
+## Mandatory warnings
+
+- Do not reuse the legacy PAP prototype as production PAD.
+- Do not let RentChain hold funds directly in the first implementation.
+- Provider sandbox success is not legal approval.
+- Do not begin live debit testing without counsel-approved authorization language.
+- Do not publicly promise PAD until provider/legal/beta readiness is confirmed.
+- Do not claim Certn is live unless the integration is actually live.
+
+## Decision outcomes
+
+| Outcome | When to use | Authorized next action |
+| --- | --- | --- |
+| `PROCEED TO PAD BETA IMPLEMENTATION` | Every critical gate passes and conditions are compatible with a bounded design | Draft a separate operator-approved implementation mission; no automatic coding or live debit |
+| `EXTEND PHASE 0 VALIDATION` | Evidence is incomplete but no disqualifying risk is established | Assign missing evidence, owner, deadline, and expiry |
+| `PAUSE — COMPLIANCE RISK` | Counsel blocks or material legal/privacy/insurance risk is unresolved | Stop implementation preparation until written resolution |
+| `PAUSE — PROVIDER/FUNDS-FLOW UNCERTAINTY` | Eligibility, payee, settlement, custody, liability, returns, or reconciliation is unclear | Continue provider diligence or evaluate another provider |
+| `PAUSE — LACK OF PILOT DEMAND` | No qualified landlord accepts a bounded paid pilot/value hypothesis | Reassess market need and pricing before payment work |
+
+## Decision record
+
+| Field | Entry |
+| --- | --- |
+| Decision/date | TBD |
+| Provider/model/version | TBD |
+| Pilot landlord/property group/province | TBD |
+| Decision outcome | TBD |
+| Critical evidence links | TBD |
+| Conditions, owners, deadlines, expiry | TBD |
+| Dissenting/blocking views | TBD |
+| Executive/product/payments/legal/security/privacy/finance/operations approvals | TBD |
+
+**Production PAD implementation must not begin until all critical gates are met.** A decision to proceed authorizes only the next governed beta implementation mission. A first live debit requires the later compliance, security, reconciliation, operational, provider, and production-readiness gates.

--- a/docs/templates/pad-tenant-comprehension-test-v1.md
+++ b/docs/templates/pad-tenant-comprehension-test-v1.md
@@ -1,0 +1,91 @@
+# PAD Tenant Comprehension Test v1
+
+Status: pre-implementation research template; not an authorization agreement
+
+## Purpose and safety boundary
+
+Validate whether tenant-style reviewers understand draft PAD authorization and lifecycle language before implementation. Use counsel-approved draft language or clearly labelled prototype copy. Do not collect real bank information, create a mandate, or initiate a debit. Provider sandbox success is not legal approval, and live testing cannot begin without counsel-approved authorization language.
+
+## Test setup
+
+- Recruit 3–5 tenant-style reviewers representing the initial pilot's language, accessibility, mobile, and financial-literacy needs where practical.
+- Review mobile first, then other relevant viewport or assistive-technology contexts.
+- Give no coaching and do not explain the correct answer before each response.
+- Show the complete draft authorization/prototype copy, including payee, amount/schedule basis, changes, timing, provider, data handling, cancellation, failure/return, and support.
+- Ask open-ended questions, record exact concepts rather than sensitive personal details, and obtain research consent.
+- Use synthetic names, properties, amounts, dates, and provider references.
+
+## Session record
+
+| Field | Entry |
+| --- | --- |
+| Reviewer code | TBD; no unnecessary identity data |
+| Date/facilitator | TBD |
+| Device/viewport/assistive technology | TBD |
+| Language/version of copy | TBD |
+| Scenario amount/date/payee | Synthetic |
+| Coaching required | None expected; record if needed |
+
+## Open-ended questions
+
+1. In your own words, what are you authorizing?
+2. Who is taking or processing the payment, and who receives it?
+3. How much will be debited? Where did you find that information?
+4. When will the debit happen, and what does a pending status mean?
+5. What happens if your rent amount or payment date changes?
+6. How would you cancel or change the authorization, and when would that take effect?
+7. Who would you contact for help about authorization, rent, payment status, or a dispute?
+8. What happens if the payment fails or is returned? Is the rent still owed?
+9. What information do you expect RentChain and the payment provider to store?
+10. What feels unclear, surprising, coercive, or concerning?
+
+Follow up without leading: “What makes you say that?”, “Where would you look?”, and “What would you expect to happen next?”
+
+## Scenario probes
+
+- The rent increases next month after proper approval and notice.
+- The debit shows processing but has not settled.
+- The bank later returns a debit that first appeared successful.
+- The tenant requests cancellation close to the next debit date.
+- The tenant paid manually while a future PAD instruction exists.
+- The tenant wants a copy of the authorization or payment evidence.
+
+Ask the reviewer to explain the expected status, action, contact, and remaining rent obligation in each scenario.
+
+## Pass criteria
+
+- Reviewer can explain the authorization and distinguish RentChain, provider, payee, and landlord roles.
+- Reviewer understands amount/schedule basis, timing, and how changes are communicated.
+- Reviewer understands cancellation method, cutoff uncertainty, and effect on future debits versus rent owed.
+- Reviewer understands failed/returned payment path and does not interpret processing as settled.
+- Reviewer knows whom to contact and can find the support path.
+- Reviewer has no major trust, coercion, privacy, accessibility, language, or comprehension issue.
+
+A single critical misunderstanding of authorization, payee, amount, timing, cancellation, data handling, or failure consequences is a `NO-GO` for that copy version. Counsel must re-review material changes.
+
+## Notes table
+
+| Question/scenario | Reviewer explanation | Accurate? | Confusion/trust issue | Copy or flow change | Severity/owner |
+| --- | --- | --- | --- | --- | --- |
+| Authorization | TBD | TBD | TBD | TBD | TBD |
+| Who processes/receives | TBD | TBD | TBD | TBD | TBD |
+| Amount/timing/change | TBD | TBD | TBD | TBD | TBD |
+| Cancellation | TBD | TBD | TBD | TBD | TBD |
+| Failure/return | TBD | TBD | TBD | TBD | TBD |
+| Data storage/privacy | TBD | TBD | TBD | TBD | TBD |
+| Support/dispute | TBD | TBD | TBD | TBD | TBD |
+| Mobile/accessibility | TBD | TBD | TBD | TBD | TBD |
+
+## Session and aggregate output
+
+| Output | Result |
+| --- | --- |
+| Issues found and severity | TBD |
+| Copy changes needed | TBD |
+| Flow/accessibility changes needed | TBD |
+| Counsel questions/re-review | TBD |
+| Support changes | TBD |
+| Individual result | `PASS`, `PASS WITH CHANGES`, or `NO-GO` |
+| Aggregate result after 3–5 tests | `READY FOR NEXT VALIDATION`, `RETEST`, or `NO-GO` |
+
+Store only approved research notes. Do not place raw bank details, unrelated personal information, provider secrets, or real payment credentials in the output.


### PR DESCRIPTION
## Summary

- adds an owner/evidence/pass-condition checklist for provider, counsel, pilot, tenant, and internal validation
- adds a provider feasibility request for Stripe ACSS or an equivalent Canadian PAD provider
- adds a Canadian payments/privacy/commercial counsel go/no-go request
- adds a discovery and paid-pilot validation script for a 3,000-unit or similar enterprise prospect
- adds a mobile-first tenant comprehension testing template
- adds the final executive go/no-go decision table

## Boundaries

- docs-only: exactly six new Markdown files
- no runtime, backend/API, or frontend product changes
- no PAD or Stripe/ACSS implementation
- no Certn implementation
- no pricing, public-site, terms, or privacy production changes
- no provider selection, legal conclusion, public promise, or live-debit authorization

## Key safeguards

- provider-led model with no RentChain funds custody
- sandbox success is not legal approval
- no live debit testing without counsel-approved authorization language
- legacy PAP prototype is not a production foundation
- paid 60–90 day pilot beside Yardi/existing PMS with staged property groups
- $30/unit/year equals $90,000/year for 3,000 units; final pricing remains pilot-validated

## Validation

- `git diff --cached --check` passed before commit
- exact six-file scope confirmed: 518 added lines
- no documentation lint command is configured
- build and manual runtime QA are not applicable to this docs-only mission