### PR TITLE
Normalize RC1 Decision Queue Preview copy

### DIFF
--- a/rentchain-frontend/src/pages/DashboardPage.test.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.test.tsx
@@ -536,14 +536,15 @@ describe("DashboardPage", () => {
           },
           {
             id: "renewals-decision",
-            sourceType: "lease",
-            sourceId: "renewals-source",
-            workspace: "lease",
+            sourceType: "renewal_notice_send_review",
+            sourceId: "lease:lease-1:renewal_notice_send_review",
+            workspace: "notices",
             severity: "needs_review",
-            title: "Open renewals focus",
-            description: "Renewal operator inputs need review.",
-            recommendedActionLabel: "Review",
-            recommendedActionHref: "/portfolio-health?entry=lease-renewals",
+            title: "Renewal tenant communication ready for approval",
+            description:
+              "Saved renewal notice draft is ready for send approval review. Email delivery remains disabled until approved send infrastructure is available.",
+            recommendedActionLabel: "Open notice review",
+            recommendedActionHref: "/leases/lease-1/workflows/notice",
             dueAt: null,
             createdAt: "2026-06-18T12:00:00.000Z",
             updatedAt: "2026-06-19T12:00:00.000Z",
@@ -558,12 +559,29 @@ describe("DashboardPage", () => {
 
     renderDashboard();
 
-    expect(await screen.findByText("Review submitted applications")).toBeInTheDocument();
+    expect(await screen.findByText("Review application activity")).toBeInTheDocument();
     expect(screen.getByTestId("decision-queue-section")).toHaveTextContent("Applications · Review funnel");
-    expect(screen.getByRole("link", { name: /Review applications: Review submitted applications/i })).toHaveAttribute(
+    expect(screen.getByTestId("decision-queue-section")).toHaveTextContent(
+      "Review current applications and recent funnel activity for follow-up opportunities."
+    );
+    expect(screen.getByRole("link", { name: /Open applications: Review application activity/i })).toHaveAttribute(
       "href",
       "/applications?entry=application-funnel&status=SUBMITTED"
     );
+    expect(screen.getByTestId("decision-queue-section")).toHaveTextContent("Review renewal communication draft");
+    expect(screen.getByTestId("decision-queue-section")).toHaveTextContent("Notices · Internal review");
+    expect(screen.getByTestId("decision-queue-section")).toHaveTextContent(
+      "A saved renewal communication draft is ready for internal review. Review the draft and approval state in the lease workflow."
+    );
+    expect(screen.getByRole("link", { name: /Review renewal draft: Review renewal communication draft/i })).toHaveAttribute(
+      "href",
+      "/leases/lease-1/workflows/notice"
+    );
+    expect(screen.getByTestId("decision-queue-section")).toHaveTextContent("Needs review");
+    expect(screen.getByTestId("decision-queue-section")).not.toHaveTextContent("Email delivery remains disabled");
+    expect(screen.getByTestId("decision-queue-section")).not.toHaveTextContent("send infrastructure");
+    expect(screen.getByTestId("decision-queue-section")).not.toHaveTextContent("applications-decision");
+    expect(screen.getByTestId("decision-queue-section")).not.toHaveTextContent("lease:lease-1:renewal_notice_send_review");
     expect(screen.getByTestId("decision-queue-section")).toHaveTextContent("Revenue analytics · Review exposure");
     expect(screen.getByRole("link", { name: /View revenue analytics: Review revenue pressure/i })).toHaveAttribute(
       "href",
@@ -573,11 +591,6 @@ describe("DashboardPage", () => {
     expect(screen.getByRole("link", { name: /View vacancy readiness: View vacancy readiness/i })).toHaveAttribute(
       "href",
       "/analytics?entry=vacancy-readiness"
-    );
-    expect(screen.getByTestId("decision-queue-section")).toHaveTextContent("Lease renewals · Review operator inputs");
-    expect(screen.getByRole("link", { name: /Review renewals: Open renewals focus/i })).toHaveAttribute(
-      "href",
-      "/portfolio-health?entry=lease-renewals"
     );
   });
 

--- a/rentchain-frontend/src/pages/DashboardPage.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.tsx
@@ -214,6 +214,12 @@ function decisionDestinationCopy(item: LandlordDecisionQueueItem): { meta: strin
   const href = String(item.recommendedActionHref || "").trim();
   const label = String(item.recommendedActionLabel || "").trim();
 
+  if (isRenewalCommunicationReviewItem(item)) {
+    return { meta: "Notices · Internal review", action: "Review renewal draft" };
+  }
+  if (isApplicationActivityReviewItem(item)) {
+    return { meta: "Applications · Review funnel", action: "Open applications" };
+  }
   if (href.includes("/applications")) {
     return { meta: "Applications · Review funnel", action: "Review applications" };
   }
@@ -276,11 +282,19 @@ function isPaymentAllocationReviewItem(item: LandlordDecisionQueueItem): boolean
 }
 
 function decisionTitle(item: LandlordDecisionQueueItem): string {
+  if (isRenewalCommunicationReviewItem(item)) return "Review renewal communication draft";
+  if (isApplicationActivityReviewItem(item)) return "Review application activity";
   if (isPaymentAllocationReviewItem(item)) return "Review payment allocation";
   return item.title || "Review required";
 }
 
 function decisionReason(item: LandlordDecisionQueueItem): string {
+  if (isRenewalCommunicationReviewItem(item)) {
+    return "A saved renewal communication draft is ready for internal review. Review the draft and approval state in the lease workflow.";
+  }
+  if (isApplicationActivityReviewItem(item)) {
+    return "Review current applications and recent funnel activity for follow-up opportunities.";
+  }
   const description = String(item.description || "").replace(/\s+/g, " ").trim();
   if (isPaymentAllocationReviewItem(item)) {
     const hasSafeAllocationContext =
@@ -290,6 +304,26 @@ function decisionReason(item: LandlordDecisionQueueItem): string {
       : "Lease has an aggregate credit balance, but one or more obligations remain unmatched. Review payment allocation before taking overdue-rent action.";
   }
   return description || "Review the recommended next step for this operational decision.";
+}
+
+function isRenewalCommunicationReviewItem(item: LandlordDecisionQueueItem): boolean {
+  return item.sourceType === "renewal_notice_send_review";
+}
+
+function isApplicationActivityReviewItem(item: LandlordDecisionQueueItem): boolean {
+  const href = String(item.recommendedActionHref || "").toLowerCase();
+  return href.includes("/applications") && href.includes("entry=application-funnel");
+}
+
+function severityLabel(severity: LandlordDecisionQueueItem["severity"]): string {
+  const labels: Record<LandlordDecisionQueueItem["severity"], string> = {
+    critical: "Critical",
+    warning: "Warning",
+    needs_review: "Needs review",
+    upcoming: "Upcoming",
+    informational: "Information",
+  };
+  return labels[severity];
 }
 
 function useMediaQuery(query: string): boolean {
@@ -791,7 +825,7 @@ function DecisionRow({ item }: { item: LandlordDecisionQueueItem }) {
         </div>
         <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
           <span style={{ ...severityStyle(item.severity), borderRadius: 8, padding: "3px 8px", fontSize: 12, fontWeight: 850, width: "fit-content", whiteSpace: "nowrap" }}>
-            {item.severity.replace(/_/g, " ")}
+            {severityLabel(item.severity)}
           </span>
           <span style={{ color: text.muted, fontSize: 12, fontWeight: 750 }}>
             {decisionTimingLabel(item)}

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
@@ -1080,7 +1080,8 @@ describe("LandlordLeaseWorkflowPage", () => {
       sourceRoute: "/leases/lease-1/workflows/notice",
       workspace: "notices",
       severity: "warning",
-      title: "Renewal tenant communication ready for approval",
+      title: "Review renewal communication draft",
+      recommendedActionLabel: "Review renewal draft",
       recommendedActionHref: "/leases/lease-1/workflows/notice",
       leaseId: "lease-1",
       propertyId: "prop-1",
@@ -1088,7 +1089,10 @@ describe("LandlordLeaseWorkflowPage", () => {
       tenantId: "tenant-1",
       dedupeKey: "lease:lease-1:renewal_notice_send_review",
     });
-    expect(createPayload.description).toContain("Email delivery is available only after approval and explicit send confirmations");
+    expect(createPayload.description).toBe(
+      "A saved renewal communication draft is ready for internal review. Review the draft and approval state in the lease workflow."
+    );
+    expect(createPayload.description).not.toMatch(/email delivery|send infrastructure|legal notice/i);
     expect(createPayload.sourceSnapshot).toMatchObject({
       tenantLabel: "Jane Tenant",
       propertyUnitLabel: "12 Harbour Road · Unit 101",

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
@@ -1190,10 +1190,10 @@ function TenantCommunicationSendReview({
         sourceRoute: decisionRoute,
         workspace: "notices",
         severity: "warning",
-        title: "Renewal tenant communication ready for approval",
+        title: "Review renewal communication draft",
         description:
-          "Saved renewal notice draft is ready for send approval review. Email delivery is available only after approval and explicit send confirmations.",
-        recommendedActionLabel: "Open notice review",
+          "A saved renewal communication draft is ready for internal review. Review the draft and approval state in the lease workflow.",
+        recommendedActionLabel: "Review renewal draft",
         recommendedActionHref: decisionRoute,
         status: "open",
         leaseId: lease.id,


### PR DESCRIPTION
## Summary

- normalize legacy persisted renewal Decision Queue Preview cards to neutral internal-review copy
- normalize analytics-derived application-funnel cards to neutral application-activity copy
- add user-facing severity labels while retaining the existing action timing cue
- update newly created renewal review records to use the same safe wording

## Routes preserved

- renewal review continues routing to the existing `/leases/:leaseId/workflows/notice` surface
- application activity continues routing to `/applications?entry=application-funnel&status=SUBMITTED`

## Scope and safety

- frontend-only; analytics derivation and backend queue behavior are unchanged
- no workflow mutation, notice sending, email delivery, reminders, AI analytics, or legal notice behavior added
- no raw queue IDs, source IDs, lease IDs, provider labels, or storage paths are rendered

## Validation

- `npm run test:single -- src/pages/DashboardPage.test.tsx src/pages/LandlordLeaseWorkflowPage.test.tsx` — 40 tests passed
- `npm run build` with Node 20.20.2 — passed
- `git diff --check` — passed
- `git diff --cached --check` — passed

## Manual QA

Pending on the preview deployment:

1. verify normalized renewal and application cards and preserved CTA routes
2. verify user-facing severity wording and absence of raw/internal IDs
3. verify desktop, reduced desktop, and mobile card spacing/CTA behavior
