### PR TITLE
Add Phase 0 receivables subledger primitives

### DIFF
--- a/rentchain-api/src/lib/accounting/__tests__/agingProjection.test.ts
+++ b/rentchain-api/src/lib/accounting/__tests__/agingProjection.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { projectReceivableAging } from "../agingProjection";
+
+const transaction = (overrides: Record<string, unknown> = {}) => ({
+  transactionId: "charge-1",
+  leaseId: "lease-1",
+  propertyId: "property-1",
+  type: "scheduled_rent_charge",
+  amountCents: 100_000,
+  currency: "cad",
+  effectiveDate: "2026-01-01",
+  dueDate: "2026-01-01",
+  ...overrides,
+});
+
+describe("projectReceivableAging", () => {
+  it("places outstanding charges into exact date-only aging buckets", () => {
+    const result = projectReceivableAging({
+      asOfDate: "2026-04-02",
+      transactions: [
+        transaction({ transactionId: "current", dueDate: "2026-04-02", amountCents: 100 }),
+        transaction({ transactionId: "d30", dueDate: "2026-03-03", amountCents: 200 }),
+        transaction({ transactionId: "d60", dueDate: "2026-02-01", amountCents: 300 }),
+        transaction({ transactionId: "d90", dueDate: "2026-01-02", amountCents: 400 }),
+        transaction({ transactionId: "d91", dueDate: "2026-01-01", amountCents: 500 }),
+      ],
+    });
+
+    expect(result.currentCents).toBe(100);
+    expect(result.days1To30Cents).toBe(200);
+    expect(result.days31To60Cents).toBe(300);
+    expect(result.days61To90Cents).toBe(400);
+    expect(result.days90PlusCents).toBe(500);
+  });
+
+  it("requires allocation lineage under the explicit policy", () => {
+    const result = projectReceivableAging({
+      asOfDate: "2026-02-01",
+      transactions: [transaction(), transaction({ transactionId: "payment-1", type: "payment_applied", amountCents: 25_000 })],
+    });
+
+    expect(result.totalOutstandingCents).toBe(100_000);
+    expect(result.findings.map((finding) => finding.code)).toContain("allocation_required");
+  });
+
+  it("supports deterministic oldest-due-first allocation", () => {
+    const inputs = [
+      transaction({ transactionId: "jan", amountCents: 60_000 }),
+      transaction({ transactionId: "feb", amountCents: 60_000, effectiveDate: "2026-02-01", dueDate: "2026-02-01" }),
+      transaction({ transactionId: "payment", type: "payment_applied", amountCents: 70_000, effectiveDate: "2026-02-02", dueDate: null }),
+    ];
+    const result = projectReceivableAging({ transactions: inputs, asOfDate: "2026-02-15", allocationPolicy: "oldest_due_first" });
+
+    expect(result.chargeRows).toEqual([
+      expect.objectContaining({ transactionId: "feb", outstandingCents: 50_000 }),
+    ]);
+  });
+
+  it("does not cancel a payment when its reversal is invalid", () => {
+    const result = projectReceivableAging({
+      asOfDate: "2026-02-01",
+      transactions: [
+        transaction(),
+        transaction({ transactionId: "payment", type: "payment_applied", amountCents: 40_000, appliesToTransactionId: "charge-1" }),
+        transaction({ transactionId: "bad-reversal", type: "payment_reversal", amountCents: 20_000, reversesTransactionId: "payment" }),
+      ],
+    });
+
+    expect(result.totalOutstandingCents).toBe(60_000);
+    expect(result.findings.map((finding) => finding.code)).toContain("payment_reversal_mismatch");
+  });
+
+  it("preserves the original balance for a valid payment reversal", () => {
+    const result = projectReceivableAging({
+      asOfDate: "2026-02-01",
+      transactions: [
+        transaction(),
+        transaction({ transactionId: "payment", type: "payment_applied", amountCents: 40_000, appliesToTransactionId: "charge-1" }),
+        transaction({ transactionId: "reversal", type: "payment_reversal", amountCents: 40_000, reversesTransactionId: "payment" }),
+      ],
+    });
+
+    expect(result.totalOutstandingCents).toBe(100_000);
+    expect(result.findings).toEqual([]);
+  });
+});

--- a/rentchain-api/src/lib/accounting/__tests__/balanceProjection.test.ts
+++ b/rentchain-api/src/lib/accounting/__tests__/balanceProjection.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { projectReceivableBalance } from "../balanceProjection";
+
+const transaction = (overrides: Record<string, unknown> = {}) => ({
+  transactionId: "tx-1",
+  leaseId: "lease-1",
+  propertyId: "property-1",
+  type: "scheduled_rent_charge",
+  amountCents: 100_000,
+  currency: "cad",
+  effectiveDate: "2026-01-01",
+  dueDate: "2026-01-01",
+  ...overrides,
+});
+
+describe("projectReceivableBalance", () => {
+  it("projects charges, reductions, and directional adjustments deterministically", () => {
+    const inputs = [
+      transaction(),
+      transaction({ transactionId: "credit-1", type: "credit", amountCents: 5_000 }),
+      transaction({ transactionId: "payment-1", type: "payment_applied", amountCents: 30_000 }),
+      transaction({ transactionId: "writeoff-1", type: "write_off", amountCents: 2_000 }),
+      transaction({ transactionId: "increase-1", type: "adjustment", amountCents: 1_000, metadata: { adjustmentDirection: "increase" } }),
+      transaction({ transactionId: "decrease-1", type: "adjustment", amountCents: 500, metadata: { adjustmentDirection: "decrease" } }),
+    ];
+
+    const first = projectReceivableBalance(inputs);
+    const second = projectReceivableBalance([...inputs].reverse());
+
+    expect(first).toEqual(second);
+    expect(first.netBalanceCents).toBe(63_500);
+    expect(first.outstandingCents).toBe(63_500);
+    expect(first.overpaymentCents).toBe(0);
+  });
+
+  it("restores a payment only for a valid matching reversal", () => {
+    const result = projectReceivableBalance([
+      transaction(),
+      transaction({ transactionId: "payment-1", type: "payment_applied", amountCents: 100_000 }),
+      transaction({
+        transactionId: "reversal-1",
+        type: "payment_reversal",
+        amountCents: 100_000,
+        reversesTransactionId: "payment-1",
+      }),
+    ]);
+
+    expect(result.netBalanceCents).toBe(100_000);
+    expect(result.reversalCents).toBe(100_000);
+    expect(result.findings).toEqual([]);
+  });
+
+  it("fails closed for mismatched and duplicate reversals", () => {
+    const result = projectReceivableBalance([
+      transaction(),
+      transaction({ transactionId: "payment-1", type: "payment_applied", amountCents: 40_000 }),
+      transaction({ transactionId: "bad", type: "payment_reversal", amountCents: 20_000, reversesTransactionId: "payment-1" }),
+      transaction({ transactionId: "valid", type: "payment_reversal", amountCents: 40_000, reversesTransactionId: "payment-1" }),
+      transaction({ transactionId: "duplicate", type: "payment_reversal", amountCents: 40_000, reversesTransactionId: "payment-1" }),
+    ]);
+
+    expect(result.netBalanceCents).toBe(100_000);
+    expect(result.findings.map((finding) => finding.code)).toEqual([
+      "duplicate_payment_reversal",
+      "payment_reversal_mismatch",
+    ]);
+  });
+
+  it("supports lease, property, and as-of scope without mutating inputs", () => {
+    const inputs = [
+      transaction(),
+      transaction({ transactionId: "future", effectiveDate: "2026-02-01" }),
+      transaction({ transactionId: "other", leaseId: "lease-2" }),
+    ];
+    const snapshot = structuredClone(inputs);
+    const result = projectReceivableBalance(inputs, { leaseId: "lease-1", propertyId: "property-1", asOfDate: "2026-01-31" });
+
+    expect(result.chargeCents).toBe(100_000);
+    expect(inputs).toEqual(snapshot);
+  });
+});

--- a/rentchain-api/src/lib/accounting/__tests__/chargeSchedulePreview.test.ts
+++ b/rentchain-api/src/lib/accounting/__tests__/chargeSchedulePreview.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { MAX_CHARGE_SCHEDULE_OCCURRENCES, buildLeaseChargeSchedulePreview } from "../chargeSchedulePreview";
+
+const base = {
+  leaseId: "lease-1",
+  propertyId: "property-1",
+  unitId: "unit-1",
+  responsibilityId: "responsibility-1",
+  tenantId: "tenant-1",
+  sourceLeaseVersion: "lease-v1",
+  leaseStartDate: "2026-01-01",
+  leaseEndDate: "2026-12-31",
+  monthlyRentCents: 200000,
+  dueDay: 1,
+  currency: "cad",
+  billingFrequency: "monthly",
+  depositAmountCents: null,
+  asOfDate: "2025-12-15",
+  previewThroughDate: "2026-12-31",
+};
+
+describe("chargeSchedulePreview", () => {
+  it("builds a deterministic monthly schedule", () => {
+    const preview = buildLeaseChargeSchedulePreview(base);
+    expect(preview.allowed).toBe(true);
+    expect(preview.occurrences).toHaveLength(12);
+    expect(preview.occurrences[0]).toEqual(expect.objectContaining({ dueDate: "2026-01-01", amountCents: 200000 }));
+    expect(preview.occurrences[11]).toEqual(expect.objectContaining({ dueDate: "2026-12-01" }));
+    expect(preview.totals.scheduledRentCents).toBe(2400000);
+  });
+
+  it("clamps due day to short months using date-only UTC arithmetic", () => {
+    const preview = buildLeaseChargeSchedulePreview({ ...base, dueDay: 31, leaseEndDate: "2026-03-31", previewThroughDate: "2026-03-31" });
+    expect(preview.occurrences.map((row) => row.dueDate)).toEqual(["2026-01-31", "2026-02-28", "2026-03-31"]);
+  });
+
+  it("does not silently prorate a partial first month", () => {
+    const preview = buildLeaseChargeSchedulePreview({ ...base, leaseStartDate: "2026-01-15", leaseEndDate: "2026-03-31", previewThroughDate: "2026-03-31" });
+    expect(preview.findings).toContainEqual(expect.objectContaining({ code: "proration_policy_required", severity: "review" }));
+    expect(preview.occurrences[0]).toEqual(expect.objectContaining({ dueDate: "2026-02-01", amountCents: 200000 }));
+  });
+
+  it("adds a separate deposit charge without custody semantics", () => {
+    const preview = buildLeaseChargeSchedulePreview({ ...base, leaseEndDate: "2026-01-31", previewThroughDate: "2026-01-31", depositAmountCents: 100000 });
+    expect(preview.occurrences.map((row) => row.type)).toEqual(["deposit_charge", "scheduled_rent_charge"]);
+    expect(preview.totals.depositChargeCents).toBe(100000);
+  });
+
+  it("fails closed for missing fields and unsupported frequency", () => {
+    const missing = buildLeaseChargeSchedulePreview({});
+    expect(missing.allowed).toBe(false);
+    expect(missing.occurrences).toEqual([]);
+    const unsupported = buildLeaseChargeSchedulePreview({ ...base, billingFrequency: "weekly" });
+    expect(unsupported.allowed).toBe(false);
+    expect(unsupported.findings).toContainEqual(expect.objectContaining({ code: "unsupported_billing_frequency" }));
+  });
+
+  it("bounds open-ended schedule previews", () => {
+    const preview = buildLeaseChargeSchedulePreview({ ...base, leaseEndDate: null, previewThroughDate: "2040-12-31" });
+    expect(preview.occurrences.length).toBe(MAX_CHARGE_SCHEDULE_OCCURRENCES);
+    expect(preview.allowed).toBe(false);
+    expect(preview.findings).toContainEqual(expect.objectContaining({ code: "preview_horizon_exceeds_max_occurrences" }));
+  });
+});

--- a/rentchain-api/src/lib/accounting/__tests__/receivablesFingerprint.test.ts
+++ b/rentchain-api/src/lib/accounting/__tests__/receivablesFingerprint.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { buildLeaseChargeSchedulePreview } from "../chargeSchedulePreview";
+import { RECEIVABLE_SCHEDULE_STATE_STALE, buildReceivablesFingerprint, validateChargeSchedulePreviewFingerprint } from "../receivablesFingerprint";
+
+const input = {
+  leaseId: "lease-1", propertyId: "property-1", sourceLeaseVersion: "v1",
+  leaseStartDate: "2026-01-01", leaseEndDate: "2026-03-31", monthlyRentCents: 100000,
+  dueDay: 1, currency: "cad", billingFrequency: "monthly", asOfDate: "2025-12-01", previewThroughDate: "2026-03-31",
+};
+
+describe("receivablesFingerprint", () => {
+  it("stably serializes object keys", () => {
+    expect(buildReceivablesFingerprint({ b: 2, a: 1 })).toBe(buildReceivablesFingerprint({ a: 1, b: 2 }));
+  });
+
+  it("produces the same schedule fingerprint for the same inputs", () => {
+    expect(buildLeaseChargeSchedulePreview(input).previewFingerprint).toBe(buildLeaseChargeSchedulePreview({ ...input }).previewFingerprint);
+  });
+
+  it("changes when material lease terms change", () => {
+    const first = buildLeaseChargeSchedulePreview(input);
+    const changed = buildLeaseChargeSchedulePreview({ ...input, monthlyRentCents: 100001 });
+    expect(first.previewFingerprint).not.toBe(changed.previewFingerprint);
+  });
+
+  it("detects missing and stale fingerprints", () => {
+    const current = buildLeaseChargeSchedulePreview(input).previewFingerprint;
+    expect(validateChargeSchedulePreviewFingerprint({ currentPreviewFingerprint: current })).toEqual({ ok: false, code: RECEIVABLE_SCHEDULE_STATE_STALE });
+    expect(validateChargeSchedulePreviewFingerprint({ expectedPreviewFingerprint: "stale", currentPreviewFingerprint: current })).toEqual({ ok: false, code: RECEIVABLE_SCHEDULE_STATE_STALE });
+    expect(validateChargeSchedulePreviewFingerprint({ expectedPreviewFingerprint: current, currentPreviewFingerprint: current })).toEqual({ ok: true });
+  });
+});

--- a/rentchain-api/src/lib/accounting/__tests__/receivablesTypes.test.ts
+++ b/rentchain-api/src/lib/accounting/__tests__/receivablesTypes.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { RECEIVABLE_TRANSACTION_TYPES, normalizeReceivableTransaction } from "../receivablesTypes";
+
+const base = {
+  transactionId: "txn-1",
+  leaseId: "lease-1",
+  propertyId: "property-1",
+  unitId: "unit-1",
+  responsibilityId: "responsibility-1",
+  tenantId: "tenant-1",
+  amountCents: 10000,
+  currency: "cad",
+  effectiveDate: "2026-01-01",
+  dueDate: "2026-01-01",
+  periodStart: "2026-01-01",
+  periodEnd: "2026-01-31",
+  sourceRef: null,
+  sourceVersion: "lease-v1",
+  reversesTransactionId: null,
+  appliesToTransactionId: null,
+  metadata: {},
+};
+
+describe("receivablesTypes", () => {
+  it.each(RECEIVABLE_TRANSACTION_TYPES)("normalizes modeled type %s", (type) => {
+    const input = {
+      ...base,
+      type,
+      ...(type === "adjustment" ? { metadata: { adjustmentDirection: "increase" } } : {}),
+      ...(type === "payment_reversal" ? { reversesTransactionId: "payment-1" } : {}),
+    };
+    const result = normalizeReceivableTransaction(input);
+    expect(result.transaction).toEqual(expect.objectContaining({ type, amountCents: 10000, currency: "cad" }));
+    if (type === "nsf_fee") {
+      expect(result.findings).toContainEqual(expect.objectContaining({ code: "nsf_fee_policy_not_enabled", severity: "review" }));
+    }
+  });
+
+  it("rejects ambiguous amounts, invalid dates, unsupported currency, and missing scope", () => {
+    const result = normalizeReceivableTransaction({
+      type: "scheduled_rent_charge",
+      amountCents: 10.5,
+      currency: "usd",
+      effectiveDate: "2026-02-30",
+    });
+    expect(result.transaction).toBeNull();
+    expect(result.findings.map((finding) => finding.code)).toEqual(
+      expect.arrayContaining(["required_field_missing", "invalid_amount_cents", "unsupported_currency", "invalid_date_only"])
+    );
+  });
+
+  it("requires adjustment direction and reversal lineage", () => {
+    expect(normalizeReceivableTransaction({ ...base, type: "adjustment" }).transaction).toBeNull();
+    expect(normalizeReceivableTransaction({ ...base, type: "payment_reversal" }).transaction).toBeNull();
+  });
+
+  it("does not mutate input data", () => {
+    const input = Object.freeze({ ...base, type: "credit", metadata: Object.freeze({}) });
+    const snapshot = JSON.stringify(input);
+    normalizeReceivableTransaction(input);
+    expect(JSON.stringify(input)).toBe(snapshot);
+  });
+});

--- a/rentchain-api/src/lib/accounting/__tests__/rentRollProjection.test.ts
+++ b/rentchain-api/src/lib/accounting/__tests__/rentRollProjection.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { projectRentRoll, type RentRollLeaseInput } from "../rentRollProjection";
+
+const lease = (overrides: Partial<RentRollLeaseInput> = {}): RentRollLeaseInput => ({
+  propertyId: "property-1",
+  propertyDisplay: "10 Harbour Street",
+  unitId: "unit-1",
+  unitDisplay: "Unit 2",
+  leaseId: "lease-1",
+  tenantDisplayName: "Example Tenant",
+  leaseStatus: "active",
+  scheduledRentCents: 100_000,
+  currency: "cad",
+  nextDueDate: "2026-02-01",
+  transactions: [
+    {
+      transactionId: "charge-1",
+      leaseId: "lease-1",
+      propertyId: "property-1",
+      type: "scheduled_rent_charge",
+      amountCents: 100_000,
+      currency: "cad",
+      effectiveDate: "2026-01-01",
+      dueDate: "2026-01-01",
+    },
+  ],
+  ...overrides,
+});
+
+describe("projectRentRoll", () => {
+  it("projects deterministic lease, property, and portfolio summaries", () => {
+    const leases = [
+      lease(),
+      lease({
+        propertyId: "property-2",
+        propertyDisplay: "20 Shore Road",
+        unitId: "unit-2",
+        unitDisplay: "Unit 4",
+        leaseId: "lease-2",
+        scheduledRentCents: 120_000,
+        transactions: [],
+      }),
+    ];
+    const result = projectRentRoll({ leases: [...leases].reverse(), asOfDate: "2026-01-31" });
+
+    expect(result.rows.map((row) => row.leaseId)).toEqual(["lease-1", "lease-2"]);
+    expect(result.portfolioSummary).toEqual({
+      scheduledRentCents: 220_000,
+      currentBalanceCents: 100_000,
+      outstandingCents: 100_000,
+      overpaymentCents: 0,
+      leaseCount: 2,
+    });
+    expect(result.propertySummaries).toHaveLength(2);
+  });
+
+  it("uses null safe-display fields instead of internal identifier fallbacks", () => {
+    const result = projectRentRoll({
+      leases: [lease({ propertyDisplay: null, unitDisplay: null, tenantDisplayName: null })],
+      asOfDate: "2026-01-31",
+    });
+
+    expect(result.rows[0]).toMatchObject({
+      propertyDisplay: null,
+      unitDisplay: null,
+      tenantDisplayName: null,
+    });
+    expect(result.findings.map((finding) => finding.code)).toEqual([
+      "property_display_not_provided",
+      "tenant_display_not_provided",
+      "unit_display_not_provided",
+    ]);
+  });
+
+  it("fails closed for invalid required lease inputs", () => {
+    const invalid = lease({ leaseId: "", scheduledRentCents: -1 });
+    const result = projectRentRoll({ leases: [invalid], asOfDate: "2026-01-31" });
+
+    expect(result.rows).toEqual([]);
+    expect(result.portfolioSummary.leaseCount).toBe(0);
+    expect(result.findings.map((finding) => finding.code)).toContain("required_field_missing");
+  });
+});

--- a/rentchain-api/src/lib/accounting/agingProjection.ts
+++ b/rentchain-api/src/lib/accounting/agingProjection.ts
@@ -1,0 +1,161 @@
+import {
+  normalizeReceivableTransaction,
+  parseDateOnly,
+  sortReceivableFindings,
+  type ReceivableFinding,
+  type ReceivableTransaction,
+} from "./receivablesTypes";
+
+export type ReceivableAgingBucket = "current" | "days_1_30" | "days_31_60" | "days_61_90" | "days_90_plus";
+export type ReceivableAgingAllocationPolicy = "explicit" | "oldest_due_first";
+
+export type ReceivableAgingRow = {
+  transactionId: string;
+  dueDate: string;
+  originalAmountCents: number;
+  outstandingCents: number;
+  daysPastDue: number;
+  bucket: ReceivableAgingBucket;
+};
+
+export type ReceivableAgingProjection = {
+  asOfDate: string;
+  allocationPolicy: ReceivableAgingAllocationPolicy;
+  currentCents: number;
+  days1To30Cents: number;
+  days31To60Cents: number;
+  days61To90Cents: number;
+  days90PlusCents: number;
+  totalOutstandingCents: number;
+  chargeRows: ReceivableAgingRow[];
+  findings: ReceivableFinding[];
+};
+
+function bucketFor(daysPastDue: number): ReceivableAgingBucket {
+  if (daysPastDue <= 0) return "current";
+  if (daysPastDue <= 30) return "days_1_30";
+  if (daysPastDue <= 60) return "days_31_60";
+  if (daysPastDue <= 90) return "days_61_90";
+  return "days_90_plus";
+}
+
+export function projectReceivableAging(input: {
+  transactions: readonly unknown[];
+  asOfDate: string;
+  allocationPolicy?: ReceivableAgingAllocationPolicy;
+  leaseId?: string;
+  propertyId?: string;
+}): ReceivableAgingProjection {
+  const findings: ReceivableFinding[] = [];
+  const asOf = parseDateOnly(input.asOfDate);
+  const policy = input.allocationPolicy || "explicit";
+  if (!asOf) findings.push({ code: "invalid_date_only", severity: "error", field: "asOfDate" });
+  const transactions: ReceivableTransaction[] = [];
+  const seen = new Set<string>();
+  for (const raw of input.transactions) {
+    const result = normalizeReceivableTransaction(raw);
+    findings.push(...result.findings);
+    if (!result.transaction) continue;
+    if (seen.has(result.transaction.transactionId)) {
+      findings.push({ code: "duplicate_transaction_id", severity: "error", transactionId: result.transaction.transactionId });
+      continue;
+    }
+    seen.add(result.transaction.transactionId);
+    if (input.leaseId && result.transaction.leaseId !== input.leaseId) continue;
+    if (input.propertyId && result.transaction.propertyId !== input.propertyId) continue;
+    if (asOf && parseDateOnly(result.transaction.effectiveDate)!.epochDay > asOf.epochDay) continue;
+    if (result.transaction.type !== "nsf_fee") transactions.push(result.transaction);
+  }
+
+  const chargeTypes = new Set(["scheduled_rent_charge", "deposit_charge", "one_time_charge"]);
+  const charges = transactions
+    .filter((transaction) => chargeTypes.has(transaction.type))
+    .filter((transaction) => {
+      if (transaction.dueDate) return true;
+      findings.push({ code: "charge_due_date_required", severity: "error", transactionId: transaction.transactionId, field: "dueDate" });
+      return false;
+    })
+    .map((transaction) => ({ transaction, outstandingCents: transaction.amountCents }))
+    .sort((a, b) => [a.transaction.dueDate, a.transaction.transactionId].join(":").localeCompare([b.transaction.dueDate, b.transaction.transactionId].join(":")));
+  const chargeById = new Map(charges.map((row) => [row.transaction.transactionId, row]));
+  const reductions = transactions.filter((transaction) => ["credit", "payment_applied", "write_off"].includes(transaction.type));
+  const reductionById = new Map(reductions.map((transaction) => [transaction.transactionId, transaction]));
+  const reversedReductionIds = new Set<string>();
+  for (const reversal of transactions.filter((transaction) => transaction.type === "payment_reversal")) {
+    const target = reversal.reversesTransactionId ? reductionById.get(reversal.reversesTransactionId) : null;
+    if (!target || target.type !== "payment_applied") {
+      findings.push({ code: "invalid_payment_reversal_target", severity: "error", transactionId: reversal.transactionId });
+      continue;
+    }
+    if (
+      target.leaseId !== reversal.leaseId ||
+      target.propertyId !== reversal.propertyId ||
+      target.currency !== reversal.currency ||
+      target.amountCents !== reversal.amountCents
+    ) {
+      findings.push({ code: "payment_reversal_mismatch", severity: "error", transactionId: reversal.transactionId });
+      continue;
+    }
+    if (reversedReductionIds.has(target.transactionId)) {
+      findings.push({ code: "duplicate_payment_reversal", severity: "error", transactionId: reversal.transactionId });
+      continue;
+    }
+    reversedReductionIds.add(target.transactionId);
+  }
+
+  for (const reduction of reductions) {
+    if (reversedReductionIds.has(reduction.transactionId)) continue;
+    let remaining = reduction.amountCents;
+    if (reduction.appliesToTransactionId) {
+      const charge = chargeById.get(reduction.appliesToTransactionId);
+      if (!charge) {
+        findings.push({ code: "allocation_target_not_found", severity: "error", transactionId: reduction.transactionId });
+        continue;
+      }
+      const applied = Math.min(remaining, charge.outstandingCents);
+      charge.outstandingCents -= applied;
+      remaining -= applied;
+    } else if (policy === "oldest_due_first") {
+      for (const charge of charges) {
+        if (remaining <= 0) break;
+        const applied = Math.min(remaining, charge.outstandingCents);
+        charge.outstandingCents -= applied;
+        remaining -= applied;
+      }
+    } else {
+      findings.push({ code: "allocation_required", severity: "review", transactionId: reduction.transactionId, field: "appliesToTransactionId" });
+      continue;
+    }
+    if (remaining > 0) findings.push({ code: "unapplied_reduction_balance", severity: "review", transactionId: reduction.transactionId });
+  }
+
+  const chargeRows: ReceivableAgingRow[] = asOf
+    ? charges
+        .filter((row) => row.outstandingCents > 0)
+        .map((row) => {
+          const due = parseDateOnly(row.transaction.dueDate)!;
+          const daysPastDue = asOf.epochDay - due.epochDay;
+          return {
+            transactionId: row.transaction.transactionId,
+            dueDate: due.value,
+            originalAmountCents: row.transaction.amountCents,
+            outstandingCents: row.outstandingCents,
+            daysPastDue,
+            bucket: bucketFor(daysPastDue),
+          };
+        })
+    : [];
+  const sumBucket = (bucket: ReceivableAgingBucket) => chargeRows.filter((row) => row.bucket === bucket).reduce((sum, row) => sum + row.outstandingCents, 0);
+  return {
+    asOfDate: asOf?.value || input.asOfDate,
+    allocationPolicy: policy,
+    currentCents: sumBucket("current"),
+    days1To30Cents: sumBucket("days_1_30"),
+    days31To60Cents: sumBucket("days_31_60"),
+    days61To90Cents: sumBucket("days_61_90"),
+    days90PlusCents: sumBucket("days_90_plus"),
+    totalOutstandingCents: chargeRows.reduce((sum, row) => sum + row.outstandingCents, 0),
+    chargeRows,
+    findings: sortReceivableFindings(findings),
+  };
+}

--- a/rentchain-api/src/lib/accounting/balanceProjection.ts
+++ b/rentchain-api/src/lib/accounting/balanceProjection.ts
@@ -1,0 +1,161 @@
+import {
+  normalizeReceivableTransaction,
+  parseDateOnly,
+  sortReceivableFindings,
+  type ReceivableFinding,
+  type ReceivableTransaction,
+} from "./receivablesTypes";
+
+export type ReceivableBalanceProjection = {
+  chargeCents: number;
+  creditCents: number;
+  appliedPaymentCents: number;
+  reversalCents: number;
+  writeOffCents: number;
+  adjustmentIncreaseCents: number;
+  adjustmentDecreaseCents: number;
+  netBalanceCents: number;
+  outstandingCents: number;
+  overpaymentCents: number;
+  transactionCount: number;
+  findings: ReceivableFinding[];
+};
+
+export type ReceivableProjectionScope = {
+  leaseId?: string;
+  propertyId?: string;
+  asOfDate?: string;
+};
+
+function normalizedTransactions(inputs: readonly unknown[], findings: ReceivableFinding[]): ReceivableTransaction[] {
+  const seen = new Set<string>();
+  const result: ReceivableTransaction[] = [];
+  for (const input of inputs) {
+    const normalized = normalizeReceivableTransaction(input);
+    findings.push(...normalized.findings);
+    if (!normalized.transaction) continue;
+    if (seen.has(normalized.transaction.transactionId)) {
+      findings.push({ code: "duplicate_transaction_id", severity: "error", transactionId: normalized.transaction.transactionId });
+      continue;
+    }
+    seen.add(normalized.transaction.transactionId);
+    result.push(normalized.transaction);
+  }
+  return result.sort((a, b) =>
+    [a.effectiveDate, a.transactionId].join(":").localeCompare([b.effectiveDate, b.transactionId].join(":"))
+  );
+}
+
+export function projectReceivableBalance(
+  inputs: readonly unknown[],
+  scope: ReceivableProjectionScope = {}
+): ReceivableBalanceProjection {
+  const findings: ReceivableFinding[] = [];
+  const asOf = scope.asOfDate ? parseDateOnly(scope.asOfDate) : null;
+  if (scope.asOfDate && !asOf) findings.push({ code: "invalid_date_only", severity: "error", field: "asOfDate" });
+  const all = normalizedTransactions(inputs, findings);
+  const scoped = all.filter((transaction) => {
+    if (scope.leaseId && transaction.leaseId !== scope.leaseId) return false;
+    if (scope.propertyId && transaction.propertyId !== scope.propertyId) return false;
+    if (asOf && parseDateOnly(transaction.effectiveDate)!.epochDay > asOf.epochDay) return false;
+    return true;
+  });
+  const byId = new Map(scoped.map((transaction) => [transaction.transactionId, transaction]));
+  const reversedTargets = new Set<string>();
+  const valid: ReceivableTransaction[] = [];
+
+  for (const transaction of scoped) {
+    if (transaction.type === "nsf_fee") continue;
+    if (transaction.type !== "payment_reversal") {
+      valid.push(transaction);
+      continue;
+    }
+    const targetId = transaction.reversesTransactionId;
+    const target = targetId ? byId.get(targetId) : null;
+    if (!target || target.type !== "payment_applied") {
+      findings.push({ code: "invalid_payment_reversal_target", severity: "error", transactionId: transaction.transactionId });
+      continue;
+    }
+    if (target.transactionId === transaction.transactionId) {
+      findings.push({ code: "self_reversal_not_allowed", severity: "error", transactionId: transaction.transactionId });
+      continue;
+    }
+    if (
+      target.leaseId !== transaction.leaseId ||
+      target.propertyId !== transaction.propertyId ||
+      target.currency !== transaction.currency ||
+      target.amountCents !== transaction.amountCents
+    ) {
+      findings.push({ code: "payment_reversal_mismatch", severity: "error", transactionId: transaction.transactionId });
+      continue;
+    }
+    if (reversedTargets.has(target.transactionId)) {
+      findings.push({ code: "duplicate_payment_reversal", severity: "error", transactionId: transaction.transactionId });
+      continue;
+    }
+    reversedTargets.add(target.transactionId);
+    valid.push(transaction);
+  }
+
+  let chargeCents = 0;
+  let creditCents = 0;
+  let appliedPaymentCents = 0;
+  let reversalCents = 0;
+  let writeOffCents = 0;
+  let adjustmentIncreaseCents = 0;
+  let adjustmentDecreaseCents = 0;
+  let netBalanceCents = 0;
+
+  for (const transaction of valid) {
+    switch (transaction.type) {
+      case "scheduled_rent_charge":
+      case "deposit_charge":
+      case "one_time_charge":
+        chargeCents += transaction.amountCents;
+        netBalanceCents += transaction.amountCents;
+        break;
+      case "credit":
+        creditCents += transaction.amountCents;
+        netBalanceCents -= transaction.amountCents;
+        break;
+      case "payment_applied":
+        appliedPaymentCents += transaction.amountCents;
+        netBalanceCents -= transaction.amountCents;
+        break;
+      case "payment_reversal":
+        reversalCents += transaction.amountCents;
+        netBalanceCents += transaction.amountCents;
+        break;
+      case "write_off":
+        writeOffCents += transaction.amountCents;
+        netBalanceCents -= transaction.amountCents;
+        break;
+      case "adjustment":
+        if (transaction.metadata.adjustmentDirection === "increase") {
+          adjustmentIncreaseCents += transaction.amountCents;
+          netBalanceCents += transaction.amountCents;
+        } else {
+          adjustmentDecreaseCents += transaction.amountCents;
+          netBalanceCents -= transaction.amountCents;
+        }
+        break;
+      case "nsf_fee":
+        break;
+    }
+  }
+
+  return {
+    chargeCents,
+    creditCents,
+    appliedPaymentCents,
+    reversalCents,
+    writeOffCents,
+    adjustmentIncreaseCents,
+    adjustmentDecreaseCents,
+    netBalanceCents,
+    outstandingCents: Math.max(0, netBalanceCents),
+    overpaymentCents: Math.max(0, -netBalanceCents),
+    transactionCount: valid.length,
+    findings: sortReceivableFindings(findings),
+  };
+}

--- a/rentchain-api/src/lib/accounting/chargeSchedulePreview.ts
+++ b/rentchain-api/src/lib/accounting/chargeSchedulePreview.ts
@@ -1,0 +1,251 @@
+import {
+  addUtcMonths,
+  cleanAccountingString,
+  daysInUtcMonth,
+  formatDateOnly,
+  parseDateOnly,
+  sortReceivableFindings,
+  type ReceivableFinding,
+  type ReceivableTransactionType,
+} from "./receivablesTypes";
+import { buildReceivablesFingerprint } from "./receivablesFingerprint";
+
+export const MAX_CHARGE_SCHEDULE_OCCURRENCES = 120;
+
+export type LeaseChargeScheduleInput = {
+  leaseId?: unknown;
+  propertyId?: unknown;
+  unitId?: unknown;
+  responsibilityId?: unknown;
+  tenantId?: unknown;
+  sourceLeaseVersion?: unknown;
+  leaseStartDate?: unknown;
+  leaseEndDate?: unknown;
+  monthlyRentCents?: unknown;
+  dueDay?: unknown;
+  currency?: unknown;
+  billingFrequency?: unknown;
+  depositAmountCents?: unknown;
+  asOfDate?: unknown;
+  previewThroughDate?: unknown;
+};
+
+export type NormalizedLeaseChargeScheduleInput = {
+  leaseId: string;
+  propertyId: string;
+  unitId: string | null;
+  responsibilityId: string | null;
+  tenantId: string | null;
+  sourceLeaseVersion: string;
+  leaseStartDate: string;
+  leaseEndDate: string | null;
+  monthlyRentCents: number;
+  dueDay: number;
+  currency: "cad";
+  billingFrequency: "monthly";
+  depositAmountCents: number | null;
+  asOfDate: string;
+  previewThroughDate: string;
+};
+
+export type LeaseChargeOccurrence = {
+  occurrenceKey: string;
+  type: Extract<ReceivableTransactionType, "scheduled_rent_charge" | "deposit_charge">;
+  amountCents: number;
+  currency: "cad";
+  dueDate: string;
+  periodStart: string;
+  periodEnd: string;
+  sourceLeaseVersion: string;
+  policyReviewRequired: boolean;
+};
+
+export type LeaseChargeSchedulePreview = {
+  allowed: boolean;
+  normalizedInput: NormalizedLeaseChargeScheduleInput | null;
+  occurrences: LeaseChargeOccurrence[];
+  totals: {
+    scheduledRentCents: number;
+    depositChargeCents: number;
+    occurrenceCount: number;
+  };
+  findings: ReceivableFinding[];
+  previewFingerprint: string;
+};
+
+function requiredString(input: LeaseChargeScheduleInput, field: keyof LeaseChargeScheduleInput, findings: ReceivableFinding[]) {
+  const value = cleanAccountingString(input[field]);
+  if (!value) findings.push({ code: "required_field_missing", severity: "error", field: String(field) });
+  return value;
+}
+
+function occurrenceKey(input: NormalizedLeaseChargeScheduleInput, occurrence: Omit<LeaseChargeOccurrence, "occurrenceKey">) {
+  return [
+    "receivable_charge",
+    input.leaseId,
+    input.responsibilityId || "lease_level",
+    input.sourceLeaseVersion,
+    occurrence.type,
+    occurrence.dueDate,
+    occurrence.periodStart,
+    occurrence.periodEnd,
+    occurrence.amountCents,
+    occurrence.currency,
+  ].join(":");
+}
+
+function emptyPreview(findings: ReceivableFinding[]): LeaseChargeSchedulePreview {
+  const sorted = sortReceivableFindings(findings);
+  return {
+    allowed: false,
+    normalizedInput: null,
+    occurrences: [],
+    totals: { scheduledRentCents: 0, depositChargeCents: 0, occurrenceCount: 0 },
+    findings: sorted,
+    previewFingerprint: buildReceivablesFingerprint({ schemaVersion: "lease_charge_schedule_preview_v1", findings: sorted.map((f) => f.code) }),
+  };
+}
+
+export function buildLeaseChargeSchedulePreview(input: LeaseChargeScheduleInput): LeaseChargeSchedulePreview {
+  const findings: ReceivableFinding[] = [];
+  const leaseId = requiredString(input, "leaseId", findings);
+  const propertyId = requiredString(input, "propertyId", findings);
+  const sourceLeaseVersion = requiredString(input, "sourceLeaseVersion", findings);
+  const start = parseDateOnly(input.leaseStartDate);
+  const end = input.leaseEndDate === null || input.leaseEndDate === undefined || input.leaseEndDate === ""
+    ? null
+    : parseDateOnly(input.leaseEndDate);
+  const asOf = parseDateOnly(input.asOfDate);
+  const through = parseDateOnly(input.previewThroughDate);
+  if (!start) findings.push({ code: "invalid_date_only", severity: "error", field: "leaseStartDate" });
+  if (input.leaseEndDate !== null && input.leaseEndDate !== undefined && input.leaseEndDate !== "" && !end) {
+    findings.push({ code: "invalid_date_only", severity: "error", field: "leaseEndDate" });
+  }
+  if (!asOf) findings.push({ code: "invalid_date_only", severity: "error", field: "asOfDate" });
+  if (!through) findings.push({ code: "invalid_date_only", severity: "error", field: "previewThroughDate" });
+  if (start && end && end.epochDay < start.epochDay) findings.push({ code: "lease_end_before_start", severity: "error", field: "leaseEndDate" });
+  if (start && through && through.epochDay < start.epochDay) findings.push({ code: "preview_horizon_before_lease", severity: "error", field: "previewThroughDate" });
+
+  const monthlyRentCents = input.monthlyRentCents;
+  if (!Number.isSafeInteger(monthlyRentCents) || Number(monthlyRentCents) <= 0) {
+    findings.push({ code: "invalid_monthly_rent_cents", severity: "error", field: "monthlyRentCents" });
+  }
+  const dueDay = input.dueDay;
+  if (!Number.isInteger(dueDay) || Number(dueDay) < 1 || Number(dueDay) > 31) {
+    findings.push({ code: "invalid_due_day", severity: "error", field: "dueDay" });
+  }
+  const currency = cleanAccountingString(input.currency, 8)?.toLowerCase();
+  if (currency !== "cad") findings.push({ code: "unsupported_currency", severity: "error", field: "currency" });
+  const billingFrequency = cleanAccountingString(input.billingFrequency, 40)?.toLowerCase();
+  if (billingFrequency !== "monthly") findings.push({ code: "unsupported_billing_frequency", severity: "error", field: "billingFrequency" });
+
+  let depositAmountCents: number | null = null;
+  if (input.depositAmountCents !== null && input.depositAmountCents !== undefined) {
+    if (!Number.isSafeInteger(input.depositAmountCents) || Number(input.depositAmountCents) < 0) {
+      findings.push({ code: "invalid_deposit_amount_cents", severity: "error", field: "depositAmountCents" });
+    } else if (Number(input.depositAmountCents) > 0) {
+      depositAmountCents = Number(input.depositAmountCents);
+    }
+  }
+  const responsibilityId = cleanAccountingString(input.responsibilityId);
+  if (!responsibilityId) findings.push({ code: "responsibility_not_modeled", severity: "review", field: "responsibilityId" });
+
+  if (findings.some((finding) => finding.severity === "error") || !leaseId || !propertyId || !sourceLeaseVersion || !start || !asOf || !through) {
+    return emptyPreview(findings);
+  }
+
+  const normalized: NormalizedLeaseChargeScheduleInput = {
+    leaseId,
+    propertyId,
+    unitId: cleanAccountingString(input.unitId),
+    responsibilityId,
+    tenantId: cleanAccountingString(input.tenantId),
+    sourceLeaseVersion,
+    leaseStartDate: start.value,
+    leaseEndDate: end?.value || null,
+    monthlyRentCents: Number(monthlyRentCents),
+    dueDay: Number(dueDay),
+    currency: "cad",
+    billingFrequency: "monthly",
+    depositAmountCents,
+    asOfDate: asOf.value,
+    previewThroughDate: through.value,
+  };
+
+  const finalEpochDay = Math.min(through.epochDay, end?.epochDay ?? through.epochDay);
+  let cursor = start.day > normalized.dueDay ? addUtcMonths(start.year, start.month) : { year: start.year, month: start.month };
+  const occurrences: LeaseChargeOccurrence[] = [];
+  if (start.day > normalized.dueDay) {
+    findings.push({ code: "proration_policy_required", severity: "review", field: "leaseStartDate" });
+  }
+  if (end && end.day < daysInUtcMonth(end.year, end.month)) {
+    findings.push({ code: "proration_policy_required", severity: "review", field: "leaseEndDate" });
+  }
+
+  while (occurrences.length < MAX_CHARGE_SCHEDULE_OCCURRENCES) {
+    const dueDate = formatDateOnly(cursor.year, cursor.month, Math.min(normalized.dueDay, daysInUtcMonth(cursor.year, cursor.month)));
+    const due = parseDateOnly(dueDate)!;
+    if (due.epochDay > finalEpochDay) break;
+    if (due.epochDay >= start.epochDay) {
+      const periodStart = formatDateOnly(cursor.year, cursor.month, 1);
+      const periodEnd = formatDateOnly(cursor.year, cursor.month, daysInUtcMonth(cursor.year, cursor.month));
+      const base = {
+        type: "scheduled_rent_charge" as const,
+        amountCents: normalized.monthlyRentCents,
+        currency: "cad" as const,
+        dueDate,
+        periodStart,
+        periodEnd,
+        sourceLeaseVersion: normalized.sourceLeaseVersion,
+        policyReviewRequired: findings.some((finding) => finding.code === "proration_policy_required"),
+      };
+      occurrences.push({ ...base, occurrenceKey: occurrenceKey(normalized, base) });
+    }
+    cursor = addUtcMonths(cursor.year, cursor.month);
+  }
+
+  const nextDueDate = formatDateOnly(cursor.year, cursor.month, Math.min(normalized.dueDay, daysInUtcMonth(cursor.year, cursor.month)));
+  if (parseDateOnly(nextDueDate)!.epochDay <= finalEpochDay) {
+    findings.push({ code: "preview_horizon_exceeds_max_occurrences", severity: "error", field: "previewThroughDate" });
+  }
+
+  if (depositAmountCents) {
+    const base = {
+      type: "deposit_charge" as const,
+      amountCents: depositAmountCents,
+      currency: "cad" as const,
+      dueDate: start.value,
+      periodStart: start.value,
+      periodEnd: start.value,
+      sourceLeaseVersion: normalized.sourceLeaseVersion,
+      policyReviewRequired: false,
+    };
+    occurrences.push({ ...base, occurrenceKey: occurrenceKey(normalized, base) });
+  }
+
+  occurrences.sort((a, b) =>
+    [a.dueDate, a.type === "deposit_charge" ? "0" : "1", a.occurrenceKey]
+      .join(":")
+      .localeCompare([b.dueDate, b.type === "deposit_charge" ? "0" : "1", b.occurrenceKey].join(":"))
+  );
+  const sortedFindings = sortReceivableFindings(findings);
+  const totals = {
+    scheduledRentCents: occurrences.filter((row) => row.type === "scheduled_rent_charge").reduce((sum, row) => sum + row.amountCents, 0),
+    depositChargeCents: occurrences.filter((row) => row.type === "deposit_charge").reduce((sum, row) => sum + row.amountCents, 0),
+    occurrenceCount: occurrences.length,
+  };
+  const fingerprintPayload = {
+    schemaVersion: "lease_charge_schedule_preview_v1",
+    ...normalized,
+    occurrences,
+    findings: sortedFindings.map((finding) => finding.code),
+  };
+  return {
+    allowed: !sortedFindings.some((finding) => finding.severity === "error"),
+    normalizedInput: normalized,
+    occurrences,
+    totals,
+    findings: sortedFindings,
+    previewFingerprint: buildReceivablesFingerprint(fingerprintPayload),
+  };
+}

--- a/rentchain-api/src/lib/accounting/index.ts
+++ b/rentchain-api/src/lib/accounting/index.ts
@@ -1,0 +1,6 @@
+export * from "./receivablesTypes";
+export * from "./receivablesFingerprint";
+export * from "./chargeSchedulePreview";
+export * from "./balanceProjection";
+export * from "./agingProjection";
+export * from "./rentRollProjection";

--- a/rentchain-api/src/lib/accounting/receivablesFingerprint.ts
+++ b/rentchain-api/src/lib/accounting/receivablesFingerprint.ts
@@ -1,0 +1,35 @@
+import { createHash } from "crypto";
+
+export const RECEIVABLE_SCHEDULE_STATE_STALE = "RECEIVABLE_SCHEDULE_STATE_STALE";
+
+function stableValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stableValue);
+  if (!value || typeof value !== "object") return value === undefined ? null : value;
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, child]) => [key, stableValue(child)])
+  );
+}
+
+export function stableSerializeReceivables(value: unknown): string {
+  return JSON.stringify(stableValue(value));
+}
+
+export function buildReceivablesFingerprint(value: unknown): string {
+  const digest = createHash("sha256").update(stableSerializeReceivables(value)).digest("hex").slice(0, 32);
+  return `lease_charge_schedule_preview:v1:${digest}`;
+}
+
+export function validateChargeSchedulePreviewFingerprint(input: {
+  expectedPreviewFingerprint?: string | null;
+  currentPreviewFingerprint: string;
+}): { ok: true } | { ok: false; code: typeof RECEIVABLE_SCHEDULE_STATE_STALE } {
+  if (
+    !input.expectedPreviewFingerprint ||
+    input.expectedPreviewFingerprint !== input.currentPreviewFingerprint
+  ) {
+    return { ok: false, code: RECEIVABLE_SCHEDULE_STATE_STALE };
+  }
+  return { ok: true };
+}

--- a/rentchain-api/src/lib/accounting/receivablesTypes.ts
+++ b/rentchain-api/src/lib/accounting/receivablesTypes.ts
@@ -1,0 +1,202 @@
+export const RECEIVABLE_TRANSACTION_TYPES = [
+  "scheduled_rent_charge",
+  "deposit_charge",
+  "one_time_charge",
+  "credit",
+  "adjustment",
+  "payment_applied",
+  "payment_reversal",
+  "write_off",
+  "nsf_fee",
+] as const;
+
+export type ReceivableTransactionType = (typeof RECEIVABLE_TRANSACTION_TYPES)[number];
+export type ReceivableAdjustmentDirection = "increase" | "decrease";
+export type ReceivableFindingSeverity = "error" | "review" | "info";
+
+export type ReceivableFinding = {
+  code: string;
+  severity: ReceivableFindingSeverity;
+  transactionId?: string | null;
+  field?: string | null;
+};
+
+export type ReceivableTransactionMetadata = {
+  policyKey?: string;
+  scheduleOccurrenceKey?: string;
+  adjustmentDirection?: ReceivableAdjustmentDirection;
+};
+
+export type ReceivableTransaction = {
+  transactionId: string;
+  leaseId: string;
+  propertyId: string;
+  unitId: string | null;
+  responsibilityId: string | null;
+  tenantId: string | null;
+  type: ReceivableTransactionType;
+  amountCents: number;
+  currency: "cad";
+  effectiveDate: string;
+  dueDate: string | null;
+  periodStart: string | null;
+  periodEnd: string | null;
+  sourceRef: string | null;
+  sourceVersion: string | null;
+  reversesTransactionId: string | null;
+  appliesToTransactionId: string | null;
+  metadata: ReceivableTransactionMetadata;
+};
+
+export type NormalizeReceivableTransactionResult = {
+  transaction: ReceivableTransaction | null;
+  findings: ReceivableFinding[];
+};
+
+const TYPE_SET = new Set<string>(RECEIVABLE_TRANSACTION_TYPES);
+const DATE_ONLY_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+export function cleanAccountingString(value: unknown, max = 300): string | null {
+  const next = typeof value === "string" ? value.trim().slice(0, max) : "";
+  return next || null;
+}
+
+export function parseDateOnly(value: unknown): { value: string; epochDay: number; year: number; month: number; day: number } | null {
+  const raw = cleanAccountingString(value, 10);
+  const match = raw ? DATE_ONLY_PATTERN.exec(raw) : null;
+  if (!match) return null;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const epochMillis = Date.UTC(year, month - 1, day);
+  const date = new Date(epochMillis);
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() + 1 !== month ||
+    date.getUTCDate() !== day
+  ) {
+    return null;
+  }
+  return { value: raw!, epochDay: Math.floor(epochMillis / 86_400_000), year, month, day };
+}
+
+export function formatDateOnly(year: number, month: number, day: number): string {
+  return `${String(year).padStart(4, "0")}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+}
+
+export function daysInUtcMonth(year: number, month: number): number {
+  return new Date(Date.UTC(year, month, 0)).getUTCDate();
+}
+
+export function addUtcMonths(year: number, month: number, count = 1): { year: number; month: number } {
+  const date = new Date(Date.UTC(year, month - 1 + count, 1));
+  return { year: date.getUTCFullYear(), month: date.getUTCMonth() + 1 };
+}
+
+function optionalDate(value: unknown, field: string, transactionId: string | null, findings: ReceivableFinding[]) {
+  if (value === null || value === undefined || value === "") return null;
+  const parsed = parseDateOnly(value);
+  if (!parsed) findings.push({ code: "invalid_date_only", severity: "error", transactionId, field });
+  return parsed?.value || null;
+}
+
+export function normalizeReceivableTransaction(input: unknown): NormalizeReceivableTransactionResult {
+  const source = input && typeof input === "object" ? (input as Record<string, unknown>) : {};
+  const transactionId = cleanAccountingString(source.transactionId);
+  const findings: ReceivableFinding[] = [];
+  const requiredString = (field: string) => {
+    const value = cleanAccountingString(source[field]);
+    if (!value) findings.push({ code: "required_field_missing", severity: "error", transactionId, field });
+    return value || "";
+  };
+
+  const leaseId = requiredString("leaseId");
+  const propertyId = requiredString("propertyId");
+  if (!transactionId) findings.push({ code: "required_field_missing", severity: "error", field: "transactionId" });
+
+  const typeValue = cleanAccountingString(source.type, 80);
+  const type = typeValue && TYPE_SET.has(typeValue) ? (typeValue as ReceivableTransactionType) : null;
+  if (!type) findings.push({ code: "unsupported_transaction_type", severity: "error", transactionId, field: "type" });
+
+  const amountCents = source.amountCents;
+  if (!Number.isSafeInteger(amountCents) || Number(amountCents) <= 0) {
+    findings.push({ code: "invalid_amount_cents", severity: "error", transactionId, field: "amountCents" });
+  }
+
+  const currencyValue = cleanAccountingString(source.currency, 8)?.toLowerCase();
+  if (currencyValue !== "cad") {
+    findings.push({ code: "unsupported_currency", severity: "error", transactionId, field: "currency" });
+  }
+
+  const effectiveDate = optionalDate(source.effectiveDate, "effectiveDate", transactionId, findings);
+  if (!effectiveDate) {
+    if (!findings.some((finding) => finding.field === "effectiveDate")) {
+      findings.push({ code: "required_field_missing", severity: "error", transactionId, field: "effectiveDate" });
+    }
+  }
+  const dueDate = optionalDate(source.dueDate, "dueDate", transactionId, findings);
+  const periodStart = optionalDate(source.periodStart, "periodStart", transactionId, findings);
+  const periodEnd = optionalDate(source.periodEnd, "periodEnd", transactionId, findings);
+  if (periodStart && periodEnd && parseDateOnly(periodEnd)!.epochDay < parseDateOnly(periodStart)!.epochDay) {
+    findings.push({ code: "invalid_period_range", severity: "error", transactionId, field: "periodEnd" });
+  }
+
+  const metadataSource = source.metadata && typeof source.metadata === "object"
+    ? (source.metadata as Record<string, unknown>)
+    : {};
+  const adjustmentDirection = cleanAccountingString(metadataSource.adjustmentDirection, 20);
+  if (type === "adjustment" && adjustmentDirection !== "increase" && adjustmentDirection !== "decrease") {
+    findings.push({ code: "adjustment_direction_required", severity: "error", transactionId, field: "metadata.adjustmentDirection" });
+  }
+  if (type === "payment_reversal" && !cleanAccountingString(source.reversesTransactionId)) {
+    findings.push({ code: "reversal_target_required", severity: "error", transactionId, field: "reversesTransactionId" });
+  }
+  if (type === "nsf_fee") {
+    findings.push({ code: "nsf_fee_policy_not_enabled", severity: "review", transactionId, field: "type" });
+  }
+
+  const hasErrors = findings.some((finding) => finding.severity === "error");
+  if (hasErrors || !type || !transactionId || !effectiveDate || currencyValue !== "cad") {
+    return { transaction: null, findings };
+  }
+
+  return {
+    transaction: {
+      transactionId,
+      leaseId,
+      propertyId,
+      unitId: cleanAccountingString(source.unitId),
+      responsibilityId: cleanAccountingString(source.responsibilityId),
+      tenantId: cleanAccountingString(source.tenantId),
+      type,
+      amountCents: Number(amountCents),
+      currency: "cad",
+      effectiveDate,
+      dueDate,
+      periodStart,
+      periodEnd,
+      sourceRef: cleanAccountingString(source.sourceRef),
+      sourceVersion: cleanAccountingString(source.sourceVersion),
+      reversesTransactionId: cleanAccountingString(source.reversesTransactionId),
+      appliesToTransactionId: cleanAccountingString(source.appliesToTransactionId),
+      metadata: {
+        ...(cleanAccountingString(metadataSource.policyKey) ? { policyKey: cleanAccountingString(metadataSource.policyKey)! } : {}),
+        ...(cleanAccountingString(metadataSource.scheduleOccurrenceKey)
+          ? { scheduleOccurrenceKey: cleanAccountingString(metadataSource.scheduleOccurrenceKey)! }
+          : {}),
+        ...(adjustmentDirection === "increase" || adjustmentDirection === "decrease"
+          ? { adjustmentDirection }
+          : {}),
+      },
+    },
+    findings,
+  };
+}
+
+export function sortReceivableFindings(findings: readonly ReceivableFinding[]): ReceivableFinding[] {
+  return [...findings].sort((a, b) =>
+    [a.code, a.transactionId || "", a.field || "", a.severity]
+      .join(":")
+      .localeCompare([b.code, b.transactionId || "", b.field || "", b.severity].join(":"))
+  );
+}

--- a/rentchain-api/src/lib/accounting/rentRollProjection.ts
+++ b/rentchain-api/src/lib/accounting/rentRollProjection.ts
@@ -1,0 +1,186 @@
+import { projectReceivableAging, type ReceivableAgingAllocationPolicy } from "./agingProjection";
+import { projectReceivableBalance } from "./balanceProjection";
+import { cleanAccountingString, parseDateOnly, sortReceivableFindings, type ReceivableFinding } from "./receivablesTypes";
+
+export type RentRollLeaseStatus = "active" | "signed_future" | "notice_period" | "ended" | "unknown";
+
+export type RentRollLeaseInput = {
+  propertyId: string;
+  propertyDisplay?: string | null;
+  unitId?: string | null;
+  unitDisplay?: string | null;
+  leaseId: string;
+  responsibilityId?: string | null;
+  tenantDisplayName?: string | null;
+  leaseStatus: RentRollLeaseStatus;
+  scheduledRentCents: number;
+  currency: "cad";
+  nextDueDate?: string | null;
+  transactions: readonly unknown[];
+};
+
+export type RentRollRow = {
+  propertyId: string;
+  propertyDisplay: string | null;
+  unitId: string | null;
+  unitDisplay: string | null;
+  leaseId: string;
+  responsibilityId: string | null;
+  tenantDisplayName: string | null;
+  leaseStatus: RentRollLeaseStatus;
+  scheduledRentCents: number;
+  currency: "cad";
+  currentBalanceCents: number;
+  outstandingCents: number;
+  overpaymentCents: number;
+  nextDueDate: string | null;
+  aging: {
+    currentCents: number;
+    days1To30Cents: number;
+    days31To60Cents: number;
+    days61To90Cents: number;
+    days90PlusCents: number;
+  };
+};
+
+export type RentRollSummary = {
+  scheduledRentCents: number;
+  currentBalanceCents: number;
+  outstandingCents: number;
+  overpaymentCents: number;
+  leaseCount: number;
+};
+
+export type RentRollPropertySummary = RentRollSummary & {
+  propertyId: string;
+  propertyDisplay: string | null;
+};
+
+export type RentRollProjection = {
+  asOfDate: string;
+  rows: RentRollRow[];
+  propertySummaries: RentRollPropertySummary[];
+  portfolioSummary: RentRollSummary;
+  findings: ReceivableFinding[];
+};
+
+const STATUS_SET = new Set<RentRollLeaseStatus>(["active", "signed_future", "notice_period", "ended", "unknown"]);
+
+export function projectRentRoll(input: {
+  leases: readonly RentRollLeaseInput[];
+  asOfDate: string;
+  agingAllocationPolicy?: ReceivableAgingAllocationPolicy;
+}): RentRollProjection {
+  const findings: ReceivableFinding[] = [];
+  const asOf = parseDateOnly(input.asOfDate);
+  if (!asOf) findings.push({ code: "invalid_date_only", severity: "error", field: "asOfDate" });
+  const rows: RentRollRow[] = [];
+
+  for (const source of input.leases) {
+    const leaseId = cleanAccountingString(source.leaseId);
+    const propertyId = cleanAccountingString(source.propertyId);
+    if (!leaseId) {
+      findings.push({ code: "required_field_missing", severity: "error", field: "leaseId" });
+      continue;
+    }
+    if (!propertyId) {
+      findings.push({ code: "required_field_missing", severity: "error", field: "propertyId", transactionId: leaseId });
+      continue;
+    }
+    if (!Number.isSafeInteger(source.scheduledRentCents) || source.scheduledRentCents < 0) {
+      findings.push({ code: "invalid_scheduled_rent_cents", severity: "error", transactionId: leaseId, field: "scheduledRentCents" });
+      continue;
+    }
+    if (source.currency !== "cad") {
+      findings.push({ code: "unsupported_currency", severity: "error", transactionId: leaseId, field: "currency" });
+      continue;
+    }
+    const propertyDisplay = cleanAccountingString(source.propertyDisplay);
+    const unitDisplay = cleanAccountingString(source.unitDisplay);
+    const tenantDisplayName = cleanAccountingString(source.tenantDisplayName);
+    if (!propertyDisplay) findings.push({ code: "property_display_not_provided", severity: "info", transactionId: leaseId });
+    if (!unitDisplay) findings.push({ code: "unit_display_not_provided", severity: "info", transactionId: leaseId });
+    if (!tenantDisplayName) findings.push({ code: "tenant_display_not_provided", severity: "info", transactionId: leaseId });
+    const nextDue = source.nextDueDate ? parseDateOnly(source.nextDueDate) : null;
+    if (source.nextDueDate && !nextDue) findings.push({ code: "invalid_date_only", severity: "error", transactionId: leaseId, field: "nextDueDate" });
+    const leaseStatus = STATUS_SET.has(source.leaseStatus) ? source.leaseStatus : "unknown";
+    if (leaseStatus !== source.leaseStatus) findings.push({ code: "unknown_lease_status", severity: "review", transactionId: leaseId });
+
+    const balance = projectReceivableBalance(source.transactions, { leaseId, propertyId, asOfDate: asOf?.value });
+    const aging = projectReceivableAging({
+      transactions: source.transactions,
+      leaseId,
+      propertyId,
+      asOfDate: asOf?.value || input.asOfDate,
+      allocationPolicy: input.agingAllocationPolicy || "explicit",
+    });
+    findings.push(...balance.findings, ...aging.findings);
+    rows.push({
+      propertyId,
+      propertyDisplay,
+      unitId: cleanAccountingString(source.unitId),
+      unitDisplay,
+      leaseId,
+      responsibilityId: cleanAccountingString(source.responsibilityId),
+      tenantDisplayName,
+      leaseStatus,
+      scheduledRentCents: source.scheduledRentCents,
+      currency: "cad",
+      currentBalanceCents: balance.netBalanceCents,
+      outstandingCents: balance.outstandingCents,
+      overpaymentCents: balance.overpaymentCents,
+      nextDueDate: nextDue?.value || null,
+      aging: {
+        currentCents: aging.currentCents,
+        days1To30Cents: aging.days1To30Cents,
+        days31To60Cents: aging.days31To60Cents,
+        days61To90Cents: aging.days61To90Cents,
+        days90PlusCents: aging.days90PlusCents,
+      },
+    });
+  }
+
+  rows.sort((a, b) =>
+    [a.propertyDisplay || "", a.unitDisplay || "", a.tenantDisplayName || "", a.leaseId]
+      .join(":")
+      .localeCompare([b.propertyDisplay || "", b.unitDisplay || "", b.tenantDisplayName || "", b.leaseId].join(":"))
+  );
+  const propertyMap = new Map<string, RentRollPropertySummary>();
+  for (const row of rows) {
+    const current = propertyMap.get(row.propertyId) || {
+      propertyId: row.propertyId,
+      propertyDisplay: row.propertyDisplay,
+      scheduledRentCents: 0,
+      currentBalanceCents: 0,
+      outstandingCents: 0,
+      overpaymentCents: 0,
+      leaseCount: 0,
+    };
+    current.scheduledRentCents += row.scheduledRentCents;
+    current.currentBalanceCents += row.currentBalanceCents;
+    current.outstandingCents += row.outstandingCents;
+    current.overpaymentCents += row.overpaymentCents;
+    current.leaseCount += 1;
+    propertyMap.set(row.propertyId, current);
+  }
+  const propertySummaries = [...propertyMap.values()].sort((a, b) =>
+    [a.propertyDisplay || "", a.propertyId].join(":").localeCompare([b.propertyDisplay || "", b.propertyId].join(":"))
+  );
+  const portfolioSummary = rows.reduce<RentRollSummary>(
+    (summary, row) => ({
+      scheduledRentCents: summary.scheduledRentCents + row.scheduledRentCents,
+      currentBalanceCents: summary.currentBalanceCents + row.currentBalanceCents,
+      outstandingCents: summary.outstandingCents + row.outstandingCents,
+      overpaymentCents: summary.overpaymentCents + row.overpaymentCents,
+      leaseCount: summary.leaseCount + 1,
+    }),
+    { scheduledRentCents: 0, currentBalanceCents: 0, outstandingCents: 0, overpaymentCents: 0, leaseCount: 0 }
+  );
+  return {
+    asOfDate: asOf?.value || input.asOfDate,
+    rows,
+    propertySummaries,
+    portfolioSummary,
+    findings: sortReceivableFindings(findings),
+  };
+}


### PR DESCRIPTION
## Summary
- add normalized CAD receivables transaction contracts and review findings
- add deterministic monthly charge schedule previews with bounded horizons and stale-state fingerprints
- add pure balance, aging, and rent-roll projections with append-safe reversal lineage
- add focused unit coverage for validation, date arithmetic, allocation, aggregation, and safe display fields

## Scope boundaries
- backend-only pure helpers under rentchain-api/src/lib/accounting
- no routes, UI, Firestore reads or writes, provider integration, PAD behavior, bank data, credentials, payment mutation, or money movement
- no RC1 demo behavior changes

## Validation
- focused accounting suite: 6 files, 34 tests passed
- backend production build passed with Node 20.20.2
- git diff --check passed
- git diff --cached --check passed
- exact staged scope confirmed: 13 files under rentchain-api/src/lib/accounting