### PR TITLE
Add Phase 0E legacy receivables source normalizer

### DIFF
--- a/rentchain-api/src/lib/accounting/__fixtures__/legacyReceivablesEquivalenceFixtures.ts
+++ b/rentchain-api/src/lib/accounting/__fixtures__/legacyReceivablesEquivalenceFixtures.ts
@@ -1,0 +1,52 @@
+import type { NormalizeLegacyReceivablesSourcesInput } from "../legacyReceivablesSourceTypes";
+
+const scope = {
+  landlordId: "landlord-a",
+  leaseId: "lease-a",
+  propertyId: "property-a",
+  tenantId: "tenant-a",
+  tenantMappingState: "resolved" as const,
+  ownershipProof: { state: "independently_verified" as const, landlordId: "landlord-a", leaseId: "lease-a" },
+};
+
+const payment = {
+  sourceKind: "payment_record" as const,
+  sourceId: "payment-a",
+  evidenceRole: "posted_transaction" as const,
+  landlordId: "landlord-a",
+  leaseId: "lease-a",
+  propertyId: "property-a",
+  tenantId: "tenant-a",
+  transactionType: "payment_applied" as const,
+  amountCents: 150000,
+  currency: "cad",
+  effectiveDate: "2026-06-01",
+  canonicalEventKey: "rent-payment-june",
+};
+
+const ledgerPayment = {
+  ...payment,
+  sourceKind: "ledger_entry" as const,
+  sourceId: "ledger-payment-a",
+};
+
+export const legacyReceivablesEquivalenceFixtures: Record<string, NormalizeLegacyReceivablesSourcesInput> = {
+  paymentOnly: { ...scope, records: [payment] },
+  linkedLedgerAndPayment: { ...scope, records: [payment, ledgerPayment] },
+  ambiguousUnlinkedDuplicates: {
+    ...scope,
+    records: [
+      { ...payment, canonicalEventKey: null },
+      { ...ledgerPayment, canonicalEventKey: null },
+    ],
+  },
+  changedEvidence: {
+    ...scope,
+    records: [{ ...payment, amountCents: 149900 }],
+  },
+  ownershipUnverified: {
+    ...scope,
+    ownershipProof: { state: "unverified", landlordId: "landlord-a", leaseId: "lease-a" },
+    records: [payment],
+  },
+};

--- a/rentchain-api/src/lib/accounting/__tests__/legacyReceivablesSourceNormalizer.test.ts
+++ b/rentchain-api/src/lib/accounting/__tests__/legacyReceivablesSourceNormalizer.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "vitest";
+import { legacyReceivablesEquivalenceFixtures as fixtures } from "../__fixtures__/legacyReceivablesEquivalenceFixtures";
+import { normalizeLegacyReceivablesSources } from "../legacyReceivablesSourceNormalizer";
+import type { NormalizeLegacyReceivablesSourcesInput } from "../legacyReceivablesSourceTypes";
+
+function base(overrides: Partial<NormalizeLegacyReceivablesSourcesInput> = {}): NormalizeLegacyReceivablesSourcesInput {
+  return {
+    landlordId: "landlord-a",
+    leaseId: "lease-a",
+    propertyId: "property-a",
+    tenantId: "tenant-a",
+    tenantMappingState: "resolved",
+    ownershipProof: { state: "independently_verified", landlordId: "landlord-a", leaseId: "lease-a" },
+    records: [],
+    ...overrides,
+  };
+}
+
+describe("normalizeLegacyReceivablesSources", () => {
+  it("produces stable output for equivalent linked payment evidence", () => {
+    const paymentOnly = normalizeLegacyReceivablesSources(fixtures.paymentOnly);
+    const linked = normalizeLegacyReceivablesSources(fixtures.linkedLedgerAndPayment);
+
+    expect(paymentOnly.sourceState).toBe("complete");
+    expect(linked.sourceState).toBe("complete");
+    expect(paymentOnly.transactions).toHaveLength(1);
+    expect(linked.transactions).toHaveLength(1);
+    expect(linked.transactions).toEqual(paymentOnly.transactions);
+    expect(linked.sourceFingerprint).toBe(paymentOnly.sourceFingerprint);
+    expect(linked.transactions[0].sourceRef).toBe("legacy_event:rent-payment-june");
+    expect(linked.transactions[0]).toMatchObject({ type: "payment_applied", amountCents: 150000 });
+  });
+
+  it("does not double-count explicitly linked ledger and payment records", () => {
+    const result = normalizeLegacyReceivablesSources(fixtures.linkedLedgerAndPayment);
+    expect(result.transactions.map((row) => row.amountCents)).toEqual([150000]);
+  });
+
+  it("fails closed for unlinked exact matches", () => {
+    const result = normalizeLegacyReceivablesSources(fixtures.ambiguousUnlinkedDuplicates);
+    expect(result).toMatchObject({ sourceState: "ambiguous", transactions: [] });
+    expect(result.findings.map((item) => item.code)).toContain("unlinked_exact_match_requires_review");
+  });
+
+  it("changes its normalized fingerprint when source evidence changes", () => {
+    const current = normalizeLegacyReceivablesSources(fixtures.paymentOnly);
+    const changed = normalizeLegacyReceivablesSources(fixtures.changedEvidence);
+    expect(changed.sourceFingerprint).not.toBe(current.sourceFingerprint);
+    expect(changed.transactions[0].amountCents).toBe(149900);
+  });
+
+  it("does not treat an in-memory fallback assertion as ownership proof", () => {
+    const result = normalizeLegacyReceivablesSources(fixtures.ownershipUnverified);
+    expect(result).toMatchObject({ sourceState: "incomplete", transactions: [] });
+    expect(result.findings.map((item) => item.code)).toContain("landlord_ownership_not_independently_verified");
+  });
+
+  it("fails closed when the proof scope differs from the requested lease", () => {
+    const result = normalizeLegacyReceivablesSources(base({
+      ownershipProof: { state: "independently_verified", landlordId: "landlord-a", leaseId: "lease-other" },
+    }));
+    expect(result.sourceState).toBe("incomplete");
+    expect(result.transactions).toEqual([]);
+  });
+
+  it("fails closed on ambiguous tenant mapping", () => {
+    const result = normalizeLegacyReceivablesSources(base({ tenantMappingState: "ambiguous" }));
+    expect(result.sourceState).toBe("ambiguous");
+    expect(result.transactions).toEqual([]);
+  });
+
+  it("rejects conflicting amounts inside an explicitly linked group", () => {
+    const records = fixtures.linkedLedgerAndPayment.records.map((record, index) =>
+      index === 1 ? { ...record, amountCents: 149000 } : record
+    );
+    const result = normalizeLegacyReceivablesSources({ ...fixtures.linkedLedgerAndPayment, records });
+    expect(result.sourceState).toBe("ambiguous");
+    expect(result.transactions).toEqual([]);
+    expect(result.findings.map((item) => item.code)).toContain("conflicting_linked_financial_evidence");
+  });
+
+  it("rejects duplicate evidence of the same source class in one event", () => {
+    const first = fixtures.paymentOnly.records[0];
+    const result = normalizeLegacyReceivablesSources({
+      ...fixtures.paymentOnly,
+      records: [first, { ...first, sourceId: "payment-b" }],
+    });
+    expect(result.sourceState).toBe("ambiguous");
+    expect(result.findings.map((item) => item.code)).toContain("ambiguous_duplicate_source_evidence");
+  });
+
+  it("does not let payment intents create receivable transactions", () => {
+    const result = normalizeLegacyReceivablesSources(base({
+      records: [{
+        sourceKind: "payment_intent",
+        sourceId: "intent-a",
+        evidenceRole: "posted_transaction",
+        landlordId: "landlord-a",
+        leaseId: "lease-a",
+        propertyId: "property-a",
+        transactionType: "payment_applied",
+        amountCents: 10000,
+        currency: "cad",
+        effectiveDate: "2026-06-01",
+      }],
+    }));
+    expect(result.sourceState).toBe("incomplete");
+    expect(result.transactions).toEqual([]);
+    expect(result.findings.map((item) => item.code)).toContain("payment_intent_cannot_create_receivable_transaction");
+  });
+
+  it("allows payment intent and reconciliation records only as corroborating evidence", () => {
+    const result = normalizeLegacyReceivablesSources(base({
+      records: [
+        {
+          sourceKind: "payment_intent",
+          sourceId: "intent-a",
+          evidenceRole: "corroborating_evidence",
+          landlordId: "landlord-a",
+          leaseId: "lease-a",
+          propertyId: "property-a",
+        },
+        {
+          sourceKind: "reconciliation_record",
+          sourceId: "reconciliation-a",
+          evidenceRole: "corroborating_evidence",
+          landlordId: "landlord-a",
+          leaseId: "lease-a",
+          propertyId: "property-a",
+        },
+      ],
+    }));
+    expect(result).toMatchObject({ sourceState: "complete", transactions: [], findings: [] });
+  });
+
+  it("keeps allocation records as corroborating evidence instead of inventing credits", () => {
+    const result = normalizeLegacyReceivablesSources(base({
+      records: [{
+        sourceKind: "allocation_record",
+        sourceId: "allocation-a",
+        evidenceRole: "posted_transaction",
+        landlordId: "landlord-a",
+        leaseId: "lease-a",
+        propertyId: "property-a",
+        transactionType: "credit",
+        amountCents: 10000,
+        currency: "cad",
+        effectiveDate: "2026-06-01",
+      }],
+    }));
+    expect(result.sourceState).toBe("incomplete");
+    expect(result.transactions).toEqual([]);
+    expect(result.findings.map((item) => item.code)).toContain("allocation_record_cannot_create_receivable_transaction");
+  });
+
+  it("maps reversal source references onto canonical transaction identities", () => {
+    const payment = fixtures.paymentOnly.records[0];
+    const result = normalizeLegacyReceivablesSources({
+      ...fixtures.paymentOnly,
+      records: [
+        payment,
+        {
+          ...payment,
+          sourceId: "reversal-a",
+          canonicalEventKey: "rent-payment-june-reversal",
+          transactionType: "payment_reversal",
+          reversesSourceId: "payment-a",
+          effectiveDate: "2026-06-03",
+        },
+      ],
+    });
+    expect(result.sourceState).toBe("complete");
+    expect(result.transactions[1]).toMatchObject({
+      transactionId: "legacy_event:rent-payment-june-reversal",
+      reversesTransactionId: "legacy_event:rent-payment-june",
+    });
+  });
+
+  it("rejects unsupported currency and mismatched record scope", () => {
+    const record = fixtures.paymentOnly.records[0];
+    const result = normalizeLegacyReceivablesSources({
+      ...fixtures.paymentOnly,
+      records: [{ ...record, landlordId: "landlord-b", currency: "usd" }],
+    });
+    expect(result.sourceState).toBe("incomplete");
+    expect(result.transactions).toEqual([]);
+    expect(result.findings.map((item) => item.code)).toEqual(
+      expect.arrayContaining(["legacy_landlord_scope_mismatch", "unsupported_currency"])
+    );
+  });
+});

--- a/rentchain-api/src/lib/accounting/index.ts
+++ b/rentchain-api/src/lib/accounting/index.ts
@@ -6,3 +6,5 @@ export * from "./agingProjection";
 export * from "./rentRollProjection";
 export * from "./leaseReceivablesDtoTypes";
 export * from "./leaseReceivablesDtoAssembler";
+export * from "./legacyReceivablesSourceTypes";
+export * from "./legacyReceivablesSourceNormalizer";

--- a/rentchain-api/src/lib/accounting/legacyReceivablesSourceNormalizer.ts
+++ b/rentchain-api/src/lib/accounting/legacyReceivablesSourceNormalizer.ts
@@ -1,0 +1,294 @@
+import crypto from "crypto";
+import {
+  LEGACY_RECEIVABLES_SOURCE_KINDS,
+  type LegacyReceivablesSourceFinding,
+  type LegacyReceivablesSourceKind,
+  type LegacyReceivablesSourceNormalizationResult,
+  type LegacyReceivablesSourceRecord,
+  type NormalizeLegacyReceivablesSourcesInput,
+} from "./legacyReceivablesSourceTypes";
+import {
+  cleanAccountingString,
+  normalizeReceivableTransaction,
+  sortReceivableFindings,
+  type ReceivableTransaction,
+} from "./receivablesTypes";
+
+const SOURCE_KINDS = new Set<string>(LEGACY_RECEIVABLES_SOURCE_KINDS);
+const EVIDENCE_ROLES = new Set(["posted_transaction", "preview_obligation", "corroborating_evidence"]);
+const SOURCE_PRECEDENCE: Record<LegacyReceivablesSourceKind, number> = {
+  ledger_entry: 600,
+  payment_record: 500,
+  allocation_record: 400,
+  reconciliation_record: 300,
+  lease_obligation: 200,
+  payment_intent: 100,
+};
+
+type ValidatedRecord = {
+  sourceKind: LegacyReceivablesSourceKind;
+  sourceId: string;
+  evidenceRole: string;
+  canonicalEventKey: string | null;
+  linkedSourceIds: string[];
+  transaction: ReceivableTransaction | null;
+  source: LegacyReceivablesSourceRecord;
+};
+
+function fingerprint(value: unknown): string {
+  return crypto.createHash("sha256").update(JSON.stringify(value)).digest("hex");
+}
+
+function finding(
+  code: string,
+  severity: "error" | "review" | "info",
+  record?: Partial<ValidatedRecord>,
+  field?: string
+): LegacyReceivablesSourceFinding {
+  return {
+    code,
+    severity,
+    ...(record?.sourceKind ? { sourceKind: record.sourceKind } : {}),
+    ...(record?.sourceId ? { sourceId: record.sourceId } : {}),
+    ...(field ? { field } : {}),
+  };
+}
+
+function transactionShape(transaction: ReceivableTransaction): string {
+  return JSON.stringify({
+    leaseId: transaction.leaseId,
+    propertyId: transaction.propertyId,
+    unitId: transaction.unitId,
+    responsibilityId: transaction.responsibilityId,
+    tenantId: transaction.tenantId,
+    type: transaction.type,
+    amountCents: transaction.amountCents,
+    currency: transaction.currency,
+    effectiveDate: transaction.effectiveDate,
+    dueDate: transaction.dueDate,
+    periodStart: transaction.periodStart,
+    periodEnd: transaction.periodEnd,
+    reversesTransactionId: transaction.reversesTransactionId,
+    appliesToTransactionId: transaction.appliesToTransactionId,
+    metadata: transaction.metadata,
+  });
+}
+
+function sortSourceFindings(findings: LegacyReceivablesSourceFinding[]) {
+  return [...findings].sort((a, b) =>
+    [a.code, a.sourceKind || "", a.sourceId || "", a.field || "", a.severity]
+      .join(":")
+      .localeCompare([b.code, b.sourceKind || "", b.sourceId || "", b.field || "", b.severity].join(":"))
+  );
+}
+
+function normalizeRecord(
+  source: LegacyReceivablesSourceRecord,
+  scope: { landlordId: string; leaseId: string; propertyId: string },
+  findings: LegacyReceivablesSourceFinding[]
+): ValidatedRecord | null {
+  const sourceKindValue = cleanAccountingString(source.sourceKind, 80);
+  const sourceKind = sourceKindValue && SOURCE_KINDS.has(sourceKindValue)
+    ? (sourceKindValue as LegacyReceivablesSourceKind)
+    : null;
+  const sourceId = cleanAccountingString(source.sourceId);
+  if (!sourceKind) findings.push(finding("legacy_source_kind_unsupported", "error", {}, "sourceKind"));
+  if (!sourceId) findings.push(finding("legacy_source_id_missing", "error", {}, "sourceId"));
+  if (!sourceKind || !sourceId) return null;
+
+  const partial = { sourceKind, sourceId };
+  const evidenceRole = cleanAccountingString(source.evidenceRole, 40);
+  if (!evidenceRole || !EVIDENCE_ROLES.has(evidenceRole)) {
+    findings.push(finding("legacy_evidence_role_unsupported", "error", partial, "evidenceRole"));
+    return null;
+  }
+  if (cleanAccountingString(source.landlordId) !== scope.landlordId) {
+    findings.push(finding("legacy_landlord_scope_mismatch", "error", partial, "landlordId"));
+  }
+  if (cleanAccountingString(source.leaseId) !== scope.leaseId) {
+    findings.push(finding("legacy_lease_scope_mismatch", "error", partial, "leaseId"));
+  }
+  if (cleanAccountingString(source.propertyId) !== scope.propertyId) {
+    findings.push(finding("legacy_property_scope_mismatch", "error", partial, "propertyId"));
+  }
+
+  const canonicalEventKey = cleanAccountingString(source.canonicalEventKey);
+  const linkedSourceIds = Array.from(
+    new Set((source.linkedSourceIds || []).map((value) => cleanAccountingString(value)).filter((value): value is string => Boolean(value)))
+  ).sort();
+
+  if (evidenceRole === "corroborating_evidence") {
+    if (source.transactionType || source.amountCents !== undefined) {
+      findings.push(finding("corroborating_evidence_cannot_create_transaction", "error", partial));
+    }
+    return { sourceKind, sourceId, evidenceRole, canonicalEventKey, linkedSourceIds, transaction: null, source };
+  }
+  if (sourceKind === "payment_intent") {
+    findings.push(finding("payment_intent_cannot_create_receivable_transaction", "error", partial));
+    return { sourceKind, sourceId, evidenceRole, canonicalEventKey, linkedSourceIds, transaction: null, source };
+  }
+  if (sourceKind === "reconciliation_record" && evidenceRole !== "corroborating_evidence") {
+    findings.push(finding("reconciliation_cannot_invent_receivable_transaction", "error", partial));
+    return { sourceKind, sourceId, evidenceRole, canonicalEventKey, linkedSourceIds, transaction: null, source };
+  }
+  if (sourceKind === "allocation_record") {
+    findings.push(finding("allocation_record_cannot_create_receivable_transaction", "error", partial));
+    return { sourceKind, sourceId, evidenceRole, canonicalEventKey, linkedSourceIds, transaction: null, source };
+  }
+  if (sourceKind === "payment_record" && source.transactionType !== "payment_applied" && source.transactionType !== "payment_reversal") {
+    findings.push(finding("payment_record_transaction_type_unsupported", "error", partial, "transactionType"));
+    return { sourceKind, sourceId, evidenceRole, canonicalEventKey, linkedSourceIds, transaction: null, source };
+  }
+  if (sourceKind === "lease_obligation" && evidenceRole !== "preview_obligation") {
+    findings.push(finding("lease_obligation_must_remain_preview", "error", partial, "evidenceRole"));
+    return { sourceKind, sourceId, evidenceRole, canonicalEventKey, linkedSourceIds, transaction: null, source };
+  }
+
+  const normalized = normalizeReceivableTransaction({
+    transactionId: `${sourceKind}:${sourceId}`,
+    leaseId: source.leaseId,
+    propertyId: source.propertyId,
+    unitId: source.unitId,
+    responsibilityId: source.responsibilityId,
+    tenantId: source.tenantId,
+    type: source.transactionType,
+    amountCents: source.amountCents,
+    currency: source.currency,
+    effectiveDate: source.effectiveDate,
+    dueDate: source.dueDate,
+    periodStart: source.periodStart,
+    periodEnd: source.periodEnd,
+    sourceRef: `${sourceKind}:${sourceId}`,
+    sourceVersion: source.sourceVersion,
+    reversesTransactionId: cleanAccountingString(source.reversesSourceId),
+    appliesToTransactionId: cleanAccountingString(source.appliesToSourceId),
+    metadata: { adjustmentDirection: source.adjustmentDirection },
+  });
+  findings.push(...sortReceivableFindings(normalized.findings).map((item) => ({ ...item, sourceKind, sourceId })));
+  return { sourceKind, sourceId, evidenceRole, canonicalEventKey, linkedSourceIds, transaction: normalized.transaction, source };
+}
+
+function explicitlyLinked(left: ValidatedRecord, right: ValidatedRecord): boolean {
+  return Boolean(
+    (left.canonicalEventKey && left.canonicalEventKey === right.canonicalEventKey) ||
+      left.linkedSourceIds.includes(right.sourceId) ||
+      right.linkedSourceIds.includes(left.sourceId)
+  );
+}
+
+export function normalizeLegacyReceivablesSources(
+  input: NormalizeLegacyReceivablesSourcesInput
+): LegacyReceivablesSourceNormalizationResult {
+  const findings: LegacyReceivablesSourceFinding[] = [];
+  const landlordId = cleanAccountingString(input.landlordId);
+  const leaseId = cleanAccountingString(input.leaseId);
+  const propertyId = cleanAccountingString(input.propertyId);
+  const proofLandlordId = cleanAccountingString(input.ownershipProof?.landlordId);
+  const proofLeaseId = cleanAccountingString(input.ownershipProof?.leaseId);
+
+  if (!landlordId || !leaseId || !propertyId) findings.push(finding("legacy_normalization_scope_incomplete", "error"));
+  if (
+    input.ownershipProof?.state !== "independently_verified" ||
+    !landlordId ||
+    !leaseId ||
+    proofLandlordId !== landlordId ||
+    proofLeaseId !== leaseId
+  ) {
+    findings.push(finding("landlord_ownership_not_independently_verified", "error"));
+  }
+  if (input.tenantMappingState === "ambiguous") findings.push(finding("tenant_mapping_ambiguous", "error"));
+  else if (input.tenantMappingState !== "resolved") findings.push(finding("tenant_mapping_incomplete", "error"));
+
+  if (findings.some((item) => item.severity === "error") || !landlordId || !leaseId || !propertyId) {
+    const sorted = sortSourceFindings(findings);
+    return { sourceState: input.tenantMappingState === "ambiguous" ? "ambiguous" : "incomplete", transactions: [], findings: sorted, sourceFingerprint: fingerprint(sorted) };
+  }
+
+  const validated = input.records
+    .map((record) => normalizeRecord(record, { landlordId, leaseId, propertyId }, findings))
+    .filter((record): record is ValidatedRecord => Boolean(record));
+  const duplicateIds = new Set<string>();
+  for (const record of validated) {
+    if (duplicateIds.has(record.sourceId)) findings.push(finding("duplicate_legacy_source_id", "error", record));
+    duplicateIds.add(record.sourceId);
+  }
+
+  const transactional = validated.filter((record) => record.transaction);
+  const used = new Set<string>();
+  const selected: ValidatedRecord[] = [];
+  for (const record of [...transactional].sort((a, b) => a.sourceId.localeCompare(b.sourceId))) {
+    if (used.has(record.sourceId)) continue;
+    const group = transactional.filter(
+      (candidate) => !used.has(candidate.sourceId) && (candidate.sourceId === record.sourceId || explicitlyLinked(record, candidate))
+    );
+    group.forEach((candidate) => used.add(candidate.sourceId));
+    if (group.length === 1) {
+      selected.push(record);
+      continue;
+    }
+    if (new Set(group.map((candidate) => candidate.sourceKind)).size !== group.length) {
+      findings.push(finding("ambiguous_duplicate_source_evidence", "error", record));
+      continue;
+    }
+    const shapes = new Set(group.map((candidate) => transactionShape(candidate.transaction!)));
+    if (shapes.size !== 1) {
+      findings.push(finding("conflicting_linked_financial_evidence", "error", record));
+      continue;
+    }
+    selected.push(
+      [...group].sort((a, b) => SOURCE_PRECEDENCE[b.sourceKind] - SOURCE_PRECEDENCE[a.sourceKind] || a.sourceId.localeCompare(b.sourceId))[0]
+    );
+  }
+
+  const exactGroups = new Map<string, ValidatedRecord[]>();
+  for (const record of selected) {
+    const key = transactionShape(record.transaction!);
+    exactGroups.set(key, [...(exactGroups.get(key) || []), record]);
+  }
+  for (const group of exactGroups.values()) {
+    if (group.length > 1) findings.push(finding("unlinked_exact_match_requires_review", "error", group[0]));
+  }
+
+  const sortedFindings = sortSourceFindings(findings);
+  const hasErrors = sortedFindings.some((item) => item.severity === "error");
+  const canonicalIdFor = (record: ValidatedRecord) =>
+    record.canonicalEventKey ? `legacy_event:${record.canonicalEventKey}` : `${record.sourceKind}:${record.sourceId}`;
+  const sourceToCanonicalId = new Map<string, string>();
+  for (const record of selected) {
+    const canonicalId = canonicalIdFor(record);
+    for (const candidate of transactional) {
+      if (candidate.sourceId === record.sourceId || explicitlyLinked(record, candidate)) {
+        sourceToCanonicalId.set(candidate.sourceId, canonicalId);
+      }
+    }
+  }
+  const transactions = hasErrors
+    ? []
+    : selected
+        .map((record) => {
+          const canonicalTransactionId = canonicalIdFor(record);
+          return {
+            ...record.transaction!,
+            transactionId: canonicalTransactionId,
+            sourceRef: canonicalTransactionId,
+            reversesTransactionId: record.transaction!.reversesTransactionId
+              ? sourceToCanonicalId.get(record.transaction!.reversesTransactionId) || record.transaction!.reversesTransactionId
+              : null,
+            appliesToTransactionId: record.transaction!.appliesToTransactionId
+              ? sourceToCanonicalId.get(record.transaction!.appliesToTransactionId) || record.transaction!.appliesToTransactionId
+              : null,
+          };
+        })
+        .sort((a, b) => [a.effectiveDate, a.transactionId].join(":").localeCompare([b.effectiveDate, b.transactionId].join(":")));
+  const sourceState = hasErrors
+    ? sortedFindings.some((item) => item.code.includes("ambiguous") || item.code.includes("conflicting") || item.code.includes("duplicate") || item.code.includes("unlinked"))
+      ? "ambiguous"
+      : "incomplete"
+    : "complete";
+  return {
+    sourceState,
+    transactions,
+    findings: sortedFindings,
+    sourceFingerprint: fingerprint({ sourceState, transactions, findings: sortedFindings }),
+  };
+}

--- a/rentchain-api/src/lib/accounting/legacyReceivablesSourceTypes.ts
+++ b/rentchain-api/src/lib/accounting/legacyReceivablesSourceTypes.ts
@@ -1,0 +1,66 @@
+import type { ReceivableFinding, ReceivableTransaction, ReceivableTransactionType } from "./receivablesTypes";
+
+export const LEGACY_RECEIVABLES_SOURCE_KINDS = [
+  "ledger_entry",
+  "payment_record",
+  "payment_intent",
+  "reconciliation_record",
+  "lease_obligation",
+  "allocation_record",
+] as const;
+
+export type LegacyReceivablesSourceKind = (typeof LEGACY_RECEIVABLES_SOURCE_KINDS)[number];
+export type LegacyReceivablesEvidenceRole = "posted_transaction" | "preview_obligation" | "corroborating_evidence";
+
+export type LegacyReceivablesOwnershipProof = {
+  state: "independently_verified" | "unverified" | "ambiguous";
+  landlordId: unknown;
+  leaseId: unknown;
+};
+
+export type LegacyReceivablesSourceRecord = {
+  sourceKind: LegacyReceivablesSourceKind | string;
+  sourceId: unknown;
+  evidenceRole: LegacyReceivablesEvidenceRole | string;
+  landlordId: unknown;
+  leaseId: unknown;
+  propertyId: unknown;
+  unitId?: unknown;
+  responsibilityId?: unknown;
+  tenantId?: unknown;
+  transactionType?: ReceivableTransactionType | string | null;
+  amountCents?: unknown;
+  currency?: unknown;
+  effectiveDate?: unknown;
+  dueDate?: unknown;
+  periodStart?: unknown;
+  periodEnd?: unknown;
+  adjustmentDirection?: unknown;
+  reversesSourceId?: unknown;
+  appliesToSourceId?: unknown;
+  canonicalEventKey?: unknown;
+  linkedSourceIds?: readonly unknown[];
+  sourceVersion?: unknown;
+};
+
+export type NormalizeLegacyReceivablesSourcesInput = {
+  landlordId: unknown;
+  leaseId: unknown;
+  propertyId: unknown;
+  tenantId?: unknown;
+  tenantMappingState: "resolved" | "missing" | "ambiguous" | string;
+  ownershipProof: LegacyReceivablesOwnershipProof;
+  records: readonly LegacyReceivablesSourceRecord[];
+};
+
+export type LegacyReceivablesSourceFinding = ReceivableFinding & {
+  sourceKind?: LegacyReceivablesSourceKind | null;
+  sourceId?: string | null;
+};
+
+export type LegacyReceivablesSourceNormalizationResult = {
+  sourceState: "complete" | "incomplete" | "ambiguous";
+  transactions: ReceivableTransaction[];
+  findings: LegacyReceivablesSourceFinding[];
+  sourceFingerprint: string;
+};


### PR DESCRIPTION
## Summary

- add a pure Phase 0E legacy receivables source normalizer under `rentchain-api/src/lib/accounting`
- define explicit source contracts, precedence, linkage-based deduplication, and fail-closed validation
- add exact-equivalence fixtures and focused coverage for ambiguous evidence and independent landlord ownership proof

## Accounting boundaries

- Phase 0E remains pure, backend-only, and unmounted
- finalized linked ledger evidence outranks equivalent payment or preview evidence without double-counting
- equal amount/date records are not silently deduplicated without explicit linkage
- payment intents, reconciliation records, and allocation records cannot invent receivable transactions
- lease obligations remain preview evidence
- tenant rent remains landlord revenue; the direct-settlement model is unchanged

No routes, UI, Firestore reads or writes, provider integration, payment mutation, money movement, bank data, or RC1 behavior changed.

## Validation

- accounting suite: 8 files, 67 tests passed
- new normalizer coverage: 14 tests passed
- backend TypeScript production build passed with Node 20.20.2
- `git diff --check` passed
- `git diff --cached --check` passed
- forbidden-scope scan passed
- changed files limited to five backend accounting files
