### PR TITLE
Add Phase 0G receivables shadow comparator

### DIFF
--- a/rentchain-api/src/lib/accounting/__tests__/receivablesShadowComparator.test.ts
+++ b/rentchain-api/src/lib/accounting/__tests__/receivablesShadowComparator.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from "vitest";
+import { compareReceivablesShadow } from "../receivablesShadowComparator";
+import type {
+  CompareReceivablesShadowInput,
+  ReceivablesShadowSourceCompleteness,
+} from "../receivablesShadowComparatorTypes";
+
+const completeSources = (): ReceivablesShadowSourceCompleteness => ({
+  lease: "complete",
+  property: "complete",
+  unit: "complete",
+  tenantResponsibility: "complete",
+  ledgerEntries: "complete",
+  paymentRecords: "empty_confirmed",
+  paymentIntents: "empty_confirmed",
+  reconciliationRecords: "empty_confirmed",
+  leaseObligations: "complete",
+  allocationRecords: "empty_confirmed",
+});
+
+const transaction = () => ({
+  sourceKind: "ledger_entry" as const,
+  sourceId: "ledger-charge-a",
+  evidenceRole: "posted_transaction" as const,
+  landlordId: "landlord-a",
+  leaseId: "lease-a",
+  propertyId: "property-a",
+  unitId: "unit-a",
+  responsibilityId: "responsibility-a",
+  tenantId: "tenant-a",
+  transactionType: "scheduled_rent_charge" as const,
+  amountCents: 100_000,
+  currency: "cad",
+  effectiveDate: "2026-01-01",
+  dueDate: "2026-01-01",
+  periodStart: "2026-01-01",
+  periodEnd: "2026-01-31",
+  canonicalEventKey: "rent-charge-2026-01",
+});
+
+function base(overrides: Partial<CompareReceivablesShadowInput> = {}): CompareReceivablesShadowInput {
+  return {
+    config: { enabled: true, landlordAllowlist: "landlord-a" },
+    requestLandlordId: "landlord-a",
+    ownershipProof: { state: "independently_verified", landlordId: "landlord-a", leaseId: "lease-a" },
+    sourceCompleteness: completeSources(),
+    normalizationInput: {
+      landlordId: "landlord-a",
+      leaseId: "lease-a",
+      propertyId: "property-a",
+      tenantId: "tenant-a",
+      tenantMappingState: "resolved",
+      ownershipProof: { state: "independently_verified", landlordId: "landlord-a", leaseId: "lease-a" },
+      records: [transaction()],
+    },
+    dtoInput: {
+      leaseId: "lease-a",
+      propertyId: "property-a",
+      unitId: "unit-a",
+      responsibilityId: "responsibility-a",
+      tenantId: "tenant-a",
+      propertyDisplayName: "10 Harbour Street",
+      unitDisplayName: "Unit 2",
+      tenantDisplayName: "Example Tenant",
+      responsibilityDisplayName: "Primary lease responsibility",
+      tenantMappingState: "resolved",
+      leaseStatus: "active",
+      leaseStartDate: "2026-01-01",
+      leaseEndDate: "2026-03-31",
+      monthlyRentCents: 100_000,
+      dueDay: 1,
+      billingFrequency: "monthly",
+      currency: "cad",
+      depositAmountCents: null,
+      sourceLeaseVersion: "lease-version-1",
+      asOfDate: "2026-02-15",
+      previewThroughDate: "2026-03-31",
+      agingAllocationPolicy: "explicit",
+    },
+    legacyProjection: { state: "available", balanceCents: 100_000 },
+    ...overrides,
+  };
+}
+
+describe("compareReceivablesShadow", () => {
+  it.each([undefined, false, "false", "TRUE", 1])("is disabled by default or for a non-explicit enabled value: %s", (enabled) => {
+    const result = compareReceivablesShadow(base({ config: { enabled, landlordAllowlist: "landlord-a" } }));
+    expect(result).toEqual({
+      ok: false,
+      enabled: false,
+      allowed: false,
+      status: "disabled",
+      reasonCode: "SHADOW_DISABLED",
+      warnings: [],
+      comparisonVersion: "receivables_shadow_comparison_v1",
+    });
+  });
+
+  it.each([undefined, "", "  ", "*", [], ["*"]])("denies empty, malformed, or wildcard allowlists", (landlordAllowlist) => {
+    const result = compareReceivablesShadow(base({ config: { enabled: true, landlordAllowlist } }));
+    expect(result).toMatchObject({ ok: false, enabled: true, allowed: false, status: "not_allowed", reasonCode: "SHADOW_NOT_ALLOWLISTED" });
+  });
+
+  it("requires exact, case-sensitive allowlist membership", () => {
+    const result = compareReceivablesShadow(base({ config: { enabled: true, landlordAllowlist: "Landlord-A, landlord-b" } }));
+    expect(result).toMatchObject({ allowed: false, reasonCode: "SHADOW_NOT_ALLOWLISTED" });
+  });
+
+  it("fails closed when authoritative ownership is not independently proven", () => {
+    const result = compareReceivablesShadow(base({
+      ownershipProof: { state: "unverified", landlordId: "landlord-a", leaseId: "lease-a" },
+    }));
+    expect(result).toMatchObject({ ok: false, allowed: true, status: "not_ready", reasonCode: "SHADOW_OWNERSHIP_UNVERIFIED" });
+  });
+
+  it("fails closed when proof or DTO scope differs from the normalized scope", () => {
+    const input = base();
+    const result = compareReceivablesShadow({ ...input, dtoInput: { ...input.dtoInput, leaseId: "lease-other" } });
+    expect(result.reasonCode).toBe("SHADOW_OWNERSHIP_UNVERIFIED");
+  });
+
+  it.each(["unavailable", "ambiguous", "truncated"] as const)("fails closed for a %s source", (state) => {
+    const result = compareReceivablesShadow(base({
+      sourceCompleteness: { ...completeSources(), ledgerEntries: state },
+    }));
+    expect(result).toMatchObject({ status: "not_ready", reasonCode: "SHADOW_SOURCE_INCOMPLETE" });
+  });
+
+  it("does not accept confirmed-empty identity sources", () => {
+    const result = compareReceivablesShadow(base({
+      sourceCompleteness: { ...completeSources(), tenantResponsibility: "empty_confirmed" },
+    }));
+    expect(result.reasonCode).toBe("SHADOW_SOURCE_INCOMPLETE");
+  });
+
+  it("fails closed when Phase 0E source normalization fails", () => {
+    const input = base();
+    const result = compareReceivablesShadow({
+      ...input,
+      normalizationInput: {
+        ...input.normalizationInput,
+        records: [{ ...transaction(), currency: "usd" }],
+      },
+    });
+    expect(result).toMatchObject({ status: "not_ready", reasonCode: "SHADOW_NORMALIZATION_FAILED" });
+  });
+
+  it.each([
+    { state: "unavailable" },
+    { state: "incomparable", balanceCents: 100_000 },
+    { state: "available", balanceCents: 100_000.5 },
+    { state: "available", balanceCents: Number.MAX_SAFE_INTEGER + 1 },
+  ])("requires an independently available safe-integer legacy projection", (legacyProjection) => {
+    const result = compareReceivablesShadow(base({ legacyProjection }));
+    expect(result.reasonCode).toBe("SHADOW_LEGACY_PARITY_UNAVAILABLE");
+  });
+
+  it("fails closed when Phase 0C cannot assemble a complete DTO", () => {
+    const input = base();
+    const result = compareReceivablesShadow({
+      ...input,
+      dtoInput: { ...input.dtoInput, dueDay: undefined },
+    });
+    expect(result).toMatchObject({ status: "not_ready", reasonCode: "SHADOW_DTO_ASSEMBLY_FAILED" });
+  });
+
+  it("fails closed on a one-cent parity mismatch", () => {
+    const result = compareReceivablesShadow(base({
+      legacyProjection: { state: "available", balanceCents: 99_999 },
+    }));
+    expect(result).toMatchObject({ status: "not_ready", reasonCode: "SHADOW_PARITY_MISMATCH" });
+  });
+
+  it("returns only minimal non-financial status for exact equivalence", () => {
+    const result = compareReceivablesShadow(base());
+    expect(result).toEqual({
+      ok: true,
+      enabled: true,
+      allowed: true,
+      status: "equivalent",
+      reasonCode: "SHADOW_EQUIVALENT",
+      warnings: [],
+      comparisonVersion: "receivables_shadow_comparison_v1",
+    });
+    expect(Object.keys(result).sort()).toEqual([
+      "allowed",
+      "comparisonVersion",
+      "enabled",
+      "ok",
+      "reasonCode",
+      "status",
+      "warnings",
+    ]);
+    const serialized = JSON.stringify(result).toLowerCase();
+    for (const forbidden of [
+      "balance",
+      "amount",
+      "charge",
+      "payment",
+      "aging",
+      "rentroll",
+      "schedule",
+      "tenant-a",
+      "lease-a",
+      "property-a",
+      "provider",
+      "processor",
+      "firestore",
+      "storage",
+    ]) {
+      expect(serialized).not.toContain(forbidden);
+    }
+  });
+});

--- a/rentchain-api/src/lib/accounting/index.ts
+++ b/rentchain-api/src/lib/accounting/index.ts
@@ -8,3 +8,5 @@ export * from "./leaseReceivablesDtoTypes";
 export * from "./leaseReceivablesDtoAssembler";
 export * from "./legacyReceivablesSourceTypes";
 export * from "./legacyReceivablesSourceNormalizer";
+export * from "./receivablesShadowComparatorTypes";
+export * from "./receivablesShadowComparator";

--- a/rentchain-api/src/lib/accounting/receivablesShadowComparator.ts
+++ b/rentchain-api/src/lib/accounting/receivablesShadowComparator.ts
@@ -1,0 +1,140 @@
+import { assembleLandlordLeaseReceivablesDto } from "./leaseReceivablesDtoAssembler";
+import { normalizeLegacyReceivablesSources } from "./legacyReceivablesSourceNormalizer";
+import {
+  RECEIVABLES_SHADOW_COMPARISON_VERSION,
+  RECEIVABLES_SHADOW_SOURCE_KEYS,
+  type CompareReceivablesShadowInput,
+  type ReceivablesShadowComparatorResult,
+  type ReceivablesShadowReasonCode,
+  type ReceivablesShadowSourceKey,
+} from "./receivablesShadowComparatorTypes";
+import { cleanAccountingString } from "./receivablesTypes";
+
+const IDENTITY_SOURCE_KEYS = new Set<ReceivablesShadowSourceKey>(["lease", "property", "tenantResponsibility"]);
+
+function disabled(reasonCode: ReceivablesShadowReasonCode): ReceivablesShadowComparatorResult {
+  return {
+    ok: false,
+    enabled: false,
+    allowed: false,
+    status: "disabled",
+    reasonCode,
+    warnings: [],
+    comparisonVersion: RECEIVABLES_SHADOW_COMPARISON_VERSION,
+  };
+}
+
+function result(
+  enabled: boolean,
+  allowed: boolean,
+  status: ReceivablesShadowComparatorResult["status"],
+  reasonCode: ReceivablesShadowReasonCode
+): ReceivablesShadowComparatorResult {
+  return {
+    ok: status === "equivalent",
+    enabled,
+    allowed,
+    status,
+    reasonCode,
+    warnings: [],
+    comparisonVersion: RECEIVABLES_SHADOW_COMPARISON_VERSION,
+  };
+}
+
+function isExplicitlyEnabled(value: unknown): boolean {
+  return value === true || value === "true";
+}
+
+function parseExactAllowlist(value: unknown): string[] | null {
+  const candidates = Array.isArray(value)
+    ? value
+    : typeof value === "string"
+      ? value.split(",")
+      : [];
+  const normalized = candidates.map((entry) => cleanAccountingString(entry)).filter((entry): entry is string => Boolean(entry));
+  if (normalized.length === 0 || normalized.some((entry) => entry === "*")) return null;
+  return [...new Set(normalized)].sort();
+}
+
+function sourcesAreComplete(input: CompareReceivablesShadowInput): boolean {
+  return RECEIVABLES_SHADOW_SOURCE_KEYS.every((key) => {
+    const state = input.sourceCompleteness?.[key];
+    return IDENTITY_SOURCE_KEYS.has(key) ? state === "complete" : state === "complete" || state === "empty_confirmed";
+  });
+}
+
+function ownershipIsExact(input: CompareReceivablesShadowInput, requestLandlordId: string): boolean {
+  const leaseId = cleanAccountingString(input.normalizationInput?.leaseId);
+  const propertyId = cleanAccountingString(input.normalizationInput?.propertyId);
+  const normalizationLandlordId = cleanAccountingString(input.normalizationInput?.landlordId);
+  const proofLandlordId = cleanAccountingString(input.ownershipProof?.landlordId);
+  const proofLeaseId = cleanAccountingString(input.ownershipProof?.leaseId);
+  const dtoLeaseId = cleanAccountingString(input.dtoInput?.leaseId);
+  const dtoPropertyId = cleanAccountingString(input.dtoInput?.propertyId);
+  return Boolean(
+    input.ownershipProof?.state === "independently_verified" &&
+      leaseId &&
+      propertyId &&
+      requestLandlordId === normalizationLandlordId &&
+      requestLandlordId === proofLandlordId &&
+      leaseId === proofLeaseId &&
+      leaseId === dtoLeaseId &&
+      propertyId === dtoPropertyId &&
+      input.normalizationInput.ownershipProof?.state === "independently_verified" &&
+      cleanAccountingString(input.normalizationInput.ownershipProof.landlordId) === requestLandlordId &&
+      cleanAccountingString(input.normalizationInput.ownershipProof.leaseId) === leaseId
+  );
+}
+
+export function compareReceivablesShadow(input: CompareReceivablesShadowInput): ReceivablesShadowComparatorResult {
+  if (!isExplicitlyEnabled(input.config?.enabled)) return disabled("SHADOW_DISABLED");
+
+  const allowlist = parseExactAllowlist(input.config?.landlordAllowlist);
+  const requestLandlordId = cleanAccountingString(input.requestLandlordId);
+  if (!allowlist || !requestLandlordId || !allowlist.includes(requestLandlordId)) {
+    return result(true, false, "not_allowed", "SHADOW_NOT_ALLOWLISTED");
+  }
+
+  if (!ownershipIsExact(input, requestLandlordId)) {
+    return result(true, true, "not_ready", "SHADOW_OWNERSHIP_UNVERIFIED");
+  }
+  if (!sourcesAreComplete(input)) {
+    return result(true, true, "not_ready", "SHADOW_SOURCE_INCOMPLETE");
+  }
+
+  const normalization = normalizeLegacyReceivablesSources(input.normalizationInput);
+  if (normalization.sourceState !== "complete" || normalization.findings.some((finding) => finding.severity === "error")) {
+    return result(true, true, "not_ready", "SHADOW_NORMALIZATION_FAILED");
+  }
+
+  if (input.legacyProjection?.state !== "available" || !Number.isSafeInteger(input.legacyProjection.balanceCents)) {
+    return result(true, true, "not_ready", "SHADOW_LEGACY_PARITY_UNAVAILABLE");
+  }
+
+  try {
+    const dto = assembleLandlordLeaseReceivablesDto({
+      ...input.dtoInput,
+      transactions: normalization.transactions,
+      transactionSourceState: normalization.sourceState,
+      legacyBalanceCents: input.legacyProjection.balanceCents,
+    });
+    if (dto.sourceEquivalence.status === "mismatch") {
+      return result(true, true, "not_ready", "SHADOW_PARITY_MISMATCH");
+    }
+    if (
+      dto.sourceEquivalence.status !== "equivalent" ||
+      dto.dataCompleteness.status !== "complete" ||
+      !dto.balanceSummary ||
+      !dto.agingSummary ||
+      !dto.rentRollSummary ||
+      dto.schedulePreviewSummary.status !== "available" ||
+      dto.schedulePreviewSummary.stale
+    ) {
+      return result(true, true, "not_ready", "SHADOW_DTO_ASSEMBLY_FAILED");
+    }
+  } catch {
+    return result(true, true, "not_ready", "SHADOW_DTO_ASSEMBLY_FAILED");
+  }
+
+  return result(true, true, "equivalent", "SHADOW_EQUIVALENT");
+}

--- a/rentchain-api/src/lib/accounting/receivablesShadowComparatorTypes.ts
+++ b/rentchain-api/src/lib/accounting/receivablesShadowComparatorTypes.ts
@@ -1,0 +1,72 @@
+import type { LandlordLeaseReceivablesAssemblerInput } from "./leaseReceivablesDtoTypes";
+import type {
+  LegacyReceivablesOwnershipProof,
+  NormalizeLegacyReceivablesSourcesInput,
+} from "./legacyReceivablesSourceTypes";
+
+export const RECEIVABLES_SHADOW_COMPARISON_VERSION = "receivables_shadow_comparison_v1" as const;
+
+export const RECEIVABLES_SHADOW_SOURCE_KEYS = [
+  "lease",
+  "property",
+  "unit",
+  "tenantResponsibility",
+  "ledgerEntries",
+  "paymentRecords",
+  "paymentIntents",
+  "reconciliationRecords",
+  "leaseObligations",
+  "allocationRecords",
+] as const;
+
+export type ReceivablesShadowSourceKey = (typeof RECEIVABLES_SHADOW_SOURCE_KEYS)[number];
+export type ReceivablesShadowSourceState = "complete" | "empty_confirmed" | "unavailable" | "ambiguous" | "truncated";
+export type ReceivablesShadowSourceCompleteness = Record<ReceivablesShadowSourceKey, ReceivablesShadowSourceState>;
+
+export type ReceivablesShadowComparatorConfig = {
+  enabled: unknown;
+  landlordAllowlist: unknown;
+};
+
+export type IndependentLegacyReceivablesProjection = {
+  state: "available" | "unavailable" | "incomparable" | string;
+  balanceCents?: unknown;
+};
+
+export type ReceivablesShadowDtoInput = Omit<
+  LandlordLeaseReceivablesAssemblerInput,
+  "transactions" | "transactionSourceState" | "legacyBalanceCents"
+>;
+
+export type CompareReceivablesShadowInput = {
+  config: ReceivablesShadowComparatorConfig;
+  requestLandlordId: unknown;
+  ownershipProof: LegacyReceivablesOwnershipProof;
+  sourceCompleteness: ReceivablesShadowSourceCompleteness;
+  normalizationInput: NormalizeLegacyReceivablesSourcesInput;
+  dtoInput: ReceivablesShadowDtoInput;
+  legacyProjection: IndependentLegacyReceivablesProjection;
+};
+
+export type ReceivablesShadowReasonCode =
+  | "SHADOW_DISABLED"
+  | "SHADOW_NOT_ALLOWLISTED"
+  | "SHADOW_OWNERSHIP_UNVERIFIED"
+  | "SHADOW_SOURCE_INCOMPLETE"
+  | "SHADOW_NORMALIZATION_FAILED"
+  | "SHADOW_LEGACY_PARITY_UNAVAILABLE"
+  | "SHADOW_DTO_ASSEMBLY_FAILED"
+  | "SHADOW_PARITY_MISMATCH"
+  | "SHADOW_EQUIVALENT";
+
+export type ReceivablesShadowComparatorStatus = "disabled" | "not_allowed" | "not_ready" | "equivalent";
+
+export type ReceivablesShadowComparatorResult = {
+  ok: boolean;
+  enabled: boolean;
+  allowed: boolean;
+  status: ReceivablesShadowComparatorStatus;
+  reasonCode: ReceivablesShadowReasonCode;
+  warnings: string[];
+  comparisonVersion: typeof RECEIVABLES_SHADOW_COMPARISON_VERSION;
+};


### PR DESCRIPTION
## Summary

- add a pure, unmounted Phase 0G receivables shadow comparator under `rentchain-api/src/lib/accounting`
- enforce explicit default-off configuration and exact non-empty landlord allowlist membership
- require independent landlord ownership proof and complete/confirmed-empty source states
- run the Phase 0E normalizer and Phase 0C DTO assembler internally
- require an independently supplied legacy projection and exact parity
- return only a minimal non-financial status object

## Safety boundary

The comparator is not a route and reads no environment or Firestore state. Callers must inject configuration, authoritative evidence, explicit query completeness, and an independently produced legacy balance. Any ownership, completeness, normalization, DTO, or parity failure returns `not_ready` without financial data.

The output is limited to `ok`, `enabled`, `allowed`, `status`, `reasonCode`, `warnings`, and `comparisonVersion`. Tests scan the serialized success response for financial fields, internal scope IDs, provider/processor terms, Firestore, and storage references.

No routes, UI, Firestore access or writes, provider/PAD integration, payment mutation, money movement, tenant bank data, existing ledger behavior, or RC1 behavior changed. Tenant rent remains landlord revenue and the direct-settlement model is unchanged.

## Validation

- accounting suite: 9 files, 93 tests passed
- new shadow comparator coverage: 26 tests passed
- backend TypeScript production build passed with Node 20.20.2
- `git diff --check` passed
- `git diff --cached --check` passed
- forbidden-scope/import scan passed
- changed files limited to four backend accounting files
