### PR TITLE
Add Phase 0I receivables source snapshot adapter

### DIFF
--- a/rentchain-api/src/lib/accounting/__fixtures__/receivablesSourceSnapshotFixtures.ts
+++ b/rentchain-api/src/lib/accounting/__fixtures__/receivablesSourceSnapshotFixtures.ts
@@ -1,0 +1,118 @@
+import type { ReceivablesSourceSnapshotAdapterInput } from "../receivablesSourceSnapshotTypes";
+
+const charge = {
+  sourceKind: "ledger_entry" as const,
+  sourceId: "ledger-charge-a",
+  evidenceRole: "posted_transaction" as const,
+  landlordId: "landlord-a",
+  leaseId: "lease-a",
+  propertyId: "property-a",
+  unitId: "unit-a",
+  responsibilityId: "responsibility-a",
+  tenantId: "tenant-a",
+  transactionType: "scheduled_rent_charge" as const,
+  amountCents: 100_000,
+  currency: "cad",
+  effectiveDate: "2026-01-01",
+  dueDate: "2026-01-01",
+  periodStart: "2026-01-01",
+  periodEnd: "2026-01-31",
+  canonicalEventKey: "rent-charge-2026-01",
+};
+
+export const completeReceivablesSourceSnapshotFixture: ReceivablesSourceSnapshotAdapterInput = {
+  comparatorConfig: { enabled: true, landlordAllowlist: "landlord-a" },
+  ownership: {
+    proofSource: "authoritative_lease",
+    landlordId: "landlord-a",
+    leaseId: "lease-a",
+    leaseLandlordId: "landlord-a",
+    propertyId: "property-a",
+    propertyLandlordId: "landlord-a",
+  },
+  lease: {
+    leaseId: "lease-a",
+    landlordId: "landlord-a",
+    propertyId: "property-a",
+    unitId: "unit-a",
+    responsibilityId: "responsibility-a",
+    tenantId: "tenant-a",
+    propertyDisplayName: "10 Harbour Street",
+    unitDisplayName: "Unit 2",
+    tenantDisplayName: "Example Tenant",
+    responsibilityDisplayName: "Primary lease responsibility",
+    leaseMappingState: "resolved",
+    propertyMappingState: "resolved",
+    unitMappingState: "resolved",
+    tenantMappingState: "resolved",
+    leaseStatus: "active",
+    leaseStartDate: "2026-01-01",
+    leaseEndDate: "2026-03-31",
+    monthlyRentCents: 100_000,
+    dueDay: 1,
+    billingFrequency: "monthly",
+    currency: "cad",
+    depositAmountCents: null,
+    sourceLeaseVersion: "lease-version-1",
+  },
+  evidence: {
+    ledgerEntries: { state: "complete", records: [charge] },
+    paymentRecords: { state: "empty_confirmed", records: [] },
+    paymentIntents: { state: "empty_confirmed", records: [] },
+    reconciliationRecords: { state: "empty_confirmed", records: [] },
+    leaseObligations: { state: "empty_confirmed", records: [] },
+    allocationRecords: { state: "empty_confirmed", records: [] },
+  },
+  legacyEffectsState: "complete",
+  legacyEffects: [{
+    effectId: "legacy-charge-a",
+    landlordId: "landlord-a",
+    leaseId: "lease-a",
+    propertyId: "property-a",
+    currency: "cad",
+    effectiveDate: "2026-01-01",
+    signedAmountCents: 100_000,
+  }],
+  asOfDate: "2026-02-15",
+  previewThroughDate: "2026-03-31",
+};
+
+export const receivablesSourceSnapshotFixtures = {
+  complete: completeReceivablesSourceSnapshotFixture,
+  missingOwnership: {
+    ...completeReceivablesSourceSnapshotFixture,
+    ownership: { ...completeReceivablesSourceSnapshotFixture.ownership, proofSource: "missing" },
+  },
+  fallbackOwnership: {
+    ...completeReceivablesSourceSnapshotFixture,
+    ownership: { ...completeReceivablesSourceSnapshotFixture.ownership, proofSource: "in_memory_fallback" },
+  },
+  ambiguousOwnership: {
+    ...completeReceivablesSourceSnapshotFixture,
+    ownership: { ...completeReceivablesSourceSnapshotFixture.ownership, proofSource: "ambiguous" },
+  },
+  duplicateEvidence: {
+    ...completeReceivablesSourceSnapshotFixture,
+    evidence: {
+      ...completeReceivablesSourceSnapshotFixture.evidence,
+      ledgerEntries: {
+        state: "complete",
+        records: [charge, { ...charge, sourceId: "ledger-charge-b" }],
+      },
+    },
+  },
+  unsafeSource: {
+    ...completeReceivablesSourceSnapshotFixture,
+    evidence: {
+      ...completeReceivablesSourceSnapshotFixture.evidence,
+      ledgerEntries: {
+        state: "complete",
+        records: [{ ...charge, bankAccountNumber: "not-allowed" } as typeof charge],
+      },
+    },
+  },
+  unsupportedTerms: {
+    ...completeReceivablesSourceSnapshotFixture,
+    lease: { ...completeReceivablesSourceSnapshotFixture.lease, currency: "usd", billingFrequency: "weekly" },
+  },
+} satisfies Record<string, ReceivablesSourceSnapshotAdapterInput>;

--- a/rentchain-api/src/lib/accounting/__tests__/receivablesSourceSnapshotAdapter.test.ts
+++ b/rentchain-api/src/lib/accounting/__tests__/receivablesSourceSnapshotAdapter.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from "vitest";
+import {
+  completeReceivablesSourceSnapshotFixture,
+  receivablesSourceSnapshotFixtures,
+} from "../__fixtures__/receivablesSourceSnapshotFixtures";
+import { buildReceivablesSourceSnapshot } from "../receivablesSourceSnapshotAdapter";
+import type { ReceivablesSourceSnapshotAdapterInput } from "../receivablesSourceSnapshotTypes";
+import { compareReceivablesShadow } from "../receivablesShadowComparator";
+
+function clone<T>(value: T): T {
+  return structuredClone(value);
+}
+
+function build(overrides: Partial<ReceivablesSourceSnapshotAdapterInput> = {}) {
+  return buildReceivablesSourceSnapshot({
+    ...clone(completeReceivablesSourceSnapshotFixture),
+    ...overrides,
+  });
+}
+
+describe("buildReceivablesSourceSnapshot", () => {
+  it("creates a stable comparator-ready package for a complete authoritative snapshot", () => {
+    const result = build();
+    expect(result).toMatchObject({
+      snapshotVersion: "receivables_source_snapshot_v1",
+      status: "ready",
+      reasonCodes: [],
+      warnings: [],
+      ownershipVerified: true,
+      completenessStatus: "complete",
+      sourceCounts: {
+        ledgerEntries: 1,
+        paymentRecords: 0,
+        paymentIntents: 0,
+        reconciliationRecords: 0,
+        leaseObligations: 0,
+        allocationRecords: 0,
+        legacyEffects: 1,
+      },
+      normalizedSourceSummary: { status: "complete", recordCount: 1, legacyEffectCount: 1 },
+    });
+    expect(result.comparatorInput).not.toBeNull();
+  });
+
+  it("feeds the Phase 0G comparator in memory without invoking a runtime path", () => {
+    const snapshot = build();
+    expect(compareReceivablesShadow(snapshot.comparatorInput!)).toEqual({
+      ok: true,
+      enabled: true,
+      allowed: true,
+      status: "equivalent",
+      reasonCode: "SHADOW_EQUIVALENT",
+      warnings: [],
+      comparisonVersion: "receivables_shadow_comparison_v1",
+    });
+  });
+
+  it("fails closed when independent ownership proof is missing", () => {
+    const result = buildReceivablesSourceSnapshot(clone(receivablesSourceSnapshotFixtures.missingOwnership));
+    expect(result).toMatchObject({ status: "incomplete", ownershipVerified: false, comparatorInput: null });
+    expect(result.reasonCodes).toContain("SNAPSHOT_OWNERSHIP_MISSING");
+  });
+
+  it("does not accept the in-memory fallback as ownership proof", () => {
+    const result = buildReceivablesSourceSnapshot(clone(receivablesSourceSnapshotFixtures.fallbackOwnership));
+    expect(result).toMatchObject({ status: "incomplete", ownershipVerified: false, comparatorInput: null });
+    expect(result.reasonCodes).toContain("SNAPSHOT_OWNERSHIP_FALLBACK_REJECTED");
+  });
+
+  it("fails closed for ambiguous ownership", () => {
+    const result = buildReceivablesSourceSnapshot(clone(receivablesSourceSnapshotFixtures.ambiguousOwnership));
+    expect(result).toMatchObject({ status: "ambiguous", ownershipVerified: false, comparatorInput: null });
+    expect(result.reasonCodes).toContain("SNAPSHOT_OWNERSHIP_AMBIGUOUS");
+  });
+
+  it("fails closed when the authoritative property scope differs", () => {
+    const input = clone(completeReceivablesSourceSnapshotFixture);
+    input.ownership.propertyLandlordId = "landlord-other";
+    const result = buildReceivablesSourceSnapshot(input);
+    expect(result).toMatchObject({ status: "incomplete", ownershipVerified: false, comparatorInput: null });
+    expect(result.reasonCodes).toContain("SNAPSHOT_SCOPE_MISMATCH");
+  });
+
+  it.each(["leaseMappingState", "propertyMappingState", "tenantMappingState"] as const)(
+    "fails closed for an ambiguous %s",
+    (field) => {
+      const input = clone(completeReceivablesSourceSnapshotFixture);
+      input.lease[field] = "ambiguous";
+      const result = buildReceivablesSourceSnapshot(input);
+      expect(result).toMatchObject({ status: "ambiguous", comparatorInput: null });
+      expect(result.reasonCodes).toEqual(expect.arrayContaining(["SNAPSHOT_MAPPING_AMBIGUOUS", "SNAPSHOT_MAPPING_INCOMPLETE"]));
+    }
+  );
+
+  it("fails closed for an ambiguous unit mapping", () => {
+    const input = clone(completeReceivablesSourceSnapshotFixture);
+    input.lease.unitMappingState = "ambiguous";
+    const result = buildReceivablesSourceSnapshot(input);
+    expect(result.status).toBe("ambiguous");
+    expect(result.comparatorInput).toBeNull();
+  });
+
+  it.each(["monthlyRentCents", "dueDay", "leaseStartDate", "sourceLeaseVersion"] as const)(
+    "fails closed when required billing term %s is missing",
+    (field) => {
+      const input = clone(completeReceivablesSourceSnapshotFixture);
+      input.lease[field] = undefined;
+      const result = buildReceivablesSourceSnapshot(input);
+      expect(result.reasonCodes).toContain("SNAPSHOT_BILLING_TERMS_INCOMPLETE");
+      expect(result.comparatorInput).toBeNull();
+    }
+  );
+
+  it("requires display context without falling back to IDs", () => {
+    const input = clone(completeReceivablesSourceSnapshotFixture);
+    input.lease.tenantDisplayName = null;
+    const result = buildReceivablesSourceSnapshot(input);
+    expect(result.reasonCodes).toContain("SNAPSHOT_BILLING_TERMS_INCOMPLETE");
+    expect(result.comparatorInput).toBeNull();
+  });
+
+  it("rejects unsafe bank data", () => {
+    const result = buildReceivablesSourceSnapshot(clone(receivablesSourceSnapshotFixtures.unsafeSource));
+    expect(result).toMatchObject({ status: "unsafe", comparatorInput: null });
+    expect(result.reasonCodes).toContain("SNAPSHOT_UNSAFE_SOURCE_DATA");
+  });
+
+  it.each([
+    ["provider IDs", { providerPaymentId: "provider-secret" }],
+    ["admin scope keys", { internalScopeKey: "support-only" }],
+    ["storage paths", { attachment: "gs://private-bucket/file" }],
+    ["Firestore paths", { referencePath: "firestore://projects/example/databases/default/documents/leases/a" }],
+  ])("rejects unsafe %s", (_label, unsafeField) => {
+    const input = clone(completeReceivablesSourceSnapshotFixture);
+    input.evidence.ledgerEntries.records = [{ ...input.evidence.ledgerEntries.records[0], ...unsafeField }];
+    const result = buildReceivablesSourceSnapshot(input);
+    expect(result.reasonCodes).toContain("SNAPSHOT_UNSAFE_SOURCE_DATA");
+    expect(result.comparatorInput).toBeNull();
+  });
+
+  it("fails closed for unsupported currency and frequency", () => {
+    const result = buildReceivablesSourceSnapshot(clone(receivablesSourceSnapshotFixtures.unsupportedTerms));
+    expect(result.reasonCodes).toEqual(expect.arrayContaining([
+      "SNAPSHOT_CURRENCY_UNSUPPORTED",
+      "SNAPSHOT_FREQUENCY_UNSUPPORTED",
+    ]));
+    expect(result.comparatorInput).toBeNull();
+  });
+
+  it.each(["unavailable", "ambiguous", "truncated"] as const)("fails closed for %s evidence", (state) => {
+    const input = clone(completeReceivablesSourceSnapshotFixture);
+    input.evidence.ledgerEntries.state = state;
+    const result = buildReceivablesSourceSnapshot(input);
+    expect(result.comparatorInput).toBeNull();
+    expect(result.reasonCodes).toContain(state === "ambiguous" ? "SNAPSHOT_SOURCE_AMBIGUOUS" : "SNAPSHOT_SOURCE_INCOMPLETE");
+  });
+
+  it("rejects records placed in the wrong source batch", () => {
+    const input = clone(completeReceivablesSourceSnapshotFixture);
+    input.evidence.paymentRecords = { state: "complete", records: input.evidence.ledgerEntries.records };
+    const result = buildReceivablesSourceSnapshot(input);
+    expect(result.reasonCodes).toContain("SNAPSHOT_SOURCE_BATCH_KIND_MISMATCH");
+    expect(result.comparatorInput).toBeNull();
+  });
+
+  it("rejects confirmed-empty batches that contain records", () => {
+    const input = clone(completeReceivablesSourceSnapshotFixture);
+    input.evidence.ledgerEntries.state = "empty_confirmed";
+    const result = buildReceivablesSourceSnapshot(input);
+    expect(result.reasonCodes).toContain("SNAPSHOT_SOURCE_INCOMPLETE");
+    expect(result.comparatorInput).toBeNull();
+  });
+
+  it("fails closed when duplicate legacy evidence cannot be safely normalized", () => {
+    const result = buildReceivablesSourceSnapshot(clone(receivablesSourceSnapshotFixtures.duplicateEvidence));
+    expect(result).toMatchObject({ status: "ambiguous", comparatorInput: null });
+    expect(result.reasonCodes).toContain("SNAPSHOT_NORMALIZATION_FAILED");
+  });
+
+  it("fails closed for invalid or duplicate independent legacy effects", () => {
+    const input = clone(completeReceivablesSourceSnapshotFixture);
+    input.legacyEffects = [input.legacyEffects[0], input.legacyEffects[0]];
+    const result = buildReceivablesSourceSnapshot(input);
+    expect(result.reasonCodes).toContain("SNAPSHOT_LEGACY_PROJECTION_INVALID");
+    expect(result.comparatorInput).toBeNull();
+  });
+
+  it("requires exact allowlist assumptions for comparator-ready output", () => {
+    const result = build({ comparatorConfig: { enabled: true, landlordAllowlist: "landlord-other" } });
+    expect(result.reasonCodes).toContain("SNAPSHOT_CONFIG_NOT_READY");
+    expect(result.comparatorInput).toBeNull();
+  });
+
+  it("returns deterministic counts, reasons, and snapshot version", () => {
+    const input = clone(completeReceivablesSourceSnapshotFixture);
+    input.lease.currency = "usd";
+    input.lease.billingFrequency = "weekly";
+    const first = buildReceivablesSourceSnapshot(input);
+    const second = buildReceivablesSourceSnapshot(clone(input));
+    expect(first).toEqual(second);
+    expect(first.reasonCodes).toEqual([...first.reasonCodes].sort());
+    expect(first.snapshotVersion).toBe("receivables_source_snapshot_v1");
+  });
+
+  it("does not mutate supplied snapshot evidence", () => {
+    const input = clone(completeReceivablesSourceSnapshotFixture);
+    const before = clone(input);
+    buildReceivablesSourceSnapshot(input);
+    expect(input).toEqual(before);
+  });
+
+  it("keeps the public-safe validation envelope non-financial", () => {
+    const { comparatorInput: _internalOnly, ...validation } = build();
+    const serialized = JSON.stringify(validation).toLowerCase();
+    for (const forbidden of ["balancecents", "amountcents", "tenant-a", "lease-a", "property-a", "provider", "processor", "firestore://", "gs://"]) {
+      expect(serialized).not.toContain(forbidden);
+    }
+  });
+});

--- a/rentchain-api/src/lib/accounting/index.ts
+++ b/rentchain-api/src/lib/accounting/index.ts
@@ -10,3 +10,5 @@ export * from "./legacyReceivablesSourceTypes";
 export * from "./legacyReceivablesSourceNormalizer";
 export * from "./receivablesShadowComparatorTypes";
 export * from "./receivablesShadowComparator";
+export * from "./receivablesSourceSnapshotTypes";
+export * from "./receivablesSourceSnapshotAdapter";

--- a/rentchain-api/src/lib/accounting/receivablesSourceSnapshotAdapter.ts
+++ b/rentchain-api/src/lib/accounting/receivablesSourceSnapshotAdapter.ts
@@ -1,0 +1,272 @@
+import { normalizeLegacyReceivablesSources } from "./legacyReceivablesSourceNormalizer";
+import type { LegacyReceivablesSourceKind, LegacyReceivablesSourceRecord } from "./legacyReceivablesSourceTypes";
+import {
+  RECEIVABLES_SOURCE_SNAPSHOT_VERSION,
+  type IndependentLegacySignedEffect,
+  type InternalReceivablesSourceSnapshotPackage,
+  type ReceivablesSnapshotEvidenceBatches,
+  type ReceivablesSourceCounts,
+  type ReceivablesSourceSnapshotAdapterInput,
+  type ReceivablesSourceSnapshotReasonCode,
+} from "./receivablesSourceSnapshotTypes";
+import type { ReceivablesShadowSourceCompleteness, ReceivablesShadowSourceState } from "./receivablesShadowComparatorTypes";
+import { cleanAccountingString, parseDateOnly } from "./receivablesTypes";
+
+const EXPECTED_BATCH_KIND: Record<keyof ReceivablesSnapshotEvidenceBatches, LegacyReceivablesSourceKind> = {
+  ledgerEntries: "ledger_entry",
+  paymentRecords: "payment_record",
+  paymentIntents: "payment_intent",
+  reconciliationRecords: "reconciliation_record",
+  leaseObligations: "lease_obligation",
+  allocationRecords: "allocation_record",
+};
+
+const UNSAFE_KEY_PATTERN = /(provider|processor|firestorepath|storagepath|internalscope|bankaccount|accountnumber|routingnumber|transitnumber|institutionnumber|iban|swift|credential|secret|token)/i;
+const UNSAFE_VALUE_PATTERN = /^(?:gs:\/\/|firestore:\/\/)|\/(?:b|v1)\/documents\//i;
+
+function containsUnsafeData(value: unknown, seen = new Set<object>()): boolean {
+  if (typeof value === "string") return UNSAFE_VALUE_PATTERN.test(value.trim());
+  if (!value || typeof value !== "object") return false;
+  if (seen.has(value)) return false;
+  seen.add(value);
+  if (Array.isArray(value)) return value.some((item) => containsUnsafeData(item, seen));
+  return Object.entries(value as Record<string, unknown>).some(
+    ([key, item]) => UNSAFE_KEY_PATTERN.test(key.replace(/[^a-z0-9]/gi, "")) || containsUnsafeData(item, seen)
+  );
+}
+
+function parseExactAllowlist(value: unknown): string[] | null {
+  const values = Array.isArray(value) ? value : typeof value === "string" ? value.split(",") : [];
+  const normalized = values.map((item) => cleanAccountingString(item)).filter((item): item is string => Boolean(item));
+  if (!normalized.length || normalized.some((item) => item === "*")) return null;
+  return [...new Set(normalized)].sort();
+}
+
+function sourceCounts(input: ReceivablesSourceSnapshotAdapterInput): ReceivablesSourceCounts {
+  return {
+    ledgerEntries: input.evidence?.ledgerEntries?.records?.length || 0,
+    paymentRecords: input.evidence?.paymentRecords?.records?.length || 0,
+    paymentIntents: input.evidence?.paymentIntents?.records?.length || 0,
+    reconciliationRecords: input.evidence?.reconciliationRecords?.records?.length || 0,
+    leaseObligations: input.evidence?.leaseObligations?.records?.length || 0,
+    allocationRecords: input.evidence?.allocationRecords?.records?.length || 0,
+    legacyEffects: input.legacyEffects?.length || 0,
+  };
+}
+
+function allEvidenceRecords(input: ReceivablesSourceSnapshotAdapterInput): LegacyReceivablesSourceRecord[] {
+  return (Object.keys(EXPECTED_BATCH_KIND) as Array<keyof ReceivablesSnapshotEvidenceBatches>).flatMap(
+    (key) => [...(input.evidence?.[key]?.records || [])]
+  );
+}
+
+function statusForReasons(reasonCodes: readonly ReceivablesSourceSnapshotReasonCode[]) {
+  if (reasonCodes.includes("SNAPSHOT_UNSAFE_SOURCE_DATA")) return "unsafe" as const;
+  if (reasonCodes.some((code) => code.includes("AMBIGUOUS") || code === "SNAPSHOT_NORMALIZATION_FAILED")) return "ambiguous" as const;
+  return "incomplete" as const;
+}
+
+function independentLegacyBalance(input: ReceivablesSourceSnapshotAdapterInput): number | null {
+  const asOf = parseDateOnly(input.asOfDate);
+  const landlordId = cleanAccountingString(input.lease.landlordId);
+  const leaseId = cleanAccountingString(input.lease.leaseId);
+  const propertyId = cleanAccountingString(input.lease.propertyId);
+  if (!asOf || !landlordId || !leaseId || !propertyId) return null;
+  const ids = new Set<string>();
+  let balance = 0;
+  for (const effect of input.legacyEffects || []) {
+    const effectId = cleanAccountingString(effect.effectId);
+    const effectiveDate = parseDateOnly(effect.effectiveDate);
+    if (
+      !effectId ||
+      ids.has(effectId) ||
+      cleanAccountingString(effect.landlordId) !== landlordId ||
+      cleanAccountingString(effect.leaseId) !== leaseId ||
+      cleanAccountingString(effect.propertyId) !== propertyId ||
+      cleanAccountingString(effect.currency, 8)?.toLowerCase() !== "cad" ||
+      !effectiveDate ||
+      !Number.isSafeInteger(effect.signedAmountCents) ||
+      Number(effect.signedAmountCents) === 0
+    ) return null;
+    ids.add(effectId);
+    if (effectiveDate.epochDay <= asOf.epochDay) balance += Number(effect.signedAmountCents);
+    if (!Number.isSafeInteger(balance)) return null;
+  }
+  return balance;
+}
+
+function sortedReasons(reasons: Set<ReceivablesSourceSnapshotReasonCode>) {
+  return [...reasons].sort();
+}
+
+function evidenceState(value: unknown): ReceivablesShadowSourceState {
+  return ["complete", "empty_confirmed", "unavailable", "ambiguous", "truncated"].includes(String(value))
+    ? value as ReceivablesShadowSourceState
+    : "unavailable";
+}
+
+function identityState(value: unknown): ReceivablesShadowSourceState {
+  if (value === "resolved") return "complete";
+  if (value === "ambiguous") return "ambiguous";
+  return "unavailable";
+}
+
+export function buildReceivablesSourceSnapshot(
+  input: ReceivablesSourceSnapshotAdapterInput
+): InternalReceivablesSourceSnapshotPackage {
+  const reasons = new Set<ReceivablesSourceSnapshotReasonCode>();
+  const counts = sourceCounts(input);
+  const records = allEvidenceRecords(input);
+  const landlordId = cleanAccountingString(input.lease?.landlordId);
+  const leaseId = cleanAccountingString(input.lease?.leaseId);
+  const propertyId = cleanAccountingString(input.lease?.propertyId);
+  const tenantId = cleanAccountingString(input.lease?.tenantId);
+
+  const allowlist = parseExactAllowlist(input.comparatorConfig?.landlordAllowlist);
+  if (
+    (input.comparatorConfig?.enabled !== true && input.comparatorConfig?.enabled !== "true") ||
+    !landlordId ||
+    !allowlist?.includes(landlordId)
+  ) reasons.add("SNAPSHOT_CONFIG_NOT_READY");
+
+  if (input.ownership?.proofSource === "in_memory_fallback") reasons.add("SNAPSHOT_OWNERSHIP_FALLBACK_REJECTED");
+  else if (input.ownership?.proofSource === "ambiguous") reasons.add("SNAPSHOT_OWNERSHIP_AMBIGUOUS");
+  else if (input.ownership?.proofSource !== "authoritative_lease") reasons.add("SNAPSHOT_OWNERSHIP_MISSING");
+
+  if (
+    !landlordId || !leaseId || !propertyId ||
+    cleanAccountingString(input.ownership?.landlordId) !== landlordId ||
+    cleanAccountingString(input.ownership?.leaseId) !== leaseId ||
+    cleanAccountingString(input.ownership?.leaseLandlordId) !== landlordId ||
+    cleanAccountingString(input.ownership?.propertyId) !== propertyId ||
+    cleanAccountingString(input.ownership?.propertyLandlordId) !== landlordId
+  ) reasons.add("SNAPSHOT_SCOPE_MISMATCH");
+
+  const mappingStates = [input.lease?.leaseMappingState, input.lease?.propertyMappingState, input.lease?.tenantMappingState];
+  if (mappingStates.includes("ambiguous") || input.lease?.unitMappingState === "ambiguous") reasons.add("SNAPSHOT_MAPPING_AMBIGUOUS");
+  if (mappingStates.some((state) => state !== "resolved") || !["resolved", "not_applicable"].includes(String(input.lease?.unitMappingState))) {
+    reasons.add("SNAPSHOT_MAPPING_INCOMPLETE");
+  }
+
+  const asOf = parseDateOnly(input.asOfDate);
+  const previewThrough = parseDateOnly(input.previewThroughDate);
+  if (
+    !asOf || !previewThrough || !parseDateOnly(input.lease?.leaseStartDate) ||
+    !Number.isSafeInteger(input.lease?.monthlyRentCents) || Number(input.lease?.monthlyRentCents) <= 0 ||
+    !Number.isInteger(input.lease?.dueDay) || Number(input.lease?.dueDay) < 1 || Number(input.lease?.dueDay) > 31 ||
+    !cleanAccountingString(input.lease?.sourceLeaseVersion) ||
+    !cleanAccountingString(input.lease?.propertyDisplayName) ||
+    !cleanAccountingString(input.lease?.tenantDisplayName) ||
+    !cleanAccountingString(input.lease?.responsibilityDisplayName) ||
+    (input.lease?.unitMappingState === "resolved" && !cleanAccountingString(input.lease?.unitDisplayName))
+  ) reasons.add("SNAPSHOT_BILLING_TERMS_INCOMPLETE");
+  if (cleanAccountingString(input.lease?.currency, 8)?.toLowerCase() !== "cad") reasons.add("SNAPSHOT_CURRENCY_UNSUPPORTED");
+  if (cleanAccountingString(input.lease?.billingFrequency, 40)?.toLowerCase() !== "monthly") reasons.add("SNAPSHOT_FREQUENCY_UNSUPPORTED");
+
+  const completeness: ReceivablesShadowSourceCompleteness = {
+    lease: identityState(input.lease?.leaseMappingState),
+    property: identityState(input.lease?.propertyMappingState),
+    unit: input.lease?.unitMappingState === "not_applicable" ? "empty_confirmed" : identityState(input.lease?.unitMappingState),
+    tenantResponsibility: identityState(input.lease?.tenantMappingState),
+    ledgerEntries: evidenceState(input.evidence?.ledgerEntries?.state),
+    paymentRecords: evidenceState(input.evidence?.paymentRecords?.state),
+    paymentIntents: evidenceState(input.evidence?.paymentIntents?.state),
+    reconciliationRecords: evidenceState(input.evidence?.reconciliationRecords?.state),
+    leaseObligations: evidenceState(input.evidence?.leaseObligations?.state),
+    allocationRecords: evidenceState(input.evidence?.allocationRecords?.state),
+  };
+  for (const [key, state] of Object.entries(completeness)) {
+    const identity = ["lease", "property", "tenantResponsibility"].includes(key);
+    if (state === "ambiguous") reasons.add("SNAPSHOT_SOURCE_AMBIGUOUS");
+    else if (identity ? state !== "complete" : state !== "complete" && state !== "empty_confirmed") reasons.add("SNAPSHOT_SOURCE_INCOMPLETE");
+  }
+  if (input.legacyEffectsState === "ambiguous") reasons.add("SNAPSHOT_SOURCE_AMBIGUOUS");
+  else if (input.legacyEffectsState !== "complete" && input.legacyEffectsState !== "empty_confirmed") reasons.add("SNAPSHOT_SOURCE_INCOMPLETE");
+
+  for (const [batchKey, expectedKind] of Object.entries(EXPECTED_BATCH_KIND) as Array<[keyof ReceivablesSnapshotEvidenceBatches, LegacyReceivablesSourceKind]>) {
+    const batch = input.evidence?.[batchKey];
+    if (batch?.state === "empty_confirmed" && (batch.records?.length || 0) > 0) {
+      reasons.add("SNAPSHOT_SOURCE_INCOMPLETE");
+    }
+    if ((batch?.records || []).some((record) => record.sourceKind !== expectedKind)) {
+      reasons.add("SNAPSHOT_SOURCE_BATCH_KIND_MISMATCH");
+    }
+  }
+  if (input.legacyEffectsState === "empty_confirmed" && (input.legacyEffects?.length || 0) > 0) {
+    reasons.add("SNAPSHOT_SOURCE_INCOMPLETE");
+  }
+  if (containsUnsafeData({ evidence: input.evidence, legacyEffects: input.legacyEffects })) reasons.add("SNAPSHOT_UNSAFE_SOURCE_DATA");
+
+  const ownershipVerified = ![
+    "SNAPSHOT_OWNERSHIP_MISSING", "SNAPSHOT_OWNERSHIP_FALLBACK_REJECTED", "SNAPSHOT_OWNERSHIP_AMBIGUOUS", "SNAPSHOT_SCOPE_MISMATCH",
+  ].some((code) => reasons.has(code as ReceivablesSourceSnapshotReasonCode));
+  const proof = { state: ownershipVerified ? "independently_verified" as const : "unverified" as const, landlordId, leaseId };
+  const normalizationInput = {
+    landlordId,
+    leaseId,
+    propertyId,
+    tenantId,
+    tenantMappingState: input.lease?.tenantMappingState,
+    ownershipProof: proof,
+    records,
+  };
+  const normalization = reasons.size === 0 ? normalizeLegacyReceivablesSources(normalizationInput) : null;
+  if (normalization && normalization.sourceState !== "complete") reasons.add("SNAPSHOT_NORMALIZATION_FAILED");
+
+  if (input.legacyEffectsState === "unavailable" || input.legacyEffectsState === "truncated") {
+    reasons.add("SNAPSHOT_LEGACY_PROJECTION_UNAVAILABLE");
+  }
+  const legacyBalance = reasons.size === 0 ? independentLegacyBalance(input) : null;
+  if (reasons.size === 0 && legacyBalance === null) reasons.add("SNAPSHOT_LEGACY_PROJECTION_INVALID");
+
+  const finalReasons = sortedReasons(reasons);
+  const ready = finalReasons.length === 0 && legacyBalance !== null;
+  const comparatorInput = ready ? {
+    config: input.comparatorConfig,
+    requestLandlordId: landlordId,
+    ownershipProof: proof,
+    sourceCompleteness: completeness,
+    normalizationInput,
+    dtoInput: {
+      leaseId,
+      propertyId,
+      unitId: input.lease.unitId,
+      responsibilityId: input.lease.responsibilityId,
+      tenantId,
+      propertyDisplayName: input.lease.propertyDisplayName,
+      unitDisplayName: input.lease.unitDisplayName,
+      tenantDisplayName: input.lease.tenantDisplayName,
+      responsibilityDisplayName: input.lease.responsibilityDisplayName,
+      tenantMappingState: input.lease.tenantMappingState,
+      leaseStatus: input.lease.leaseStatus,
+      leaseStartDate: input.lease.leaseStartDate,
+      leaseEndDate: input.lease.leaseEndDate,
+      monthlyRentCents: input.lease.monthlyRentCents,
+      dueDay: input.lease.dueDay,
+      billingFrequency: input.lease.billingFrequency,
+      currency: input.lease.currency,
+      depositAmountCents: input.lease.depositAmountCents,
+      sourceLeaseVersion: input.lease.sourceLeaseVersion,
+      asOfDate: input.asOfDate,
+      previewThroughDate: input.previewThroughDate,
+      agingAllocationPolicy: "explicit" as const,
+    },
+    legacyProjection: { state: "available" as const, balanceCents: legacyBalance },
+  } : null;
+
+  return {
+    snapshotVersion: RECEIVABLES_SOURCE_SNAPSHOT_VERSION,
+    status: ready ? "ready" : statusForReasons(finalReasons),
+    reasonCodes: finalReasons,
+    warnings: [],
+    ownershipVerified,
+    completenessStatus: ready ? "complete" : finalReasons.some((code) => code.includes("AMBIGUOUS")) ? "ambiguous" : "incomplete",
+    sourceCounts: counts,
+    normalizedSourceSummary: {
+      status: normalization?.sourceState || "not_run",
+      recordCount: records.length,
+      legacyEffectCount: input.legacyEffects?.length || 0,
+    },
+    comparatorInput,
+  };
+}

--- a/rentchain-api/src/lib/accounting/receivablesSourceSnapshotTypes.ts
+++ b/rentchain-api/src/lib/accounting/receivablesSourceSnapshotTypes.ts
@@ -1,0 +1,128 @@
+import type { LegacyReceivablesSourceRecord } from "./legacyReceivablesSourceTypes";
+import type {
+  CompareReceivablesShadowInput,
+  ReceivablesShadowComparatorConfig,
+  ReceivablesShadowSourceState,
+} from "./receivablesShadowComparatorTypes";
+
+export const RECEIVABLES_SOURCE_SNAPSHOT_VERSION = "receivables_source_snapshot_v1" as const;
+
+export type ReceivablesSnapshotMappingState = "resolved" | "missing" | "ambiguous";
+export type ReceivablesSnapshotUnitMappingState = ReceivablesSnapshotMappingState | "not_applicable";
+
+export type ReceivablesSnapshotOwnershipContext = {
+  proofSource: "authoritative_lease" | "in_memory_fallback" | "missing" | "ambiguous" | string;
+  landlordId: unknown;
+  leaseId: unknown;
+  leaseLandlordId: unknown;
+  propertyId: unknown;
+  propertyLandlordId: unknown;
+};
+
+export type ReceivablesSnapshotLeaseContext = {
+  leaseId: unknown;
+  landlordId: unknown;
+  propertyId: unknown;
+  unitId?: unknown;
+  responsibilityId?: unknown;
+  tenantId?: unknown;
+  propertyDisplayName?: unknown;
+  unitDisplayName?: unknown;
+  tenantDisplayName?: unknown;
+  responsibilityDisplayName?: unknown;
+  leaseMappingState: ReceivablesSnapshotMappingState | string;
+  propertyMappingState: ReceivablesSnapshotMappingState | string;
+  unitMappingState: ReceivablesSnapshotUnitMappingState | string;
+  tenantMappingState: ReceivablesSnapshotMappingState | string;
+  leaseStatus: unknown;
+  leaseStartDate: unknown;
+  leaseEndDate?: unknown;
+  monthlyRentCents: unknown;
+  dueDay: unknown;
+  billingFrequency: unknown;
+  currency: unknown;
+  depositAmountCents?: unknown;
+  sourceLeaseVersion: unknown;
+};
+
+export type ReceivablesSnapshotEvidenceBatch = {
+  state: ReceivablesShadowSourceState | string;
+  records: readonly LegacyReceivablesSourceRecord[];
+};
+
+export type ReceivablesSnapshotEvidenceBatches = {
+  ledgerEntries: ReceivablesSnapshotEvidenceBatch;
+  paymentRecords: ReceivablesSnapshotEvidenceBatch;
+  paymentIntents: ReceivablesSnapshotEvidenceBatch;
+  reconciliationRecords: ReceivablesSnapshotEvidenceBatch;
+  leaseObligations: ReceivablesSnapshotEvidenceBatch;
+  allocationRecords: ReceivablesSnapshotEvidenceBatch;
+};
+
+export type IndependentLegacySignedEffect = {
+  effectId: unknown;
+  landlordId: unknown;
+  leaseId: unknown;
+  propertyId: unknown;
+  currency: unknown;
+  effectiveDate: unknown;
+  signedAmountCents: unknown;
+};
+
+export type ReceivablesSourceSnapshotAdapterInput = {
+  comparatorConfig: ReceivablesShadowComparatorConfig;
+  ownership: ReceivablesSnapshotOwnershipContext;
+  lease: ReceivablesSnapshotLeaseContext;
+  evidence: ReceivablesSnapshotEvidenceBatches;
+  legacyEffectsState: "complete" | "empty_confirmed" | "unavailable" | "ambiguous" | "truncated" | string;
+  legacyEffects: readonly IndependentLegacySignedEffect[];
+  asOfDate: unknown;
+  previewThroughDate: unknown;
+};
+
+export type ReceivablesSourceSnapshotReasonCode =
+  | "SNAPSHOT_CONFIG_NOT_READY"
+  | "SNAPSHOT_OWNERSHIP_MISSING"
+  | "SNAPSHOT_OWNERSHIP_FALLBACK_REJECTED"
+  | "SNAPSHOT_OWNERSHIP_AMBIGUOUS"
+  | "SNAPSHOT_SCOPE_MISMATCH"
+  | "SNAPSHOT_MAPPING_INCOMPLETE"
+  | "SNAPSHOT_MAPPING_AMBIGUOUS"
+  | "SNAPSHOT_BILLING_TERMS_INCOMPLETE"
+  | "SNAPSHOT_CURRENCY_UNSUPPORTED"
+  | "SNAPSHOT_FREQUENCY_UNSUPPORTED"
+  | "SNAPSHOT_SOURCE_INCOMPLETE"
+  | "SNAPSHOT_SOURCE_AMBIGUOUS"
+  | "SNAPSHOT_SOURCE_BATCH_KIND_MISMATCH"
+  | "SNAPSHOT_UNSAFE_SOURCE_DATA"
+  | "SNAPSHOT_NORMALIZATION_FAILED"
+  | "SNAPSHOT_LEGACY_PROJECTION_UNAVAILABLE"
+  | "SNAPSHOT_LEGACY_PROJECTION_INVALID";
+
+export type ReceivablesSourceSnapshotStatus = "ready" | "incomplete" | "ambiguous" | "unsafe";
+
+export type ReceivablesSourceCounts = {
+  ledgerEntries: number;
+  paymentRecords: number;
+  paymentIntents: number;
+  reconciliationRecords: number;
+  leaseObligations: number;
+  allocationRecords: number;
+  legacyEffects: number;
+};
+
+export type InternalReceivablesSourceSnapshotPackage = {
+  snapshotVersion: typeof RECEIVABLES_SOURCE_SNAPSHOT_VERSION;
+  status: ReceivablesSourceSnapshotStatus;
+  reasonCodes: ReceivablesSourceSnapshotReasonCode[];
+  warnings: string[];
+  ownershipVerified: boolean;
+  completenessStatus: "complete" | "incomplete" | "ambiguous";
+  sourceCounts: ReceivablesSourceCounts;
+  normalizedSourceSummary: {
+    status: "complete" | "incomplete" | "ambiguous" | "not_run";
+    recordCount: number;
+    legacyEffectCount: number;
+  };
+  comparatorInput: CompareReceivablesShadowInput | null;
+};


### PR DESCRIPTION
## Summary

- add a pure, unmounted Phase 0I receivables source snapshot adapter under `rentchain-api/src/lib/accounting`
- define explicit ownership, lease/mapping, evidence-batch, independent legacy-effect, snapshot-result, and internal comparator-input contracts
- enforce authoritative ownership, exact allowlist assumptions, complete/confirmed-empty source states, billing terms, CAD/monthly support, batch-kind integrity, and safe source scope
- reject in-memory fallback ownership and recursively reject bank, provider/processor, admin-scope, Firestore/storage path, credential, secret, and token fields
- preflight Phase 0E normalization and calculate an independent legacy signed-effect balance before emitting an internal Phase 0G input
- add deterministic fixtures and focused compatibility tests

## Safety boundary

The adapter receives all evidence as input. It has no Firestore, route, job, environment, network, provider, or runtime-service dependency. The Phase 0G comparator remains library-only and is invoked only in an in-memory test.

The public-safe validation envelope contains status, reason codes, ownership/completeness state, and source counts. Financial source structures exist only inside the explicitly internal `comparatorInput`, which is null for every unsafe or incomplete snapshot.

No routes, jobs, UI, Firestore reads/writes, provider/PAD integration, payment mutation, money movement, tenant bank-data handling, existing ledger behavior, or RC1 behavior changed. Tenant rent remains landlord revenue and the direct-settlement model is unchanged.

## Validation

- accounting suite: 10 files, 125 tests passed
- new snapshot adapter coverage: 32 tests passed
- backend TypeScript production build passed with Node 20.20.2
- `git diff --check` passed
- `git diff --cached --check` passed
- forbidden-scope/import and runtime-invocation scans passed
- changed files limited to five backend accounting files
