### PR TITLE
Add Phase 0K receivables diagnostic runner core

### DIFF
--- a/rentchain-api/src/lib/accounting/__tests__/receivablesDiagnosticRunnerCore.test.ts
+++ b/rentchain-api/src/lib/accounting/__tests__/receivablesDiagnosticRunnerCore.test.ts
@@ -1,0 +1,193 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { completeReceivablesSourceSnapshotFixture } from "../__fixtures__/receivablesSourceSnapshotFixtures";
+import { runReceivablesDiagnostic } from "../receivablesDiagnosticRunnerCore";
+import type { RunReceivablesDiagnosticInput } from "../receivablesDiagnosticRunnerTypes";
+
+function clone<T>(value: T): T {
+  return structuredClone(value);
+}
+
+function base(overrides: Partial<RunReceivablesDiagnosticInput> = {}): RunReceivablesDiagnosticInput {
+  return {
+    diagnosticConfig: { enabled: true },
+    target: { landlordId: "landlord-a", leaseId: "lease-a", context: "lease_receivables" },
+    allowlistDecision: {
+      approved: true,
+      landlordId: "landlord-a",
+      leaseId: "lease-a",
+      context: "lease_receivables",
+      reason: "Approved diagnostic fixture",
+      expiresOn: "2026-02-28",
+    },
+    operatorIntent: {
+      intentType: "receivables_diagnostic",
+      operatorIdentifier: "operator-a",
+      operatorDisplayName: "Accounting Support",
+      reason: "Validate projection parity",
+      landlordId: "landlord-a",
+      leaseId: "lease-a",
+      context: "lease_receivables",
+    },
+    sourceSnapshotInput: clone(completeReceivablesSourceSnapshotFixture),
+    asOfDate: "2026-02-15",
+    diagnosticRunMetadata: { checkedAt: "2026-02-15T12:00:00.000Z" },
+    expectedComparatorVersion: "receivables_shadow_comparison_v1",
+    ...overrides,
+  };
+}
+
+describe("runReceivablesDiagnostic", () => {
+  it("returns a deterministic minimal status for a complete safe injected diagnostic", () => {
+    expect(runReceivablesDiagnostic(base())).toEqual({
+      ok: true,
+      status: "equivalent",
+      reasonCodes: ["SHADOW_EQUIVALENT"],
+      warnings: [],
+      diagnosticVersion: "receivables_diagnostic_runner_v1",
+      snapshotVersion: "receivables_source_snapshot_v1",
+      comparatorVersion: "receivables_shadow_comparison_v1",
+      checkedAt: "2026-02-15T12:00:00.000Z",
+    });
+  });
+
+  it("is disabled by default", () => {
+    expect(runReceivablesDiagnostic(base({ diagnosticConfig: undefined }))).toMatchObject({
+      ok: false,
+      reasonCodes: ["DIAGNOSTIC_DISABLED"],
+    });
+  });
+
+  it("fails closed when allowlist approval is missing", () => {
+    expect(runReceivablesDiagnostic(base({ allowlistDecision: undefined }))).toMatchObject({
+      status: "rejected",
+      reasonCodes: ["DIAGNOSTIC_ALLOWLIST_MISSING"],
+    });
+  });
+
+  it("fails closed when allowlist approval is false", () => {
+    const input = base();
+    input.allowlistDecision!.approved = false;
+    expect(runReceivablesDiagnostic(input).reasonCodes).toEqual(["DIAGNOSTIC_ALLOWLIST_NOT_APPROVED"]);
+  });
+
+  it("requires an exact landlord, lease, and context allowlist match", () => {
+    const input = base();
+    input.allowlistDecision!.leaseId = "lease-other";
+    expect(runReceivablesDiagnostic(input).reasonCodes).toEqual(["DIAGNOSTIC_ALLOWLIST_SCOPE_MISMATCH"]);
+  });
+
+  it("rejects expired or unexplained allowlist decisions", () => {
+    const expired = base();
+    expired.allowlistDecision!.expiresOn = "2026-02-14";
+    expect(runReceivablesDiagnostic(expired).reasonCodes).toEqual(["DIAGNOSTIC_ALLOWLIST_EXPIRED"]);
+    const unexplained = base();
+    unexplained.allowlistDecision!.reason = " ";
+    expect(runReceivablesDiagnostic(unexplained).reasonCodes).toEqual(["DIAGNOSTIC_ALLOWLIST_REASON_MISSING"]);
+  });
+
+  it("fails closed when operator intent is missing", () => {
+    expect(runReceivablesDiagnostic(base({ operatorIntent: undefined })).reasonCodes).toEqual([
+      "DIAGNOSTIC_OPERATOR_INTENT_MISSING",
+    ]);
+  });
+
+  it("requires operator identity, reason, diagnostic intent, and exact scope", () => {
+    const missingIdentity = base();
+    missingIdentity.operatorIntent!.operatorIdentifier = null;
+    expect(runReceivablesDiagnostic(missingIdentity).reasonCodes).toEqual(["DIAGNOSTIC_OPERATOR_IDENTITY_MISSING"]);
+    const missingReason = base();
+    missingReason.operatorIntent!.reason = "";
+    expect(runReceivablesDiagnostic(missingReason).reasonCodes).toEqual(["DIAGNOSTIC_OPERATOR_REASON_MISSING"]);
+    const wrongIntent = base();
+    wrongIntent.operatorIntent!.intentType = "report_export";
+    expect(runReceivablesDiagnostic(wrongIntent).reasonCodes).toEqual(["DIAGNOSTIC_OPERATOR_INTENT_INVALID"]);
+    const wrongScope = base();
+    wrongScope.operatorIntent!.context = "portfolio_receivables";
+    expect(runReceivablesDiagnostic(wrongScope).reasonCodes).toEqual(["DIAGNOSTIC_OPERATOR_SCOPE_MISMATCH"]);
+  });
+
+  it("requires valid injected metadata and matching as-of/source scope", () => {
+    expect(runReceivablesDiagnostic(base({ diagnosticRunMetadata: undefined })).reasonCodes).toEqual([
+      "DIAGNOSTIC_METADATA_INVALID",
+    ]);
+    expect(runReceivablesDiagnostic(base({ asOfDate: "02/15/2026" })).reasonCodes).toEqual([
+      "DIAGNOSTIC_AS_OF_DATE_INVALID",
+    ]);
+    const mismatch = base();
+    mismatch.sourceSnapshotInput!.lease.leaseId = "lease-other";
+    expect(runReceivablesDiagnostic(mismatch).reasonCodes).toEqual(["DIAGNOSTIC_SNAPSHOT_SCOPE_MISMATCH"]);
+  });
+
+  it("fails closed on snapshot ownership failure", () => {
+    const input = base();
+    input.sourceSnapshotInput!.ownership.proofSource = "in_memory_fallback";
+    expect(runReceivablesDiagnostic(input).reasonCodes).toContain("SNAPSHOT_OWNERSHIP_FALLBACK_REJECTED");
+  });
+
+  it("fails closed on incomplete and ambiguous snapshot evidence", () => {
+    const incomplete = base();
+    incomplete.sourceSnapshotInput!.evidence.ledgerEntries.state = "truncated";
+    expect(runReceivablesDiagnostic(incomplete).reasonCodes).toContain("SNAPSHOT_SOURCE_INCOMPLETE");
+    const ambiguous = base();
+    ambiguous.sourceSnapshotInput!.lease.tenantMappingState = "ambiguous";
+    expect(runReceivablesDiagnostic(ambiguous).reasonCodes).toEqual(expect.arrayContaining([
+      "SNAPSHOT_MAPPING_AMBIGUOUS",
+      "SNAPSHOT_SOURCE_AMBIGUOUS",
+    ]));
+  });
+
+  it("fails closed on unsafe source data", () => {
+    const input = base();
+    input.sourceSnapshotInput!.evidence.ledgerEntries.records = [{
+      ...input.sourceSnapshotInput!.evidence.ledgerEntries.records[0],
+      bankAccountNumber: "not-allowed",
+    }];
+    expect(runReceivablesDiagnostic(input).reasonCodes).toEqual(["SNAPSHOT_UNSAFE_SOURCE_DATA"]);
+  });
+
+  it("fails closed when the injected comparator remains disabled", () => {
+    const input = base();
+    input.sourceSnapshotInput!.comparatorConfig.enabled = false;
+    expect(runReceivablesDiagnostic(input).reasonCodes).toEqual(["SNAPSHOT_CONFIG_NOT_READY"]);
+  });
+
+  it("fails closed on comparator parity failure", () => {
+    const input = base();
+    input.sourceSnapshotInput!.legacyEffects[0].signedAmountCents = 99_999;
+    expect(runReceivablesDiagnostic(input).reasonCodes).toEqual(["SHADOW_PARITY_MISMATCH"]);
+  });
+
+  it("rejects an unexpected comparator contract version", () => {
+    expect(runReceivablesDiagnostic(base({ expectedComparatorVersion: "future-version" })).reasonCodes).toEqual([
+      "DIAGNOSTIC_COMPARATOR_VERSION_MISMATCH",
+    ]);
+  });
+
+  it("never returns financial values, scope identifiers, or internal source inputs", () => {
+    const result = runReceivablesDiagnostic(base());
+    expect(Object.keys(result).sort()).toEqual([
+      "checkedAt",
+      "comparatorVersion",
+      "diagnosticVersion",
+      "ok",
+      "reasonCodes",
+      "snapshotVersion",
+      "status",
+      "warnings",
+    ]);
+    const serialized = JSON.stringify(result).toLowerCase();
+    for (const forbidden of [
+      "balance", "amount", "charge", "payment", "allocation", "aging", "rentroll", "schedule",
+      "tenant-a", "lease-a", "landlord-a", "property-a", "operator-a", "provider", "processor", "firestore", "storage",
+    ]) expect(serialized).not.toContain(forbidden);
+  });
+
+  it("has no runtime, route, Firestore, provider, scheduler, or job-framework dependency", () => {
+    const source = readFileSync(new URL("../receivablesDiagnosticRunnerCore.ts", import.meta.url), "utf8").toLowerCase();
+    for (const forbidden of [
+      "firebase", "firestore", "express", "router", "request", "response", "cron", "scheduler", "pubsub",
+      "rotessa", "provider", "process.env", "setinterval", "settimeout",
+    ]) expect(source).not.toContain(forbidden);
+  });
+});

--- a/rentchain-api/src/lib/accounting/index.ts
+++ b/rentchain-api/src/lib/accounting/index.ts
@@ -12,3 +12,5 @@ export * from "./receivablesShadowComparatorTypes";
 export * from "./receivablesShadowComparator";
 export * from "./receivablesSourceSnapshotTypes";
 export * from "./receivablesSourceSnapshotAdapter";
+export * from "./receivablesDiagnosticRunnerTypes";
+export * from "./receivablesDiagnosticRunnerCore";

--- a/rentchain-api/src/lib/accounting/receivablesDiagnosticRunnerCore.ts
+++ b/rentchain-api/src/lib/accounting/receivablesDiagnosticRunnerCore.ts
@@ -1,0 +1,132 @@
+import { compareReceivablesShadow } from "./receivablesShadowComparator";
+import { RECEIVABLES_SHADOW_COMPARISON_VERSION } from "./receivablesShadowComparatorTypes";
+import {
+  RECEIVABLES_DIAGNOSTIC_RUNNER_VERSION,
+  type ReceivablesDiagnosticRunnerReasonCode,
+  type ReceivablesDiagnosticRunnerResult,
+  type ReceivablesDiagnosticScope,
+  type RunReceivablesDiagnosticInput,
+} from "./receivablesDiagnosticRunnerTypes";
+import { buildReceivablesSourceSnapshot } from "./receivablesSourceSnapshotAdapter";
+import { RECEIVABLES_SOURCE_SNAPSHOT_VERSION } from "./receivablesSourceSnapshotTypes";
+import { cleanAccountingString, parseDateOnly } from "./receivablesTypes";
+
+function normalizedScope(scope: ReceivablesDiagnosticScope | undefined) {
+  return {
+    landlordId: cleanAccountingString(scope?.landlordId),
+    leaseId: cleanAccountingString(scope?.leaseId),
+    context: cleanAccountingString(scope?.context),
+  };
+}
+
+function scopesMatch(left: ReceivablesDiagnosticScope | undefined, right: ReceivablesDiagnosticScope | undefined): boolean {
+  const a = normalizedScope(left);
+  const b = normalizedScope(right);
+  return Boolean(
+    a.landlordId && a.leaseId && a.context &&
+    a.landlordId === b.landlordId && a.leaseId === b.leaseId && a.context === b.context
+  );
+}
+
+function checkedAt(value: unknown): string | null {
+  const normalized = cleanAccountingString(value, 80);
+  if (!normalized || !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/.test(normalized)) return null;
+  return Number.isNaN(Date.parse(normalized)) ? null : normalized;
+}
+
+function rejected(
+  reasonCodes: readonly ReceivablesDiagnosticRunnerReasonCode[],
+  timestamp: string
+): ReceivablesDiagnosticRunnerResult {
+  return {
+    ok: false,
+    status: "rejected",
+    reasonCodes: [...new Set(reasonCodes)].sort(),
+    warnings: [],
+    diagnosticVersion: RECEIVABLES_DIAGNOSTIC_RUNNER_VERSION,
+    snapshotVersion: RECEIVABLES_SOURCE_SNAPSHOT_VERSION,
+    comparatorVersion: RECEIVABLES_SHADOW_COMPARISON_VERSION,
+    checkedAt: timestamp,
+  };
+}
+
+export function runReceivablesDiagnostic(
+  input: RunReceivablesDiagnosticInput
+): ReceivablesDiagnosticRunnerResult {
+  const timestamp = checkedAt(input.diagnosticRunMetadata?.checkedAt);
+  if (!timestamp) return rejected(["DIAGNOSTIC_METADATA_INVALID"], "");
+  if (input.diagnosticConfig?.enabled !== true) return rejected(["DIAGNOSTIC_DISABLED"], timestamp);
+
+  const target = normalizedScope(input.target);
+  if (!target.landlordId || !target.leaseId || !target.context) {
+    return rejected(["DIAGNOSTIC_TARGET_INVALID"], timestamp);
+  }
+
+  if (!input.allowlistDecision) return rejected(["DIAGNOSTIC_ALLOWLIST_MISSING"], timestamp);
+  if (input.allowlistDecision.approved !== true) {
+    return rejected(["DIAGNOSTIC_ALLOWLIST_NOT_APPROVED"], timestamp);
+  }
+  if (!scopesMatch(input.target, input.allowlistDecision)) {
+    return rejected(["DIAGNOSTIC_ALLOWLIST_SCOPE_MISMATCH"], timestamp);
+  }
+  if (!cleanAccountingString(input.allowlistDecision.reason)) {
+    return rejected(["DIAGNOSTIC_ALLOWLIST_REASON_MISSING"], timestamp);
+  }
+  if (input.allowlistDecision.expiresOn !== undefined) {
+    const expiry = parseDateOnly(input.allowlistDecision.expiresOn);
+    const runDate = parseDateOnly(timestamp.slice(0, 10));
+    if (!expiry || !runDate || expiry.epochDay < runDate.epochDay) {
+      return rejected(["DIAGNOSTIC_ALLOWLIST_EXPIRED"], timestamp);
+    }
+  }
+
+  if (!input.operatorIntent) return rejected(["DIAGNOSTIC_OPERATOR_INTENT_MISSING"], timestamp);
+  if (
+    !cleanAccountingString(input.operatorIntent.operatorIdentifier) ||
+    !cleanAccountingString(input.operatorIntent.operatorDisplayName)
+  ) return rejected(["DIAGNOSTIC_OPERATOR_IDENTITY_MISSING"], timestamp);
+  if (!cleanAccountingString(input.operatorIntent.reason)) {
+    return rejected(["DIAGNOSTIC_OPERATOR_REASON_MISSING"], timestamp);
+  }
+  if (!scopesMatch(input.target, input.operatorIntent)) {
+    return rejected(["DIAGNOSTIC_OPERATOR_SCOPE_MISMATCH"], timestamp);
+  }
+  if (input.operatorIntent.intentType !== "receivables_diagnostic") {
+    return rejected(["DIAGNOSTIC_OPERATOR_INTENT_INVALID"], timestamp);
+  }
+
+  const asOf = parseDateOnly(input.asOfDate);
+  if (!asOf) return rejected(["DIAGNOSTIC_AS_OF_DATE_INVALID"], timestamp);
+  if (!input.sourceSnapshotInput) return rejected(["DIAGNOSTIC_SNAPSHOT_INPUT_MISSING"], timestamp);
+  if (
+    cleanAccountingString(input.sourceSnapshotInput.asOfDate) !== asOf.value ||
+    cleanAccountingString(input.sourceSnapshotInput.lease?.landlordId) !== target.landlordId ||
+    cleanAccountingString(input.sourceSnapshotInput.lease?.leaseId) !== target.leaseId
+  ) return rejected(["DIAGNOSTIC_SNAPSHOT_SCOPE_MISMATCH"], timestamp);
+
+  if (
+    input.expectedComparatorVersion !== undefined &&
+    cleanAccountingString(input.expectedComparatorVersion) !== RECEIVABLES_SHADOW_COMPARISON_VERSION
+  ) return rejected(["DIAGNOSTIC_COMPARATOR_VERSION_MISMATCH"], timestamp);
+
+  const snapshot = buildReceivablesSourceSnapshot(input.sourceSnapshotInput);
+  if (snapshot.status !== "ready" || !snapshot.comparatorInput) {
+    return rejected(snapshot.reasonCodes.length ? snapshot.reasonCodes : ["DIAGNOSTIC_SNAPSHOT_INPUT_MISSING"], timestamp);
+  }
+
+  const comparison = compareReceivablesShadow(snapshot.comparatorInput);
+  if (!comparison.ok || comparison.status !== "equivalent" || comparison.reasonCode !== "SHADOW_EQUIVALENT") {
+    return rejected([comparison.reasonCode], timestamp);
+  }
+
+  return {
+    ok: true,
+    status: "equivalent",
+    reasonCodes: ["SHADOW_EQUIVALENT"],
+    warnings: [],
+    diagnosticVersion: RECEIVABLES_DIAGNOSTIC_RUNNER_VERSION,
+    snapshotVersion: snapshot.snapshotVersion,
+    comparatorVersion: comparison.comparisonVersion,
+    checkedAt: timestamp,
+  };
+}

--- a/rentchain-api/src/lib/accounting/receivablesDiagnosticRunnerTypes.ts
+++ b/rentchain-api/src/lib/accounting/receivablesDiagnosticRunnerTypes.ts
@@ -1,0 +1,77 @@
+import type { ReceivablesShadowReasonCode } from "./receivablesShadowComparatorTypes";
+import type {
+  ReceivablesSourceSnapshotAdapterInput,
+  ReceivablesSourceSnapshotReasonCode,
+} from "./receivablesSourceSnapshotTypes";
+
+export const RECEIVABLES_DIAGNOSTIC_RUNNER_VERSION = "receivables_diagnostic_runner_v1" as const;
+
+export type ReceivablesDiagnosticScope = {
+  landlordId: unknown;
+  leaseId: unknown;
+  context: unknown;
+};
+
+export type ReceivablesDiagnosticAllowlistDecision = ReceivablesDiagnosticScope & {
+  approved: unknown;
+  reason: unknown;
+  expiresOn?: unknown;
+};
+
+export type ReceivablesDiagnosticOperatorIntent = ReceivablesDiagnosticScope & {
+  intentType: unknown;
+  operatorIdentifier: unknown;
+  operatorDisplayName: unknown;
+  reason: unknown;
+};
+
+export type ReceivablesDiagnosticRunMetadata = {
+  checkedAt: unknown;
+};
+
+export type RunReceivablesDiagnosticInput = {
+  diagnosticConfig?: {
+    enabled: unknown;
+  };
+  target?: ReceivablesDiagnosticScope;
+  allowlistDecision?: ReceivablesDiagnosticAllowlistDecision;
+  operatorIntent?: ReceivablesDiagnosticOperatorIntent;
+  sourceSnapshotInput?: ReceivablesSourceSnapshotAdapterInput;
+  asOfDate: unknown;
+  diagnosticRunMetadata?: ReceivablesDiagnosticRunMetadata;
+  expectedComparatorVersion?: unknown;
+};
+
+export type ReceivablesDiagnosticRunnerReasonCode =
+  | "DIAGNOSTIC_DISABLED"
+  | "DIAGNOSTIC_TARGET_INVALID"
+  | "DIAGNOSTIC_ALLOWLIST_MISSING"
+  | "DIAGNOSTIC_ALLOWLIST_NOT_APPROVED"
+  | "DIAGNOSTIC_ALLOWLIST_SCOPE_MISMATCH"
+  | "DIAGNOSTIC_ALLOWLIST_REASON_MISSING"
+  | "DIAGNOSTIC_ALLOWLIST_EXPIRED"
+  | "DIAGNOSTIC_OPERATOR_INTENT_MISSING"
+  | "DIAGNOSTIC_OPERATOR_IDENTITY_MISSING"
+  | "DIAGNOSTIC_OPERATOR_REASON_MISSING"
+  | "DIAGNOSTIC_OPERATOR_SCOPE_MISMATCH"
+  | "DIAGNOSTIC_OPERATOR_INTENT_INVALID"
+  | "DIAGNOSTIC_METADATA_INVALID"
+  | "DIAGNOSTIC_AS_OF_DATE_INVALID"
+  | "DIAGNOSTIC_SNAPSHOT_INPUT_MISSING"
+  | "DIAGNOSTIC_SNAPSHOT_SCOPE_MISMATCH"
+  | "DIAGNOSTIC_COMPARATOR_VERSION_MISMATCH"
+  | ReceivablesSourceSnapshotReasonCode
+  | ReceivablesShadowReasonCode;
+
+export type ReceivablesDiagnosticRunnerStatus = "rejected" | "equivalent";
+
+export type ReceivablesDiagnosticRunnerResult = {
+  ok: boolean;
+  status: ReceivablesDiagnosticRunnerStatus;
+  reasonCodes: ReceivablesDiagnosticRunnerReasonCode[];
+  warnings: string[];
+  diagnosticVersion: typeof RECEIVABLES_DIAGNOSTIC_RUNNER_VERSION;
+  snapshotVersion: string;
+  comparatorVersion: string;
+  checkedAt: string;
+};


### PR DESCRIPTION
## Summary

- adds the Phase 0K pure, unmounted receivables diagnostic runner core
- adds explicit injected contracts for diagnostic enablement, exact allowlist approval, operator intent, target scope, timestamps, and source snapshots
- runs the Phase 0I snapshot adapter and Phase 0G comparator only inside the pure runner flow
- returns a fixed minimal non-financial result with deterministic versions and reason codes
- adds focused fail-closed coverage for allowlist, intent, ownership, completeness, unsafe source data, comparator enablement, version, and parity failures

## Safety boundary

The runner is a library function only. Operator intent and allowlist approval are inputs to validate, not runtime authentication or configuration. It is not registered, scheduled, mounted, or invoked by any production path.

- no runnable job or scheduler
- no route or frontend UI
- no Firestore reads or writes
- no production source provider
- no provider, Rotessa, PAD, bank-data, payment-mutation, or money-movement behavior
- no balances, charges, payments, allocations, aging, rent roll, schedules, tenant balances, or scope identifiers in output
- no existing ledger or RC1 behavior change

## Validation

- accounting suite: 11 files, 142 tests passed
- new runner-core coverage: 17 tests
- backend TypeScript production build passed with Node 20.20.2
- `git diff --check` passed
- `git diff --cached --check` passed
- forbidden dependency/scope scans passed
- changed files limited to four backend accounting files

## Manual QA

Not required because the runner remains unmounted and has no user-visible or runtime effect.
