### PR TITLE
Add Phase 0N authoritative source provider core

### DIFF
--- a/rentchain-api/src/lib/accounting/__fixtures__/receivablesAuthoritativeSourceProviderFixtures.ts
+++ b/rentchain-api/src/lib/accounting/__fixtures__/receivablesAuthoritativeSourceProviderFixtures.ts
@@ -1,0 +1,51 @@
+import {
+  RECEIVABLES_AUTHORITATIVE_SOURCE_MANIFEST_VERSION,
+  type BuildReceivablesAuthoritativeSourceInput,
+  type ReceivablesAuthoritativeReadReceipt,
+  type ReceivablesAuthoritativeSourceClass,
+} from "../receivablesAuthoritativeSourceProviderTypes";
+
+function receipt<T>(sourceClass: ReceivablesAuthoritativeSourceClass, records: readonly T[], empty = false): ReceivablesAuthoritativeReadReceipt<T> {
+  return {
+    sourceClass, sourceVersion: `${sourceClass}_v1`, readBoundaryVersion: "read-boundary-1",
+    completenessState: empty ? "empty_confirmed" : "complete", authoritative: true, capped: false,
+    completenessProven: true, postReadFiltered: false, aliasOwnershipMapping: false, catchToEmpty: false,
+    suitableForFinancialDiagnostics: true, reasonCodes: [],
+    scope: { landlordId: "landlord-a", leaseId: "lease-a", propertyId: "property-a" }, records,
+  };
+}
+
+const charge = {
+  sourceKind: "ledger_entry" as const, sourceId: "ledger-charge-a", evidenceRole: "posted_transaction" as const,
+  landlordId: "landlord-a", leaseId: "lease-a", propertyId: "property-a", unitId: "unit-a",
+  responsibilityId: "responsibility-a", tenantId: "tenant-a", transactionType: "scheduled_rent_charge" as const,
+  amountCents: 100_000, currency: "cad", effectiveDate: "2026-01-01", dueDate: "2026-01-01",
+  periodStart: "2026-01-01", periodEnd: "2026-01-31", canonicalEventKey: "rent-charge-2026-01",
+};
+
+export const completeReceivablesAuthoritativeSourceProviderFixture: BuildReceivablesAuthoritativeSourceInput = {
+  providerEnabled: true,
+  sourceManifestVersion: RECEIVABLES_AUTHORITATIVE_SOURCE_MANIFEST_VERSION,
+  target: { landlordId: "landlord-a", leaseId: "lease-a", context: "lease_receivables" },
+  comparatorConfig: { enabled: true, landlordAllowlist: "landlord-a" },
+  asOfDate: "2026-02-15", previewThroughDate: "2026-03-31",
+  receipts: {
+    ownership: receipt("ownership", [{ proofSource: "canonical_direct", landlordId: "landlord-a", leaseId: "lease-a", leaseLandlordId: "landlord-a", propertyId: "property-a", propertyLandlordId: "landlord-a" }]),
+    lease: receipt("lease", [{
+      leaseId: "lease-a", landlordId: "landlord-a", canonicalLandlordId: "landlord-a", propertyId: "property-a",
+      unitId: "unit-a", responsibilityId: "responsibility-a", tenantId: "tenant-a", directDocument: true,
+      ownershipField: "landlordId", ownershipAliasConflict: false, propertyDisplayName: "10 Harbour Street",
+      unitDisplayName: "Unit 2", tenantDisplayName: "Example Tenant", responsibilityDisplayName: "Primary responsibility",
+      leaseMappingState: "resolved", propertyMappingState: "resolved", unitMappingState: "resolved", tenantMappingState: "resolved",
+      leaseStatus: "active", leaseStartDate: "2026-01-01", leaseEndDate: "2026-03-31", monthlyRentCents: 100_000,
+      dueDay: 1, billingFrequency: "monthly", currency: "cad", depositAmountCents: null, sourceLeaseVersion: "lease-version-1",
+    }]),
+    property: receipt("property", [{ propertyId: "property-a", landlordId: "landlord-a", displayName: "10 Harbour Street" }]),
+    unit: receipt("unit", [{ unitId: "unit-a", propertyId: "property-a", landlordId: "landlord-a", displayName: "Unit 2" }]),
+    tenant: receipt("tenant", [{ tenantId: "tenant-a", leaseId: "lease-a", displayName: "Example Tenant" }]),
+    ledger: receipt("ledger", [charge]),
+    payment: receipt("payment", [], true), paymentIntent: receipt("payment_intent", [], true),
+    reconciliation: receipt("reconciliation", [], true), obligation: receipt("obligation", [], true), allocation: receipt("allocation", [], true),
+    legacyEffects: receipt("legacy_effects", [{ effectId: "legacy-charge-a", landlordId: "landlord-a", leaseId: "lease-a", propertyId: "property-a", currency: "cad", effectiveDate: "2026-01-01", signedAmountCents: 100_000 }]),
+  },
+};

--- a/rentchain-api/src/lib/accounting/__tests__/receivablesAuthoritativeSourceProviderCore.test.ts
+++ b/rentchain-api/src/lib/accounting/__tests__/receivablesAuthoritativeSourceProviderCore.test.ts
@@ -1,0 +1,115 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { completeReceivablesAuthoritativeSourceProviderFixture } from "../__fixtures__/receivablesAuthoritativeSourceProviderFixtures";
+import { buildReceivablesAuthoritativeSource } from "../receivablesAuthoritativeSourceProviderCore";
+import type { BuildReceivablesAuthoritativeSourceInput } from "../receivablesAuthoritativeSourceProviderTypes";
+import { buildReceivablesSourceSnapshot } from "../receivablesSourceSnapshotAdapter";
+
+const clone = <T>(value: T): T => structuredClone(value);
+const build = (change?: (input: BuildReceivablesAuthoritativeSourceInput) => void) => {
+  const input = clone(completeReceivablesAuthoritativeSourceProviderFixture); change?.(input);
+  return buildReceivablesAuthoritativeSource(input);
+};
+
+describe("buildReceivablesAuthoritativeSource", () => {
+  it("produces a safe Phase 0I input from complete authoritative receipts", () => {
+    const result = build();
+    expect(result).toMatchObject({
+      providerCoreVersion: "receivables_authoritative_source_provider_v1", status: "safe", reasonCodes: [], warnings: [],
+      ownershipProofSummary: { status: "verified", method: "canonical_direct" },
+      sourceCompletenessSummary: { status: "complete", completeCount: 7, emptyCount: 5 },
+      receiptSummary: { requiredCount: 12, acceptedCount: 12, manifestVersion: "receivables_authoritative_source_manifest_v1" },
+    });
+    expect(result.safeSnapshotInput).not.toBeNull();
+  });
+
+  it("feeds Phase 0I in memory without runtime invocation", () => {
+    const provider = build();
+    expect(buildReceivablesSourceSnapshot(provider.safeSnapshotInput!)).toMatchObject({ status: "ready", reasonCodes: [] });
+  });
+
+  it("fails closed when ownership is missing", () => {
+    expect(build((i) => { delete i.receipts!.ownership; }).reasonCodes).toContain("PROVIDER_RECEIPT_MISSING");
+  });
+
+  it.each([
+    ["alias-only", "aliasOwnershipMapping", "PROVIDER_SOURCE_ALIAS_REJECTED"],
+    ["post-read filtered", "postReadFiltered", "PROVIDER_SOURCE_POST_FILTER_REJECTED"],
+    ["catch-to-empty", "catchToEmpty", "PROVIDER_SOURCE_CATCH_TO_EMPTY_REJECTED"],
+  ] as const)("rejects %s ownership", (_label, field, code) => {
+    expect(build((i) => { (i.receipts!.ownership as any)[field] = true; }).reasonCodes).toContain(code);
+  });
+
+  it("rejects capped results without completeness proof", () => {
+    expect(build((i) => { i.receipts!.ledger!.capped = true; i.receipts!.ledger!.completenessProven = false; }).reasonCodes)
+      .toContain("PROVIDER_SOURCE_CAPPED_INCOMPLETE");
+  });
+
+  it("rejects incomplete ledger evidence", () => {
+    expect(build((i) => { i.receipts!.ledger!.completenessState = "partial"; }).reasonCodes).toContain("PROVIDER_SOURCE_INCOMPLETE");
+  });
+
+  it("rejects overlapping payment evidence without canonical linkage", () => {
+    const result = build((i) => {
+      const charge = i.receipts!.ledger!.records[0];
+      i.receipts!.payment!.completenessState = "complete";
+      i.receipts!.payment!.records = [{ ...charge, sourceKind: "payment_record", sourceId: "payment-a" }];
+    });
+    expect(result.reasonCodes).toContain("PROVIDER_CANONICAL_NORMALIZATION_FAILED");
+  });
+
+  it("prevents payment intents and reconciliation from inventing transactions", () => {
+    for (const key of ["paymentIntent", "reconciliation"] as const) {
+      const result = build((i) => {
+        const kind = key === "paymentIntent" ? "payment_intent" : "reconciliation_record";
+        i.receipts![key]!.completenessState = "complete";
+        i.receipts![key]!.records = [{
+          sourceKind: kind, sourceId: `${kind}-a`, evidenceRole: "posted_transaction", landlordId: "landlord-a",
+          leaseId: "lease-a", propertyId: "property-a", transactionType: "payment_applied", amountCents: 100_000,
+          currency: "cad", effectiveDate: "2026-01-15",
+        }];
+      });
+      expect(result.reasonCodes).toContain("PROVIDER_CANONICAL_NORMALIZATION_FAILED");
+    }
+  });
+
+  it.each([
+    ["bank data", { bankAccountNumber: "secret" }],
+    ["provider data", { providerPaymentId: "provider-a" }],
+    ["admin data", { adminScope: "support" }],
+    ["Firestore path", { reference: "firestore://projects/p/databases/default/documents/x/y" }],
+    ["storage path", { attachment: "gs://bucket/private" }],
+  ])("rejects unsafe %s", (_label, unsafeField) => {
+    const result = build((i) => { i.receipts!.ledger!.records = [{ ...i.receipts!.ledger!.records[0], ...unsafeField }]; });
+    expect(result).toMatchObject({ status: "unsafe", safeSnapshotInput: null });
+    expect(result.reasonCodes).toContain("PROVIDER_UNSAFE_SOURCE_DATA");
+  });
+
+  it("rejects internal IDs used as display labels", () => {
+    expect(build((i) => { i.receipts!.tenant!.records[0].displayName = "tenant-a"; }).reasonCodes)
+      .toContain("PROVIDER_DISPLAY_ID_FALLBACK_REJECTED");
+  });
+
+  it("fails closed for mismatched read boundaries and scope", () => {
+    expect(build((i) => { i.receipts!.payment!.readBoundaryVersion = "other"; }).reasonCodes).toContain("PROVIDER_READ_BOUNDARY_MISMATCH");
+    expect(build((i) => { i.receipts!.ledger!.scope.leaseId = "other"; }).reasonCodes).toContain("PROVIDER_SCOPE_MISMATCH");
+  });
+
+  it("keeps the public-safe validation envelope non-financial", () => {
+    const { safeSnapshotInput: _internal, ...safe } = build();
+    const serialized = JSON.stringify(safe).toLowerCase();
+    for (const forbidden of ["balance", "amount", "charge", "payment-a", "tenant-a", "lease-a", "landlord-a", "property-a", "provider-a", "firestore://", "gs://"])
+      expect(serialized).not.toContain(forbidden);
+  });
+
+  it("does not mutate injected receipts", () => {
+    const input = clone(completeReceivablesAuthoritativeSourceProviderFixture); const before = clone(input);
+    buildReceivablesAuthoritativeSource(input); expect(input).toEqual(before);
+  });
+
+  it("has no Firestore, route, job, scheduler, provider, or runtime dependency", () => {
+    const source = readFileSync(new URL("../receivablesAuthoritativeSourceProviderCore.ts", import.meta.url), "utf8").toLowerCase();
+    for (const forbidden of ["from \"../firebase\"", "from \"firebase-admin", "@google-cloud/firestore", "express", "router", "cron", "scheduler", "pubsub", "rotessa", "process.env", "leaseservice"])
+      expect(source).not.toContain(forbidden);
+  });
+});

--- a/rentchain-api/src/lib/accounting/index.ts
+++ b/rentchain-api/src/lib/accounting/index.ts
@@ -14,3 +14,5 @@ export * from "./receivablesSourceSnapshotTypes";
 export * from "./receivablesSourceSnapshotAdapter";
 export * from "./receivablesDiagnosticRunnerTypes";
 export * from "./receivablesDiagnosticRunnerCore";
+export * from "./receivablesAuthoritativeSourceProviderTypes";
+export * from "./receivablesAuthoritativeSourceProviderCore";

--- a/rentchain-api/src/lib/accounting/receivablesAuthoritativeSourceProviderCore.ts
+++ b/rentchain-api/src/lib/accounting/receivablesAuthoritativeSourceProviderCore.ts
@@ -1,0 +1,164 @@
+import { normalizeLegacyReceivablesSources } from "./legacyReceivablesSourceNormalizer";
+import type { LegacyReceivablesSourceKind, LegacyReceivablesSourceRecord } from "./legacyReceivablesSourceTypes";
+import {
+  RECEIVABLES_AUTHORITATIVE_SOURCE_MANIFEST_VERSION,
+  RECEIVABLES_AUTHORITATIVE_SOURCE_PROVIDER_VERSION,
+  type BuildReceivablesAuthoritativeSourceInput,
+  type ReceivablesAuthoritativeReadReceipt,
+  type ReceivablesAuthoritativeSourceClass,
+  type ReceivablesAuthoritativeSourceProviderReasonCode,
+  type ReceivablesAuthoritativeSourceProviderResult,
+} from "./receivablesAuthoritativeSourceProviderTypes";
+import type { IndependentLegacySignedEffect, ReceivablesSnapshotEvidenceBatch } from "./receivablesSourceSnapshotTypes";
+import { cleanAccountingString, parseDateOnly } from "./receivablesTypes";
+
+const RECEIPT_KEYS = ["ownership", "lease", "property", "unit", "tenant", "ledger", "payment", "paymentIntent", "reconciliation", "obligation", "allocation", "legacyEffects"] as const;
+const EXPECTED_CLASSES: Record<(typeof RECEIPT_KEYS)[number], ReceivablesAuthoritativeSourceClass> = {
+  ownership: "ownership", lease: "lease", property: "property", unit: "unit", tenant: "tenant",
+  ledger: "ledger", payment: "payment", paymentIntent: "payment_intent", reconciliation: "reconciliation",
+  obligation: "obligation", allocation: "allocation", legacyEffects: "legacy_effects",
+};
+const EXPECTED_KINDS: Record<string, LegacyReceivablesSourceKind> = {
+  ledger: "ledger_entry", payment: "payment_record", paymentIntent: "payment_intent",
+  reconciliation: "reconciliation_record", obligation: "lease_obligation", allocation: "allocation_record",
+};
+const UNSAFE_KEY = /(provider|processor|firestore|storage|bank|routing|transit|institution|iban|swift|credential|secret|token|admin|internalScope|createdByEmail|reversedByEmail)/i;
+const UNSAFE_VALUE = /^(?:gs:\/\/|firestore:\/\/)|\/(?:b|v1)\/documents\//i;
+
+function unsafe(value: unknown, seen = new Set<object>()): boolean {
+  if (typeof value === "string") return UNSAFE_VALUE.test(value.trim());
+  if (!value || typeof value !== "object") return false;
+  if (seen.has(value)) return false;
+  seen.add(value);
+  if (Array.isArray(value)) return value.some((item) => unsafe(item, seen));
+  return Object.entries(value as Record<string, unknown>).some(([key, item]) => UNSAFE_KEY.test(key) || unsafe(item, seen));
+}
+
+function result(reasons: Set<ReceivablesAuthoritativeSourceProviderReasonCode>, acceptedCount: number, completeCount: number, emptyCount: number, snapshot: ReceivablesAuthoritativeSourceProviderResult["safeSnapshotInput"] = null): ReceivablesAuthoritativeSourceProviderResult {
+  const reasonCodes = [...reasons].sort();
+  const ambiguous = reasonCodes.some((code) => code.includes("AMBIGUOUS"));
+  const isUnsafe = reasonCodes.includes("PROVIDER_UNSAFE_SOURCE_DATA");
+  const safe = reasonCodes.length === 0 && Boolean(snapshot);
+  return {
+    providerCoreVersion: RECEIVABLES_AUTHORITATIVE_SOURCE_PROVIDER_VERSION,
+    status: safe ? "safe" : isUnsafe ? "unsafe" : ambiguous ? "ambiguous" : "not_ready",
+    reasonCodes,
+    warnings: [],
+    ownershipProofSummary: { status: safe ? "verified" : ambiguous ? "ambiguous" : "unverified", method: safe ? "canonical_direct" : "none" },
+    sourceCompletenessSummary: { status: safe ? "complete" : ambiguous ? "ambiguous" : "incomplete", completeCount, emptyCount },
+    safeSnapshotInput: safe ? snapshot : null,
+    unsafeFieldSummary: { detected: isUnsafe, categories: isUnsafe ? ["restricted_source_field"] : [] },
+    receiptSummary: { requiredCount: RECEIPT_KEYS.length, acceptedCount, manifestVersion: RECEIVABLES_AUTHORITATIVE_SOURCE_MANIFEST_VERSION },
+  };
+}
+
+export function buildReceivablesAuthoritativeSource(
+  input: BuildReceivablesAuthoritativeSourceInput
+): ReceivablesAuthoritativeSourceProviderResult {
+  const reasons = new Set<ReceivablesAuthoritativeSourceProviderReasonCode>();
+  if (input.providerEnabled !== true) reasons.add("PROVIDER_DISABLED");
+  if (input.sourceManifestVersion !== RECEIVABLES_AUTHORITATIVE_SOURCE_MANIFEST_VERSION) reasons.add("PROVIDER_MANIFEST_VERSION_MISMATCH");
+  const landlordId = cleanAccountingString(input.target?.landlordId);
+  const leaseId = cleanAccountingString(input.target?.leaseId);
+  const context = cleanAccountingString(input.target?.context);
+  const asOf = parseDateOnly(input.asOfDate);
+  const previewThrough = parseDateOnly(input.previewThroughDate);
+  if (!landlordId || !leaseId || context !== "lease_receivables" || !asOf || !previewThrough) reasons.add("PROVIDER_TARGET_INVALID");
+
+  let acceptedCount = 0;
+  let completeCount = 0;
+  let emptyCount = 0;
+  let boundary: string | null = null;
+  for (const key of RECEIPT_KEYS) {
+    const receipt = input.receipts?.[key] as ReceivablesAuthoritativeReadReceipt<unknown> | undefined;
+    if (!receipt) { reasons.add("PROVIDER_RECEIPT_MISSING"); continue; }
+    if (receipt.sourceClass !== EXPECTED_CLASSES[key]) reasons.add("PROVIDER_RECEIPT_CLASS_MISMATCH");
+    const sourceVersion = cleanAccountingString(receipt.sourceVersion);
+    const readBoundary = cleanAccountingString(receipt.readBoundaryVersion);
+    if (!sourceVersion || !readBoundary) reasons.add("PROVIDER_RECEIPT_VERSION_MISSING");
+    else if (boundary && boundary !== readBoundary) reasons.add("PROVIDER_READ_BOUNDARY_MISMATCH");
+    else boundary = readBoundary;
+    if (receipt.authoritative !== true) reasons.add("PROVIDER_SOURCE_NOT_AUTHORITATIVE");
+    if (receipt.suitableForFinancialDiagnostics !== true) reasons.add("PROVIDER_SOURCE_UNSUITABLE");
+    if (receipt.aliasOwnershipMapping === true) reasons.add("PROVIDER_SOURCE_ALIAS_REJECTED");
+    if (receipt.postReadFiltered === true) reasons.add("PROVIDER_SOURCE_POST_FILTER_REJECTED");
+    if (receipt.catchToEmpty === true) reasons.add("PROVIDER_SOURCE_CATCH_TO_EMPTY_REJECTED");
+    if (receipt.capped === true && receipt.completenessProven !== true) reasons.add("PROVIDER_SOURCE_CAPPED_INCOMPLETE");
+    if (!["complete", "empty_confirmed"].includes(String(receipt.completenessState))) reasons.add(receipt.completenessState === "ambiguous" ? "PROVIDER_MAPPING_AMBIGUOUS" : "PROVIDER_SOURCE_INCOMPLETE");
+    if (receipt.completenessState === "empty_confirmed" && receipt.records.length) reasons.add("PROVIDER_SOURCE_STATE_CONFLICT");
+    if (receipt.completenessState === "complete" && !receipt.records.length) reasons.add("PROVIDER_SOURCE_STATE_CONFLICT");
+    if (cleanAccountingString(receipt.scope?.landlordId) !== landlordId || cleanAccountingString(receipt.scope?.leaseId) !== leaseId) reasons.add("PROVIDER_SCOPE_MISMATCH");
+    if (unsafe(receipt.records)) reasons.add("PROVIDER_UNSAFE_SOURCE_DATA");
+    if (receipt.completenessState === "complete") completeCount += 1;
+    if (receipt.completenessState === "empty_confirmed") emptyCount += 1;
+    acceptedCount += 1;
+  }
+
+  if (reasons.size || !landlordId || !leaseId || !asOf || !previewThrough) return result(reasons, acceptedCount, completeCount, emptyCount);
+  const receipts = input.receipts!;
+  const ownership = receipts.ownership!.records[0];
+  const lease = receipts.lease!.records[0];
+  const property = receipts.property!.records[0];
+  if (!ownership || !lease || !property) reasons.add("PROVIDER_OWNERSHIP_MISSING");
+  if (ownership?.proofSource === "ambiguous") reasons.add("PROVIDER_OWNERSHIP_AMBIGUOUS");
+  if (
+    ownership?.proofSource !== "canonical_direct" || lease?.directDocument !== true || lease?.ownershipField !== "landlordId" ||
+    lease?.ownershipAliasConflict === true || cleanAccountingString(ownership?.landlordId) !== landlordId ||
+    cleanAccountingString(ownership?.leaseId) !== leaseId || cleanAccountingString(ownership?.leaseLandlordId) !== landlordId ||
+    cleanAccountingString(ownership?.propertyLandlordId) !== landlordId || cleanAccountingString(lease?.canonicalLandlordId) !== landlordId
+  ) reasons.add("PROVIDER_OWNERSHIP_UNVERIFIED");
+  const propertyId = cleanAccountingString(lease?.propertyId);
+  if (!propertyId || cleanAccountingString(ownership?.propertyId) !== propertyId || cleanAccountingString(property?.propertyId) !== propertyId || cleanAccountingString(property?.landlordId) !== landlordId) reasons.add("PROVIDER_MAPPING_CONFLICT");
+
+  const unitId = cleanAccountingString(lease?.unitId);
+  const tenantId = cleanAccountingString(lease?.tenantId);
+  const responsibilityId = cleanAccountingString(lease?.responsibilityId);
+  const unit = receipts.unit!.records[0];
+  const tenant = receipts.tenant!.records[0];
+  if (unitId) {
+    if (!unit || cleanAccountingString(unit.unitId) !== unitId || cleanAccountingString(unit.propertyId) !== propertyId || cleanAccountingString(unit.landlordId) !== landlordId) reasons.add("PROVIDER_MAPPING_CONFLICT");
+  } else if (receipts.unit!.completenessState !== "empty_confirmed") reasons.add("PROVIDER_MAPPING_INCOMPLETE");
+  if (!tenantId || !tenant || cleanAccountingString(tenant.tenantId) !== tenantId || cleanAccountingString(tenant.leaseId) !== leaseId || !responsibilityId) reasons.add("PROVIDER_MAPPING_CONFLICT");
+  const labels = [property?.displayName, unitId ? unit?.displayName : "not_applicable", tenant?.displayName, lease?.responsibilityDisplayName].map((value) => cleanAccountingString(value));
+  if (labels.some((value) => !value)) reasons.add("PROVIDER_DISPLAY_LABEL_MISSING");
+  if ([propertyId, unitId, tenantId, responsibilityId].filter(Boolean).some((id) => labels.includes(id))) reasons.add("PROVIDER_DISPLAY_ID_FALLBACK_REJECTED");
+
+  const evidenceKeys = ["ledger", "payment", "paymentIntent", "reconciliation", "obligation", "allocation"] as const;
+  const records: LegacyReceivablesSourceRecord[] = [];
+  for (const key of evidenceKeys) {
+    const receipt = receipts[key]!;
+    const expectedKind = EXPECTED_KINDS[key];
+    if (receipt.records.some((record) => record.sourceKind !== expectedKind)) reasons.add("PROVIDER_EVIDENCE_KIND_MISMATCH");
+    records.push(...receipt.records);
+  }
+  const normalization = normalizeLegacyReceivablesSources({
+    landlordId, leaseId, propertyId: propertyId || "", tenantId,
+    tenantMappingState: "resolved", ownershipProof: { state: "independently_verified", landlordId, leaseId }, records,
+  });
+  if (normalization.sourceState !== "complete" || normalization.findings.some((finding) => finding.severity === "error")) reasons.add("PROVIDER_CANONICAL_NORMALIZATION_FAILED");
+  if (reasons.size || !propertyId || !tenantId || !responsibilityId) return result(reasons, acceptedCount, completeCount, emptyCount);
+
+  const batch = (key: typeof evidenceKeys[number]): ReceivablesSnapshotEvidenceBatch => ({
+    state: receipts[key]!.completenessState, records: receipts[key]!.records,
+  });
+  const snapshot = {
+    comparatorConfig: input.comparatorConfig,
+    ownership: { proofSource: "authoritative_lease", landlordId, leaseId, leaseLandlordId: landlordId, propertyId, propertyLandlordId: landlordId },
+    lease: {
+      ...lease, landlordId, leaseId, propertyId, unitId, tenantId, responsibilityId,
+      propertyDisplayName: cleanAccountingString(property.displayName),
+      unitDisplayName: unitId ? cleanAccountingString(unit!.displayName) : null,
+      tenantDisplayName: cleanAccountingString(tenant.displayName),
+      leaseMappingState: "resolved", propertyMappingState: "resolved",
+      unitMappingState: unitId ? "resolved" : "not_applicable", tenantMappingState: "resolved",
+    },
+    evidence: {
+      ledgerEntries: batch("ledger"), paymentRecords: batch("payment"), paymentIntents: batch("paymentIntent"),
+      reconciliationRecords: batch("reconciliation"), leaseObligations: batch("obligation"), allocationRecords: batch("allocation"),
+    },
+    legacyEffectsState: receipts.legacyEffects!.completenessState,
+    legacyEffects: receipts.legacyEffects!.records as readonly IndependentLegacySignedEffect[],
+    asOfDate: asOf.value, previewThroughDate: previewThrough.value,
+  };
+  return result(reasons, acceptedCount, completeCount, emptyCount, snapshot);
+}

--- a/rentchain-api/src/lib/accounting/receivablesAuthoritativeSourceProviderTypes.ts
+++ b/rentchain-api/src/lib/accounting/receivablesAuthoritativeSourceProviderTypes.ts
@@ -1,0 +1,117 @@
+import type { LegacyReceivablesSourceRecord } from "./legacyReceivablesSourceTypes";
+import type {
+  IndependentLegacySignedEffect,
+  ReceivablesSourceSnapshotAdapterInput,
+  ReceivablesSnapshotLeaseContext,
+} from "./receivablesSourceSnapshotTypes";
+
+export const RECEIVABLES_AUTHORITATIVE_SOURCE_PROVIDER_VERSION = "receivables_authoritative_source_provider_v1" as const;
+export const RECEIVABLES_AUTHORITATIVE_SOURCE_MANIFEST_VERSION = "receivables_authoritative_source_manifest_v1" as const;
+
+export type ReceivablesAuthoritativeSourceClass =
+  | "ownership" | "lease" | "property" | "unit" | "tenant"
+  | "ledger" | "payment" | "payment_intent" | "reconciliation" | "obligation" | "allocation"
+  | "legacy_effects";
+
+export type ReceivablesAuthoritativeCompletenessState =
+  | "complete" | "empty_confirmed" | "unknown" | "partial" | "ambiguous" | "unavailable";
+
+export type ReceivablesAuthoritativeReadReceipt<T> = {
+  sourceClass: ReceivablesAuthoritativeSourceClass | string;
+  sourceVersion: unknown;
+  readBoundaryVersion: unknown;
+  completenessState: ReceivablesAuthoritativeCompletenessState | string;
+  authoritative: unknown;
+  capped: unknown;
+  completenessProven: unknown;
+  postReadFiltered: unknown;
+  aliasOwnershipMapping: unknown;
+  catchToEmpty: unknown;
+  suitableForFinancialDiagnostics: unknown;
+  reasonCodes: readonly unknown[];
+  scope: { landlordId: unknown; leaseId: unknown; propertyId?: unknown };
+  records: readonly T[];
+};
+
+export type ReceivablesAuthoritativeOwnershipRecord = {
+  proofSource: unknown;
+  landlordId: unknown;
+  leaseId: unknown;
+  leaseLandlordId: unknown;
+  propertyId: unknown;
+  propertyLandlordId: unknown;
+};
+
+export type ReceivablesAuthoritativeLeaseRecord = ReceivablesSnapshotLeaseContext & {
+  canonicalLandlordId: unknown;
+  directDocument: unknown;
+  ownershipField: unknown;
+  ownershipAliasConflict: unknown;
+};
+
+export type ReceivablesAuthoritativePropertyRecord = {
+  propertyId: unknown;
+  landlordId: unknown;
+  displayName: unknown;
+};
+
+export type ReceivablesAuthoritativeUnitRecord = {
+  unitId: unknown;
+  propertyId: unknown;
+  landlordId: unknown;
+  displayName: unknown;
+};
+
+export type ReceivablesAuthoritativeTenantRecord = {
+  tenantId: unknown;
+  leaseId: unknown;
+  displayName: unknown;
+};
+
+export type ReceivablesAuthoritativeSourceProviderReceipts = {
+  ownership: ReceivablesAuthoritativeReadReceipt<ReceivablesAuthoritativeOwnershipRecord>;
+  lease: ReceivablesAuthoritativeReadReceipt<ReceivablesAuthoritativeLeaseRecord>;
+  property: ReceivablesAuthoritativeReadReceipt<ReceivablesAuthoritativePropertyRecord>;
+  unit: ReceivablesAuthoritativeReadReceipt<ReceivablesAuthoritativeUnitRecord>;
+  tenant: ReceivablesAuthoritativeReadReceipt<ReceivablesAuthoritativeTenantRecord>;
+  ledger: ReceivablesAuthoritativeReadReceipt<LegacyReceivablesSourceRecord>;
+  payment: ReceivablesAuthoritativeReadReceipt<LegacyReceivablesSourceRecord>;
+  paymentIntent: ReceivablesAuthoritativeReadReceipt<LegacyReceivablesSourceRecord>;
+  reconciliation: ReceivablesAuthoritativeReadReceipt<LegacyReceivablesSourceRecord>;
+  obligation: ReceivablesAuthoritativeReadReceipt<LegacyReceivablesSourceRecord>;
+  allocation: ReceivablesAuthoritativeReadReceipt<LegacyReceivablesSourceRecord>;
+  legacyEffects: ReceivablesAuthoritativeReadReceipt<IndependentLegacySignedEffect>;
+};
+
+export type BuildReceivablesAuthoritativeSourceInput = {
+  providerEnabled: unknown;
+  sourceManifestVersion: unknown;
+  target: { landlordId: unknown; leaseId: unknown; context: unknown };
+  comparatorConfig: ReceivablesSourceSnapshotAdapterInput["comparatorConfig"];
+  asOfDate: unknown;
+  previewThroughDate: unknown;
+  receipts?: Partial<ReceivablesAuthoritativeSourceProviderReceipts>;
+};
+
+export type ReceivablesAuthoritativeSourceProviderReasonCode =
+  | "PROVIDER_DISABLED" | "PROVIDER_MANIFEST_VERSION_MISMATCH" | "PROVIDER_TARGET_INVALID"
+  | "PROVIDER_RECEIPT_MISSING" | "PROVIDER_RECEIPT_CLASS_MISMATCH" | "PROVIDER_RECEIPT_VERSION_MISSING"
+  | "PROVIDER_READ_BOUNDARY_MISMATCH" | "PROVIDER_SOURCE_NOT_AUTHORITATIVE" | "PROVIDER_SOURCE_UNSUITABLE"
+  | "PROVIDER_SOURCE_ALIAS_REJECTED" | "PROVIDER_SOURCE_POST_FILTER_REJECTED" | "PROVIDER_SOURCE_CATCH_TO_EMPTY_REJECTED"
+  | "PROVIDER_SOURCE_CAPPED_INCOMPLETE" | "PROVIDER_SOURCE_INCOMPLETE" | "PROVIDER_SOURCE_STATE_CONFLICT"
+  | "PROVIDER_SCOPE_MISMATCH" | "PROVIDER_OWNERSHIP_MISSING" | "PROVIDER_OWNERSHIP_AMBIGUOUS"
+  | "PROVIDER_OWNERSHIP_UNVERIFIED" | "PROVIDER_MAPPING_INCOMPLETE" | "PROVIDER_MAPPING_AMBIGUOUS"
+  | "PROVIDER_MAPPING_CONFLICT" | "PROVIDER_DISPLAY_LABEL_MISSING" | "PROVIDER_DISPLAY_ID_FALLBACK_REJECTED"
+  | "PROVIDER_UNSAFE_SOURCE_DATA" | "PROVIDER_EVIDENCE_KIND_MISMATCH" | "PROVIDER_CANONICAL_NORMALIZATION_FAILED";
+
+export type ReceivablesAuthoritativeSourceProviderResult = {
+  providerCoreVersion: typeof RECEIVABLES_AUTHORITATIVE_SOURCE_PROVIDER_VERSION;
+  status: "safe" | "not_ready" | "ambiguous" | "unsafe";
+  reasonCodes: ReceivablesAuthoritativeSourceProviderReasonCode[];
+  warnings: string[];
+  ownershipProofSummary: { status: "verified" | "unverified" | "ambiguous"; method: "canonical_direct" | "none" };
+  sourceCompletenessSummary: { status: "complete" | "incomplete" | "ambiguous"; completeCount: number; emptyCount: number };
+  safeSnapshotInput: ReceivablesSourceSnapshotAdapterInput | null;
+  unsafeFieldSummary: { detected: boolean; categories: string[] };
+  receiptSummary: { requiredCount: number; acceptedCount: number; manifestVersion: typeof RECEIVABLES_AUTHORITATIVE_SOURCE_MANIFEST_VERSION };
+};


### PR DESCRIPTION
## Summary

- adds the Phase 0N pure, unmounted authoritative source-provider core
- adds twelve explicit injected read-receipt classes covering ownership, mappings, six Phase 0E evidence families, and independent legacy effects
- validates canonical ownership, exact scope, common read boundaries, source versions, completeness, caps, filtering, aliases, and catch-to-empty behavior
- preflights Phase 0E normalization to reject unlinked overlap and evidence that invents transactions
- emits a Phase 0I snapshot input only when every receipt is authoritative, safe, and complete

## Safety boundary

The provider core consumes injected receipts only. It has no Firestore adapter or read dependency and is not mounted, registered, scheduled, or invoked by runtime code.

- no Firestore SDK/import, reads, or writes
- no route, job, scheduler, queue, command, or frontend UI
- no production source provider
- no provider, Rotessa, PAD, bank-data, payment-mutation, or money-movement behavior
- no landlord-visible financial reads or existing ledger behavior change
- no RC1 behavior change

## Validation

- accounting suite: 12 files, 162 tests passed
- new provider-core coverage: 20 focused tests
- backend TypeScript production build passed with Node 20.20.2
- `git diff --check` passed
- `git diff --cached --check` passed
- forbidden dependency and scope scans passed
- changed files limited to five backend accounting files

## Manual QA

Not required because the provider core remains unmounted and has no user-visible or runtime effect.
