### PR TITLE
Add Phase 0R schema readiness classifier

### DIFF
--- a/rentchain-api/src/lib/accounting/__fixtures__/receivablesSchemaReadinessFixtures.ts
+++ b/rentchain-api/src/lib/accounting/__fixtures__/receivablesSchemaReadinessFixtures.ts
@@ -1,0 +1,87 @@
+import {
+  RECEIVABLES_SCHEMA_READINESS_EVIDENCE_VERSION,
+  type ClassifyReceivablesSchemaReadinessInput,
+  type ReceivablesReadinessEvidenceBase,
+} from "../receivablesSchemaReadinessTypes";
+
+const readyBase = (): ReceivablesReadinessEvidenceBase => ({
+  evidenceVersion: RECEIVABLES_SCHEMA_READINESS_EVIDENCE_VERSION,
+  state: "ready",
+  confirmed: true,
+  conflictsDetected: false,
+});
+
+export const completeReceivablesSchemaReadinessFixture: ClassifyReceivablesSchemaReadinessInput = {
+  checkedAt: "2026-07-19T12:00:00.000Z",
+  evidenceManifestVersion: RECEIVABLES_SCHEMA_READINESS_EVIDENCE_VERSION,
+  schema: {
+    ...readyBase(),
+    requiredCollectionsCovered: true,
+    supportedSchemaVersionsOnly: true,
+    canonicalOwnershipFieldsPresent: true,
+    canonicalMappingFieldsPresent: true,
+    sourceRevisionFieldsPresent: true,
+  },
+  indexes: {
+    ...readyBase(),
+    requiredIndexCount: 6,
+    readyIndexCount: 6,
+    exactQueryCoverageProven: true,
+    deployedIndexesReady: true,
+  },
+  iam: {
+    ...readyBase(),
+    dedicatedIdentityPresent: true,
+    readOnlyAccessProven: true,
+    writeAccessDenied: true,
+    privilegedAccessDenied: true,
+    longLivedKeysAbsent: true,
+    environmentBindingProven: true,
+  },
+  completeness: {
+    ...readyBase(),
+    exactScopeQueriesProven: true,
+    exhaustionProven: true,
+    catchToEmptyAbsent: true,
+    postReadFilteringAbsent: true,
+  },
+  consistentRead: {
+    ...readyBase(),
+    readBoundaryProtocolDefined: true,
+    crossSourceBoundaryProven: true,
+    concurrentChangeInvalidatesSnapshot: true,
+  },
+  pagination: {
+    ...readyBase(),
+    deterministicOrderingProven: true,
+    cursorProgressionProven: true,
+    capFailsClosed: true,
+    ambiguousCapHandling: false,
+  },
+  unsafeFieldExclusion: {
+    ...readyBase(),
+    allowlistProjectionProven: true,
+    restrictedFieldsExcluded: true,
+    safeLoggingProven: true,
+  },
+  rollout: {
+    ...readyBase(),
+    orderedGatesDefined: true,
+    defaultOffUntilVerified: true,
+    productionMutationDeferred: true,
+    operatorApprovalGatesDefined: true,
+  },
+  rollback: {
+    ...readyBase(),
+    phaseSpecificRollbackDefined: true,
+    appendSafeHistoryProtected: true,
+    broaderIdentityFallbackProhibited: true,
+  },
+  verification: {
+    ...readyBase(),
+    automatedTestsDefined: true,
+    negativePermissionTestsDefined: true,
+    productionSafetyChecksDefined: true,
+    postChangeVerificationDefined: true,
+  },
+};

--- a/rentchain-api/src/lib/accounting/__tests__/receivablesSchemaReadinessClassifier.test.ts
+++ b/rentchain-api/src/lib/accounting/__tests__/receivablesSchemaReadinessClassifier.test.ts
@@ -1,0 +1,137 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { completeReceivablesSchemaReadinessFixture } from "../__fixtures__/receivablesSchemaReadinessFixtures";
+import { classifyReceivablesSchemaReadiness } from "../receivablesSchemaReadinessClassifier";
+import type { ClassifyReceivablesSchemaReadinessInput } from "../receivablesSchemaReadinessTypes";
+
+const clone = <T>(value: T): T => structuredClone(value);
+const classify = (change?: (input: ClassifyReceivablesSchemaReadinessInput) => void) => {
+  const input = clone(completeReceivablesSchemaReadinessFixture);
+  change?.(input);
+  return classifyReceivablesSchemaReadiness(input);
+};
+
+describe("classifyReceivablesSchemaReadiness", () => {
+  it("returns ready for complete injected evidence", () => {
+    expect(classify()).toEqual({
+      ok: true,
+      readinessStatus: "ready",
+      phase: "phase_0r",
+      classifierVersion: "receivables_schema_readiness_classifier_v1",
+      reasonCodes: [],
+      warnings: [],
+      checkedAt: "2026-07-19T12:00:00.000Z",
+      requiredNextSteps: [],
+    });
+  });
+
+  it("fails closed when schema evidence is missing", () => {
+    const result = classify((input) => { delete input.schema; });
+    expect(result).toMatchObject({ ok: false, readinessStatus: "not_ready" });
+    expect(result.reasonCodes).toContain("READINESS_EVIDENCE_MISSING");
+  });
+
+  it("fails closed when canonical ownership fields are missing", () => {
+    const result = classify((input) => { input.schema!.canonicalOwnershipFieldsPresent = false; });
+    expect(result.reasonCodes).toContain("READINESS_SCHEMA_OWNERSHIP_FIELDS_MISSING");
+  });
+
+  it("fails closed when index evidence is missing", () => {
+    const result = classify((input) => { delete input.indexes; });
+    expect(result.reasonCodes).toContain("READINESS_EVIDENCE_MISSING");
+  });
+
+  it("returns partial for incomplete index coverage", () => {
+    const result = classify((input) => {
+      input.indexes!.state = "partial";
+      input.indexes!.readyIndexCount = 4;
+    });
+    expect(result.readinessStatus).toBe("partial");
+    expect(result.reasonCodes).toContain("READINESS_INDEX_COVERAGE_INCOMPLETE");
+  });
+
+  it("blocks a write-capable identity", () => {
+    const result = classify((input) => { input.iam!.writeAccessDenied = false; });
+    expect(result).toMatchObject({ ok: false, readinessStatus: "blocked" });
+    expect(result.reasonCodes).toContain("READINESS_IAM_WRITE_CAPABLE");
+  });
+
+  it("fails closed without completeness proof", () => {
+    const result = classify((input) => { input.completeness!.exhaustionProven = false; });
+    expect(result.reasonCodes).toContain("READINESS_COMPLETENESS_EXHAUSTION_UNPROVEN");
+  });
+
+  it("returns ambiguous when capped-query evidence is ambiguous", () => {
+    const result = classify((input) => {
+      input.pagination!.state = "ambiguous";
+      input.pagination!.ambiguousCapHandling = true;
+    });
+    expect(result.readinessStatus).toBe("ambiguous");
+    expect(result.reasonCodes).toContain("READINESS_PAGINATION_CAP_AMBIGUOUS");
+  });
+
+  it("fails closed without unsafe-field exclusion", () => {
+    const result = classify((input) => { input.unsafeFieldExclusion!.restrictedFieldsExcluded = false; });
+    expect(result.reasonCodes).toContain("READINESS_UNSAFE_FIELD_EXCLUSION_UNPROVEN");
+  });
+
+  it("fails closed without rollback and verification evidence", () => {
+    const result = classify((input) => {
+      input.rollback!.phaseSpecificRollbackDefined = false;
+      input.verification!.postChangeVerificationDefined = false;
+    });
+    expect(result.reasonCodes).toEqual(expect.arrayContaining([
+      "READINESS_ROLLBACK_PLAN_MISSING",
+      "READINESS_VERIFICATION_POST_CHANGE_MISSING",
+    ]));
+  });
+
+  it("fails closed for conflicting evidence", () => {
+    const result = classify((input) => { input.schema!.conflictsDetected = true; });
+    expect(result.readinessStatus).toBe("ambiguous");
+    expect(result.reasonCodes).toContain("READINESS_EVIDENCE_CONFLICT");
+  });
+
+  it("blocks unsafe evidence", () => {
+    const result = classify((input) => { input.unsafeFieldExclusion!.state = "unsafe"; });
+    expect(result.readinessStatus).toBe("blocked");
+    expect(result.reasonCodes).toContain("READINESS_EVIDENCE_UNSAFE");
+  });
+
+  it("returns sorted deterministic reason codes and next steps", () => {
+    const first = classify((input) => {
+      input.schema!.canonicalOwnershipFieldsPresent = false;
+      input.iam!.dedicatedIdentityPresent = false;
+    });
+    const second = classify((input) => {
+      input.schema!.canonicalOwnershipFieldsPresent = false;
+      input.iam!.dedicatedIdentityPresent = false;
+    });
+    expect(first).toEqual(second);
+    expect(first.reasonCodes).toEqual([...first.reasonCodes].sort());
+    expect(first.requiredNextSteps).toEqual([...first.requiredNextSteps].sort());
+  });
+
+  it("does not mutate injected evidence", () => {
+    const input = clone(completeReceivablesSchemaReadinessFixture);
+    const before = clone(input);
+    classifyReceivablesSchemaReadiness(input);
+    expect(input).toEqual(before);
+  });
+
+  it("keeps the output non-financial and scope-free", () => {
+    const serialized = JSON.stringify(classify()).toLowerCase();
+    for (const forbidden of [
+      "balance", "amount", "charge", "payment", "allocation", "rent roll", "aging",
+      "tenant", "landlord", "leaseid", "propertyid", "firestore", "storage", "bank", "provider",
+    ]) expect(serialized).not.toContain(forbidden);
+  });
+
+  it("has no Firestore, IAM, infrastructure, route, job, scheduler, provider, or runtime dependency", () => {
+    const source = readFileSync(new URL("../receivablesSchemaReadinessClassifier.ts", import.meta.url), "utf8").toLowerCase();
+    for (const forbidden of [
+      "firebase", "@google-cloud", "firestore", "terraform", "google_project_iam", "express",
+      "router", "cron", "scheduler", "pubsub", "rotessa", "stripe", "process.env", "../firebase",
+    ]) expect(source).not.toContain(forbidden);
+  });
+});

--- a/rentchain-api/src/lib/accounting/index.ts
+++ b/rentchain-api/src/lib/accounting/index.ts
@@ -16,3 +16,5 @@ export * from "./receivablesDiagnosticRunnerTypes";
 export * from "./receivablesDiagnosticRunnerCore";
 export * from "./receivablesAuthoritativeSourceProviderTypes";
 export * from "./receivablesAuthoritativeSourceProviderCore";
+export * from "./receivablesSchemaReadinessTypes";
+export * from "./receivablesSchemaReadinessClassifier";

--- a/rentchain-api/src/lib/accounting/receivablesSchemaReadinessClassifier.ts
+++ b/rentchain-api/src/lib/accounting/receivablesSchemaReadinessClassifier.ts
@@ -1,0 +1,222 @@
+import {
+  RECEIVABLES_SCHEMA_READINESS_CLASSIFIER_VERSION,
+  RECEIVABLES_SCHEMA_READINESS_EVIDENCE_VERSION,
+  RECEIVABLES_SCHEMA_READINESS_PHASE,
+  type ClassifyReceivablesSchemaReadinessInput,
+  type ReceivablesReadinessEvidenceBase,
+  type ReceivablesSchemaReadinessEvidenceState,
+  type ReceivablesSchemaReadinessReasonCode,
+  type ReceivablesSchemaReadinessResult,
+  type ReceivablesSchemaReadinessStatus,
+} from "./receivablesSchemaReadinessTypes";
+
+const EVIDENCE_KEYS = [
+  "schema",
+  "indexes",
+  "iam",
+  "completeness",
+  "consistentRead",
+  "pagination",
+  "unsafeFieldExclusion",
+  "rollout",
+  "rollback",
+  "verification",
+] as const;
+
+const VALID_STATES = new Set<ReceivablesSchemaReadinessEvidenceState>([
+  "ready",
+  "not_ready",
+  "partial",
+  "ambiguous",
+  "unsafe",
+]);
+
+const NEXT_STEP_BY_PREFIX: ReadonlyArray<readonly [string, string]> = [
+  ["READINESS_SCHEMA", "Resolve schema compatibility evidence."],
+  ["READINESS_INDEX", "Complete exact-query index readiness evidence."],
+  ["READINESS_IAM", "Prove the dedicated read-only identity boundary."],
+  ["READINESS_COMPLETENESS", "Complete source completeness proof."],
+  ["READINESS_CONSISTENCY", "Prove one consistent read boundary."],
+  ["READINESS_PAGINATION", "Complete pagination and cap handling proof."],
+  ["READINESS_UNSAFE_FIELD", "Prove restricted-field exclusion and safe logging."],
+  ["READINESS_ROLLOUT", "Resolve rollout sequencing and approval gates."],
+  ["READINESS_ROLLBACK", "Complete phase-specific rollback evidence."],
+  ["READINESS_VERIFICATION", "Complete automated and production verification evidence."],
+  ["READINESS_EVIDENCE", "Supply complete, compatible, conflict-free evidence."],
+  ["READINESS_MANIFEST", "Use the supported evidence manifest version."],
+  ["READINESS_CHECKED_AT", "Supply a valid deterministic check timestamp."],
+];
+
+function isoTimestamp(value: unknown): string | null {
+  if (typeof value !== "string" || !value.trim()) return null;
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) return null;
+  return new Date(parsed).toISOString();
+}
+
+function positiveInteger(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : null;
+}
+
+function requireTrue(value: unknown, code: ReceivablesSchemaReadinessReasonCode, reasons: Set<ReceivablesSchemaReadinessReasonCode>) {
+  if (value !== true) reasons.add(code);
+}
+
+function validateBase(
+  evidence: ReceivablesReadinessEvidenceBase,
+  reasons: Set<ReceivablesSchemaReadinessReasonCode>
+) {
+  if (evidence.evidenceVersion !== RECEIVABLES_SCHEMA_READINESS_EVIDENCE_VERSION) {
+    reasons.add("READINESS_EVIDENCE_VERSION_MISMATCH");
+  }
+  if (evidence.confirmed !== true) reasons.add("READINESS_EVIDENCE_UNCONFIRMED");
+  if (evidence.conflictsDetected === true) reasons.add("READINESS_EVIDENCE_CONFLICT");
+  if (!VALID_STATES.has(evidence.state as ReceivablesSchemaReadinessEvidenceState)) {
+    reasons.add("READINESS_EVIDENCE_STATE_INVALID");
+    return;
+  }
+  if (evidence.state === "not_ready") reasons.add("READINESS_EVIDENCE_NOT_READY");
+  if (evidence.state === "partial") reasons.add("READINESS_EVIDENCE_PARTIAL");
+  if (evidence.state === "ambiguous") reasons.add("READINESS_EVIDENCE_AMBIGUOUS");
+  if (evidence.state === "unsafe") reasons.add("READINESS_EVIDENCE_UNSAFE");
+}
+
+function readinessStatus(reasons: readonly ReceivablesSchemaReadinessReasonCode[]): ReceivablesSchemaReadinessStatus {
+  if (!reasons.length) return "ready";
+  if (
+    reasons.some((code) =>
+      code === "READINESS_EVIDENCE_UNSAFE" ||
+      code === "READINESS_IAM_WRITE_CAPABLE" ||
+      code === "READINESS_IAM_PRIVILEGED_ACCESS_PRESENT" ||
+      code === "READINESS_IAM_LONG_LIVED_KEY_PRESENT" ||
+      code === "READINESS_COMPLETENESS_CATCH_TO_EMPTY_PRESENT" ||
+      code === "READINESS_COMPLETENESS_POST_FILTER_PRESENT" ||
+      code === "READINESS_ROLLOUT_MUTATION_NOT_DEFERRED" ||
+      code === "READINESS_ROLLBACK_BROAD_IDENTITY_FALLBACK_ALLOWED"
+    )
+  ) return "blocked";
+  if (reasons.some((code) => code.includes("AMBIGUOUS") || code === "READINESS_EVIDENCE_CONFLICT")) return "ambiguous";
+  if (reasons.includes("READINESS_EVIDENCE_PARTIAL") || reasons.includes("READINESS_INDEX_COVERAGE_INCOMPLETE")) return "partial";
+  return "not_ready";
+}
+
+function nextSteps(reasonCodes: readonly ReceivablesSchemaReadinessReasonCode[]): string[] {
+  const steps = new Set<string>();
+  for (const reason of reasonCodes) {
+    const match = NEXT_STEP_BY_PREFIX.find(([prefix]) => reason.startsWith(prefix));
+    if (match) steps.add(match[1]);
+  }
+  return [...steps].sort();
+}
+
+export function classifyReceivablesSchemaReadiness(
+  input: ClassifyReceivablesSchemaReadinessInput
+): ReceivablesSchemaReadinessResult {
+  const reasons = new Set<ReceivablesSchemaReadinessReasonCode>();
+  const timestamp = isoTimestamp(input.checkedAt);
+  if (!timestamp) reasons.add("READINESS_CHECKED_AT_INVALID");
+  if (input.evidenceManifestVersion !== RECEIVABLES_SCHEMA_READINESS_EVIDENCE_VERSION) {
+    reasons.add("READINESS_MANIFEST_VERSION_MISMATCH");
+  }
+
+  for (const key of EVIDENCE_KEYS) {
+    const evidence = input[key];
+    if (!evidence) reasons.add("READINESS_EVIDENCE_MISSING");
+    else validateBase(evidence, reasons);
+  }
+
+  const schema = input.schema;
+  if (schema) {
+    requireTrue(schema.requiredCollectionsCovered, "READINESS_SCHEMA_COLLECTION_COVERAGE_MISSING", reasons);
+    requireTrue(schema.supportedSchemaVersionsOnly, "READINESS_SCHEMA_VERSION_UNSUPPORTED", reasons);
+    requireTrue(schema.canonicalOwnershipFieldsPresent, "READINESS_SCHEMA_OWNERSHIP_FIELDS_MISSING", reasons);
+    requireTrue(schema.canonicalMappingFieldsPresent, "READINESS_SCHEMA_MAPPING_FIELDS_MISSING", reasons);
+    requireTrue(schema.sourceRevisionFieldsPresent, "READINESS_SCHEMA_SOURCE_REVISION_MISSING", reasons);
+  }
+
+  const indexes = input.indexes;
+  if (indexes) {
+    const required = positiveInteger(indexes.requiredIndexCount);
+    const ready = positiveInteger(indexes.readyIndexCount);
+    if (required === null || ready === null || required === 0 || ready > required) reasons.add("READINESS_INDEX_COUNT_INVALID");
+    else if (ready !== required) reasons.add("READINESS_INDEX_COVERAGE_INCOMPLETE");
+    requireTrue(indexes.exactQueryCoverageProven, "READINESS_INDEX_EXACT_QUERY_UNPROVEN", reasons);
+    requireTrue(indexes.deployedIndexesReady, "READINESS_INDEX_DEPLOYMENT_UNREADY", reasons);
+  }
+
+  const iam = input.iam;
+  if (iam) {
+    requireTrue(iam.dedicatedIdentityPresent, "READINESS_IAM_IDENTITY_MISSING", reasons);
+    requireTrue(iam.readOnlyAccessProven, "READINESS_IAM_READ_ONLY_UNPROVEN", reasons);
+    if (iam.writeAccessDenied !== true) reasons.add("READINESS_IAM_WRITE_CAPABLE");
+    if (iam.privilegedAccessDenied !== true) reasons.add("READINESS_IAM_PRIVILEGED_ACCESS_PRESENT");
+    if (iam.longLivedKeysAbsent !== true) reasons.add("READINESS_IAM_LONG_LIVED_KEY_PRESENT");
+    requireTrue(iam.environmentBindingProven, "READINESS_IAM_ENVIRONMENT_BINDING_UNPROVEN", reasons);
+  }
+
+  const completeness = input.completeness;
+  if (completeness) {
+    requireTrue(completeness.exactScopeQueriesProven, "READINESS_COMPLETENESS_EXACT_SCOPE_UNPROVEN", reasons);
+    requireTrue(completeness.exhaustionProven, "READINESS_COMPLETENESS_EXHAUSTION_UNPROVEN", reasons);
+    if (completeness.catchToEmptyAbsent !== true) reasons.add("READINESS_COMPLETENESS_CATCH_TO_EMPTY_PRESENT");
+    if (completeness.postReadFilteringAbsent !== true) reasons.add("READINESS_COMPLETENESS_POST_FILTER_PRESENT");
+  }
+
+  const consistentRead = input.consistentRead;
+  if (consistentRead) {
+    requireTrue(consistentRead.readBoundaryProtocolDefined, "READINESS_CONSISTENCY_PROTOCOL_MISSING", reasons);
+    requireTrue(consistentRead.crossSourceBoundaryProven, "READINESS_CONSISTENCY_BOUNDARY_UNPROVEN", reasons);
+    requireTrue(consistentRead.concurrentChangeInvalidatesSnapshot, "READINESS_CONSISTENCY_CONCURRENT_CHANGE_UNSAFE", reasons);
+  }
+
+  const pagination = input.pagination;
+  if (pagination) {
+    requireTrue(pagination.deterministicOrderingProven, "READINESS_PAGINATION_ORDER_UNPROVEN", reasons);
+    requireTrue(pagination.cursorProgressionProven, "READINESS_PAGINATION_CURSOR_UNPROVEN", reasons);
+    requireTrue(pagination.capFailsClosed, "READINESS_PAGINATION_CAP_FAIL_CLOSED_UNPROVEN", reasons);
+    if (pagination.ambiguousCapHandling !== false) reasons.add("READINESS_PAGINATION_CAP_AMBIGUOUS");
+  }
+
+  const unsafeFields = input.unsafeFieldExclusion;
+  if (unsafeFields) {
+    requireTrue(unsafeFields.allowlistProjectionProven, "READINESS_UNSAFE_FIELD_ALLOWLIST_UNPROVEN", reasons);
+    requireTrue(unsafeFields.restrictedFieldsExcluded, "READINESS_UNSAFE_FIELD_EXCLUSION_UNPROVEN", reasons);
+    requireTrue(unsafeFields.safeLoggingProven, "READINESS_SAFE_LOGGING_UNPROVEN", reasons);
+  }
+
+  const rollout = input.rollout;
+  if (rollout) {
+    requireTrue(rollout.orderedGatesDefined, "READINESS_ROLLOUT_ORDER_AMBIGUOUS", reasons);
+    requireTrue(rollout.defaultOffUntilVerified, "READINESS_ROLLOUT_DEFAULT_OFF_UNPROVEN", reasons);
+    if (rollout.productionMutationDeferred !== true) reasons.add("READINESS_ROLLOUT_MUTATION_NOT_DEFERRED");
+    requireTrue(rollout.operatorApprovalGatesDefined, "READINESS_ROLLOUT_APPROVAL_GATES_MISSING", reasons);
+  }
+
+  const rollback = input.rollback;
+  if (rollback) {
+    requireTrue(rollback.phaseSpecificRollbackDefined, "READINESS_ROLLBACK_PLAN_MISSING", reasons);
+    requireTrue(rollback.appendSafeHistoryProtected, "READINESS_ROLLBACK_APPEND_SAFETY_UNPROVEN", reasons);
+    if (rollback.broaderIdentityFallbackProhibited !== true) reasons.add("READINESS_ROLLBACK_BROAD_IDENTITY_FALLBACK_ALLOWED");
+  }
+
+  const verification = input.verification;
+  if (verification) {
+    requireTrue(verification.automatedTestsDefined, "READINESS_VERIFICATION_AUTOMATION_MISSING", reasons);
+    requireTrue(verification.negativePermissionTestsDefined, "READINESS_VERIFICATION_NEGATIVE_PERMISSION_MISSING", reasons);
+    requireTrue(verification.productionSafetyChecksDefined, "READINESS_VERIFICATION_PRODUCTION_SAFETY_MISSING", reasons);
+    requireTrue(verification.postChangeVerificationDefined, "READINESS_VERIFICATION_POST_CHANGE_MISSING", reasons);
+  }
+
+  const reasonCodes = [...reasons].sort();
+  const status = readinessStatus(reasonCodes);
+  return {
+    ok: status === "ready",
+    readinessStatus: status,
+    phase: RECEIVABLES_SCHEMA_READINESS_PHASE,
+    classifierVersion: RECEIVABLES_SCHEMA_READINESS_CLASSIFIER_VERSION,
+    reasonCodes,
+    warnings: status === "ready" ? [] : ["Future source-adapter planning remains gated."],
+    checkedAt: timestamp,
+    requiredNextSteps: nextSteps(reasonCodes),
+  };
+}

--- a/rentchain-api/src/lib/accounting/receivablesSchemaReadinessTypes.ts
+++ b/rentchain-api/src/lib/accounting/receivablesSchemaReadinessTypes.ts
@@ -1,0 +1,168 @@
+export const RECEIVABLES_SCHEMA_READINESS_CLASSIFIER_VERSION = "receivables_schema_readiness_classifier_v1" as const;
+export const RECEIVABLES_SCHEMA_READINESS_EVIDENCE_VERSION = "receivables_schema_readiness_evidence_v1" as const;
+export const RECEIVABLES_SCHEMA_READINESS_PHASE = "phase_0r" as const;
+
+export type ReceivablesSchemaReadinessEvidenceState =
+  | "ready"
+  | "not_ready"
+  | "partial"
+  | "ambiguous"
+  | "unsafe";
+
+export type ReceivablesSchemaReadinessStatus = "ready" | "not_ready" | "partial" | "blocked" | "ambiguous";
+
+export type ReceivablesReadinessEvidenceBase = {
+  evidenceVersion: unknown;
+  state: ReceivablesSchemaReadinessEvidenceState | string;
+  confirmed: unknown;
+  conflictsDetected: unknown;
+};
+
+export type ReceivablesSchemaEvidence = ReceivablesReadinessEvidenceBase & {
+  requiredCollectionsCovered: unknown;
+  supportedSchemaVersionsOnly: unknown;
+  canonicalOwnershipFieldsPresent: unknown;
+  canonicalMappingFieldsPresent: unknown;
+  sourceRevisionFieldsPresent: unknown;
+};
+
+export type ReceivablesIndexEvidence = ReceivablesReadinessEvidenceBase & {
+  requiredIndexCount: unknown;
+  readyIndexCount: unknown;
+  exactQueryCoverageProven: unknown;
+  deployedIndexesReady: unknown;
+};
+
+export type ReceivablesIamEvidence = ReceivablesReadinessEvidenceBase & {
+  dedicatedIdentityPresent: unknown;
+  readOnlyAccessProven: unknown;
+  writeAccessDenied: unknown;
+  privilegedAccessDenied: unknown;
+  longLivedKeysAbsent: unknown;
+  environmentBindingProven: unknown;
+};
+
+export type ReceivablesCompletenessEvidence = ReceivablesReadinessEvidenceBase & {
+  exactScopeQueriesProven: unknown;
+  exhaustionProven: unknown;
+  catchToEmptyAbsent: unknown;
+  postReadFilteringAbsent: unknown;
+};
+
+export type ReceivablesConsistentReadEvidence = ReceivablesReadinessEvidenceBase & {
+  readBoundaryProtocolDefined: unknown;
+  crossSourceBoundaryProven: unknown;
+  concurrentChangeInvalidatesSnapshot: unknown;
+};
+
+export type ReceivablesPaginationEvidence = ReceivablesReadinessEvidenceBase & {
+  deterministicOrderingProven: unknown;
+  cursorProgressionProven: unknown;
+  capFailsClosed: unknown;
+  ambiguousCapHandling: unknown;
+};
+
+export type ReceivablesUnsafeFieldEvidence = ReceivablesReadinessEvidenceBase & {
+  allowlistProjectionProven: unknown;
+  restrictedFieldsExcluded: unknown;
+  safeLoggingProven: unknown;
+};
+
+export type ReceivablesRolloutEvidence = ReceivablesReadinessEvidenceBase & {
+  orderedGatesDefined: unknown;
+  defaultOffUntilVerified: unknown;
+  productionMutationDeferred: unknown;
+  operatorApprovalGatesDefined: unknown;
+};
+
+export type ReceivablesRollbackEvidence = ReceivablesReadinessEvidenceBase & {
+  phaseSpecificRollbackDefined: unknown;
+  appendSafeHistoryProtected: unknown;
+  broaderIdentityFallbackProhibited: unknown;
+};
+
+export type ReceivablesVerificationEvidence = ReceivablesReadinessEvidenceBase & {
+  automatedTestsDefined: unknown;
+  negativePermissionTestsDefined: unknown;
+  productionSafetyChecksDefined: unknown;
+  postChangeVerificationDefined: unknown;
+};
+
+export type ClassifyReceivablesSchemaReadinessInput = {
+  checkedAt: unknown;
+  evidenceManifestVersion: unknown;
+  schema?: ReceivablesSchemaEvidence;
+  indexes?: ReceivablesIndexEvidence;
+  iam?: ReceivablesIamEvidence;
+  completeness?: ReceivablesCompletenessEvidence;
+  consistentRead?: ReceivablesConsistentReadEvidence;
+  pagination?: ReceivablesPaginationEvidence;
+  unsafeFieldExclusion?: ReceivablesUnsafeFieldEvidence;
+  rollout?: ReceivablesRolloutEvidence;
+  rollback?: ReceivablesRollbackEvidence;
+  verification?: ReceivablesVerificationEvidence;
+};
+
+export type ReceivablesSchemaReadinessReasonCode =
+  | "READINESS_MANIFEST_VERSION_MISMATCH"
+  | "READINESS_CHECKED_AT_INVALID"
+  | "READINESS_EVIDENCE_MISSING"
+  | "READINESS_EVIDENCE_VERSION_MISMATCH"
+  | "READINESS_EVIDENCE_UNCONFIRMED"
+  | "READINESS_EVIDENCE_STATE_INVALID"
+  | "READINESS_EVIDENCE_NOT_READY"
+  | "READINESS_EVIDENCE_PARTIAL"
+  | "READINESS_EVIDENCE_AMBIGUOUS"
+  | "READINESS_EVIDENCE_UNSAFE"
+  | "READINESS_EVIDENCE_CONFLICT"
+  | "READINESS_SCHEMA_COLLECTION_COVERAGE_MISSING"
+  | "READINESS_SCHEMA_VERSION_UNSUPPORTED"
+  | "READINESS_SCHEMA_OWNERSHIP_FIELDS_MISSING"
+  | "READINESS_SCHEMA_MAPPING_FIELDS_MISSING"
+  | "READINESS_SCHEMA_SOURCE_REVISION_MISSING"
+  | "READINESS_INDEX_COUNT_INVALID"
+  | "READINESS_INDEX_COVERAGE_INCOMPLETE"
+  | "READINESS_INDEX_EXACT_QUERY_UNPROVEN"
+  | "READINESS_INDEX_DEPLOYMENT_UNREADY"
+  | "READINESS_IAM_IDENTITY_MISSING"
+  | "READINESS_IAM_READ_ONLY_UNPROVEN"
+  | "READINESS_IAM_WRITE_CAPABLE"
+  | "READINESS_IAM_PRIVILEGED_ACCESS_PRESENT"
+  | "READINESS_IAM_LONG_LIVED_KEY_PRESENT"
+  | "READINESS_IAM_ENVIRONMENT_BINDING_UNPROVEN"
+  | "READINESS_COMPLETENESS_EXACT_SCOPE_UNPROVEN"
+  | "READINESS_COMPLETENESS_EXHAUSTION_UNPROVEN"
+  | "READINESS_COMPLETENESS_CATCH_TO_EMPTY_PRESENT"
+  | "READINESS_COMPLETENESS_POST_FILTER_PRESENT"
+  | "READINESS_CONSISTENCY_PROTOCOL_MISSING"
+  | "READINESS_CONSISTENCY_BOUNDARY_UNPROVEN"
+  | "READINESS_CONSISTENCY_CONCURRENT_CHANGE_UNSAFE"
+  | "READINESS_PAGINATION_ORDER_UNPROVEN"
+  | "READINESS_PAGINATION_CURSOR_UNPROVEN"
+  | "READINESS_PAGINATION_CAP_FAIL_CLOSED_UNPROVEN"
+  | "READINESS_PAGINATION_CAP_AMBIGUOUS"
+  | "READINESS_UNSAFE_FIELD_ALLOWLIST_UNPROVEN"
+  | "READINESS_UNSAFE_FIELD_EXCLUSION_UNPROVEN"
+  | "READINESS_SAFE_LOGGING_UNPROVEN"
+  | "READINESS_ROLLOUT_ORDER_AMBIGUOUS"
+  | "READINESS_ROLLOUT_DEFAULT_OFF_UNPROVEN"
+  | "READINESS_ROLLOUT_MUTATION_NOT_DEFERRED"
+  | "READINESS_ROLLOUT_APPROVAL_GATES_MISSING"
+  | "READINESS_ROLLBACK_PLAN_MISSING"
+  | "READINESS_ROLLBACK_APPEND_SAFETY_UNPROVEN"
+  | "READINESS_ROLLBACK_BROAD_IDENTITY_FALLBACK_ALLOWED"
+  | "READINESS_VERIFICATION_AUTOMATION_MISSING"
+  | "READINESS_VERIFICATION_NEGATIVE_PERMISSION_MISSING"
+  | "READINESS_VERIFICATION_PRODUCTION_SAFETY_MISSING"
+  | "READINESS_VERIFICATION_POST_CHANGE_MISSING";
+
+export type ReceivablesSchemaReadinessResult = {
+  ok: boolean;
+  readinessStatus: ReceivablesSchemaReadinessStatus;
+  phase: typeof RECEIVABLES_SCHEMA_READINESS_PHASE;
+  classifierVersion: typeof RECEIVABLES_SCHEMA_READINESS_CLASSIFIER_VERSION;
+  reasonCodes: ReceivablesSchemaReadinessReasonCode[];
+  warnings: string[];
+  checkedAt: string | null;
+  requiredNextSteps: string[];
+};


### PR DESCRIPTION
## Summary

- Adds the Phase 0R backend-only receivables schema-readiness classifier.
- Adds injected evidence contracts for schema, indexes, IAM/read-only identity, completeness, consistent reads, pagination, unsafe-field exclusion, rollout, rollback, and verification.
- Adds deterministic ready, not-ready, partial, ambiguous, and blocked classification with sorted reason codes and non-financial next steps.
- Adds focused fixtures and tests for success and every required fail-closed boundary.
- Exports the classifier through the existing accounting barrel.

## Safety boundaries

- Pure and unmounted; injected evidence only
- No Firestore adapter, Firestore reads, or Firestore writes
- No indexes, IAM, infrastructure, CI, or deployment changes
- No route, job, scheduler, CLI, frontend, or runtime invocation
- No provider integration, Rotessa/PAD, payment mutation, bank data, or money movement
- No financial totals or internal scope identifiers in classifier output
- No existing ledger or RC1 behavior changes
- Direct-settlement model and landlord-revenue boundary preserved

## Validation

- New focused classifier suite: 16 tests passed
- Complete accounting suite: 13 files, 178 tests passed
- Backend production TypeScript build passed with Node 20.20.2
- `git diff --check` passed
- `git diff --cached --check` passed
- Forbidden dependency and protected-scope scans passed
- Changed files limited to five backend accounting files

Manual QA is not required because the classifier remains unmounted and has no user-visible effect.
