### PR TITLE
Add Phase 0U schema inventory command core

### DIFF
--- a/rentchain-api/src/lib/accounting/__fixtures__/receivablesSchemaInventoryCommandFixtures.ts
+++ b/rentchain-api/src/lib/accounting/__fixtures__/receivablesSchemaInventoryCommandFixtures.ts
@@ -1,0 +1,89 @@
+import {
+  RECEIVABLES_SCHEMA_INVENTORY_CLAIM_SCOPE,
+  RECEIVABLES_SCHEMA_INVENTORY_RECEIPT_VERSION,
+  type ReceivablesSchemaInventoryReceiptBase,
+  type RunReceivablesSchemaInventoryCommandInput,
+} from "../receivablesSchemaInventoryCommandTypes";
+
+const readyBase = (): ReceivablesSchemaInventoryReceiptBase => ({
+  receiptVersion: RECEIVABLES_SCHEMA_INVENTORY_RECEIPT_VERSION,
+  state: "ready",
+  confirmed: true,
+  conflictsDetected: false,
+  claimScope: RECEIVABLES_SCHEMA_INVENTORY_CLAIM_SCOPE,
+});
+
+export const completeReceivablesSchemaInventoryCommandFixture: RunReceivablesSchemaInventoryCommandInput = {
+  checkedAt: "2026-07-20T12:00:00.000Z",
+  receiptManifestVersion: RECEIVABLES_SCHEMA_INVENTORY_RECEIPT_VERSION,
+  schema: {
+    ...readyBase(),
+    requiredSourcesCovered: true,
+    supportedVersionsOnly: true,
+    canonicalOwnershipPresent: true,
+    canonicalMappingsPresent: true,
+    sourceRevisionsPresent: true,
+  },
+  indexes: {
+    ...readyBase(),
+    requiredCount: 6,
+    attestedReadyCount: 6,
+    exactQueryCoverageAttested: true,
+    targetStateAttested: true,
+  },
+  iam: {
+    ...readyBase(),
+    dedicatedIdentityAttested: true,
+    shortLivedIdentityAttested: true,
+    readOnlyAttested: true,
+    writeDeniedAttested: true,
+    privilegedAccessDeniedAttested: true,
+    environmentBindingAttested: true,
+  },
+  completeness: {
+    ...readyBase(),
+    exactScopeAttested: true,
+    exhaustionAttested: true,
+    catchToEmptyAbsent: true,
+    postReadFilteringAbsent: true,
+  },
+  consistency: {
+    ...readyBase(),
+    boundaryProtocolAttested: true,
+    crossSourceBoundaryAttested: true,
+    concurrentChangeInvalidates: true,
+  },
+  pagination: {
+    ...readyBase(),
+    deterministicOrderingAttested: true,
+    cursorProgressionAttested: true,
+    capFailsClosed: true,
+    capHandlingAmbiguous: false,
+  },
+  unsafeFieldExclusion: {
+    ...readyBase(),
+    allowlistProjectionAttested: true,
+    restrictedFieldsExcluded: true,
+    safeOutputAttested: true,
+  },
+  rollout: {
+    ...readyBase(),
+    orderedGatesAttested: true,
+    defaultOffAttested: true,
+    mutationDeferred: true,
+    operatorApprovalRequired: true,
+  },
+  rollback: {
+    ...readyBase(),
+    rollbackPlanAttested: true,
+    appendSafeHistoryProtected: true,
+    broaderIdentityFallbackProhibited: true,
+  },
+  verification: {
+    ...readyBase(),
+    automatedTestsAttested: true,
+    negativePermissionTestsAttested: true,
+    controlledContextChecksAttested: true,
+    postChangeChecksAttested: true,
+  },
+};

--- a/rentchain-api/src/lib/accounting/__tests__/receivablesSchemaInventoryCommandCore.test.ts
+++ b/rentchain-api/src/lib/accounting/__tests__/receivablesSchemaInventoryCommandCore.test.ts
@@ -1,0 +1,173 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { completeReceivablesSchemaInventoryCommandFixture } from "../__fixtures__/receivablesSchemaInventoryCommandFixtures";
+import { runReceivablesSchemaInventoryCommandCore } from "../receivablesSchemaInventoryCommandCore";
+import type { RunReceivablesSchemaInventoryCommandInput } from "../receivablesSchemaInventoryCommandTypes";
+
+const clone = <T>(value: T): T => structuredClone(value);
+const run = (change?: (input: RunReceivablesSchemaInventoryCommandInput) => void) => {
+  const input = clone(completeReceivablesSchemaInventoryCommandFixture);
+  change?.(input);
+  return runReceivablesSchemaInventoryCommandCore(input);
+};
+
+describe("runReceivablesSchemaInventoryCommandCore", () => {
+  it("returns only ready_for_next_audit for complete safe injected receipts", () => {
+    expect(run()).toEqual({
+      ok: true,
+      inventoryStatus: "ready_for_next_audit",
+      commandCoreVersion: "receivables_schema_inventory_command_core_v1",
+      phase: "phase_0u",
+      reasonCodes: [],
+      warnings: ["Injected receipts support next-audit discussion only."],
+      checkedAt: "2026-07-20T12:00:00.000Z",
+      requiredNextSteps: [],
+      receiptSummary: {
+        required: 10,
+        received: 10,
+        ready: 10,
+        notReady: 0,
+        partial: 0,
+        ambiguous: 0,
+        unsafe: 0,
+      },
+    });
+  });
+
+  it.each([
+    ["schema", "INVENTORY_RECEIPT_MISSING"],
+    ["indexes", "INVENTORY_RECEIPT_MISSING"],
+    ["iam", "INVENTORY_RECEIPT_MISSING"],
+    ["completeness", "INVENTORY_RECEIPT_MISSING"],
+    ["consistency", "INVENTORY_RECEIPT_MISSING"],
+    ["pagination", "INVENTORY_RECEIPT_MISSING"],
+    ["unsafeFieldExclusion", "INVENTORY_RECEIPT_MISSING"],
+    ["rollout", "INVENTORY_RECEIPT_MISSING"],
+    ["rollback", "INVENTORY_RECEIPT_MISSING"],
+    ["verification", "INVENTORY_RECEIPT_MISSING"],
+  ] as const)("fails closed when the %s receipt is missing", (key, reason) => {
+    const result = run((input) => { delete input[key]; });
+    expect(result).toMatchObject({ ok: false, inventoryStatus: "not_ready" });
+    expect(result.reasonCodes).toContain(reason);
+    expect(result.receiptSummary.received).toBe(9);
+  });
+
+  it("returns partial for a partial receipt set", () => {
+    const result = run((input) => {
+      input.indexes!.state = "partial";
+      input.indexes!.attestedReadyCount = 4;
+    });
+    expect(result.inventoryStatus).toBe("partial");
+    expect(result.reasonCodes).toContain("INVENTORY_INDEX_COVERAGE_INCOMPLETE");
+    expect(result.receiptSummary.partial).toBe(1);
+  });
+
+  it("blocks write-capable IAM evidence", () => {
+    const result = run((input) => { input.iam!.writeDeniedAttested = false; });
+    expect(result).toMatchObject({ ok: false, inventoryStatus: "blocked" });
+    expect(result.reasonCodes).toContain("INVENTORY_IAM_WRITE_CAPABLE");
+  });
+
+  it("fails closed without completeness proof", () => {
+    const result = run((input) => { input.completeness!.exhaustionAttested = false; });
+    expect(result.inventoryStatus).toBe("not_ready");
+    expect(result.reasonCodes).toContain("INVENTORY_COMPLETENESS_EXHAUSTION_UNPROVEN");
+  });
+
+  it("fails closed without consistency proof", () => {
+    const result = run((input) => { input.consistency!.crossSourceBoundaryAttested = false; });
+    expect(result.reasonCodes).toContain("INVENTORY_CONSISTENCY_BOUNDARY_UNPROVEN");
+  });
+
+  it("returns ambiguous for ambiguous capped-query evidence", () => {
+    const result = run((input) => {
+      input.pagination!.state = "ambiguous";
+      input.pagination!.capHandlingAmbiguous = true;
+    });
+    expect(result.inventoryStatus).toBe("ambiguous");
+    expect(result.reasonCodes).toContain("INVENTORY_PAGINATION_CAP_AMBIGUOUS");
+  });
+
+  it("fails closed without unsafe-field exclusion", () => {
+    const result = run((input) => { input.unsafeFieldExclusion!.restrictedFieldsExcluded = false; });
+    expect(result.reasonCodes).toContain("INVENTORY_UNSAFE_FIELD_EXCLUSION_UNPROVEN");
+  });
+
+  it("fails closed without rollout, rollback, and verification proof", () => {
+    const result = run((input) => {
+      input.rollout!.orderedGatesAttested = false;
+      input.rollback!.rollbackPlanAttested = false;
+      input.verification!.postChangeChecksAttested = false;
+    });
+    expect(result.reasonCodes).toEqual(expect.arrayContaining([
+      "INVENTORY_ROLLOUT_ORDER_UNPROVEN",
+      "INVENTORY_ROLLBACK_PLAN_MISSING",
+      "INVENTORY_VERIFICATION_POST_CHANGE_MISSING",
+    ]));
+  });
+
+  it("fails closed for contradictory receipts", () => {
+    const result = run((input) => { input.schema!.conflictsDetected = true; });
+    expect(result.inventoryStatus).toBe("ambiguous");
+    expect(result.reasonCodes).toContain("INVENTORY_RECEIPT_CONTRADICTORY");
+  });
+
+  it("blocks unsafe receipts", () => {
+    const result = run((input) => { input.schema!.state = "unsafe"; });
+    expect(result.inventoryStatus).toBe("blocked");
+    expect(result.reasonCodes).toContain("INVENTORY_RECEIPT_UNSAFE");
+  });
+
+  it.each([
+    "ready_for_production",
+    "ready_for_adapter",
+    "ready_for_deployment",
+    "ready_for_runtime_reads",
+  ])("rejects the unsupported operational claim %s", (claimScope) => {
+    const result = run((input) => { input.schema!.claimScope = claimScope; });
+    expect(result.inventoryStatus).toBe("blocked");
+    expect(result.reasonCodes).toContain("INVENTORY_OPERATIONAL_CLAIM_REJECTED");
+  });
+
+  it("returns sorted deterministic reasons and next steps", () => {
+    const first = run((input) => {
+      input.schema!.canonicalOwnershipPresent = false;
+      input.iam!.dedicatedIdentityAttested = false;
+    });
+    const second = run((input) => {
+      input.schema!.canonicalOwnershipPresent = false;
+      input.iam!.dedicatedIdentityAttested = false;
+    });
+    expect(first).toEqual(second);
+    expect(first.reasonCodes).toEqual([...first.reasonCodes].sort());
+    expect(first.requiredNextSteps).toEqual([...first.requiredNextSteps].sort());
+  });
+
+  it("does not mutate injected receipts", () => {
+    const input = clone(completeReceivablesSchemaInventoryCommandFixture);
+    const before = clone(input);
+    runReceivablesSchemaInventoryCommandCore(input);
+    expect(input).toEqual(before);
+  });
+
+  it("keeps output non-financial, scope-free, and infrastructure-free", () => {
+    const serialized = JSON.stringify(run()).toLowerCase();
+    for (const forbidden of [
+      "balance", "amount", "charge", "payment", "allocation", "rent roll", "aging",
+      "schedule", "tenant", "landlord", "leaseid", "propertyid", "firestore", "storage",
+      "bank", "credential", "secret", "provider", "environment", "scopekey",
+    ]) expect(serialized).not.toContain(forbidden);
+  });
+
+  it("uses injected evidence only and has no runtime dependency", () => {
+    const source = readFileSync(
+      new URL("../receivablesSchemaInventoryCommandCore.ts", import.meta.url),
+      "utf8"
+    ).toLowerCase();
+    for (const forbidden of [
+      "firebase", "@google-cloud", "firestore", "terraform", "process.env", "process.argv",
+      "express", "router", "cron", "scheduler", "pubsub", "rotessa", "stripe",
+      "readfilesync", "writefilesync", "fetch(", "axios", "child_process",
+    ]) expect(source).not.toContain(forbidden);
+  });
+});

--- a/rentchain-api/src/lib/accounting/index.ts
+++ b/rentchain-api/src/lib/accounting/index.ts
@@ -18,3 +18,5 @@ export * from "./receivablesAuthoritativeSourceProviderTypes";
 export * from "./receivablesAuthoritativeSourceProviderCore";
 export * from "./receivablesSchemaReadinessTypes";
 export * from "./receivablesSchemaReadinessClassifier";
+export * from "./receivablesSchemaInventoryCommandTypes";
+export * from "./receivablesSchemaInventoryCommandCore";

--- a/rentchain-api/src/lib/accounting/receivablesSchemaInventoryCommandCore.ts
+++ b/rentchain-api/src/lib/accounting/receivablesSchemaInventoryCommandCore.ts
@@ -1,0 +1,279 @@
+import {
+  RECEIVABLES_SCHEMA_INVENTORY_CLAIM_SCOPE,
+  RECEIVABLES_SCHEMA_INVENTORY_COMMAND_CORE_VERSION,
+  RECEIVABLES_SCHEMA_INVENTORY_PHASE,
+  RECEIVABLES_SCHEMA_INVENTORY_RECEIPT_VERSION,
+  type ReceivablesSchemaInventoryCommandResult,
+  type ReceivablesSchemaInventoryReasonCode,
+  type ReceivablesSchemaInventoryReceiptBase,
+  type ReceivablesSchemaInventoryReceiptState,
+  type ReceivablesSchemaInventoryReceiptSummary,
+  type ReceivablesSchemaInventoryStatus,
+  type RunReceivablesSchemaInventoryCommandInput,
+} from "./receivablesSchemaInventoryCommandTypes";
+
+const RECEIPT_KEYS = [
+  "schema",
+  "indexes",
+  "iam",
+  "completeness",
+  "consistency",
+  "pagination",
+  "unsafeFieldExclusion",
+  "rollout",
+  "rollback",
+  "verification",
+] as const;
+
+const VALID_STATES = new Set<ReceivablesSchemaInventoryReceiptState>([
+  "ready",
+  "not_ready",
+  "partial",
+  "ambiguous",
+  "unsafe",
+]);
+
+const NEXT_STEP_BY_PREFIX: ReadonlyArray<readonly [string, string]> = [
+  ["INVENTORY_SCHEMA", "Resolve schema receipt evidence."],
+  ["INVENTORY_INDEX", "Complete index receipt evidence."],
+  ["INVENTORY_IAM", "Resolve read-only identity receipt evidence."],
+  ["INVENTORY_COMPLETENESS", "Complete source exhaustion evidence."],
+  ["INVENTORY_CONSISTENCY", "Resolve consistent-boundary evidence."],
+  ["INVENTORY_PAGINATION", "Resolve pagination and cap evidence."],
+  ["INVENTORY_UNSAFE_FIELD", "Prove restricted-field exclusion."],
+  ["INVENTORY_SAFE_OUTPUT", "Prove bounded output safety."],
+  ["INVENTORY_ROLLOUT", "Complete controlled rollout evidence."],
+  ["INVENTORY_ROLLBACK", "Complete rollback evidence."],
+  ["INVENTORY_VERIFICATION", "Complete verification evidence."],
+  ["INVENTORY_OPERATIONAL", "Remove unsupported operational claims."],
+  ["INVENTORY_RECEIPT", "Supply complete and consistent receipts."],
+  ["INVENTORY_MANIFEST", "Use the supported receipt manifest."],
+  ["INVENTORY_CHECKED_AT", "Supply a valid check timestamp."],
+];
+
+function isoTimestamp(value: unknown): string | null {
+  if (typeof value !== "string" || !value.trim()) return null;
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) return null;
+  return new Date(parsed).toISOString();
+}
+
+function nonNegativeInteger(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : null;
+}
+
+function requireTrue(
+  value: unknown,
+  code: ReceivablesSchemaInventoryReasonCode,
+  reasons: Set<ReceivablesSchemaInventoryReasonCode>
+) {
+  if (value !== true) reasons.add(code);
+}
+
+function validateBase(
+  receipt: ReceivablesSchemaInventoryReceiptBase,
+  reasons: Set<ReceivablesSchemaInventoryReasonCode>
+) {
+  if (receipt.receiptVersion !== RECEIVABLES_SCHEMA_INVENTORY_RECEIPT_VERSION) {
+    reasons.add("INVENTORY_RECEIPT_VERSION_MISMATCH");
+  }
+  if (receipt.confirmed !== true) reasons.add("INVENTORY_RECEIPT_UNCONFIRMED");
+  if (receipt.conflictsDetected === true) reasons.add("INVENTORY_RECEIPT_CONTRADICTORY");
+  if (receipt.claimScope !== RECEIVABLES_SCHEMA_INVENTORY_CLAIM_SCOPE) {
+    reasons.add("INVENTORY_OPERATIONAL_CLAIM_REJECTED");
+  }
+  if (!VALID_STATES.has(receipt.state as ReceivablesSchemaInventoryReceiptState)) {
+    reasons.add("INVENTORY_RECEIPT_STATE_INVALID");
+    return;
+  }
+  if (receipt.state === "not_ready") reasons.add("INVENTORY_RECEIPT_NOT_READY");
+  if (receipt.state === "partial") reasons.add("INVENTORY_RECEIPT_PARTIAL");
+  if (receipt.state === "ambiguous") reasons.add("INVENTORY_RECEIPT_AMBIGUOUS");
+  if (receipt.state === "unsafe") reasons.add("INVENTORY_RECEIPT_UNSAFE");
+}
+
+function receiptSummary(input: RunReceivablesSchemaInventoryCommandInput): ReceivablesSchemaInventoryReceiptSummary {
+  const summary: ReceivablesSchemaInventoryReceiptSummary = {
+    required: RECEIPT_KEYS.length,
+    received: 0,
+    ready: 0,
+    notReady: 0,
+    partial: 0,
+    ambiguous: 0,
+    unsafe: 0,
+  };
+  for (const key of RECEIPT_KEYS) {
+    const receipt = input[key];
+    if (!receipt) continue;
+    summary.received += 1;
+    if (receipt.state === "ready") summary.ready += 1;
+    else if (receipt.state === "not_ready") summary.notReady += 1;
+    else if (receipt.state === "partial") summary.partial += 1;
+    else if (receipt.state === "ambiguous") summary.ambiguous += 1;
+    else if (receipt.state === "unsafe") summary.unsafe += 1;
+  }
+  return summary;
+}
+
+function inventoryStatus(reasons: readonly ReceivablesSchemaInventoryReasonCode[]): ReceivablesSchemaInventoryStatus {
+  if (!reasons.length) return "ready_for_next_audit";
+  if (
+    reasons.some((code) =>
+      code === "INVENTORY_RECEIPT_UNSAFE" ||
+      code === "INVENTORY_OPERATIONAL_CLAIM_REJECTED" ||
+      code === "INVENTORY_IAM_WRITE_CAPABLE" ||
+      code === "INVENTORY_IAM_PRIVILEGED_ACCESS_PRESENT" ||
+      code === "INVENTORY_COMPLETENESS_CATCH_TO_EMPTY_PRESENT" ||
+      code === "INVENTORY_COMPLETENESS_POST_FILTER_PRESENT" ||
+      code === "INVENTORY_ROLLOUT_MUTATION_NOT_DEFERRED" ||
+      code === "INVENTORY_ROLLBACK_BROAD_IDENTITY_FALLBACK_ALLOWED"
+    )
+  ) return "blocked";
+  if (
+    reasons.some((code) =>
+      code === "INVENTORY_RECEIPT_AMBIGUOUS" ||
+      code === "INVENTORY_RECEIPT_CONTRADICTORY" ||
+      code === "INVENTORY_PAGINATION_CAP_AMBIGUOUS"
+    )
+  ) return "ambiguous";
+  if (
+    reasons.includes("INVENTORY_RECEIPT_PARTIAL") ||
+    reasons.includes("INVENTORY_INDEX_COVERAGE_INCOMPLETE")
+  ) return "partial";
+  return "not_ready";
+}
+
+function nextSteps(reasonCodes: readonly ReceivablesSchemaInventoryReasonCode[]): string[] {
+  const steps = new Set<string>();
+  for (const reason of reasonCodes) {
+    const match = NEXT_STEP_BY_PREFIX.find(([prefix]) => reason.startsWith(prefix));
+    if (match) steps.add(match[1]);
+  }
+  return [...steps].sort();
+}
+
+export function runReceivablesSchemaInventoryCommandCore(
+  input: RunReceivablesSchemaInventoryCommandInput
+): ReceivablesSchemaInventoryCommandResult {
+  const reasons = new Set<ReceivablesSchemaInventoryReasonCode>();
+  const checkedAt = isoTimestamp(input.checkedAt);
+  if (!checkedAt) reasons.add("INVENTORY_CHECKED_AT_INVALID");
+  if (input.receiptManifestVersion !== RECEIVABLES_SCHEMA_INVENTORY_RECEIPT_VERSION) {
+    reasons.add("INVENTORY_MANIFEST_VERSION_MISMATCH");
+  }
+
+  for (const key of RECEIPT_KEYS) {
+    const receipt = input[key];
+    if (!receipt) reasons.add("INVENTORY_RECEIPT_MISSING");
+    else validateBase(receipt, reasons);
+  }
+
+  const schema = input.schema;
+  if (schema) {
+    requireTrue(schema.requiredSourcesCovered, "INVENTORY_SCHEMA_SOURCE_COVERAGE_MISSING", reasons);
+    requireTrue(schema.supportedVersionsOnly, "INVENTORY_SCHEMA_VERSION_UNSUPPORTED", reasons);
+    requireTrue(schema.canonicalOwnershipPresent, "INVENTORY_SCHEMA_OWNERSHIP_MISSING", reasons);
+    requireTrue(schema.canonicalMappingsPresent, "INVENTORY_SCHEMA_MAPPING_MISSING", reasons);
+    requireTrue(schema.sourceRevisionsPresent, "INVENTORY_SCHEMA_REVISION_MISSING", reasons);
+  }
+
+  const indexes = input.indexes;
+  if (indexes) {
+    const required = nonNegativeInteger(indexes.requiredCount);
+    const ready = nonNegativeInteger(indexes.attestedReadyCount);
+    if (required === null || ready === null || required === 0 || ready > required) {
+      reasons.add("INVENTORY_INDEX_COUNT_INVALID");
+    } else if (ready !== required) {
+      reasons.add("INVENTORY_INDEX_COVERAGE_INCOMPLETE");
+    }
+    requireTrue(indexes.exactQueryCoverageAttested, "INVENTORY_INDEX_QUERY_ATTESTATION_MISSING", reasons);
+    requireTrue(indexes.targetStateAttested, "INVENTORY_INDEX_TARGET_ATTESTATION_MISSING", reasons);
+  }
+
+  const iam = input.iam;
+  if (iam) {
+    requireTrue(iam.dedicatedIdentityAttested, "INVENTORY_IAM_IDENTITY_MISSING", reasons);
+    requireTrue(iam.shortLivedIdentityAttested, "INVENTORY_IAM_SHORT_LIVED_UNPROVEN", reasons);
+    requireTrue(iam.readOnlyAttested, "INVENTORY_IAM_READ_ONLY_UNPROVEN", reasons);
+    if (iam.writeDeniedAttested !== true) reasons.add("INVENTORY_IAM_WRITE_CAPABLE");
+    if (iam.privilegedAccessDeniedAttested !== true) reasons.add("INVENTORY_IAM_PRIVILEGED_ACCESS_PRESENT");
+    requireTrue(iam.environmentBindingAttested, "INVENTORY_IAM_ENVIRONMENT_BINDING_UNPROVEN", reasons);
+  }
+
+  const completeness = input.completeness;
+  if (completeness) {
+    requireTrue(completeness.exactScopeAttested, "INVENTORY_COMPLETENESS_EXACT_SCOPE_UNPROVEN", reasons);
+    requireTrue(completeness.exhaustionAttested, "INVENTORY_COMPLETENESS_EXHAUSTION_UNPROVEN", reasons);
+    if (completeness.catchToEmptyAbsent !== true) reasons.add("INVENTORY_COMPLETENESS_CATCH_TO_EMPTY_PRESENT");
+    if (completeness.postReadFilteringAbsent !== true) reasons.add("INVENTORY_COMPLETENESS_POST_FILTER_PRESENT");
+  }
+
+  const consistency = input.consistency;
+  if (consistency) {
+    requireTrue(consistency.boundaryProtocolAttested, "INVENTORY_CONSISTENCY_PROTOCOL_MISSING", reasons);
+    requireTrue(consistency.crossSourceBoundaryAttested, "INVENTORY_CONSISTENCY_BOUNDARY_UNPROVEN", reasons);
+    requireTrue(consistency.concurrentChangeInvalidates, "INVENTORY_CONSISTENCY_CONCURRENT_CHANGE_UNSAFE", reasons);
+  }
+
+  const pagination = input.pagination;
+  if (pagination) {
+    requireTrue(pagination.deterministicOrderingAttested, "INVENTORY_PAGINATION_ORDER_UNPROVEN", reasons);
+    requireTrue(pagination.cursorProgressionAttested, "INVENTORY_PAGINATION_CURSOR_UNPROVEN", reasons);
+    requireTrue(pagination.capFailsClosed, "INVENTORY_PAGINATION_CAP_FAIL_CLOSED_UNPROVEN", reasons);
+    if (pagination.capHandlingAmbiguous !== false) reasons.add("INVENTORY_PAGINATION_CAP_AMBIGUOUS");
+  }
+
+  const unsafeFields = input.unsafeFieldExclusion;
+  if (unsafeFields) {
+    requireTrue(unsafeFields.allowlistProjectionAttested, "INVENTORY_UNSAFE_FIELD_ALLOWLIST_UNPROVEN", reasons);
+    requireTrue(unsafeFields.restrictedFieldsExcluded, "INVENTORY_UNSAFE_FIELD_EXCLUSION_UNPROVEN", reasons);
+    requireTrue(unsafeFields.safeOutputAttested, "INVENTORY_SAFE_OUTPUT_UNPROVEN", reasons);
+  }
+
+  const rollout = input.rollout;
+  if (rollout) {
+    requireTrue(rollout.orderedGatesAttested, "INVENTORY_ROLLOUT_ORDER_UNPROVEN", reasons);
+    requireTrue(rollout.defaultOffAttested, "INVENTORY_ROLLOUT_DEFAULT_OFF_UNPROVEN", reasons);
+    if (rollout.mutationDeferred !== true) reasons.add("INVENTORY_ROLLOUT_MUTATION_NOT_DEFERRED");
+    requireTrue(rollout.operatorApprovalRequired, "INVENTORY_ROLLOUT_APPROVAL_MISSING", reasons);
+  }
+
+  const rollback = input.rollback;
+  if (rollback) {
+    requireTrue(rollback.rollbackPlanAttested, "INVENTORY_ROLLBACK_PLAN_MISSING", reasons);
+    requireTrue(rollback.appendSafeHistoryProtected, "INVENTORY_ROLLBACK_APPEND_SAFETY_UNPROVEN", reasons);
+    if (rollback.broaderIdentityFallbackProhibited !== true) {
+      reasons.add("INVENTORY_ROLLBACK_BROAD_IDENTITY_FALLBACK_ALLOWED");
+    }
+  }
+
+  const verification = input.verification;
+  if (verification) {
+    requireTrue(verification.automatedTestsAttested, "INVENTORY_VERIFICATION_AUTOMATION_MISSING", reasons);
+    requireTrue(
+      verification.negativePermissionTestsAttested,
+      "INVENTORY_VERIFICATION_NEGATIVE_PERMISSION_MISSING",
+      reasons
+    );
+    requireTrue(
+      verification.controlledContextChecksAttested,
+      "INVENTORY_VERIFICATION_CONTROLLED_CONTEXT_MISSING",
+      reasons
+    );
+    requireTrue(verification.postChangeChecksAttested, "INVENTORY_VERIFICATION_POST_CHANGE_MISSING", reasons);
+  }
+
+  const reasonCodes = [...reasons].sort();
+  const status = inventoryStatus(reasonCodes);
+  return {
+    ok: status === "ready_for_next_audit",
+    inventoryStatus: status,
+    commandCoreVersion: RECEIVABLES_SCHEMA_INVENTORY_COMMAND_CORE_VERSION,
+    phase: RECEIVABLES_SCHEMA_INVENTORY_PHASE,
+    reasonCodes,
+    warnings: ["Injected receipts support next-audit discussion only."],
+    checkedAt,
+    requiredNextSteps: nextSteps(reasonCodes),
+    receiptSummary: receiptSummary(input),
+  };
+}

--- a/rentchain-api/src/lib/accounting/receivablesSchemaInventoryCommandTypes.ts
+++ b/rentchain-api/src/lib/accounting/receivablesSchemaInventoryCommandTypes.ts
@@ -1,0 +1,189 @@
+export const RECEIVABLES_SCHEMA_INVENTORY_COMMAND_CORE_VERSION =
+  "receivables_schema_inventory_command_core_v1" as const;
+export const RECEIVABLES_SCHEMA_INVENTORY_RECEIPT_VERSION =
+  "receivables_schema_inventory_receipt_v1" as const;
+export const RECEIVABLES_SCHEMA_INVENTORY_PHASE = "phase_0u" as const;
+export const RECEIVABLES_SCHEMA_INVENTORY_CLAIM_SCOPE = "next_audit_only" as const;
+
+export type ReceivablesSchemaInventoryReceiptState =
+  | "ready"
+  | "not_ready"
+  | "partial"
+  | "ambiguous"
+  | "unsafe";
+
+export type ReceivablesSchemaInventoryStatus =
+  | "ready_for_next_audit"
+  | "not_ready"
+  | "partial"
+  | "blocked"
+  | "ambiguous";
+
+export type ReceivablesSchemaInventoryReceiptBase = {
+  receiptVersion: unknown;
+  state: ReceivablesSchemaInventoryReceiptState | string;
+  confirmed: unknown;
+  conflictsDetected: unknown;
+  claimScope: unknown;
+};
+
+export type ReceivablesSchemaInventorySchemaReceipt = ReceivablesSchemaInventoryReceiptBase & {
+  requiredSourcesCovered: unknown;
+  supportedVersionsOnly: unknown;
+  canonicalOwnershipPresent: unknown;
+  canonicalMappingsPresent: unknown;
+  sourceRevisionsPresent: unknown;
+};
+
+export type ReceivablesSchemaInventoryIndexReceipt = ReceivablesSchemaInventoryReceiptBase & {
+  requiredCount: unknown;
+  attestedReadyCount: unknown;
+  exactQueryCoverageAttested: unknown;
+  targetStateAttested: unknown;
+};
+
+export type ReceivablesSchemaInventoryIamReceipt = ReceivablesSchemaInventoryReceiptBase & {
+  dedicatedIdentityAttested: unknown;
+  shortLivedIdentityAttested: unknown;
+  readOnlyAttested: unknown;
+  writeDeniedAttested: unknown;
+  privilegedAccessDeniedAttested: unknown;
+  environmentBindingAttested: unknown;
+};
+
+export type ReceivablesSchemaInventoryCompletenessReceipt = ReceivablesSchemaInventoryReceiptBase & {
+  exactScopeAttested: unknown;
+  exhaustionAttested: unknown;
+  catchToEmptyAbsent: unknown;
+  postReadFilteringAbsent: unknown;
+};
+
+export type ReceivablesSchemaInventoryConsistencyReceipt = ReceivablesSchemaInventoryReceiptBase & {
+  boundaryProtocolAttested: unknown;
+  crossSourceBoundaryAttested: unknown;
+  concurrentChangeInvalidates: unknown;
+};
+
+export type ReceivablesSchemaInventoryPaginationReceipt = ReceivablesSchemaInventoryReceiptBase & {
+  deterministicOrderingAttested: unknown;
+  cursorProgressionAttested: unknown;
+  capFailsClosed: unknown;
+  capHandlingAmbiguous: unknown;
+};
+
+export type ReceivablesSchemaInventoryUnsafeFieldReceipt = ReceivablesSchemaInventoryReceiptBase & {
+  allowlistProjectionAttested: unknown;
+  restrictedFieldsExcluded: unknown;
+  safeOutputAttested: unknown;
+};
+
+export type ReceivablesSchemaInventoryRolloutReceipt = ReceivablesSchemaInventoryReceiptBase & {
+  orderedGatesAttested: unknown;
+  defaultOffAttested: unknown;
+  mutationDeferred: unknown;
+  operatorApprovalRequired: unknown;
+};
+
+export type ReceivablesSchemaInventoryRollbackReceipt = ReceivablesSchemaInventoryReceiptBase & {
+  rollbackPlanAttested: unknown;
+  appendSafeHistoryProtected: unknown;
+  broaderIdentityFallbackProhibited: unknown;
+};
+
+export type ReceivablesSchemaInventoryVerificationReceipt = ReceivablesSchemaInventoryReceiptBase & {
+  automatedTestsAttested: unknown;
+  negativePermissionTestsAttested: unknown;
+  controlledContextChecksAttested: unknown;
+  postChangeChecksAttested: unknown;
+};
+
+export type RunReceivablesSchemaInventoryCommandInput = {
+  checkedAt: unknown;
+  receiptManifestVersion: unknown;
+  schema?: ReceivablesSchemaInventorySchemaReceipt;
+  indexes?: ReceivablesSchemaInventoryIndexReceipt;
+  iam?: ReceivablesSchemaInventoryIamReceipt;
+  completeness?: ReceivablesSchemaInventoryCompletenessReceipt;
+  consistency?: ReceivablesSchemaInventoryConsistencyReceipt;
+  pagination?: ReceivablesSchemaInventoryPaginationReceipt;
+  unsafeFieldExclusion?: ReceivablesSchemaInventoryUnsafeFieldReceipt;
+  rollout?: ReceivablesSchemaInventoryRolloutReceipt;
+  rollback?: ReceivablesSchemaInventoryRollbackReceipt;
+  verification?: ReceivablesSchemaInventoryVerificationReceipt;
+};
+
+export type ReceivablesSchemaInventoryReasonCode =
+  | "INVENTORY_MANIFEST_VERSION_MISMATCH"
+  | "INVENTORY_CHECKED_AT_INVALID"
+  | "INVENTORY_RECEIPT_MISSING"
+  | "INVENTORY_RECEIPT_VERSION_MISMATCH"
+  | "INVENTORY_RECEIPT_UNCONFIRMED"
+  | "INVENTORY_RECEIPT_STATE_INVALID"
+  | "INVENTORY_RECEIPT_NOT_READY"
+  | "INVENTORY_RECEIPT_PARTIAL"
+  | "INVENTORY_RECEIPT_AMBIGUOUS"
+  | "INVENTORY_RECEIPT_UNSAFE"
+  | "INVENTORY_RECEIPT_CONTRADICTORY"
+  | "INVENTORY_OPERATIONAL_CLAIM_REJECTED"
+  | "INVENTORY_SCHEMA_SOURCE_COVERAGE_MISSING"
+  | "INVENTORY_SCHEMA_VERSION_UNSUPPORTED"
+  | "INVENTORY_SCHEMA_OWNERSHIP_MISSING"
+  | "INVENTORY_SCHEMA_MAPPING_MISSING"
+  | "INVENTORY_SCHEMA_REVISION_MISSING"
+  | "INVENTORY_INDEX_COUNT_INVALID"
+  | "INVENTORY_INDEX_COVERAGE_INCOMPLETE"
+  | "INVENTORY_INDEX_QUERY_ATTESTATION_MISSING"
+  | "INVENTORY_INDEX_TARGET_ATTESTATION_MISSING"
+  | "INVENTORY_IAM_IDENTITY_MISSING"
+  | "INVENTORY_IAM_SHORT_LIVED_UNPROVEN"
+  | "INVENTORY_IAM_READ_ONLY_UNPROVEN"
+  | "INVENTORY_IAM_WRITE_CAPABLE"
+  | "INVENTORY_IAM_PRIVILEGED_ACCESS_PRESENT"
+  | "INVENTORY_IAM_ENVIRONMENT_BINDING_UNPROVEN"
+  | "INVENTORY_COMPLETENESS_EXACT_SCOPE_UNPROVEN"
+  | "INVENTORY_COMPLETENESS_EXHAUSTION_UNPROVEN"
+  | "INVENTORY_COMPLETENESS_CATCH_TO_EMPTY_PRESENT"
+  | "INVENTORY_COMPLETENESS_POST_FILTER_PRESENT"
+  | "INVENTORY_CONSISTENCY_PROTOCOL_MISSING"
+  | "INVENTORY_CONSISTENCY_BOUNDARY_UNPROVEN"
+  | "INVENTORY_CONSISTENCY_CONCURRENT_CHANGE_UNSAFE"
+  | "INVENTORY_PAGINATION_ORDER_UNPROVEN"
+  | "INVENTORY_PAGINATION_CURSOR_UNPROVEN"
+  | "INVENTORY_PAGINATION_CAP_FAIL_CLOSED_UNPROVEN"
+  | "INVENTORY_PAGINATION_CAP_AMBIGUOUS"
+  | "INVENTORY_UNSAFE_FIELD_ALLOWLIST_UNPROVEN"
+  | "INVENTORY_UNSAFE_FIELD_EXCLUSION_UNPROVEN"
+  | "INVENTORY_SAFE_OUTPUT_UNPROVEN"
+  | "INVENTORY_ROLLOUT_ORDER_UNPROVEN"
+  | "INVENTORY_ROLLOUT_DEFAULT_OFF_UNPROVEN"
+  | "INVENTORY_ROLLOUT_MUTATION_NOT_DEFERRED"
+  | "INVENTORY_ROLLOUT_APPROVAL_MISSING"
+  | "INVENTORY_ROLLBACK_PLAN_MISSING"
+  | "INVENTORY_ROLLBACK_APPEND_SAFETY_UNPROVEN"
+  | "INVENTORY_ROLLBACK_BROAD_IDENTITY_FALLBACK_ALLOWED"
+  | "INVENTORY_VERIFICATION_AUTOMATION_MISSING"
+  | "INVENTORY_VERIFICATION_NEGATIVE_PERMISSION_MISSING"
+  | "INVENTORY_VERIFICATION_CONTROLLED_CONTEXT_MISSING"
+  | "INVENTORY_VERIFICATION_POST_CHANGE_MISSING";
+
+export type ReceivablesSchemaInventoryReceiptSummary = {
+  required: number;
+  received: number;
+  ready: number;
+  notReady: number;
+  partial: number;
+  ambiguous: number;
+  unsafe: number;
+};
+
+export type ReceivablesSchemaInventoryCommandResult = {
+  ok: boolean;
+  inventoryStatus: ReceivablesSchemaInventoryStatus;
+  commandCoreVersion: typeof RECEIVABLES_SCHEMA_INVENTORY_COMMAND_CORE_VERSION;
+  phase: typeof RECEIVABLES_SCHEMA_INVENTORY_PHASE;
+  reasonCodes: ReceivablesSchemaInventoryReasonCode[];
+  warnings: string[];
+  checkedAt: string | null;
+  requiredNextSteps: string[];
+  receiptSummary: ReceivablesSchemaInventoryReceiptSummary;
+};


### PR DESCRIPTION
## Summary

- adds the Phase 0U pure schema-inventory command core
- adds ten injected evidence receipt contracts covering schema, indexes, IAM, completeness, consistency, pagination, unsafe-field exclusion, rollout, rollback, and verification
- adds a deterministic non-financial inventory envelope and bounded receipt summary
- adds fail-closed validation for missing, partial, ambiguous, unsafe, contradictory, write-capable, and unsupported-claim evidence
- rejects production, adapter, deployment, and runtime-read readiness claims

## Boundary

The core is backend-only, pure, unmounted, and invoked only from tests. Even complete receipts produce only `ready_for_next_audit`; they do not establish operational readiness.

No Firestore imports or reads/writes, CLI, environment access, route, job, scheduler, UI, index, infrastructure, IAM change, provider integration, payment mutation, money movement, bank data, landlord-visible financial output, or RC1 behavior change is included.

The direct-settlement model and landlord-revenue boundary remain preserved. Tenant rent is not modeled as RentChain revenue.

## Validation

- new focused tests: 28/28 passed
- complete accounting suite: 14 files, 206 tests passed
- backend production TypeScript build passed with Node 20.20.2
- `git diff --check` passed
- `git diff --cached --check` passed before commit
- forbidden dependency, runtime invocation, output, and protected-scope scans passed
- changed files limited to five backend accounting core/type/fixture/test/export files

Manual QA is not required because the core remains unmounted and has no user-visible behavior.
