### PR TITLE
Add Phase 0W schema inventory local command

### DIFF
--- a/rentchain-api/src/lib/accounting/__fixtures__/schemaInventorySanitizedReceipts.unsafe.json
+++ b/rentchain-api/src/lib/accounting/__fixtures__/schemaInventorySanitizedReceipts.unsafe.json
@@ -1,0 +1,17 @@
+{
+  "checkedAt": "2026-07-20T12:00:00.000Z",
+  "receiptManifestVersion": "receivables_schema_inventory_receipt_v1",
+  "schema": {
+    "receiptVersion": "receivables_schema_inventory_receipt_v1",
+    "state": "ready",
+    "confirmed": true,
+    "conflictsDetected": false,
+    "claimScope": "next_audit_only",
+    "requiredSourcesCovered": true,
+    "supportedVersionsOnly": true,
+    "canonicalOwnershipPresent": true,
+    "canonicalMappingsPresent": true,
+    "sourceRevisionsPresent": true,
+    "firestorePath": "restricted/sample"
+  }
+}

--- a/rentchain-api/src/lib/accounting/__fixtures__/schemaInventorySanitizedReceipts.valid.json
+++ b/rentchain-api/src/lib/accounting/__fixtures__/schemaInventorySanitizedReceipts.valid.json
@@ -1,0 +1,114 @@
+{
+  "checkedAt": "2026-07-20T12:00:00.000Z",
+  "receiptManifestVersion": "receivables_schema_inventory_receipt_v1",
+  "schema": {
+    "receiptVersion": "receivables_schema_inventory_receipt_v1",
+    "state": "ready",
+    "confirmed": true,
+    "conflictsDetected": false,
+    "claimScope": "next_audit_only",
+    "requiredSourcesCovered": true,
+    "supportedVersionsOnly": true,
+    "canonicalOwnershipPresent": true,
+    "canonicalMappingsPresent": true,
+    "sourceRevisionsPresent": true
+  },
+  "indexes": {
+    "receiptVersion": "receivables_schema_inventory_receipt_v1",
+    "state": "ready",
+    "confirmed": true,
+    "conflictsDetected": false,
+    "claimScope": "next_audit_only",
+    "requiredCount": 6,
+    "attestedReadyCount": 6,
+    "exactQueryCoverageAttested": true,
+    "targetStateAttested": true
+  },
+  "iam": {
+    "receiptVersion": "receivables_schema_inventory_receipt_v1",
+    "state": "ready",
+    "confirmed": true,
+    "conflictsDetected": false,
+    "claimScope": "next_audit_only",
+    "dedicatedIdentityAttested": true,
+    "shortLivedIdentityAttested": true,
+    "readOnlyAttested": true,
+    "writeDeniedAttested": true,
+    "privilegedAccessDeniedAttested": true,
+    "environmentBindingAttested": true
+  },
+  "completeness": {
+    "receiptVersion": "receivables_schema_inventory_receipt_v1",
+    "state": "ready",
+    "confirmed": true,
+    "conflictsDetected": false,
+    "claimScope": "next_audit_only",
+    "exactScopeAttested": true,
+    "exhaustionAttested": true,
+    "catchToEmptyAbsent": true,
+    "postReadFilteringAbsent": true
+  },
+  "consistency": {
+    "receiptVersion": "receivables_schema_inventory_receipt_v1",
+    "state": "ready",
+    "confirmed": true,
+    "conflictsDetected": false,
+    "claimScope": "next_audit_only",
+    "boundaryProtocolAttested": true,
+    "crossSourceBoundaryAttested": true,
+    "concurrentChangeInvalidates": true
+  },
+  "pagination": {
+    "receiptVersion": "receivables_schema_inventory_receipt_v1",
+    "state": "ready",
+    "confirmed": true,
+    "conflictsDetected": false,
+    "claimScope": "next_audit_only",
+    "deterministicOrderingAttested": true,
+    "cursorProgressionAttested": true,
+    "capFailsClosed": true,
+    "capHandlingAmbiguous": false
+  },
+  "unsafeFieldExclusion": {
+    "receiptVersion": "receivables_schema_inventory_receipt_v1",
+    "state": "ready",
+    "confirmed": true,
+    "conflictsDetected": false,
+    "claimScope": "next_audit_only",
+    "allowlistProjectionAttested": true,
+    "restrictedFieldsExcluded": true,
+    "safeOutputAttested": true
+  },
+  "rollout": {
+    "receiptVersion": "receivables_schema_inventory_receipt_v1",
+    "state": "ready",
+    "confirmed": true,
+    "conflictsDetected": false,
+    "claimScope": "next_audit_only",
+    "orderedGatesAttested": true,
+    "defaultOffAttested": true,
+    "mutationDeferred": true,
+    "operatorApprovalRequired": true
+  },
+  "rollback": {
+    "receiptVersion": "receivables_schema_inventory_receipt_v1",
+    "state": "ready",
+    "confirmed": true,
+    "conflictsDetected": false,
+    "claimScope": "next_audit_only",
+    "rollbackPlanAttested": true,
+    "appendSafeHistoryProtected": true,
+    "broaderIdentityFallbackProhibited": true
+  },
+  "verification": {
+    "receiptVersion": "receivables_schema_inventory_receipt_v1",
+    "state": "ready",
+    "confirmed": true,
+    "conflictsDetected": false,
+    "claimScope": "next_audit_only",
+    "automatedTestsAttested": true,
+    "negativePermissionTestsAttested": true,
+    "controlledContextChecksAttested": true,
+    "postChangeChecksAttested": true
+  }
+}

--- a/rentchain-api/src/lib/accounting/__tests__/receivablesSchemaInventoryLocalCommand.test.ts
+++ b/rentchain-api/src/lib/accounting/__tests__/receivablesSchemaInventoryLocalCommand.test.ts
@@ -1,0 +1,241 @@
+import {
+  copyFileSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { runReceivablesSchemaInventoryLocalCommand } from "../receivablesSchemaInventoryLocalCommand";
+import {
+  RECEIVABLES_SCHEMA_INVENTORY_LOCAL_COMMAND_MAX_BYTES,
+  ReceivablesSchemaInventoryLocalCommandError,
+} from "../receivablesSchemaInventoryLocalCommandTypes";
+
+const validFixture = new URL(
+  "../__fixtures__/schemaInventorySanitizedReceipts.valid.json",
+  import.meta.url
+);
+const unsafeFixture = new URL(
+  "../__fixtures__/schemaInventorySanitizedReceipts.unsafe.json",
+  import.meta.url
+);
+const temporaryRoots: string[] = [];
+
+function temporaryRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "rentchain-schema-inventory-"));
+  temporaryRoots.push(root);
+  return root;
+}
+
+function copyFixture(root: string, source = validFixture, name = "receipts.json"): string {
+  const fixtureDirectory = join(root, "inputs");
+  mkdirSync(fixtureDirectory, { recursive: true });
+  copyFileSync(source, join(fixtureDirectory, name));
+  return `inputs/${name}`;
+}
+
+function expectError(action: () => unknown, code: string) {
+  try {
+    action();
+    throw new Error("expected local command rejection");
+  } catch (error) {
+    expect(error).toBeInstanceOf(ReceivablesSchemaInventoryLocalCommandError);
+    expect(error).toMatchObject({ code, message: code });
+  }
+}
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("runReceivablesSchemaInventoryLocalCommand", () => {
+  it("reads one explicit sanitized receipt file and returns the Phase 0U envelope", () => {
+    const root = temporaryRoot();
+    const result = runReceivablesSchemaInventoryLocalCommand({
+      approvedRoot: root,
+      inputFilePath: copyFixture(root),
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      inventoryStatus: "ready_for_next_audit",
+      commandCoreVersion: "receivables_schema_inventory_command_core_v1",
+      phase: "phase_0u",
+      reasonCodes: [],
+      warnings: ["Injected receipts support next-audit discussion only."],
+      checkedAt: "2026-07-20T12:00:00.000Z",
+      requiredNextSteps: [],
+      receiptSummary: {
+        required: 10,
+        received: 10,
+        ready: 10,
+        notReady: 0,
+        partial: 0,
+        ambiguous: 0,
+        unsafe: 0,
+      },
+    });
+  });
+
+  it("requires an explicit input file path", () => {
+    const root = temporaryRoot();
+    expectError(
+      () => runReceivablesSchemaInventoryLocalCommand({ approvedRoot: root, inputFilePath: "" }),
+      "LOCAL_INVENTORY_INPUT_PATH_REQUIRED"
+    );
+  });
+
+  it("rejects absolute paths and traversal", () => {
+    const root = temporaryRoot();
+    expectError(
+      () => runReceivablesSchemaInventoryLocalCommand({ approvedRoot: root, inputFilePath: validFixture.pathname }),
+      "LOCAL_INVENTORY_INPUT_PATH_INVALID"
+    );
+    expectError(
+      () => runReceivablesSchemaInventoryLocalCommand({ approvedRoot: root, inputFilePath: "../receipts.json" }),
+      "LOCAL_INVENTORY_INPUT_PATH_INVALID"
+    );
+  });
+
+  it("rejects a missing file without exposing its path", () => {
+    const root = temporaryRoot();
+    expectError(
+      () => runReceivablesSchemaInventoryLocalCommand({ approvedRoot: root, inputFilePath: "inputs/missing.json" }),
+      "LOCAL_INVENTORY_FILE_NOT_FOUND"
+    );
+  });
+
+  it("rejects malformed JSON", () => {
+    const root = temporaryRoot();
+    mkdirSync(join(root, "inputs"));
+    writeFileSync(join(root, "inputs", "bad.json"), "{not-json", "utf8");
+    expectError(
+      () => runReceivablesSchemaInventoryLocalCommand({ approvedRoot: root, inputFilePath: "inputs/bad.json" }),
+      "LOCAL_INVENTORY_JSON_MALFORMED"
+    );
+  });
+
+  it("rejects unsafe receipt data", () => {
+    const root = temporaryRoot();
+    expectError(
+      () => runReceivablesSchemaInventoryLocalCommand({
+        approvedRoot: root,
+        inputFilePath: copyFixture(root, unsafeFixture),
+      }),
+      "LOCAL_INVENTORY_RECEIPTS_UNSAFE"
+    );
+  });
+
+  it.each([
+    ["credential", "credential"],
+    ["bank field", "bankAccount"],
+    ["provider secret", "providerSecret"],
+    ["financial amount", "amount"],
+    ["balance", "tenantBalance"],
+    ["charge", "charge"],
+    ["payment", "payment"],
+    ["allocation", "allocation"],
+    ["rent roll", "rentRoll"],
+    ["aging", "aging"],
+    ["schedule", "receivableSchedule"],
+    ["environment value", "environmentValue"],
+  ])("rejects an unsafe %s field", (_label, unsafeKey) => {
+    const root = temporaryRoot();
+    const raw = JSON.parse(readFileSync(validFixture, "utf8")) as Record<string, unknown>;
+    raw[unsafeKey] = "restricted";
+    mkdirSync(join(root, "inputs"));
+    writeFileSync(join(root, "inputs", "unsafe.json"), JSON.stringify(raw), "utf8");
+    expectError(
+      () => runReceivablesSchemaInventoryLocalCommand({ approvedRoot: root, inputFilePath: "inputs/unsafe.json" }),
+      "LOCAL_INVENTORY_RECEIPTS_UNSAFE"
+    );
+  });
+
+  it("rejects unsupported receipt fields and non-object JSON", () => {
+    const root = temporaryRoot();
+    mkdirSync(join(root, "inputs"));
+    writeFileSync(join(root, "inputs", "unknown.json"), JSON.stringify({ unexpected: true }), "utf8");
+    writeFileSync(join(root, "inputs", "array.json"), "[]", "utf8");
+    for (const inputFilePath of ["inputs/unknown.json", "inputs/array.json"]) {
+      expectError(
+        () => runReceivablesSchemaInventoryLocalCommand({ approvedRoot: root, inputFilePath }),
+        "LOCAL_INVENTORY_RECEIPTS_INVALID"
+      );
+    }
+  });
+
+  it("passes sanitized receipt validation failures through Phase 0U", () => {
+    const root = temporaryRoot();
+    const raw = JSON.parse(readFileSync(validFixture, "utf8")) as {
+      schema: { confirmed: boolean };
+    };
+    raw.schema.confirmed = false;
+    mkdirSync(join(root, "inputs"));
+    writeFileSync(join(root, "inputs", "unconfirmed.json"), JSON.stringify(raw), "utf8");
+    const result = runReceivablesSchemaInventoryLocalCommand({
+      approvedRoot: root,
+      inputFilePath: "inputs/unconfirmed.json",
+    });
+    expect(result).toMatchObject({ ok: false, inventoryStatus: "not_ready" });
+    expect(result.reasonCodes).toContain("INVENTORY_RECEIPT_UNCONFIRMED");
+  });
+
+  it("rejects symlinks and directories", () => {
+    const root = temporaryRoot();
+    const realPath = copyFixture(root);
+    symlinkSync(join(root, realPath), join(root, "inputs", "linked.json"));
+    for (const inputFilePath of ["inputs/linked.json", "inputs"]) {
+      expectError(
+        () => runReceivablesSchemaInventoryLocalCommand({ approvedRoot: root, inputFilePath }),
+        inputFilePath.endsWith(".json")
+          ? "LOCAL_INVENTORY_FILE_UNSAFE"
+          : "LOCAL_INVENTORY_INPUT_PATH_INVALID"
+      );
+    }
+  });
+
+  it("rejects oversized files before parsing", () => {
+    const root = temporaryRoot();
+    mkdirSync(join(root, "inputs"));
+    writeFileSync(
+      join(root, "inputs", "large.json"),
+      "x".repeat(RECEIVABLES_SCHEMA_INVENTORY_LOCAL_COMMAND_MAX_BYTES + 1),
+      "utf8"
+    );
+    expectError(
+      () => runReceivablesSchemaInventoryLocalCommand({ approvedRoot: root, inputFilePath: "inputs/large.json" }),
+      "LOCAL_INVENTORY_FILE_TOO_LARGE"
+    );
+  });
+
+  it("keeps successful output non-financial and path-free", () => {
+    const root = temporaryRoot();
+    const serialized = JSON.stringify(runReceivablesSchemaInventoryLocalCommand({
+      approvedRoot: root,
+      inputFilePath: copyFixture(root),
+    })).toLowerCase();
+    for (const forbidden of [
+      "balance", "amount", "charge", "payment", "allocation", "rent roll", "aging",
+      "schedule", "tenant", "landlord", "firestore", "bank", "credential", "secret",
+      "provider", root.toLowerCase(), "receipts.json",
+    ]) expect(serialized).not.toContain(forbidden);
+  });
+
+  it("has no Firestore, environment, network, runtime, or mutation dependency", () => {
+    const source = readFileSync(
+      new URL("../receivablesSchemaInventoryLocalCommand.ts", import.meta.url),
+      "utf8"
+    ).toLowerCase();
+    for (const forbidden of [
+      "from \"firebase", "from '@google-cloud", "process.env", "process.argv", "dotenv",
+      "from \"express", "from \"@google-cloud/pubsub", "from \"rotessa", "from \"stripe",
+      "cron.schedule", "scheduler.",
+      "writefilesync", "appendfilesync", "fetch(", "axios", "child_process", "readdirsync",
+    ]) expect(source).not.toContain(forbidden);
+  });
+});

--- a/rentchain-api/src/lib/accounting/index.ts
+++ b/rentchain-api/src/lib/accounting/index.ts
@@ -20,3 +20,5 @@ export * from "./receivablesSchemaReadinessTypes";
 export * from "./receivablesSchemaReadinessClassifier";
 export * from "./receivablesSchemaInventoryCommandTypes";
 export * from "./receivablesSchemaInventoryCommandCore";
+export * from "./receivablesSchemaInventoryLocalCommandTypes";
+export * from "./receivablesSchemaInventoryLocalCommand";

--- a/rentchain-api/src/lib/accounting/receivablesSchemaInventoryLocalCommand.ts
+++ b/rentchain-api/src/lib/accounting/receivablesSchemaInventoryLocalCommand.ts
@@ -1,0 +1,217 @@
+import {
+  closeSync,
+  constants,
+  fstatSync,
+  lstatSync,
+  openSync,
+  readFileSync,
+  realpathSync,
+  statSync,
+} from "node:fs";
+import { extname, isAbsolute, relative, resolve } from "node:path";
+import { runReceivablesSchemaInventoryCommandCore } from "./receivablesSchemaInventoryCommandCore";
+import type { RunReceivablesSchemaInventoryCommandInput } from "./receivablesSchemaInventoryCommandTypes";
+import {
+  RECEIVABLES_SCHEMA_INVENTORY_LOCAL_COMMAND_MAX_BYTES,
+  ReceivablesSchemaInventoryLocalCommandError,
+  type ReceivablesSchemaInventoryLocalCommandErrorCode,
+  type ReceivablesSchemaInventoryLocalCommandResult,
+  type RunReceivablesSchemaInventoryLocalCommandInput,
+} from "./receivablesSchemaInventoryLocalCommandTypes";
+
+const TOP_LEVEL_KEYS = new Set([
+  "checkedAt",
+  "receiptManifestVersion",
+  "schema",
+  "indexes",
+  "iam",
+  "completeness",
+  "consistency",
+  "pagination",
+  "unsafeFieldExclusion",
+  "rollout",
+  "rollback",
+  "verification",
+]);
+
+const BASE_KEYS = ["receiptVersion", "state", "confirmed", "conflictsDetected", "claimScope"];
+
+const RECEIPT_KEYS: Readonly<Record<string, readonly string[]>> = {
+  schema: [
+    ...BASE_KEYS,
+    "requiredSourcesCovered",
+    "supportedVersionsOnly",
+    "canonicalOwnershipPresent",
+    "canonicalMappingsPresent",
+    "sourceRevisionsPresent",
+  ],
+  indexes: [
+    ...BASE_KEYS,
+    "requiredCount",
+    "attestedReadyCount",
+    "exactQueryCoverageAttested",
+    "targetStateAttested",
+  ],
+  iam: [
+    ...BASE_KEYS,
+    "dedicatedIdentityAttested",
+    "shortLivedIdentityAttested",
+    "readOnlyAttested",
+    "writeDeniedAttested",
+    "privilegedAccessDeniedAttested",
+    "environmentBindingAttested",
+  ],
+  completeness: [
+    ...BASE_KEYS,
+    "exactScopeAttested",
+    "exhaustionAttested",
+    "catchToEmptyAbsent",
+    "postReadFilteringAbsent",
+  ],
+  consistency: [
+    ...BASE_KEYS,
+    "boundaryProtocolAttested",
+    "crossSourceBoundaryAttested",
+    "concurrentChangeInvalidates",
+  ],
+  pagination: [
+    ...BASE_KEYS,
+    "deterministicOrderingAttested",
+    "cursorProgressionAttested",
+    "capFailsClosed",
+    "capHandlingAmbiguous",
+  ],
+  unsafeFieldExclusion: [
+    ...BASE_KEYS,
+    "allowlistProjectionAttested",
+    "restrictedFieldsExcluded",
+    "safeOutputAttested",
+  ],
+  rollout: [
+    ...BASE_KEYS,
+    "orderedGatesAttested",
+    "defaultOffAttested",
+    "mutationDeferred",
+    "operatorApprovalRequired",
+  ],
+  rollback: [
+    ...BASE_KEYS,
+    "rollbackPlanAttested",
+    "appendSafeHistoryProtected",
+    "broaderIdentityFallbackProhibited",
+  ],
+  verification: [
+    ...BASE_KEYS,
+    "automatedTestsAttested",
+    "negativePermissionTestsAttested",
+    "controlledContextChecksAttested",
+    "postChangeChecksAttested",
+  ],
+};
+
+const UNSAFE_TERM =
+  /(?:firestore|firebase|credential|secret|password|private.?key|access.?token|api.?key|bank|routing|transit|institution.?number|account.?number|provider|rotessa|stripe|payment|allocation|balance|charge|rent.?roll|aging|receivable.?schedule|tenant.?balance|amount|storage.?path|document.?path|collection.?path|process\.env|environment.?value)/i;
+
+function reject(code: ReceivablesSchemaInventoryLocalCommandErrorCode): never {
+  throw new ReceivablesSchemaInventoryLocalCommandError(code);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isInsideRoot(root: string, target: string): boolean {
+  const pathFromRoot = relative(root, target);
+  return pathFromRoot !== "" && !pathFromRoot.startsWith("..") && !isAbsolute(pathFromRoot);
+}
+
+function validateReceiptShape(value: unknown): asserts value is RunReceivablesSchemaInventoryCommandInput {
+  if (!isRecord(value)) reject("LOCAL_INVENTORY_RECEIPTS_INVALID");
+  if (Object.keys(value).some((key) => !TOP_LEVEL_KEYS.has(key))) {
+    reject("LOCAL_INVENTORY_RECEIPTS_INVALID");
+  }
+
+  for (const [receiptKey, allowedKeys] of Object.entries(RECEIPT_KEYS)) {
+    const receipt = value[receiptKey];
+    if (receipt === undefined) continue;
+    if (!isRecord(receipt)) reject("LOCAL_INVENTORY_RECEIPTS_INVALID");
+    const allowed = new Set(allowedKeys);
+    if (Object.keys(receipt).some((key) => !allowed.has(key))) {
+      reject("LOCAL_INVENTORY_RECEIPTS_INVALID");
+    }
+  }
+}
+
+function containsUnsafeData(value: unknown): boolean {
+  if (typeof value === "string") return UNSAFE_TERM.test(value) || value.includes("/");
+  if (Array.isArray(value)) return value.some(containsUnsafeData);
+  if (!isRecord(value)) return false;
+  return Object.entries(value).some(
+    ([key, nestedValue]) => UNSAFE_TERM.test(key) || containsUnsafeData(nestedValue)
+  );
+}
+
+function readBoundedReceiptFile(input: RunReceivablesSchemaInventoryLocalCommandInput): string {
+  if (typeof input.inputFilePath !== "string" || !input.inputFilePath.trim()) {
+    reject("LOCAL_INVENTORY_INPUT_PATH_REQUIRED");
+  }
+  if (isAbsolute(input.inputFilePath) || extname(input.inputFilePath).toLowerCase() !== ".json") {
+    reject("LOCAL_INVENTORY_INPUT_PATH_INVALID");
+  }
+
+  let approvedRoot: string;
+  try {
+    approvedRoot = realpathSync(input.approvedRoot);
+    if (!statSync(approvedRoot).isDirectory()) reject("LOCAL_INVENTORY_APPROVED_ROOT_INVALID");
+  } catch (error) {
+    if (error instanceof ReceivablesSchemaInventoryLocalCommandError) throw error;
+    reject("LOCAL_INVENTORY_APPROVED_ROOT_INVALID");
+  }
+
+  const candidate = resolve(approvedRoot, input.inputFilePath);
+  if (!isInsideRoot(approvedRoot, candidate)) reject("LOCAL_INVENTORY_INPUT_PATH_INVALID");
+
+  let descriptor: number | undefined;
+  try {
+    const initialStat = lstatSync(candidate);
+    if (initialStat.isSymbolicLink() || !initialStat.isFile()) reject("LOCAL_INVENTORY_FILE_UNSAFE");
+    if (initialStat.size > RECEIVABLES_SCHEMA_INVENTORY_LOCAL_COMMAND_MAX_BYTES) {
+      reject("LOCAL_INVENTORY_FILE_TOO_LARGE");
+    }
+    const canonicalFile = realpathSync(candidate);
+    if (!isInsideRoot(approvedRoot, canonicalFile)) reject("LOCAL_INVENTORY_FILE_UNSAFE");
+    descriptor = openSync(canonicalFile, constants.O_RDONLY | constants.O_NOFOLLOW);
+    const openedStat = fstatSync(descriptor);
+    if (!openedStat.isFile()) reject("LOCAL_INVENTORY_FILE_UNSAFE");
+    if (openedStat.size > RECEIVABLES_SCHEMA_INVENTORY_LOCAL_COMMAND_MAX_BYTES) {
+      reject("LOCAL_INVENTORY_FILE_TOO_LARGE");
+    }
+    const bytes = readFileSync(descriptor);
+    if (bytes.byteLength > RECEIVABLES_SCHEMA_INVENTORY_LOCAL_COMMAND_MAX_BYTES) {
+      reject("LOCAL_INVENTORY_FILE_TOO_LARGE");
+    }
+    return bytes.toString("utf8");
+  } catch (error) {
+    if (error instanceof ReceivablesSchemaInventoryLocalCommandError) throw error;
+    const code = isRecord(error) && error.code;
+    if (code === "ENOENT") reject("LOCAL_INVENTORY_FILE_NOT_FOUND");
+    reject("LOCAL_INVENTORY_FILE_UNREADABLE");
+  } finally {
+    if (descriptor !== undefined) closeSync(descriptor);
+  }
+}
+
+export function runReceivablesSchemaInventoryLocalCommand(
+  input: RunReceivablesSchemaInventoryLocalCommandInput
+): ReceivablesSchemaInventoryLocalCommandResult {
+  const source = readBoundedReceiptFile(input);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(source);
+  } catch {
+    reject("LOCAL_INVENTORY_JSON_MALFORMED");
+  }
+  if (containsUnsafeData(parsed)) reject("LOCAL_INVENTORY_RECEIPTS_UNSAFE");
+  validateReceiptShape(parsed);
+  return runReceivablesSchemaInventoryCommandCore(parsed);
+}

--- a/rentchain-api/src/lib/accounting/receivablesSchemaInventoryLocalCommandTypes.ts
+++ b/rentchain-api/src/lib/accounting/receivablesSchemaInventoryLocalCommandTypes.ts
@@ -1,0 +1,36 @@
+import type { ReceivablesSchemaInventoryCommandResult } from "./receivablesSchemaInventoryCommandTypes";
+
+export const RECEIVABLES_SCHEMA_INVENTORY_LOCAL_COMMAND_VERSION =
+  "receivables_schema_inventory_local_command_v1" as const;
+
+export const RECEIVABLES_SCHEMA_INVENTORY_LOCAL_COMMAND_MAX_BYTES = 64 * 1024;
+
+export type ReceivablesSchemaInventoryLocalCommandErrorCode =
+  | "LOCAL_INVENTORY_INPUT_PATH_REQUIRED"
+  | "LOCAL_INVENTORY_INPUT_PATH_INVALID"
+  | "LOCAL_INVENTORY_APPROVED_ROOT_INVALID"
+  | "LOCAL_INVENTORY_FILE_NOT_FOUND"
+  | "LOCAL_INVENTORY_FILE_UNSAFE"
+  | "LOCAL_INVENTORY_FILE_TOO_LARGE"
+  | "LOCAL_INVENTORY_FILE_UNREADABLE"
+  | "LOCAL_INVENTORY_JSON_MALFORMED"
+  | "LOCAL_INVENTORY_RECEIPTS_INVALID"
+  | "LOCAL_INVENTORY_RECEIPTS_UNSAFE";
+
+export type RunReceivablesSchemaInventoryLocalCommandInput = {
+  approvedRoot: string;
+  inputFilePath: string;
+};
+
+export type ReceivablesSchemaInventoryLocalCommandResult =
+  ReceivablesSchemaInventoryCommandResult;
+
+export class ReceivablesSchemaInventoryLocalCommandError extends Error {
+  readonly code: ReceivablesSchemaInventoryLocalCommandErrorCode;
+
+  constructor(code: ReceivablesSchemaInventoryLocalCommandErrorCode) {
+    super(code);
+    this.name = "ReceivablesSchemaInventoryLocalCommandError";
+    this.code = code;
+  }
+}


### PR DESCRIPTION
## Summary

- adds the Phase 0W backend-only local schema-inventory command wrapper
- requires an explicit relative sanitized JSON receipt-file path under an injected approved root
- uses bounded, regular-file-only, no-symlink reads with traversal and oversize rejection
- validates strict receipt-only field allowlists and rejects unsafe path, credential, environment, bank, provider, and financial content
- invokes the Phase 0U command core only after local file and receipt sanitization succeeds
- returns the unchanged non-financial Phase 0U envelope, capped at `ready_for_next_audit`

## Implementation boundary

This is a local-command function and test harness, not a package script or deployed executable. It has no `process.argv`, environment lookup, directory discovery, network access, Firestore client, route, job, scheduler, UI, or runtime registration. A broader invocation context remains deferred for a later audit.

## Safety behavior

- one explicit `.json` input path; absolute paths and traversal are rejected
- approved root must resolve to a directory
- symlinks, non-regular files, missing files, unreadable files, and files over 64 KiB fail closed
- malformed, non-object, unsupported-field, or unsafe JSON fails closed with fixed non-sensitive error codes
- sanitized but incomplete or invalid receipts pass through Phase 0U fail-closed reason codes
- no input path, raw receipt body, financial value, credential, provider field, or environment value is returned

## Validation

- focused Phase 0W tests: 24 passed
- complete backend accounting suite: 15 files, 230 tests passed
- backend production TypeScript build passed with Node 20.20.2
- `git diff --check` passed
- `git diff --cached --check` passed before commit
- forbidden dependency, runtime invocation, protected-scope, and changed-file scans passed
- changed files are limited to six backend accounting files

## Non-goals preserved

- no Firestore imports, reads, or writes
- no environment or credential access
- no auto-discovery, package command, production runtime integration, route, job, scheduler, or UI
- no infrastructure, index, IAM, provider, payment, Rotessa/PAD, bank-data, or money-movement changes
- no financial read exposure or existing ledger behavior change
- no RC1 demo behavior change
- direct-settlement and landlord-revenue boundaries preserved

Manual product QA is not required because the wrapper is backend-only, local-only, unmounted, and has no user-visible or runtime effect.
