### PR TITLE
Add Phase 1A local inventory dev entrypoint adapter

### DIFF
--- a/rentchain-api/src/lib/accounting/__tests__/receivablesLocalInventoryDevEntrypoint.test.ts
+++ b/rentchain-api/src/lib/accounting/__tests__/receivablesLocalInventoryDevEntrypoint.test.ts
@@ -1,0 +1,283 @@
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runReceivablesLocalInventoryDevEntrypoint } from "../receivablesLocalInventoryDevEntrypoint";
+import { runReceivablesSchemaInventoryLocalCommand } from "../receivablesSchemaInventoryLocalCommand";
+import type { ReceivablesSchemaInventoryLocalCommandResult } from "../receivablesSchemaInventoryLocalCommandTypes";
+
+const validFixture = new URL(
+  "../__fixtures__/schemaInventorySanitizedReceipts.valid.json",
+  import.meta.url
+);
+const unsafeFixture = new URL(
+  "../__fixtures__/schemaInventorySanitizedReceipts.unsafe.json",
+  import.meta.url
+);
+const roots: string[] = [];
+
+function root(): string {
+  const value = mkdtempSync(join(tmpdir(), "rentchain-dev-entrypoint-"));
+  roots.push(value);
+  return value;
+}
+
+function fixture(targetRoot: string, source = validFixture, name = "receipts.json"): string {
+  mkdirSync(join(targetRoot, "inputs"), { recursive: true });
+  copyFileSync(source, join(targetRoot, "inputs", name));
+  return `inputs/${name}`;
+}
+
+function harness(targetRoot = root()) {
+  const output: string[] = [];
+  const errors: string[] = [];
+  return {
+    targetRoot,
+    output,
+    errors,
+    dependencies: {
+      approvedRoot: targetRoot,
+      runLocalCommand: runReceivablesSchemaInventoryLocalCommand,
+      writeOutput: (value: string) => output.push(value),
+      writeError: (value: string) => errors.push(value),
+    },
+  };
+}
+
+afterEach(() => {
+  for (const value of roots.splice(0)) rmSync(value, { recursive: true, force: true });
+});
+
+describe("runReceivablesLocalInventoryDevEntrypoint", () => {
+  it("maps one injected sanitized input to the Phase 0U envelope", () => {
+    const context = harness();
+    const result = runReceivablesLocalInventoryDevEntrypoint({
+      args: ["--input", fixture(context.targetRoot)],
+      dependencies: context.dependencies,
+    });
+    expect(result).toEqual({ status: "ready_for_next_audit", exitCode: 0 });
+    expect(context.errors).toEqual([]);
+    expect(JSON.parse(context.output[0])).toMatchObject({
+      ok: true,
+      inventoryStatus: "ready_for_next_audit",
+      commandCoreVersion: "receivables_schema_inventory_command_core_v1",
+      phase: "phase_0u",
+      reasonCodes: [],
+      warnings: ["Injected receipts support next-audit discussion only."],
+    });
+  });
+
+  it.each([
+    [[]],
+    [["--input"]],
+    [["--input", ""]],
+    [["--unknown", "inputs/receipts.json"]],
+    [["inputs/receipts.json"]],
+    [["--input", "one.json", "--input", "two.json"]],
+  ])("rejects invalid injected arguments without calling Phase 0W", (args) => {
+    const context = harness();
+    const runLocalCommand = vi.fn(context.dependencies.runLocalCommand);
+    const result = runReceivablesLocalInventoryDevEntrypoint({
+      args,
+      dependencies: { ...context.dependencies, runLocalCommand },
+    });
+    expect(result).toEqual({ status: "invalid_invocation", exitCode: 64 });
+    expect(runLocalCommand).not.toHaveBeenCalled();
+    expect(context.output).toEqual([]);
+    expect(context.errors).toEqual(["DEV_ENTRYPOINT_INVALID_INVOCATION"]);
+  });
+
+  it("injects the approved root and explicit path unchanged", () => {
+    const context = harness();
+    const runLocalCommand = vi.fn((): ReceivablesSchemaInventoryLocalCommandResult => ({
+      ok: false,
+      inventoryStatus: "not_ready",
+      commandCoreVersion: "receivables_schema_inventory_command_core_v1",
+      phase: "phase_0u",
+      reasonCodes: ["INVENTORY_RECEIPT_MISSING"],
+      warnings: ["Injected receipts support next-audit discussion only."],
+      checkedAt: null,
+      requiredNextSteps: ["Supply complete and consistent receipts."],
+      receiptSummary: {
+        required: 10, received: 0, ready: 0, notReady: 0, partial: 0, ambiguous: 0, unsafe: 0,
+      },
+    }));
+    const args = ["--input", "inputs/receipts.json"] as const;
+    const before = [...args];
+    const result = runReceivablesLocalInventoryDevEntrypoint({
+      args,
+      dependencies: { ...context.dependencies, runLocalCommand },
+    });
+    expect(runLocalCommand).toHaveBeenCalledWith({
+      approvedRoot: context.targetRoot,
+      inputFilePath: "inputs/receipts.json",
+    });
+    expect(args).toEqual(before);
+    expect(result).toEqual({ status: "not_ready", exitCode: 2 });
+    expect(context.errors).toEqual([]);
+  });
+
+  it.each([
+    ["missing", "inputs/missing.json"],
+    ["traversal", "../receipts.json"],
+  ])("preserves the Phase 0W %s rejection", (_label, inputFilePath) => {
+    const context = harness();
+    const result = runReceivablesLocalInventoryDevEntrypoint({
+      args: ["--input", inputFilePath],
+      dependencies: context.dependencies,
+    });
+    expect(result).toEqual({ status: "invalid_input", exitCode: 65 });
+    expect(context.output).toEqual([]);
+    expect(context.errors).toEqual(["DEV_ENTRYPOINT_INPUT_REJECTED"]);
+  });
+
+  it("preserves malformed, unsafe, and symlink Phase 0W rejections", () => {
+    const context = harness();
+    mkdirSync(join(context.targetRoot, "inputs"), { recursive: true });
+    writeFileSync(join(context.targetRoot, "inputs", "malformed.json"), "{bad", "utf8");
+    fixture(context.targetRoot, unsafeFixture, "unsafe.json");
+    fixture(context.targetRoot, validFixture, "real.json");
+    symlinkSync(
+      join(context.targetRoot, "inputs", "real.json"),
+      join(context.targetRoot, "inputs", "linked.json")
+    );
+    for (const inputFilePath of [
+      "inputs/malformed.json",
+      "inputs/unsafe.json",
+      "inputs/linked.json",
+    ]) {
+      context.output.length = 0;
+      context.errors.length = 0;
+      expect(runReceivablesLocalInventoryDevEntrypoint({
+        args: ["--input", inputFilePath],
+        dependencies: context.dependencies,
+      })).toEqual({ status: "invalid_input", exitCode: 65 });
+      expect(context.output).toEqual([]);
+      expect(context.errors).toEqual(["DEV_ENTRYPOINT_INPUT_REJECTED"]);
+    }
+  });
+
+  it("returns non-ready Phase 0U results through the bounded output sink", () => {
+    const context = harness();
+    const raw = JSON.parse(readFileSync(validFixture, "utf8")) as { schema: { confirmed: boolean } };
+    raw.schema.confirmed = false;
+    mkdirSync(join(context.targetRoot, "inputs"));
+    writeFileSync(join(context.targetRoot, "inputs", "not-ready.json"), JSON.stringify(raw), "utf8");
+    const result = runReceivablesLocalInventoryDevEntrypoint({
+      args: ["--input", "inputs/not-ready.json"],
+      dependencies: context.dependencies,
+    });
+    expect(result).toEqual({ status: "not_ready", exitCode: 2 });
+    expect(JSON.parse(context.output[0])).toMatchObject({
+      ok: false,
+      inventoryStatus: "not_ready",
+      reasonCodes: expect.arrayContaining(["INVENTORY_RECEIPT_UNCONFIRMED"]),
+    });
+    expect(context.errors).toEqual([]);
+  });
+
+  it("projects only the Phase 0U envelope from an injected result", () => {
+    const context = harness();
+    const source = runReceivablesSchemaInventoryLocalCommand;
+    const runLocalCommand = vi.fn((input) => ({
+      ...source(input),
+      unexpectedInternalField: "must-not-escape",
+    }));
+    const result = runReceivablesLocalInventoryDevEntrypoint({
+      args: ["--input", fixture(context.targetRoot)],
+      dependencies: { ...context.dependencies, runLocalCommand },
+    });
+    expect(result).toEqual({ status: "ready_for_next_audit", exitCode: 0 });
+    expect(context.output[0]).not.toContain("unexpectedInternalField");
+    expect(context.output[0]).not.toContain("must-not-escape");
+  });
+
+  it.each(["bankAccount", "paymentAmount", "providerSecret", "firestorePath"])(
+    "blocks unsafe injected output containing %s",
+    (unsafeValue) => {
+      const context = harness();
+      const runLocalCommand = vi.fn(() => ({
+        ok: true,
+        inventoryStatus: "ready_for_next_audit",
+        commandCoreVersion: "receivables_schema_inventory_command_core_v1",
+        phase: "phase_0u",
+        reasonCodes: [],
+        warnings: [unsafeValue],
+        checkedAt: null,
+        requiredNextSteps: [],
+        receiptSummary: {
+          required: 10, received: 10, ready: 10, notReady: 0, partial: 0, ambiguous: 0, unsafe: 0,
+        },
+      } as ReceivablesSchemaInventoryLocalCommandResult));
+      expect(runReceivablesLocalInventoryDevEntrypoint({
+        args: ["--input", "inputs/receipts.json"],
+        dependencies: { ...context.dependencies, runLocalCommand },
+      })).toEqual({ status: "internal_failure", exitCode: 70 });
+      expect(context.output).toEqual([]);
+      expect(context.errors).toEqual(["DEV_ENTRYPOINT_INTERNAL_FAILURE"]);
+    }
+  );
+
+  it("maps unexpected dependencies and output-sink failures to a generic code", () => {
+    const context = harness();
+    for (const dependencies of [
+      { ...context.dependencies, runLocalCommand: () => { throw new Error("sensitive detail"); } },
+      { ...context.dependencies, writeOutput: () => { throw new Error("sensitive detail"); } },
+    ]) {
+      context.output.length = 0;
+      context.errors.length = 0;
+      expect(runReceivablesLocalInventoryDevEntrypoint({
+        args: ["--input", fixture(context.targetRoot, validFixture, `${context.errors.length}.json`)],
+        dependencies,
+      })).toEqual({ status: "internal_failure", exitCode: 70 });
+      expect(context.output).toEqual([]);
+      expect(context.errors).toEqual(["DEV_ENTRYPOINT_INTERNAL_FAILURE"]);
+    }
+  });
+
+  it("keeps output non-financial, path-free, and operator-neutral", () => {
+    const context = harness();
+    runReceivablesLocalInventoryDevEntrypoint({
+      args: ["--input", fixture(context.targetRoot)],
+      dependencies: context.dependencies,
+    });
+    const serialized = context.output.join("").toLowerCase();
+    for (const forbidden of [
+      "balance", "amount", "charge", "payment", "allocation", "rent roll", "aging",
+      "schedule", "tenant", "landlord", "firestore", "bank", "credential", "secret",
+      "provider", "operator", "production", "operational", context.targetRoot.toLowerCase(),
+      "receipts.json",
+    ]) expect(serialized).not.toContain(forbidden);
+  });
+
+  it("has no process, environment, Firestore, runtime, global-output, or mutation dependency", () => {
+    const source = readFileSync(
+      new URL("../receivablesLocalInventoryDevEntrypoint.ts", import.meta.url),
+      "utf8"
+    ).toLowerCase();
+    for (const forbidden of [
+      "process.argv", "process.env", "process.stdin", "console.", "from \"firebase",
+      "from \"@google-cloud", "from \"dotenv", "from \"express", "from \"rotessa",
+      "from \"stripe", "from \"node:fs", "cron.schedule", "scheduler.", "writefile(",
+      "appendfile(", "readdir(", "fetch(", "axios.", "from \"node:child_process",
+    ]) expect(source).not.toContain(forbidden);
+  });
+
+  it("is absent from package scripts, the accounting barrel, and runtime startup", () => {
+    const packageSource = readFileSync(new URL("../../../../package.json", import.meta.url), "utf8");
+    const barrelSource = readFileSync(new URL("../index.ts", import.meta.url), "utf8");
+    const runtimeSource = readFileSync(new URL("../../../index.ts", import.meta.url), "utf8");
+    for (const source of [packageSource, barrelSource, runtimeSource]) {
+      expect(source).not.toContain("receivablesLocalInventoryDevEntrypoint");
+      expect(source).not.toContain("phase-1a-receivables-local-inventory");
+    }
+  });
+});

--- a/rentchain-api/src/lib/accounting/receivablesLocalInventoryDevEntrypoint.ts
+++ b/rentchain-api/src/lib/accounting/receivablesLocalInventoryDevEntrypoint.ts
@@ -1,0 +1,141 @@
+import {
+  RECEIVABLES_SCHEMA_INVENTORY_COMMAND_CORE_VERSION,
+  RECEIVABLES_SCHEMA_INVENTORY_PHASE,
+  type ReceivablesSchemaInventoryCommandResult,
+} from "./receivablesSchemaInventoryCommandTypes";
+import { ReceivablesSchemaInventoryLocalCommandError } from "./receivablesSchemaInventoryLocalCommandTypes";
+import type {
+  ReceivablesLocalInventoryDevEntrypointDependencies,
+  ReceivablesLocalInventoryDevEntrypointResult,
+  RunReceivablesLocalInventoryDevEntrypointInput,
+} from "./receivablesLocalInventoryDevEntrypointTypes";
+
+const INPUT_FLAG = "--input";
+const MAX_OUTPUT_BYTES = 16 * 1024;
+const SAFE_STATUSES = new Set([
+  "ready_for_next_audit",
+  "not_ready",
+  "partial",
+  "blocked",
+  "ambiguous",
+]);
+const UNSAFE_OUTPUT_TERM =
+  /(?:firestore|firebase|credential|secret|password|private.?key|access.?token|api.?key|bank|routing|transit|account.?number|provider|rotessa|stripe|payment|allocation|balance|charge|rent.?roll|aging|receivable.?schedule|tenant.?balance|amount|storage.?path|document.?path|collection.?path|environment.?value)/i;
+
+function fixedFailure(
+  dependencies: ReceivablesLocalInventoryDevEntrypointDependencies,
+  code: "DEV_ENTRYPOINT_INVALID_INVOCATION" | "DEV_ENTRYPOINT_INPUT_REJECTED" | "DEV_ENTRYPOINT_INTERNAL_FAILURE",
+  result: ReceivablesLocalInventoryDevEntrypointResult
+): ReceivablesLocalInventoryDevEntrypointResult {
+  try {
+    dependencies.writeError(code);
+  } catch {
+    // Injected sinks are test contracts. Sink failures must not expose raw errors.
+  }
+  return result;
+}
+
+function inputFilePath(args: readonly string[]): string | null {
+  if (args.length !== 2 || args[0] !== INPUT_FLAG) return null;
+  const value = args[1];
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+function stringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+function nonNegativeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0;
+}
+
+function safeResult(value: ReceivablesSchemaInventoryCommandResult): boolean {
+  const summary = value.receiptSummary;
+  return (
+    typeof value.ok === "boolean" &&
+    SAFE_STATUSES.has(value.inventoryStatus) &&
+    value.commandCoreVersion === RECEIVABLES_SCHEMA_INVENTORY_COMMAND_CORE_VERSION &&
+    value.phase === RECEIVABLES_SCHEMA_INVENTORY_PHASE &&
+    stringArray(value.reasonCodes) &&
+    stringArray(value.warnings) &&
+    (typeof value.checkedAt === "string" || value.checkedAt === null) &&
+    stringArray(value.requiredNextSteps) &&
+    typeof summary === "object" &&
+    summary !== null &&
+    nonNegativeInteger(summary.required) &&
+    nonNegativeInteger(summary.received) &&
+    nonNegativeInteger(summary.ready) &&
+    nonNegativeInteger(summary.notReady) &&
+    nonNegativeInteger(summary.partial) &&
+    nonNegativeInteger(summary.ambiguous) &&
+    nonNegativeInteger(summary.unsafe)
+  );
+}
+
+function serializeResult(value: ReceivablesSchemaInventoryCommandResult): string | null {
+  if (!safeResult(value)) return null;
+  const projection: ReceivablesSchemaInventoryCommandResult = {
+    ok: value.ok,
+    inventoryStatus: value.inventoryStatus,
+    commandCoreVersion: value.commandCoreVersion,
+    phase: value.phase,
+    reasonCodes: [...value.reasonCodes],
+    warnings: [...value.warnings],
+    checkedAt: value.checkedAt,
+    requiredNextSteps: [...value.requiredNextSteps],
+    receiptSummary: { ...value.receiptSummary },
+  };
+  const serialized = JSON.stringify(projection);
+  if (Buffer.byteLength(serialized, "utf8") > MAX_OUTPUT_BYTES || UNSAFE_OUTPUT_TERM.test(serialized)) {
+    return null;
+  }
+  return serialized;
+}
+
+export function runReceivablesLocalInventoryDevEntrypoint(
+  input: RunReceivablesLocalInventoryDevEntrypointInput
+): ReceivablesLocalInventoryDevEntrypointResult {
+  const path = inputFilePath(input.args);
+  if (!path) {
+    return fixedFailure(input.dependencies, "DEV_ENTRYPOINT_INVALID_INVOCATION", {
+      status: "invalid_invocation",
+      exitCode: 64,
+    });
+  }
+
+  try {
+    const result = input.dependencies.runLocalCommand({
+      approvedRoot: input.dependencies.approvedRoot,
+      inputFilePath: path,
+    });
+    const serialized = serializeResult(result);
+    if (!serialized) {
+      return fixedFailure(input.dependencies, "DEV_ENTRYPOINT_INTERNAL_FAILURE", {
+        status: "internal_failure",
+        exitCode: 70,
+      });
+    }
+    try {
+      input.dependencies.writeOutput(serialized);
+    } catch {
+      return fixedFailure(input.dependencies, "DEV_ENTRYPOINT_INTERNAL_FAILURE", {
+        status: "internal_failure",
+        exitCode: 70,
+      });
+    }
+    return result.ok
+      ? { status: "ready_for_next_audit", exitCode: 0 }
+      : { status: "not_ready", exitCode: 2 };
+  } catch (error) {
+    if (error instanceof ReceivablesSchemaInventoryLocalCommandError) {
+      return fixedFailure(input.dependencies, "DEV_ENTRYPOINT_INPUT_REJECTED", {
+        status: "invalid_input",
+        exitCode: 65,
+      });
+    }
+    return fixedFailure(input.dependencies, "DEV_ENTRYPOINT_INTERNAL_FAILURE", {
+      status: "internal_failure",
+      exitCode: 70,
+    });
+  }
+}

--- a/rentchain-api/src/lib/accounting/receivablesLocalInventoryDevEntrypointTypes.ts
+++ b/rentchain-api/src/lib/accounting/receivablesLocalInventoryDevEntrypointTypes.ts
@@ -1,0 +1,33 @@
+import type {
+  ReceivablesSchemaInventoryLocalCommandResult,
+  RunReceivablesSchemaInventoryLocalCommandInput,
+} from "./receivablesSchemaInventoryLocalCommandTypes";
+
+export const RECEIVABLES_LOCAL_INVENTORY_DEV_ENTRYPOINT_VERSION =
+  "receivables_local_inventory_dev_entrypoint_v1" as const;
+
+export type ReceivablesLocalInventoryDevEntrypointStatus =
+  | "ready_for_next_audit"
+  | "not_ready"
+  | "invalid_invocation"
+  | "invalid_input"
+  | "internal_failure";
+
+export type ReceivablesLocalInventoryDevEntrypointResult = {
+  status: ReceivablesLocalInventoryDevEntrypointStatus;
+  exitCode: 0 | 2 | 64 | 65 | 70;
+};
+
+export type ReceivablesLocalInventoryDevEntrypointDependencies = {
+  approvedRoot: string;
+  runLocalCommand: (
+    input: RunReceivablesSchemaInventoryLocalCommandInput
+  ) => ReceivablesSchemaInventoryLocalCommandResult;
+  writeOutput: (value: string) => void;
+  writeError: (value: string) => void;
+};
+
+export type RunReceivablesLocalInventoryDevEntrypointInput = {
+  args: readonly string[];
+  dependencies: ReceivablesLocalInventoryDevEntrypointDependencies;
+};


### PR DESCRIPTION
## Summary

- adds the Phase 1A backend-only local-inventory dev-entrypoint adapter and types
- keeps the adapter unregistered, absent from the accounting barrel, and invoked only by focused tests
- injects arguments, approved root, Phase 0W execution, and bounded output/error sinks
- parses exactly one explicit sanitized receipt-file argument and delegates all file/receipt safety checks to Phase 0W
- maps ready, non-ready, invalid invocation, invalid input, and internal failure to deterministic non-financial status categories
- projects only the Phase 0U envelope and blocks unsafe or oversized injected output

## Registration and authority boundary

This is an entrypoint-contract test surface, not a runnable command. It adds no package script, CLI registration, process/global access, accounting barrel export, runtime import, route, job, scheduler, or UI. Human/operator use remains unauthorized, and no execution documentation is added.

## Safety behavior

- no process arguments, environment variables, stdin, global console, filesystem, network, or configuration dependency in the adapter
- Phase 0W remains the sole file-loading, path, size, shape, and unsafe-content boundary
- local Phase 0W failures map to one fixed input-rejection code without path or raw error leakage
- unexpected dependency or sink failures map to one generic internal-failure code
- success and non-ready results use an exact Phase 0U field projection
- output is capped and rejected if it contains prohibited financial, path, credential, bank, provider, or environment content
- injected arguments are not mutated and no retry, fallback, discovery, or persistence is added

## Validation

- focused Phase 1A tests: 21 passed
- complete accounting suite: 16 files, 251 tests passed
- backend production TypeScript build passed with Node 20.20.2
- `git diff --check` passed
- `git diff --cached --check` passed before commit
- call-site, process/environment, Firestore, runtime-registration, package/barrel, output, and protected-scope scans passed
- changed files are limited to three backend accounting-library files

## Non-goals preserved

- no package script, CLI command, runnable utility, or execution instructions
- no `process.argv`, `process.env`, stdin, console, or global configuration access
- no Firestore/Firebase/cloud SDK import or access
- no runtime call site, route, job, scheduler, server, worker, frontend, or UI
- no infrastructure, index, IAM, provider, payment, PAD, Rotessa, bank-data, or money-movement change
- no financial read exposure, operator authorization, or production/operational-readiness claim
- no existing ledger or RC1 behavior change
- direct-settlement and landlord-revenue boundaries preserved

Manual product QA is not required because the adapter is unregistered, test-invoked only, and has no user-visible or runtime effect.
