### PR TITLE
Add Phase 1F operator authorization decision record

### DIFF
--- a/docs/strategy/phase-1f-receivables-operator-authorization-decision-record-v1.md
+++ b/docs/strategy/phase-1f-receivables-operator-authorization-decision-record-v1.md
@@ -1,0 +1,322 @@
+# Phase 1F Receivables Operator Authorization Decision Record v1
+
+Status: blank decision-record template only; operator use remains unauthorized, and every record defaults to `defer`
+
+## 1. Executive summary
+
+Phase 1E established a non-authorizing evidence-review matrix with artifact-level `pass`, `fail`, and `defer` results and package statuses that intentionally exclude an authorized or ready state. This Phase 1F document provides a formal, blank record structure for summarizing a future review request without embedding evidence bodies or permitting execution.
+
+The template cannot authorize operator use. Its final disposition is fixed to `defer` in Phase 1F. Any future record created from it must remain non-sensitive, version-bound, append-safe by supersession, and explicit that completion does not permit anyone to invoke the Phase 1A adapter or Phase 0W wrapper.
+
+This document contains no execution commands or operator procedure. It creates no package script, CLI instruction, runtime registration, Firestore or environment access, route, job, UI, persistence, or financial output. It makes no production or operational-readiness claim.
+
+Tenant rent remains landlord or property-manager revenue, not RentChain revenue. Direct settlement remains the future payment posture. Rotessa, PAD, provider execution, bank data, payment mutation, money movement, custody, pooled funds, landlord payout liabilities, and settlement float remain out of scope.
+
+## 2. Current accounting foundation recap
+
+The accounting foundation remains backend-only, staged, and unmounted: deterministic receivables projections, landlord-safe DTO assembly, legacy-source normalization, a disabled comparator, receipt-driven provider and readiness cores, the Phase 0U command core, the Phase 0W sanitized-file wrapper, and the Phase 1A injected dev-entrypoint adapter.
+
+Phase 1A remains unregistered and test-invoked. It is absent from package scripts, the accounting barrel, runtime startup, routes, jobs, schedulers, and UI, and it does not read process arguments, environment values, Firestore, or global runtime configuration.
+
+Phases 1C through 1E define future control, evidence, and review structures only. They do not prove that a compliant evidence package exists and do not authorize human use.
+
+## 3. Purpose of the decision-record template
+
+The template standardizes how a future reviewer could record:
+
+- the bounded, non-financial requested use case;
+- requestor and reviewer roles without source or financial identifiers;
+- the exact evidence-package and control versions;
+- category-level pass, fail, and defer outcomes;
+- scope limitations and prohibited conclusions;
+- expiry, review, revocation, incident, and escalation fields;
+- remediation requirements and supersession links; and
+- a final disposition that remains fail-closed.
+
+The template is a governance record shape, not an execution interface, approval workflow, persistence design, or authorization grant.
+
+## 4. Explicit non-authorization statement
+
+Operator and developer use outside existing focused tests remains unauthorized.
+
+No completed field, reviewer name, signature, evidence reference, matrix pass, or record disposition permits anyone to import, invoke, wrap, register, expose, or document execution of the Phase 1A adapter or Phase 0W wrapper.
+
+For Phase 1F, `authorized` and `ready` are unavailable dispositions. Every new or copied record must initialize and remain at `defer`. Only a later, separately approved governance mission could define whether a final authorization process is safe; this template does not do so.
+
+## 5. Decision record overview
+
+Use one immutable record per requested review. The blank record metadata is:
+
+| Field | Required template value |
+| --- | --- |
+| Record version | `phase_1f_receivables_operator_authorization_decision_record_v1` |
+| Record reference | `[required non-sensitive reference]` |
+| Supersedes | `[none or prior non-sensitive record reference]` |
+| Created date | `[required date-only value]` |
+| Evidence package reference | `[required non-sensitive immutable reference]` |
+| Evidence matrix version | `[required exact version]` |
+| Code/contract manifest reference | `[required non-sensitive immutable reference]` |
+| Record state | `draft` |
+| Final disposition | `defer` |
+| Authorization available | `no` |
+
+The record must contain references and reviewer conclusions only. It must not contain receipt bodies, output envelopes, raw paths, source records, identifiers, credentials, personal/provider/bank data, or financial values.
+
+## 6. Requested use case
+
+| Field | Template entry |
+| --- | --- |
+| Bounded business purpose | `[required; non-financial and next-audit-only]` |
+| Review question | `[required; one narrow evidence-readiness question]` |
+| Evidence classification | `[synthetic-only or separately reviewed future classification]` |
+| Requested operator role | `[required role; no credentials or personal identifiers]` |
+| Proposed host class | `[required policy class; no path or host identifier]` |
+| Proposed review window | `[required start and expiry dates]` |
+| Explicit exclusions | `runtime, Firestore, environment, provider, payment, financial output, routes, jobs, UI` |
+
+The requested use case must not describe steps, commands, source queries, production access, payment behavior, or operational execution. Any use case that requires those capabilities is out of scope and makes the record `defer` or `blocked` under the evidence matrix.
+
+## 7. Requestor information
+
+| Field | Template entry |
+| --- | --- |
+| Request sponsor name | `[required approved business identity]` |
+| Sponsor role | `[required]` |
+| Sponsor organization/team | `[required non-sensitive label]` |
+| Business owner | `[required]` |
+| Technical owner | `[required]` |
+| Conflict declaration | `[none declared or disclosed reference]` |
+| Sponsor acknowledgement version | `[required]` |
+| Request date | `[required date-only value]` |
+
+The record must not include personal contact details, account IDs, credentials, tokens, tenant/landlord identifiers, or provider references. The sponsor cannot act as receipt preparer, sole receipt approver, operator, all domain reviewers, and final decision owner for the same request.
+
+## 8. Reviewer names and roles
+
+| Review domain | Reviewer name | Reviewer role | Independence/conflict state | Review state |
+| --- | --- | --- | --- | --- |
+| Accounting architecture | `[required]` | `[required]` | `[required]` | `defer` |
+| Implementation boundary | `[required]` | `[required]` | `[required]` | `defer` |
+| Security | `[required]` | `[required]` | `[required]` | `defer` |
+| Privacy | `[required]` | `[required]` | `[required]` | `defer` |
+| Operations governance | `[required]` | `[required]` | `[required]` | `defer` |
+| Receipt provenance | `[required if applicable]` | `[required]` | `[required]` | `defer` |
+| Receipt approval | `[required]` | `[required]` | `[required]` | `defer` |
+| Consolidated package review | `[required]` | `[required]` | `[required]` | `defer` |
+
+Every reviewer must be named, qualified, signed, version-aware, and independent of the artifact they approve. Self-review, proxy approval without accountability, or unresolved conflict blocks the record.
+
+## 9. Evidence package status
+
+| Field | Template entry |
+| --- | --- |
+| Package reference | `[required]` |
+| Package version | `[required]` |
+| Package status | `deferred` |
+| Required artifact count | `[required aggregate only]` |
+| Pass count | `[required aggregate only]` |
+| Fail count | `[required aggregate only]` |
+| Defer count | `[required aggregate only]` |
+| Blocking finding present | `[yes/no; default yes until reviewed]` |
+| Freshness state | `[current/expired/superseded/unverifiable]` |
+| Version alignment | `[aligned/misaligned/unverified]` |
+| Sensitive-content check | `[pass/fail/defer]` |
+
+The record must not embed evidence artifacts. `complete_for_future_authorization_review`, if referenced from Phase 1E, still does not change Phase 1F's final disposition from `defer`.
+
+## 10. Review matrix summary
+
+| Evidence category | Artifact reference | Owner role | Reviewer role | Status | Finding code | Freshness | Conflict state | Remediation reference |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Request and purpose | `[required]` | `[required]` | `[required]` | `defer` | `[required]` | `[required]` | `[required]` | `[if any]` |
+| Roles and independence | `[required]` | `[required]` | `[required]` | `defer` | `[required]` | `[required]` | `[required]` | `[if any]` |
+| Accounting boundaries | `[required]` | `[required]` | `[required]` | `defer` | `[required]` | `[required]` | `[required]` | `[if any]` |
+| Implementation boundary | `[required]` | `[required]` | `[required]` | `defer` | `[required]` | `[required]` | `[required]` | `[if any]` |
+| Receipt provenance | `[required]` | `[required]` | `[required]` | `defer` | `[required]` | `[required]` | `[required]` | `[if any]` |
+| Receipt approval | `[required]` | `[required]` | `[required]` | `defer` | `[required]` | `[required]` | `[required]` | `[if any]` |
+| Host/root/file handling | `[required]` | `[required]` | `[required]` | `defer` | `[required]` | `[required]` | `[required]` | `[if any]` |
+| Output handling | `[required]` | `[required]` | `[required]` | `defer` | `[required]` | `[required]` | `[required]` | `[if any]` |
+| Retention/deletion | `[required]` | `[required]` | `[required]` | `defer` | `[required]` | `[required]` | `[required]` | `[if any]` |
+| Training/acknowledgement | `[required]` | `[required]` | `[required]` | `defer` | `[required]` | `[required]` | `[required]` | `[if any]` |
+| Escalation/incident | `[required]` | `[required]` | `[required]` | `defer` | `[required]` | `[required]` | `[required]` | `[if any]` |
+| Audit-trail decision | `[required]` | `[required]` | `[required]` | `defer` | `[required]` | `[required]` | `[required]` | `[if any]` |
+| Consolidated sign-off | `[required]` | `[required]` | `[required]` | `defer` | `[required]` | `[required]` | `[required]` | `[if any]` |
+
+Rows are append-safe by supersession and cannot be scored or averaged. One fail or blocking finding controls the package.
+
+## 11. Pass/fail/defer decision fields
+
+| Field | Template entry |
+| --- | --- |
+| Category decision | `[pass/fail/defer; default defer]` |
+| Fixed finding code | `[required]` |
+| Non-sensitive rationale | `[required; no evidence body]` |
+| Acceptance criteria evaluated | `[required criteria-version reference]` |
+| Blocking finding | `[yes/no]` |
+| Evidence owner acknowledgement | `[required state]` |
+| Independent reviewer sign-off | `[required state]` |
+| Review date | `[required date-only value]` |
+| Evidence expiry date | `[required date-only value]` |
+| Supersedes decision | `[none or prior reference]` |
+
+`pass` means only that one evidence category meets Phase 1E criteria. `fail` sets the package to `blocked`. `defer` keeps it `deferred`. None of these values authorizes operator use.
+
+## 12. Scope limitations
+
+Every record must preserve these fixed limitations:
+
+- evidence readiness review only; no live source or environment inspection;
+- no execution instructions, commands, package scripts, CLI, runtime registration, routes, jobs, schedulers, or UI;
+- no Firestore, emulator, environment, credential, cloud, network, provider, payment, PAD, or bank-data access;
+- no financial output, balances, charges, payments, allocations, rent roll, aging, schedules, or tenant balances;
+- no persistence of receipt bodies or output envelopes;
+- no production, operational, compliance, accounting-assurance, schema-readiness, financial-readiness, or payment-readiness conclusion;
+- no change to existing ledger or RC1 demo behavior; and
+- direct settlement, landlord revenue, and no custody, pooling, payout liability, or money movement.
+
+Any requested exception is out of scope and keeps the disposition at `defer` or makes the evidence package `blocked`.
+
+## 13. Expiry and review date fields
+
+| Field | Template entry |
+| --- | --- |
+| Record created date | `[required]` |
+| Evidence cutoff date | `[required]` |
+| Domain review dates | `[required references]` |
+| Earliest artifact expiry | `[required]` |
+| Package expiry date | `[required; no later than earliest artifact expiry]` |
+| Scheduled re-review date | `[required if package remains active]` |
+| Expiry state | `[current/expired/unverifiable; default unverifiable]` |
+| Supersession date | `[if applicable]` |
+
+Any expired, superseded, misaligned, or unverifiable artifact returns the package and record to `defer`. Dates are evidence metadata only, not proof that a source or environment was inspected.
+
+## 14. Revocation conditions
+
+The record must list revocation or invalidation conditions, including:
+
+- code, adapter, wrapper, core, receipt, policy, training, matrix, or template version change;
+- request, operator, role, purpose, host class, evidence class, or review-window change;
+- reviewer conflict, identity mismatch, missing signature, or separation-of-duties failure;
+- provenance, completeness, consistency, redaction, integrity, custody, or sanitization failure;
+- sensitive or financial content discovery;
+- unexpected process, environment, Firestore, network, provider, payment, runtime, route, job, UI, or output behavior;
+- retention, deletion, containment, escalation, or incident-control failure;
+- evidence expiry, supersession, contradiction, or material amendment; and
+- any false operational, production, accounting, financial, compliance, or payment-readiness claim.
+
+Because authorization is unavailable in Phase 1F, these conditions invalidate review eligibility and preserve `defer` or `blocked` status.
+
+## 15. Incident and escalation contacts
+
+Record contacts by approved role, not personal contact details:
+
+| Escalation domain | Responsible role | Backup role | Contact-channel policy reference | Acknowledgement state |
+| --- | --- | --- | --- | --- |
+| Implementation | `[required]` | `[required]` | `[required non-sensitive reference]` | `[required]` |
+| Security | `[required]` | `[required]` | `[required non-sensitive reference]` | `[required]` |
+| Privacy | `[required]` | `[required]` | `[required non-sensitive reference]` | `[required]` |
+| Operations governance | `[required]` | `[required]` | `[required non-sensitive reference]` | `[required]` |
+| Accounting architecture | `[required]` | `[required]` | `[required non-sensitive reference]` | `[required]` |
+| Final package review | `[required]` | `[required]` | `[required non-sensitive reference]` | `[required]` |
+
+The record must contain only fixed non-sensitive incident codes. It must never contain receipt content, raw errors, paths, identifiers, personal/provider/bank data, credentials, or financial values.
+
+## 16. Required remediation items
+
+| Field | Template entry |
+| --- | --- |
+| Finding reference | `[required]` |
+| Affected category | `[required]` |
+| Finding status | `[fail/defer]` |
+| Root-cause class | `[fixed non-sensitive code]` |
+| Required replacement artifact | `[required artifact class]` |
+| Responsible owner | `[required role]` |
+| Required independent reviewers | `[required roles]` |
+| Target review date | `[required]` |
+| Disposal/containment evidence | `[required if applicable]` |
+| Retraining required | `[yes/no]` |
+| Superseding record required | `yes` |
+
+Remediation must create new immutable evidence and append-safe supersession. It cannot rely on waiver, urgency, assumed absence, same-session exception, in-place editing, or stronger evidence in another category.
+
+## 17. Final disposition
+
+Phase 1F final-disposition block:
+
+| Field | Required value |
+| --- | --- |
+| Final disposition | `defer` |
+| Operator use authorized | `no` |
+| Execution documentation permitted | `no` |
+| Package/CLI/runtime registration permitted | `no` |
+| Firestore/environment access permitted | `no` |
+| Financial output permitted | `no` |
+| Reason | `Phase 1F is a non-authorizing template; a separate governance decision is required` |
+| Final package reviewer | `[required for record completeness]` |
+| Record date | `[required]` |
+| Supersession status | `[current/superseded]` |
+
+No user of this template may replace `defer` with `authorized`, `approved`, `ready`, `production_ready`, or `operational_ready`. Those statuses are unavailable.
+
+## 18. Conditions that keep operator use deferred
+
+Operator use remains deferred when:
+
+- any required field, artifact, role, signature, review, training record, or acknowledgement is missing;
+- any evidence is stale, expired, superseded, conflicting, mutable, self-approved, sensitive, or version-misaligned;
+- any category is `fail` or `defer` or any blocking finding exists;
+- source-derived provenance, exact scope, completeness, consistency, redaction, integrity, approval, or custody is unproven;
+- host/root, output, retention, deletion, incident, escalation, or audit-trail controls remain documentary rather than evidenced;
+- execution, runtime, Firestore, environment, provider, payment, financial, route, job, UI, persistence, or user-visible scope is requested;
+- the record or evidence package contains raw/sensitive content; or
+- no separately approved governance process exists for a final authorization decision.
+
+In Phase 1F the final condition is always true, so every record remains deferred.
+
+## 19. Non-goals
+
+- No operator or developer use authorization.
+- No execution procedure, command, package script, CLI instruction, executable, local-command exposure, or runtime registration.
+- No Firestore, emulator, environment, credential, cloud, network, provider, or payment access.
+- No route, job, scheduler, server, worker, UI, or landlord-visible financial read.
+- No source provider, receipt producer, migration, backfill, index, IAM, infrastructure, deployment, persistence, or audit-record implementation.
+- No receipt body, output envelope, report, log, telemetry, screenshot, ticket, chat, email, or CI artifact retention.
+- No financial output, balance, charge, payment, allocation, rent roll, aging, schedule, or tenant balance.
+- No payment mutation, Rotessa, PAD, bank data, settlement, custody, pooled funds, payout liability, or money movement.
+- No production, operational, compliance, accounting-assurance, certification, schema-readiness, or payment-readiness claim.
+- No authorized or ready disposition in Phase 1F.
+- No change to existing ledger or RC1 demo behavior.
+- No treatment of tenant rent as RentChain revenue.
+
+## 20. Recommended next PR, if any
+
+The only safe next step is a docs-only decision-record governance-readiness audit:
+
+`audit/phase-1g-receivables-operator-decision-record-governance-readiness-v1`
+
+Suggested document:
+
+`docs/strategy/phase-1g-receivables-operator-decision-record-governance-readiness-v1.md`
+
+Phase 1G may review whether the template is sufficiently non-sensitive, append-safe, conflict-aware, version-bound, and clearly non-authorizing. It may define what additional policy evidence is missing before the template could be instantiated even for a synthetic tabletop review.
+
+Phase 1G must remain docs-only, pre-use, non-executable, and non-authorizing. It must not instantiate a real record, evaluate real evidence, add execution instructions, register a command, introduce Firestore/environment/runtime/persistence behavior, or create an authorized/ready status.
+
+## 21. Risks and guardrails
+
+| Risk | Guardrail |
+| --- | --- |
+| Formal template looks like authorization | Fix final disposition to defer and authorization available to no |
+| Names and record fields become sensitive | Permit approved identities and non-sensitive references only; prohibit account and source IDs |
+| Evidence bodies are pasted into the record | Require references and conclusions only |
+| Matrix passes are converted to readiness | State that category pass and package completeness grant no authority |
+| Reviewer independence is superficial | Require conflict fields, role separation, and blocking self-review |
+| Stale evidence survives through the record | Tie dates to earliest artifact expiry and require supersession |
+| Revocation is meaningless without authorization | Treat revocation conditions as review invalidation in Phase 1F |
+| Remediation rewrites history | Require new artifacts and superseding records |
+| Contact fields leak personal data | Record roles and policy references, not personal contact details |
+| Documentation enables execution | Keep commands, package, CLI, runtime, Firestore, environment, route, job, and UI scope prohibited |
+| Accounting work drifts into payment execution | Preserve direct settlement, landlord revenue, and no custody or money movement |
+
+Phase 1F therefore provides only a blank, deferred decision-record shape. Operator use remains unauthorized, and the Phase 1A adapter remains unregistered and test-invoked.


### PR DESCRIPTION
## Summary

- creates the Phase 1F receivables operator-authorization decision-record template
- keeps human/operator use explicitly unauthorized
- provides blank requested-use, requestor, reviewer, evidence-package, matrix, scope, expiry, revocation, incident, remediation, and disposition fields
- initializes every category and the final disposition to `defer`
- fixes operator authorization to `no` and makes authorized/ready statuses unavailable
- recommends only a docs-only Phase 1G governance-readiness audit

## Boundaries

- docs-only; one strategy file
- no execution commands or operator procedure
- no package script, CLI instruction, executable, runtime registration, route, job, scheduler, or UI
- no Firestore, environment, infrastructure, IAM, provider, payment, PAD, Rotessa, bank-data, money-movement, persistence, or financial-output behavior
- no operator, production, or operational-readiness authorization
- direct-settlement and landlord-revenue boundaries preserved
- RC1 behavior unchanged

## Validation

- all 21 required sections present
- `git diff --check` passed
- `git diff --cached --check` passed
- competitor-name scan passed
- execution-command pattern scan passed
- protected-scope scan passed
- exact docs-only one-file scope confirmed
- branch synchronized and working tree clean after push

Manual QA is not required because this PR changes documentation only.