### PR TITLE
Add Phase 1G operator governance readiness audit

### DIFF
--- a/docs/strategy/phase-1g-receivables-operator-governance-readiness-v1.md
+++ b/docs/strategy/phase-1g-receivables-operator-governance-readiness-v1.md
@@ -1,0 +1,271 @@
+# Phase 1G Receivables Operator Governance Readiness v1
+
+Status: governance-readiness audit only; operator use remains unauthorized and the authorization process remains deferred
+
+## 1. Executive summary
+
+Phases 1C through 1F form a coherent governance design for a future operator-authorization review. Together they define controls, required evidence, review criteria, and a decision-record shape that defaults to `defer` and makes authorized or ready statuses unavailable.
+
+That documentation is not operational governance evidence. No named and approved role assignment, authoritative receipt producer, approved host/root context, enforceable retention/deletion mechanism, tested incident process, approved audit-trail posture, or revocation mechanism has been proven. Phase 1F cannot be instantiated as an authorization record because its final disposition is fixed to `defer` and authorization is fixed to `no`.
+
+Decision: governance is not complete enough to begin an operator-use authorization process. Human use, execution instructions, local command exposure, package/CLI registration, and runtime use remain deferred. The next safe step may be a docs-only Phase 1H governance gap-closure evidence plan; no implementation or authorization PR is justified.
+
+Tenant rent remains landlord or property-manager revenue, not RentChain revenue. Direct settlement remains the future payment posture. Rotessa, PAD, provider execution, bank data, payment mutation, money movement, custody, pooled funds, landlord payout liabilities, and settlement float remain out of scope.
+
+## 2. Current accounting foundation recap
+
+The accounting foundation remains backend-only, staged, and unmounted. It includes deterministic receivables projections, safe DTO assembly, legacy-source normalization, a disabled comparator, receipt-driven provider/readiness cores, the Phase 0U command core, the Phase 0W sanitized-file wrapper, and the Phase 1A injected dev-entrypoint adapter.
+
+Phase 1A remains unregistered and test-invoked. It has no package script, accounting-barrel export, runtime startup registration, route, job, scheduler, UI, process-argument access, environment access, Firestore dependency, or human authorization.
+
+Phases 1C–1F add documentation only. They have not added an evidence producer, runtime access, persistence, a supported entrypoint, operator instruction, or a real authorization workflow.
+
+## 3. Governance artifact inventory
+
+| Artifact | Function | Implemented control evidence? | Authorization effect |
+| --- | --- | --- | --- |
+| Phase 1C control plan | Defines roles, request contents, provenance, custody, output, retention, training, escalation, and audit expectations | No; requirements only | None |
+| Phase 1D evidence checklist | Defines artifact owners, reviewers, acceptance conditions, freshness, and sign-off package contents | No; checklist only | None |
+| Phase 1E review matrix | Defines `pass`, `fail`, `defer`, blocking findings, remediation, and package aggregation | No; matrix only | None |
+| Phase 1F decision record | Defines blank request/reviewer/evidence/date/revocation/remediation fields | No; template fixed to `defer` | Explicitly no authorization |
+
+The artifacts align on direct settlement, landlord revenue, non-financial output, no persistence by default, and fail-closed review. None establishes the real actors, systems, evidence, or enforcement needed for controlled use.
+
+## 4. What Phase 1C provides
+
+Phase 1C provides a strong control architecture:
+
+- named role types and separation-of-duties expectations;
+- version-bound authorization-request contents;
+- receipt provenance, sanitization, integrity, and custody requirements;
+- local host/root and file-handling expectations;
+- bounded non-financial output interpretation;
+- no-retention and deletion posture;
+- training, acknowledgement, escalation, incident, audit, and revocation expectations; and
+- explicit prohibition on operator use and execution documentation.
+
+It does not assign real people, approve policies, implement controls, or supply evidence that the controls work.
+
+## 5. What Phase 1D provides
+
+Phase 1D converts the control plan into evidence categories with accountable owner roles, independent reviewer roles, minimum artifacts, expiry/freshness rules, and fail-closed defaults. It distinguishes non-sensitive control references from prohibited receipt, output, path, identifier, personal, provider, bank, and financial content.
+
+It also defines the expected sign-off package order and preserves `reject` for prohibited evidence and `defer` for incomplete evidence.
+
+It does not create or approve any evidence artifact, nominate real owners/reviewers, validate independence, or prove that a reviewable package can be assembled.
+
+## 6. What Phase 1E provides
+
+Phase 1E standardizes artifact-level `pass`, `fail`, and `defer` decisions. It prevents scoring or compensating controls from hiding a failed category, makes blocking findings control the whole package, and defines remediation through new immutable evidence and append-safe supersession.
+
+Its most favorable package state is `complete_for_future_authorization_review`, which is explicitly not authorization. It intentionally omits approved, authorized, and ready statuses.
+
+It does not supply reviewer tooling, enforce independence, persist review history, test remediation, or create a future authorization decision process.
+
+## 7. What Phase 1F provides
+
+Phase 1F supplies a blank, non-sensitive decision-record shape covering request, requestor, reviewers, evidence package, matrix summary, scope, dates, revocation, escalation, remediation, and final disposition.
+
+Every category and the final disposition defaults to `defer`; operator authorization is fixed to `no`; execution documentation, runtime registration, Firestore/environment access, and financial output are fixed to `no`.
+
+The template is deliberately incapable of recording authorization. It has no approved instantiation process, storage, identity verification, signature mechanism, append-safe persistence, or final authorization workflow.
+
+## 8. Governance completeness assessment
+
+| Governance domain | Design completeness | Evidence completeness | Readiness decision |
+| --- | --- | --- | --- |
+| Scope and non-goals | Strong and consistent | Documented | Sufficient for continued planning only |
+| Roles and separation | Role types defined | No real assignments, eligibility, or conflict checks | Incomplete |
+| Evidence package | Contents and review rules defined | No package or evidence producer | Incomplete |
+| Decision record | Blank fail-closed template defined | No approved instantiation or governance | Incomplete |
+| Retention/deletion | No-retention posture defined | No enforceable mechanism or deletion proof | Incomplete |
+| Escalation/incident | Stops and role classes defined | No approved contacts, exercises, or response evidence | Incomplete |
+| Audit trail | Minimal metadata boundaries defined | No approved no-persistence decision or safe implementation | Incomplete |
+| Revocation | Conditions defined | No authority source or enforcement mechanism | Incomplete |
+
+Overall result: governance documentation is internally coherent, but governance evidence is materially incomplete. Operator authorization review may not begin.
+
+## 9. Reviewer-role readiness
+
+The artifacts identify appropriate reviewer domains: request sponsor, accounting architecture, implementation, security, privacy, operations governance, receipt producer/preparer/approver, consolidated package reviewer, and final authorization owner.
+
+Remaining blockers:
+
+- no named role owners or eligibility standard;
+- no approved separation-of-duties matrix for the actual organization;
+- no identity or signature mechanism;
+- no conflict disclosure, adjudication, or recusal process;
+- no backup/delegation rules that preserve independence;
+- no final authorization authority charter; and
+- no evidence that reviewers understand the non-financial and no-authorization boundaries.
+
+Reviewer-role readiness is `defer`.
+
+## 10. Evidence-package readiness
+
+Phase 1D and 1E define a thorough package structure and review discipline. However:
+
+- synthetic fixtures are the only currently approved evidence class;
+- no separately audited authoritative receipt producer exists;
+- no real provenance, ownership, exact-scope, completeness, consistency, redaction, or integrity evidence exists;
+- no version/freshness registry binds artifacts to an immutable package;
+- no safe repository or transfer mechanism for non-sensitive references is approved;
+- no evidence-package assembler or validation process is authorized; and
+- no complete package has undergone independent review.
+
+Evidence-package readiness is `defer`. A source-derived package would be `blocked` until producer authority is separately proven.
+
+## 11. Decision-record readiness
+
+Phase 1F is structurally suitable for a synthetic tabletop review because it defaults every decision to `defer`, disallows authorization, and excludes sensitive evidence bodies. It is not ready for real instantiation because:
+
+- there is no approved record custodian;
+- identity and reviewer signatures are not defined;
+- immutable creation and append-safe supersession are not implemented;
+- field validation and sensitive-content exclusion are not enforced;
+- expiry and revocation state changes have no authority source;
+- no storage, access, projection, retention, or deletion posture is approved; and
+- no final authorization process exists to consume the record.
+
+Decision-record readiness is `defer`. Phase 1F should remain a blank reference artifact.
+
+## 12. Retention/deletion readiness
+
+The documents consistently require no retention of receipt inputs or output envelopes beyond a bounded review session and prohibit leakage through editor history, shell/terminal capture, clipboard managers, telemetry, sync, backups, screenshots, tickets, chat, email, and CI artifacts.
+
+Missing evidence includes:
+
+- approved host controls that can enforce the no-retention posture;
+- a verified ephemeral-root lifecycle;
+- coverage and configuration evidence for backup, sync, indexing, endpoint telemetry, and crash reporting;
+- a deletion deadline and accountable verifier;
+- an approved deletion-verification method;
+- legal-hold and incident exceptions that do not retain prohibited content; and
+- an escalation/revocation response when deletion cannot be proven.
+
+Retention/deletion readiness is `defer`.
+
+## 13. Escalation and incident-readiness
+
+Phase 1C–1F define sound stop conditions and escalation domains, but operational readiness is unproven. There are no approved role contacts, acknowledgement records, severity mapping, response-time expectations, containment playbook, tabletop exercise, evidence-disposal procedure, or resumption authority.
+
+There is also no proof that an incident can be recorded using only fixed non-sensitive reason codes without exposing receipt content, output, paths, identifiers, personal/provider/bank data, credentials, or financial values.
+
+Escalation and incident-readiness is `defer`. Any suspected exposure must continue to invalidate the candidate receipt and request.
+
+## 14. Audit-trail readiness
+
+The artifacts define a minimal candidate metadata boundary and require append-safe supersession. They also correctly state that no persistence is authorized.
+
+Remaining blockers:
+
+- no explicit approved choice between no persistence and a minimal audit trail;
+- no canonical schema or audience projection;
+- no authority-sensitive write/read model;
+- no append-safe implementation or correction/supersession proof;
+- no retention/deletion/access review;
+- no protection against embedding source, receipt, output, identifier, path, personal/provider/bank, credential, or financial content; and
+- no incident-access or legal-hold policy.
+
+Audit-trail readiness is `defer`. No storage implementation should proceed from this audit.
+
+## 15. Revocation-control readiness
+
+Phase 1C and 1F list appropriate invalidation conditions: version, purpose, operator, role, host, evidence class, conflict, provenance, custody, sanitization, sensitive-data, dependency, retention, deletion, incident, expiry, and false-readiness changes.
+
+Revocation cannot be operational while authorization itself is unavailable. There is no canonical authorization source, effective-state model, revocation authority, notification path, enforcement point, expiry monitor, or proof that a revoked record cannot be reused.
+
+Revocation-control readiness is `defer`. Current behavior is simpler and safer: there is no operator authorization to revoke.
+
+## 16. Remaining governance gaps
+
+The blocking gaps are:
+
+1. Approved organizational role assignments and separation-of-duties/conflict policy.
+2. A separately audited authoritative receipt-producer design and evidence chain.
+3. An approved local host, root, integrity, custody, and no-ambient-access policy.
+4. Enforceable retention/deletion controls with independent verification.
+5. Versioned training, acknowledgement, and prohibited-conclusion review.
+6. Tested escalation, containment, incident, and resumption governance.
+7. An explicit no-persistence decision or separately approved minimal audit-trail design.
+8. A canonical authorization authority and revocation state model, if authorization is ever proposed.
+9. Evidence freshness, expiry, conflict, supersession, and package-custody governance.
+10. A separate final go/no-go process that can evaluate evidence without creating execution capability.
+
+Documentation completeness cannot close these gaps by itself.
+
+## 17. Operator-use authorization decision
+
+Decision: `defer`.
+
+- Operator use authorized: `no`.
+- Execution documentation permitted: `no`.
+- Package/CLI/local-command exposure permitted: `no`.
+- Runtime registration permitted: `no`.
+- Firestore or environment access permitted: `no`.
+- Financial output permitted: `no`.
+- Production or operational-readiness claim permitted: `no`.
+
+The governance artifacts are complete enough to guide further planning, but not sufficient to open an authorization process. No future operator-use authorization request should be accepted until real evidence closes every blocking gap and a later audit explicitly approves the review process itself.
+
+## 18. Conditions that keep operator use deferred
+
+Operator use remains deferred while any of the following is true:
+
+- role owners, reviewer independence, identity, signature, or conflict governance is unproven;
+- the evidence package relies on synthetic data for a source-derived purpose or lacks an authoritative producer;
+- host/root, integrity, custody, sensitive-content, output, retention, deletion, or incident controls are documentary rather than enforced and tested;
+- the decision record cannot be instantiated, validated, superseded, and protected safely;
+- audit-trail and revocation authority remain undefined;
+- evidence is missing, stale, expired, conflicting, mutable, self-approved, or version-misaligned;
+- any blocking finding from Phase 1E remains open;
+- execution, runtime, Firestore, environment, route, job, UI, provider, payment, financial, persistence, or user-visible scope is introduced; or
+- a separate final authorization-review process has not been explicitly approved.
+
+All conditions currently apply in whole or in part. Operator use therefore remains unauthorized.
+
+## 19. Non-goals
+
+- No operator or developer use authorization.
+- No execution procedure, command, package script, CLI instruction, executable, local-command exposure, or runtime registration.
+- No Firestore, emulator, environment, credential, cloud, network, provider, or payment access.
+- No route, job, scheduler, server, worker, UI, or landlord-visible financial read.
+- No source provider, receipt producer, migration, backfill, index, IAM, infrastructure, deployment, persistence, or audit-record implementation.
+- No real decision-record instance or evidence-package review.
+- No receipt body, output envelope, report, log, telemetry, screenshot, ticket, chat, email, or CI artifact retention.
+- No financial output, balance, charge, payment, allocation, rent roll, aging, schedule, or tenant balance.
+- No payment mutation, Rotessa, PAD, bank data, settlement, custody, pooled funds, payout liability, or money movement.
+- No authorized/ready status or production, operational, compliance, accounting-assurance, certification, schema-readiness, or payment-readiness claim.
+- No change to existing ledger or RC1 demo behavior.
+- No treatment of tenant rent as RentChain revenue.
+
+## 20. Recommended next PR, if any
+
+The only safe next step is a docs-only governance gap-closure evidence plan:
+
+`docs/phase-1h-receivables-operator-governance-gap-closure-plan-v1`
+
+Suggested document:
+
+`docs/strategy/phase-1h-receivables-operator-governance-gap-closure-plan-v1.md`
+
+Phase 1H may assign evidence categories to owner roles, define dependency order, acceptance evidence, freshness rules, review gates, and stop conditions for closing the ten Phase 1G governance gaps. It must treat all assignments as proposed roles unless organizational owners separately accept them.
+
+Phase 1H must remain docs-only, pre-use, non-executable, and non-authorizing. It must not instantiate a real decision record, add execution instructions, register a command, introduce Firestore/environment/runtime/persistence behavior, create an authorized/ready status, or claim a gap is closed without external evidence.
+
+## 21. Risks and guardrails
+
+| Risk | Guardrail |
+| --- | --- |
+| Documentation maturity is confused with governance readiness | Separate design completeness from implemented and tested evidence |
+| Placeholder roles are treated as assignments | Require explicit organizational acceptance, eligibility, conflict, and identity proof |
+| Synthetic evidence is used for real-source claims | Block source-derived use until a separately audited producer exists |
+| Blank decision template becomes an approval form | Keep authorization fixed to no and final disposition fixed to defer |
+| No-retention language is assumed enforceable | Require host controls, deletion proof, and independent verification |
+| Incident plan is untested | Require role acknowledgement and tabletop evidence before readiness |
+| Audit metadata becomes a sensitive store | Preserve no-persistence default and require separate schema/projection review |
+| Revocation is claimed without an authority source | Keep authorization unavailable until a canonical state model exists |
+| Gap closure expands into implementation | Limit the next step to docs-only evidence planning |
+| Accounting work drifts into payment execution | Preserve direct settlement, landlord revenue, and no custody or money movement |
+
+Phase 1G therefore concludes that governance design is coherent but operational governance evidence is incomplete. Operator use and any authorization process remain deferred.


### PR DESCRIPTION
## Summary
- creates the Phase 1G governance-readiness audit
- reviews Phase 1C, 1D, 1E, and 1F governance artifacts together
- documents remaining gaps across reviewer roles, evidence packages, decision records, retention and deletion, escalation and incidents, audit trails, and revocation
- keeps operator use and the authorization process deferred
- recommends only a docs-only Phase 1H governance gap-closure evidence plan

## Boundaries
- operator use remains unauthorized
- no execution commands, package scripts, CLI instructions, or runtime registration
- no Firestore or environment access, routes, jobs, UI, or financial output
- no production or operational readiness claims
- Rotessa, PAD, provider integration, payment processing, bank data, and money movement remain out of scope
- direct settlement and the landlord-revenue boundary are preserved
- no RC1 behavior changes

## Validation
- docs-only one-file scope confirmed
- all 21 required sections present
- git diff --check passed
- git diff --cached --check passed
- competitor-name scan passed
- execution-command pattern scan passed
- protected-scope scan passed
- no runtime behavior changed
- manual QA not required