### PR TITLE
Add Phase 1H governance gap closure evidence plan

### DIFF
--- a/docs/strategy/phase-1h-receivables-governance-gap-closure-evidence-plan-v1.md
+++ b/docs/strategy/phase-1h-receivables-governance-gap-closure-evidence-plan-v1.md
@@ -1,0 +1,324 @@
+# Phase 1H Receivables Governance Gap-Closure Evidence Plan v1
+
+Status: evidence-planning only; operator use remains unauthorized and authorization review remains deferred
+
+## 1. Executive summary
+
+Phase 1G found that the Phase 1C through Phase 1F governance documents form a coherent design but do not prove that the required controls exist or work. This plan maps every Phase 1G gap to the evidence, proposed owner role, independent reviewer role, acceptance criteria, and fail-closed disposition needed before a future authorization-review readiness audit could be considered.
+
+No gap is closed by this document. Role assignments are proposed role classes, not accepted organizational appointments. Evidence descriptions are requirements, not evidence artifacts. Operator use and authorization review remain deferred until every blocking gap is supported by current, immutable, independently reviewed evidence and a later docs-only audit explicitly determines that the evidence package is complete enough for review.
+
+Tenant rent remains landlord or property-manager revenue, not RentChain revenue. Direct settlement remains the future payment posture. Rotessa, PAD, provider execution, bank data, payment mutation, money movement, custody, pooled funds, landlord payout liabilities, and settlement float remain out of scope.
+
+## 2. Current accounting foundation recap
+
+The receivables foundation remains staged, backend-only, and unmounted. It includes deterministic receivables primitives, safe DTO assembly, legacy-source normalization, disabled comparison and readiness cores, the receipt-driven schema inventory core, the sanitized-file wrapper, and the injected Phase 1A dev-entrypoint adapter.
+
+Phase 1A remains unregistered and test-invoked only. There is no package script, command registration, runtime call site, Firestore or environment access, route, job, scheduler, UI, financial output, or human-use authorization.
+
+Phases 1C through 1G are documentation artifacts only. They define governance expectations, evidence categories, review rules, a defer-only decision-record template, and the remaining gaps. They do not implement or authorize an evidence producer, operator workflow, persistent audit record, authorization process, or execution capability.
+
+## 3. Purpose of the gap-closure evidence plan
+
+This plan establishes a controlled path for collecting non-sensitive governance evidence without enabling use of the Phase 1A adapter. It is intended to:
+
+- preserve the ten blocking gaps identified in Phase 1G;
+- prevent policy prose from being mistaken for implemented control evidence;
+- identify accountable owner and independent reviewer role classes;
+- define minimum evidence, acceptance, freshness, and supersession requirements;
+- make fail and defer outcomes explicit;
+- sequence review so downstream evidence cannot mask an upstream failure; and
+- keep all operator, authorization-review, execution, runtime, financial, and payment behavior unavailable.
+
+The plan governs evidence about controls. It must never contain receipt bodies, source records, output envelopes, raw identifiers, paths, credentials, personal data, provider data, bank data, or financial values.
+
+## 4. Explicit non-authorization statement
+
+This document does not authorize operator or developer use. It does not approve an authorization review, execution procedure, command, entrypoint exposure, source read, or production workflow.
+
+The only valid current disposition is `defer`. An evidence item may later be assessed as meeting its stated acceptance criteria, but that assessment would close only the named governance gap. It would not authorize use, permit execution documentation, create an authorized or ready state, or approve an authorization review.
+
+## 5. Phase 1G governance gaps summary
+
+Phase 1G identified ten blocking gaps:
+
+1. Approved organizational role assignments and separation-of-duties/conflict policy.
+2. A separately audited authoritative receipt-producer design and evidence chain.
+3. An approved local host, root, integrity, custody, and no-ambient-access policy.
+4. Enforceable retention/deletion controls with independent verification.
+5. Versioned training, acknowledgement, and prohibited-conclusion review.
+6. Tested escalation, containment, incident, and resumption governance.
+7. An explicit no-persistence decision or separately approved minimal audit-trail design.
+8. A canonical authorization authority and revocation state model, if authorization is ever proposed.
+9. Evidence freshness, expiry, conflict, supersession, and package-custody governance.
+10. A separate final go/no-go process that evaluates evidence without creating execution capability.
+
+These gaps are interdependent. A complete document for one gap cannot compensate for missing implementation evidence in another.
+
+## 6. Gap closure matrix
+
+| Gap | Minimum closure evidence | Proposed owner role | Independent reviewer role | Current status |
+| --- | --- | --- | --- | --- |
+| 1. Roles and separation | Approved role charter, assignment register, eligibility rules, conflict/recusal process, delegation rules, acknowledgement records | Operations governance owner | Security and privacy reviewers | `defer` |
+| 2. Receipt producer and chain | Separately audited producer design, authority proof, provenance model, exact-scope/completeness rules, redaction contract, integrity and version evidence | Accounting architecture owner | Security and implementation reviewers | `defer` |
+| 3. Host/root/custody | Approved local-context control specification, root lifecycle, integrity/custody controls, ambient-access exclusions, independent control test evidence | Security owner | Privacy and operations governance reviewers | `defer` |
+| 4. Retention/deletion | Approved no-retention policy, deletion deadline, backup/sync/telemetry coverage, deletion verification, exception and failure handling | Privacy owner | Security and operations governance reviewers | `defer` |
+| 5. Training | Versioned curriculum, prohibited-conclusion module, operator/reviewer acknowledgements, assessment and expiry criteria | Operations governance owner | Accounting architecture and privacy reviewers | `defer` |
+| 6. Incident governance | Contact roster, severity model, containment/disposal/resumption plan, non-sensitive logging rules, completed tabletop and remediation evidence | Security incident owner | Privacy and operations governance reviewers | `defer` |
+| 7. Audit-trail posture | Approved no-persistence decision or separately reviewed minimal metadata design, audience/access, append-safe correction, retention/deletion, sensitive-field exclusions | Governance records owner | Security and privacy reviewers | `defer` |
+| 8. Revocation | Authority charter, canonical state model, revocation conditions, enforcement points, notification, expiry, reuse prevention, test evidence | Final authorization owner | Security and operations governance reviewers | `defer` |
+| 9. Package governance | Evidence manifest, version/freshness rules, immutable references, custody, conflict detection, supersession history, independent package review | Evidence package custodian | Consolidated package reviewer | `defer` |
+| 10. Final go/no-go | Approved review charter, required participants, decision boundaries, fixed fail/defer states, independence proof, non-execution mandate | Executive governance sponsor | Legal/privacy/security/accounting reviewers as applicable | `defer` |
+
+## 7. Reviewer-role gap evidence
+
+Gap 1 requires evidence that real organizational actors can perform the roles defined in Phase 1C without self-approval or unresolved conflicts.
+
+Required artifacts:
+
+- an approved role charter describing authority, eligibility, accountability, and prohibited role combinations;
+- a dated assignment register using approved organizational identities rather than free-form aliases;
+- separation-of-duties and independence rules for preparation, approval, review, custody, and final disposition;
+- a conflict-disclosure, recusal, replacement, and adjudication policy;
+- delegation and backup rules that preserve independence;
+- acknowledgement that non-financial output cannot prove accounting correctness or operational readiness; and
+- evidence of approval by security, privacy, accounting architecture, and operations governance role classes.
+
+Acceptance requires complete assignments for every required role, no unresolved conflict, verifiable approval identity, current acknowledgements, and a defined final authority charter. Missing assignments, self-review, ambiguous authority, expired acknowledgement, or an unresolved conflict results in `defer`; falsified or prohibited evidence results in `fail`.
+
+## 8. Evidence-package gap evidence
+
+Gaps 2 and 9 require proof that evidence can be produced, normalized, referenced, reviewed, and superseded without exposing source or financial content.
+
+Required artifacts:
+
+- a separately approved authoritative receipt-producer design identifying authority sources and prohibited fallbacks;
+- provenance, exact-scope, ownership, completeness, consistency, pagination, redaction, integrity, and version contracts;
+- proof that synthetic fixtures are not represented as source-derived evidence;
+- an evidence manifest schema containing only non-sensitive references, versions, dates, hashes where approved, owner/reviewer roles, status, and supersession relationships;
+- freshness and expiry rules for every evidence category;
+- custody and transfer rules that exclude receipt bodies, outputs, identifiers, paths, personal/provider/bank data, credentials, and financial values;
+- conflict detection and append-safe supersession expectations; and
+- an independently reviewed synthetic package demonstrating that the manifest can reject missing, stale, conflicting, mutable, or self-approved evidence.
+
+No real source-derived package is permitted until the producer authority and its redaction/completeness controls have been separately audited. Any catch-to-empty, capped-without-proof, alias-only, post-filtered, ambiguous, or overlapping evidence chain remains blocked.
+
+## 9. Decision-record gap evidence
+
+Phase 1F remains a blank defer-only template. Gap closure for decision-record governance requires:
+
+- an approved record custodian and audience model;
+- identity, reviewer-attestation, and separation-of-duties rules;
+- field-level validation and sensitive-content exclusion requirements;
+- immutable creation and append-safe correction/supersession expectations;
+- explicit version binding to the request, evidence manifest, review matrix, policies, and software artifacts;
+- expiry, invalidation, and revocation state-change authority;
+- approved retention, deletion, access-review, and incident-access rules; and
+- a synthetic tabletop record proving that every incomplete or blocked category preserves `defer` and authorization `no`.
+
+Acceptance does not permit an authorization outcome. It only proves that a future record could represent a fail-closed review accurately. Until a later audit approves a separate authorization process, the template must not gain authorized or ready states.
+
+## 10. Retention/deletion gap evidence
+
+Gaps 3 and 4 require control evidence for the complete local data lifecycle.
+
+Required artifacts:
+
+- an approved host and ephemeral-root control specification;
+- proof that the root cannot be silently widened, auto-discovered, synced, backed up, indexed, or reused;
+- coverage evidence for editor history, clipboard managers, terminal capture, crash reporting, telemetry, temporary storage, screenshots, tickets, chat, email, and CI artifacts;
+- a bounded deletion deadline and accountable deletion verifier;
+- an independent deletion-verification method that does not preserve prohibited content;
+- rules for failed deletion, device loss, unexpected persistence, legal hold, and incident containment; and
+- a completed synthetic control test showing fail-closed behavior when deletion or custody cannot be proven.
+
+Acceptance requires enforceable controls and independent test evidence, not policy acknowledgement alone. Any uncontrolled backup, sync, telemetry, cache, history, or unverifiable deletion requires `defer`; confirmed prohibited retention requires `fail` and incident escalation.
+
+## 11. Escalation/incident gap evidence
+
+Gap 6 requires evidence that suspected exposure or control failure can be contained without leaking more data.
+
+Required artifacts:
+
+- an approved role-based contact roster with acknowledgement and backup coverage;
+- severity, reporting-time, containment, evidence-disposal, investigation, notification, and resumption rules;
+- fixed non-sensitive incident categories and reason codes;
+- an explicit prohibition on including receipts, outputs, paths, identifiers, personal/provider/bank data, credentials, or financial values in incident records;
+- revocation and invalidation triggers for affected evidence, requests, roles, hosts, and versions;
+- a completed tabletop exercise covering suspected exposure, incomplete deletion, custody break, reviewer conflict, and false-readiness claims; and
+- remediation and independent retest evidence for every tabletop finding.
+
+Acceptance requires no open high-severity tabletop finding, complete role acknowledgement, tested containment, and a separately approved resumption authority. Missing contacts, untested response, unsafe logging, or unresolved findings require `defer` or `fail` according to severity.
+
+## 12. Audit-trail gap evidence
+
+Gap 7 must first resolve whether any audit persistence is justified. The default remains no persistence.
+
+Option A evidence:
+
+- an explicit approved no-persistence decision;
+- proof that no audit write path or ambient logging exists; and
+- a review explaining how future evidence remains accountable without retaining prohibited content.
+
+Option B may be considered only through a separate docs-first audit and requires:
+
+- a minimal non-financial metadata schema and strict audience projections;
+- authority-sensitive read/write boundaries;
+- append-safe creation, correction, and supersession rules;
+- retention, deletion, access-review, incident-access, and legal-hold policies;
+- a prohibited-field threat model and validation evidence; and
+- proof that receipt bodies, outputs, identifiers, paths, personal/provider/bank data, credentials, and financial values cannot be stored.
+
+Phase 1H does not choose or implement either option. Until one posture is explicitly approved, audit-trail readiness remains `defer`.
+
+## 13. Revocation-control gap evidence
+
+Gap 8 is conditional because there is currently no authorization to revoke. If a future authorization process is ever proposed, required evidence includes:
+
+- a canonical authorization authority charter;
+- a versioned state model that excludes implicit or inferred authorization;
+- explicit expiry and revocation conditions;
+- named revocation authority and independent oversight;
+- notification, acknowledgement, and escalation expectations;
+- enforcement points that fail closed when state is absent, expired, ambiguous, or revoked;
+- proof that stale records, copied artifacts, delegated identities, and superseded versions cannot be reused; and
+- synthetic tests of immediate revocation, expiry, incident revocation, conflict revocation, and failed notification.
+
+Until this evidence exists and a later audit accepts it, the safe state is authorization `no`; revocation readiness remains `defer`.
+
+## 14. Evidence owner and reviewer assignments
+
+The following are proposed role classes only. They do not appoint people or grant authority.
+
+| Evidence domain | Accountable owner role | Required independent reviewers | Prohibited combination |
+| --- | --- | --- | --- |
+| Roles and authorization charter | Operations governance owner | Security, privacy, accounting architecture | Owner cannot be final sole approver |
+| Receipt producer and provenance | Accounting architecture owner | Security, implementation, privacy | Producer/preparer cannot approve own evidence |
+| Host/root/custody | Security owner | Privacy, operations governance | Host administrator cannot be sole verifier |
+| Retention/deletion | Privacy owner | Security, operations governance | Deletion performer cannot be sole verifier |
+| Training/acknowledgement | Operations governance owner | Accounting architecture, privacy | Curriculum author cannot self-certify completion |
+| Incident/resumption | Security incident owner | Privacy, operations governance | Incident subject cannot authorize resumption |
+| Audit-trail posture | Governance records owner | Security, privacy | Schema owner cannot approve audience/access alone |
+| Revocation | Final authorization owner | Security, operations governance | Request sponsor cannot control revocation alone |
+| Evidence package | Evidence package custodian | Consolidated package reviewer | Custodian cannot provide final package disposition |
+| Final go/no-go process | Executive governance sponsor | Independent legal/privacy/security/accounting roles as applicable | No implementation or operator role may self-authorize |
+
+Actual identities, eligibility, conflicts, delegation, acknowledgement, and acceptance must be evidenced before these assignments become effective.
+
+## 15. Acceptance criteria for each gap
+
+A gap may be recorded as `evidence_complete_for_gap_review` only when all of the following hold:
+
+1. Every required artifact exists as a non-sensitive, immutable, versioned reference.
+2. The accountable owner and independent reviewers are eligible, identified, conflict-checked, and current.
+3. Evidence is bound to the exact policy, artifact, purpose, host class, and software versions under review.
+4. Freshness and expiry requirements are satisfied.
+5. Required control tests or tabletop exercises have passed with no unresolved blocking finding.
+6. Sensitive-content exclusions have been independently checked.
+7. Conflicts and superseded artifacts are explicitly resolved through append-safe history.
+8. Acceptance is unanimous where the controlling Phase 1C–1F artifact requires it.
+9. The evidence closes only the named gap and makes no operator, authorization, execution, production, operational, accounting-assurance, or payment-readiness claim.
+10. A consolidated package reviewer confirms that closure does not depend on an unclosed upstream gap.
+
+`evidence_complete_for_gap_review` is not an authorized or ready state and does not allow authorization review to begin.
+
+## 16. Fail/defer conditions for each gap
+
+Use `defer` when evidence is missing, partial, stale, expired, version-misaligned, ambiguous, mutable, untested, self-reviewed, or dependent on another open gap.
+
+Use `fail` when evidence is materially false or contradictory; contains prohibited content; shows an unresolved separation-of-duties conflict; proves unauthorized source, runtime, Firestore, environment, financial, provider, or payment behavior; shows uncontrolled retention or exposure; or bypasses a required reviewer or control.
+
+No compensating score, majority vote, low-risk label, or downstream pass may override a `fail` or `defer`. Remediation requires a new immutable artifact, explicit supersession of the prior artifact, conflict resolution, independent re-review, and renewed freshness assessment.
+
+## 17. Sign-off sequencing
+
+Evidence review must proceed in dependency order:
+
+1. Approve role eligibility, independence, conflict, identity, and authority rules.
+2. Review receipt-producer authority and evidence-package provenance/completeness contracts.
+3. Review host/root/custody and retention/deletion controls.
+4. Review training and prohibited-conclusion acknowledgements.
+5. Review escalation, incident, containment, disposal, and resumption evidence.
+6. Decide and review the audit-trail posture.
+7. Review package freshness, expiry, conflict, custody, and supersession evidence.
+8. Review decision-record governance.
+9. Review revocation governance only if a future authorization model is proposed.
+10. Conduct a separate docs-only consolidated gap-closure readiness audit.
+
+No step may start merely because a previous owner submitted evidence; the preceding step must have completed independent review without an open blocking finding. Step 10 may conclude only whether the evidence package is complete enough to consider designing an authorization-review process. It cannot authorize use or execution.
+
+## 18. What remains blocked until each gap is closed
+
+| Open gap | Capabilities and claims that remain blocked |
+| --- | --- |
+| Roles and separation | Evidence approval, consolidated review, final disposition, operator nomination |
+| Receipt producer and chain | Source-derived receipts, real-data claims, completeness or authority claims |
+| Host/root/custody | Human handling of receipt files, local exposure, execution documentation |
+| Retention/deletion | Any bounded operator session, output handling, evidence disposal claim |
+| Training | Operator participation, reviewer participation, output interpretation |
+| Incident governance | Any activity that could require containment, investigation, or resumption |
+| Audit-trail posture | Persistent review records, audit-history claims, record instantiation |
+| Revocation | Any authorization model, expiry claim, suspension, or reuse-prevention claim |
+| Package governance | Consolidated evidence status, freshness claim, gap-closure assertion |
+| Final go/no-go | Authorization-review design, authorization request acceptance, operator use |
+
+All rows are currently blocked. Closing one row does not unblock another.
+
+## 19. Conditions that keep operator use deferred
+
+Operator use and authorization review remain deferred while any required gap evidence is absent, incomplete, stale, expired, conflicting, mutable, self-approved, untested, version-misaligned, or dependent on an open upstream gap.
+
+They also remain deferred if:
+
+- organizational owners have not explicitly accepted their roles;
+- receipt-producer authority or source completeness is not independently proven;
+- host, custody, retention, deletion, incident, audit, or revocation controls exist only as prose;
+- a blocking Phase 1E finding remains unresolved;
+- the evidence package contains or references prohibited sensitive content;
+- a future review process has not been separately audited and approved for consideration; or
+- scope expands into execution instructions, registration, runtime behavior, Firestore/environment access, routes, jobs, UI, financial output, providers, payment processing, persistence, or user-visible behavior.
+
+Every condition currently applies in whole or in part. The disposition remains `defer` and operator authorization remains `no`.
+
+## 20. Non-goals
+
+- No operator or developer use authorization and no authorization-review approval.
+- No execution procedure, command, package script, CLI instruction, executable, local-command exposure, or runtime registration.
+- No Firestore, emulator, environment, credential, cloud, network, provider, or payment access.
+- No route, job, scheduler, server, worker, UI, or landlord-visible financial read.
+- No source provider, receipt producer, migration, backfill, index, IAM, infrastructure, deployment, persistence, or audit-record implementation.
+- No real evidence collection, decision-record instance, authorization request, or evidence-package sign-off.
+- No receipt body, output envelope, identifier, path, personal/provider/bank data, credential, or financial-value retention.
+- No financial output, balance, charge, payment, allocation, rent roll, aging, schedule, or tenant balance.
+- No payment mutation, Rotessa, PAD, settlement, custody, pooled funds, payout liability, or money movement.
+- No authorized or ready state and no production, operational, compliance, accounting-assurance, certification, schema-readiness, or payment-readiness claim.
+- No change to existing ledger behavior or RC1 demo behavior.
+- No treatment of tenant rent as RentChain revenue.
+
+## 21. Recommended next PR, if any
+
+No implementation PR or automatic follow-on documentation PR is justified by this plan alone. The next work is organizational evidence preparation and independent review outside the runtime product path.
+
+Only after non-sensitive evidence exists for all ten gaps should a docs-only readiness audit be considered:
+
+`audit/phase-1i-receivables-governance-gap-closure-readiness-v1`
+
+That future audit would verify evidence references, freshness, independence, conflicts, test/tabletop outcomes, and sequencing. It must remain pre-use, non-executable, and non-authorizing; it may only conclude whether governance evidence is complete enough to consider a separately scoped authorization-review process. It must not add an authorized or ready state or claim any gap closed without independently reviewable evidence.
+
+## 22. Risks and guardrails
+
+| Risk | Guardrail |
+| --- | --- |
+| Evidence requirements are mistaken for evidence | Mark every current gap `defer` and require independently reviewable artifacts |
+| Proposed role classes are treated as appointments | Require explicit organizational acceptance, identity, eligibility, and conflict proof |
+| One closed gap is used to bypass another | Preserve dependency ordering and prohibit compensating scores |
+| Synthetic fixtures support source-derived claims | Block real-source claims until producer authority is separately audited |
+| Evidence package leaks sensitive or financial content | Store only approved non-sensitive references and enforce prohibited-field review |
+| Retention policy is mistaken for deletion proof | Require enforceable controls, independent verification, and failure escalation |
+| Tabletop completion hides unresolved findings | Require remediation and independent retest before acceptance |
+| Audit trail creates a sensitive persistence surface | Preserve no-persistence default pending a separate approved design |
+| Revocation is designed before authorization authority exists | Keep authorization fixed to no and review revocation only conditionally |
+| Gap closure becomes execution enablement | Keep all commands, registrations, runtime access, routes, jobs, UI, and financial output prohibited |
+| Accounting governance drifts into payment execution | Preserve direct settlement, landlord revenue, and no custody or money movement |
+
+Phase 1H therefore defines the evidence required to close the Phase 1G governance gaps while preserving the present decision: operator use remains unauthorized and authorization review remains deferred.


### PR DESCRIPTION
## Summary
- creates the Phase 1H governance gap-closure evidence plan
- keeps operator use unauthorized and authorization review deferred
- maps all ten Phase 1G governance gaps to required evidence, proposed owner and reviewer roles, acceptance criteria, fail/defer conditions, and sign-off sequencing
- documents what remains blocked until every gap is independently closed
- recommends no automatic follow-on PR; only a future docs-only Phase 1I readiness audit after real non-sensitive evidence exists

## Boundaries
- no execution commands, package scripts, CLI instructions, or runtime registration
- no operator-use authorization or authorization-review approval
- no Firestore or environment access, routes, jobs, schedulers, UI, or financial output
- no production or operational readiness claims and no authorized or ready state
- Rotessa, PAD, provider integration, payment processing, bank data, and money movement remain out of scope
- direct settlement and the landlord-revenue boundary are preserved
- no RC1 behavior changes

## Validation
- docs-only one-file scope confirmed
- all 22 required sections present
- git diff --check passed
- git diff --cached --check passed
- competitor-name scan passed
- execution-command pattern scan passed
- protected-scope scan passed
- no runtime behavior changed
- manual QA not required