### PR TITLE
Add Phase 1I operator authorization evidence package

### DIFF
--- a/docs/strategy/phase-1i-receivables-operator-authorization-evidence-package-v1.md
+++ b/docs/strategy/phase-1i-receivables-operator-authorization-evidence-package-v1.md
@@ -55,6 +55,7 @@ Placeholders such as `[MANUAL INPUT REQUIRED]`, `[TBD]`, `[UNASSIGNED]`, `[DRAFT
 | --- | --- |
 | Package name | Phase 1I Receivables Operator Authorization Evidence Package |
 | Package version | v1 draft |
+| Package owner | Paul / Founder |
 | Package status | Reviewable but deferred |
 | Operator use | Unauthorized |
 | Execution | Not authorized |
@@ -69,11 +70,11 @@ Placeholders such as `[MANUAL INPUT REQUIRED]`, `[TBD]`, `[UNASSIGNED]`, `[DRAFT
 
 | Review area | Reviewer role | Assigned person | Status | Notes |
 | --- | --- | --- | --- | --- |
-| Business purpose | Founder or product owner | [MANUAL INPUT REQUIRED] | [UNASSIGNED] — Deferred | Confirms business purpose and scope only |
-| Technical safety | Backend-accounting reviewer | [MANUAL INPUT REQUIRED] | [UNASSIGNED] — Deferred | Confirms no runtime, Firestore, payment, or financial-output exposure |
-| Privacy/security | Privacy-security reviewer | [MANUAL INPUT REQUIRED] | [UNASSIGNED] — Deferred | Confirms no sensitive data is present |
+| Business purpose | Founder or product owner | Paul / Founder | [ASSIGNED] — Deferred | Confirms business purpose and scope only |
+| Technical safety | Backend-accounting reviewer | Reviewer A / Technical reviewer | [ASSIGNED] — Deferred | Confirms no runtime, Firestore, payment, or financial-output exposure |
+| Privacy/security | Privacy-security reviewer | Reviewer B / Privacy-security reviewer | [ASSIGNED] — Deferred | Confirms no sensitive data is present |
 | Accounting | Accountant-bookkeeper-controller reviewer | [MANUAL INPUT REQUIRED] | [UNASSIGNED] — Deferred | Confirms output is not treated as books or a rent balance |
-| Final decision owner | Authorized approver role | [MANUAL INPUT REQUIRED] | [UNASSIGNED] — Deferred | May only defer or approve a next review step; cannot authorize use here |
+| Final decision owner | Authorized approver role | Paul / Founder | [ASSIGNED] — Deferred | May only defer or approve a next review step; cannot authorize use here |
 
 Assignment rules:
 
@@ -86,14 +87,14 @@ Assignment rules:
 
 | Evidence item | Owner | Reviewer | Status | Notes |
 | --- | --- | --- | --- | --- |
-| Reviewer assignment table | [MANUAL INPUT REQUIRED] | [MANUAL INPUT REQUIRED] | [DRAFT] / Deferred | Must prove role eligibility and independence |
-| Evidence owner table | [MANUAL INPUT REQUIRED] | [MANUAL INPUT REQUIRED] | [DRAFT] / Deferred | Must prevent self-approval |
-| Sanitized receipt provenance sample | [MANUAL INPUT REQUIRED] | [MANUAL INPUT REQUIRED] | Sample only / Deferred | Synthetic evidence only |
-| Retention/deletion plan | [MANUAL INPUT REQUIRED] | [MANUAL INPUT REQUIRED] | [DRAFT] / Deferred | Policy text is not enforcement proof |
-| Escalation contacts | [MANUAL INPUT REQUIRED] | [MANUAL INPUT REQUIRED] | [UNASSIGNED] / Deferred | Role-based contacts only |
-| Audit-trail example | [MANUAL INPUT REQUIRED] | [MANUAL INPUT REQUIRED] | Sample only / Deferred | No persistence is approved |
-| Sign-off package sample | [MANUAL INPUT REQUIRED] | [MANUAL INPUT REQUIRED] | Sample only / Deferred | Cannot authorize operator use |
-| Gap reviewability table | [MANUAL INPUT REQUIRED] | [MANUAL INPUT REQUIRED] | [DRAFT] / Deferred | Every row defaults to Defer |
+| Reviewer assignment table | Paul / Founder | Reviewer A / Technical reviewer | Draft / Deferred | Must prove role eligibility and independence |
+| Evidence owner table | Paul / Founder | Reviewer A / Technical reviewer | Draft / Deferred | Must prevent self-approval |
+| Sanitized receipt provenance sample | Reviewer A / Technical reviewer | Reviewer B / Privacy-security reviewer | Sample only / Deferred | Synthetic evidence only |
+| Retention/deletion plan | Paul / Founder | Reviewer B / Privacy-security reviewer | Draft / Deferred | Policy text is not enforcement proof |
+| Escalation contacts | Paul / Founder | Reviewer B / Privacy-security reviewer | Draft / Deferred | Role-based contacts only |
+| Audit-trail example | Reviewer A / Technical reviewer | Paul / Founder | Sample only / Deferred | No persistence is approved |
+| Sign-off package sample | Paul / Founder | Reviewer A / Technical reviewer and Reviewer B / Privacy-security reviewer | Sample only / Deferred | Cannot authorize operator use |
+| Gap reviewability table | Paul / Founder | Reviewer A / Technical reviewer and Reviewer B / Privacy-security reviewer | Draft / Deferred | Every row defaults to Defer |
 
 If an evidence owner or independent reviewer is missing, the related gap remains open. Ownership of a template does not prove the underlying control exists.
 
@@ -105,10 +106,10 @@ The sample contains no real tenant names, tenant emails, bank data, rent amounts
 
 | Manual field | Value |
 | --- | --- |
-| Prepared by | [MANUAL INPUT REQUIRED] |
-| Prepared date | [MANUAL INPUT REQUIRED] |
+| Prepared by | Reviewer A / Technical reviewer |
+| Prepared date | [TO BE COMPLETED DURING REVIEW] |
 | Source type | Synthetic sample only |
-| Reviewer | [MANUAL INPUT REQUIRED] |
+| Reviewer | Reviewer B / Privacy-security reviewer |
 | Review status | Deferred |
 
 ```json
@@ -174,10 +175,10 @@ Discovery of sensitive data, financial amounts, credentials, paths, provider sec
 
 | Field | Value |
 | --- | --- |
-| Retention owner | [MANUAL INPUT REQUIRED] |
-| Deletion reviewer | [MANUAL INPUT REQUIRED] |
-| Approved local review folder | [MANUAL INPUT REQUIRED] |
-| Retention period | [MANUAL INPUT REQUIRED] |
+| Retention owner | Paul / Founder |
+| Deletion reviewer | Reviewer B / Privacy-security reviewer |
+| Approved local review folder | [TBD] — approved local review folder not yet designated |
+| Retention period | [TBD] — proposed period not yet reviewed |
 | Deletion confirmation required | Yes |
 | Current status | [DRAFT] / Deferred |
 
@@ -198,8 +199,8 @@ This sample plan is not proof that host, storage, retention, or deletion control
 
 | Manual field | Value |
 | --- | --- |
-| Primary role assignment | [MANUAL INPUT REQUIRED] |
-| Backup role assignment | [MANUAL INPUT REQUIRED] |
+| Primary role assignment | Paul / Founder |
+| Backup role assignment | Reviewer B / Privacy-security reviewer |
 | Escalation status | Deferred |
 
 The package does not require or permit personal phone numbers, personal email addresses, or other personal contact details. Missing role assignments keep the package deferred.
@@ -268,14 +269,14 @@ Any missing, placeholder-only, stale, conflicting, unsafe, or self-approved atta
 
 | Gap | Evidence artifact | Owner | Reviewer | Reviewable? | Current status | Decision |
 | --- | --- | --- | --- | --- | --- | --- |
-| Reviewer assignments | Reviewer assignment table | [UNASSIGNED] | [UNASSIGNED] | No | Draft / Incomplete | Defer |
-| Evidence owners | Evidence owner table | [UNASSIGNED] | [UNASSIGNED] | No | Draft / Incomplete | Defer |
-| Sanitized receipt provenance | Synthetic provenance sample | [UNASSIGNED] | [UNASSIGNED] | Sample only | Sample only / Deferred | Defer |
-| Retention/deletion plan | Plan sample and future control evidence | [UNASSIGNED] | [UNASSIGNED] | No | Draft / Incomplete | Defer |
-| Escalation contacts | Role-based contact table | [UNASSIGNED] | [UNASSIGNED] | No | Draft / Incomplete | Defer |
-| Audit trail | Non-persistent audit example | [UNASSIGNED] | [UNASSIGNED] | Sample only | Sample only / Deferred | Defer |
-| Sign-off package | Sign-off page sample | [UNASSIGNED] | [UNASSIGNED] | Sample only | Sample only / Deferred | Defer |
-| Non-sensitive proof | Non-sensitive proof summary | [UNASSIGNED] | [UNASSIGNED] | Draft only | Draft / Deferred | Defer |
+| Reviewer assignments | Reviewer assignment table | Paul / Founder | Reviewer A / Technical reviewer | Partial | Draft / Incomplete | Defer |
+| Evidence owners | Evidence owner table | Paul / Founder | Reviewer A / Technical reviewer | Partial | Draft / Incomplete | Defer |
+| Sanitized receipt provenance | Synthetic provenance sample | Reviewer A / Technical reviewer | Reviewer B / Privacy-security reviewer | Sample only | Sample only / Deferred | Defer |
+| Retention/deletion plan | Plan sample and future control evidence | Paul / Founder | Reviewer B / Privacy-security reviewer | Partial | Draft / Incomplete | Defer |
+| Escalation contacts | Role-based contact table | Paul / Founder | Reviewer B / Privacy-security reviewer | Partial | Draft / Incomplete | Defer |
+| Audit trail | Non-persistent audit example | Reviewer A / Technical reviewer | Paul / Founder | Sample only | Sample only / Deferred | Defer |
+| Sign-off package | Sign-off page sample | Paul / Founder | Reviewer A / Technical reviewer and Reviewer B / Privacy-security reviewer | Sample only | Sample only / Deferred | Defer |
+| Non-sensitive proof | Non-sensitive proof summary | Paul / Founder | Reviewer A / Technical reviewer and Reviewer B / Privacy-security reviewer | Draft only | Draft / Deferred | Defer |
 
 If any row is not reviewable, Phase 1I cannot proceed to a Stage 3 review. `Sample only` and `Draft only` are not complete or passing states.
 

--- a/docs/strategy/phase-1i-receivables-operator-authorization-evidence-package-v1.md
+++ b/docs/strategy/phase-1i-receivables-operator-authorization-evidence-package-v1.md
@@ -1,0 +1,367 @@
+# Phase 1I Receivables Operator Authorization Evidence Package v1
+
+Status: draft evidence package; reviewable but deferred; operator use remains unauthorized
+
+## 1. Executive summary
+
+This package is a draft evidence package with manual-input placeholders. Operator use remains unauthorized. This package is not an execution procedure and does not approve an authorization review.
+
+Its purpose is to demonstrate that the governance process can be organized for review using synthetic, redacted, role-based, or otherwise non-sensitive evidence. It is intended to help reviewers determine whether evidence categories are reviewable, incomplete, blocked, or deferred. It does not establish that any Phase 1H governance gap is closed.
+
+The intended planning transition is from Stage 2 in progress toward Stage 2 evidence completeness for a later Stage 3 readiness review. This document does not complete that transition. Every approval and decision field defaults to `Deferred` unless the field is explicitly unavailable.
+
+Tenant rent remains landlord or property-manager revenue, not RentChain revenue. Direct settlement remains the future payment posture. RentChain-held funds, pooled rent accounts, trust custody, landlord payout liabilities, and settlement float remain out of scope.
+
+## 2. Explicit non-authorization statement
+
+This package does not authorize:
+
+- operator or developer use;
+- execution commands;
+- package scripts;
+- CLI instructions;
+- Firestore access;
+- environment access;
+- production data access;
+- runtime invocation or registration;
+- routes, jobs, schedulers, or UI;
+- financial output or financial reporting;
+- payment or PAD processing;
+- Rotessa or other provider integration;
+- production readiness; or
+- operational readiness.
+
+The package cannot be used as an operator procedure, access approval, control exception, go-live approval, or substitute for a later separately approved review process.
+
+## 3. Current accounting foundation recap
+
+The staged receivables/accounting foundation from Phase 0 through Phase 1H is complete within each approved scope. It remains non-payment-processing and preserves the direct-settlement and landlord-revenue boundaries.
+
+The Phase 0W local wrapper exists, but operator use is not authorized. The Phase 1A dev-entrypoint adapter remains unregistered, dependency-injected, and test-invoked only. It has no package script, command registration, runtime call site, Firestore or environment access, route, job, scheduler, UI, or financial output.
+
+Phase 1H concluded that no automatic follow-on implementation PR should proceed until independently reviewable, non-sensitive evidence exists for all governance gaps. Phase 1I is only a manual-input package template for organizing that evidence. It does not provide the evidence, close a gap, or approve Stage 3 review.
+
+## 4. Purpose of this evidence package
+
+The package organizes future evidence references, role assignments, review states, and fail-closed decisions in one non-sensitive structure. Reviewers may later use a completed version to assess whether each evidence category is reviewable, incomplete, blocked, or deferred.
+
+The package is not intended to approve tool use. It must not contain real tenant or payment records, receipt bodies, output envelopes, raw identifiers, provider secrets, credentials, Firestore or storage paths, internal scope keys, environment values, bank data, or financial amounts.
+
+Placeholders such as `[MANUAL INPUT REQUIRED]`, `[TBD]`, `[UNASSIGNED]`, `[DRAFT]`, and `[DEFERRED]` identify missing evidence. A placeholder is not evidence and cannot receive a passing disposition.
+
+## 5. Evidence package status
+
+| Field | Value |
+| --- | --- |
+| Package name | Phase 1I Receivables Operator Authorization Evidence Package |
+| Package version | v1 draft |
+| Package status | Reviewable but deferred |
+| Operator use | Unauthorized |
+| Execution | Not authorized |
+| Authorization review | Deferred |
+| Production readiness | Not claimed |
+| Operational readiness | Not claimed |
+| Gap-closure claim | None |
+
+`Reviewable but deferred` means only that the empty package structure can be inspected. It does not mean the evidence is complete, the package is approved, or a Stage 3 review may begin.
+
+## 6. Reviewer assignments
+
+| Review area | Reviewer role | Assigned person | Status | Notes |
+| --- | --- | --- | --- | --- |
+| Business purpose | Founder or product owner | [MANUAL INPUT REQUIRED] | [UNASSIGNED] — Deferred | Confirms business purpose and scope only |
+| Technical safety | Backend-accounting reviewer | [MANUAL INPUT REQUIRED] | [UNASSIGNED] — Deferred | Confirms no runtime, Firestore, payment, or financial-output exposure |
+| Privacy/security | Privacy-security reviewer | [MANUAL INPUT REQUIRED] | [UNASSIGNED] — Deferred | Confirms no sensitive data is present |
+| Accounting | Accountant-bookkeeper-controller reviewer | [MANUAL INPUT REQUIRED] | [UNASSIGNED] — Deferred | Confirms output is not treated as books or a rent balance |
+| Final decision owner | Authorized approver role | [MANUAL INPUT REQUIRED] | [UNASSIGNED] — Deferred | May only defer or approve a next review step; cannot authorize use here |
+
+Assignment rules:
+
+- An assignment requires identity, eligibility, independence, conflict, recusal, delegation, and acknowledgement evidence defined by Phase 1H.
+- The preparer may not approve their own evidence.
+- `[ASSIGNED]` may replace `[UNASSIGNED]` only after independent assignment review; the decision field still remains `Deferred` in this package.
+- If any reviewer is unassigned, operator use and authorization review remain deferred.
+
+## 7. Evidence owners
+
+| Evidence item | Owner | Reviewer | Status | Notes |
+| --- | --- | --- | --- | --- |
+| Reviewer assignment table | [MANUAL INPUT REQUIRED] | [MANUAL INPUT REQUIRED] | [DRAFT] / Deferred | Must prove role eligibility and independence |
+| Evidence owner table | [MANUAL INPUT REQUIRED] | [MANUAL INPUT REQUIRED] | [DRAFT] / Deferred | Must prevent self-approval |
+| Sanitized receipt provenance sample | [MANUAL INPUT REQUIRED] | [MANUAL INPUT REQUIRED] | Sample only / Deferred | Synthetic evidence only |
+| Retention/deletion plan | [MANUAL INPUT REQUIRED] | [MANUAL INPUT REQUIRED] | [DRAFT] / Deferred | Policy text is not enforcement proof |
+| Escalation contacts | [MANUAL INPUT REQUIRED] | [MANUAL INPUT REQUIRED] | [UNASSIGNED] / Deferred | Role-based contacts only |
+| Audit-trail example | [MANUAL INPUT REQUIRED] | [MANUAL INPUT REQUIRED] | Sample only / Deferred | No persistence is approved |
+| Sign-off package sample | [MANUAL INPUT REQUIRED] | [MANUAL INPUT REQUIRED] | Sample only / Deferred | Cannot authorize operator use |
+| Gap reviewability table | [MANUAL INPUT REQUIRED] | [MANUAL INPUT REQUIRED] | [DRAFT] / Deferred | Every row defaults to Defer |
+
+If an evidence owner or independent reviewer is missing, the related gap remains open. Ownership of a template does not prove the underlying control exists.
+
+## 8. Sanitized receipt provenance sample
+
+This is a synthetic sample only. It was not exported from production or Firestore and was not generated from real tenant, lease, rent, payment, property, unit, ledger, provider, or bank records.
+
+The sample contains no real tenant names, tenant emails, bank data, rent amounts, payment amounts, provider IDs or secrets, Firestore paths, credentials, environment values, storage paths, internal scope keys, or raw internal identifiers.
+
+| Manual field | Value |
+| --- | --- |
+| Prepared by | [MANUAL INPUT REQUIRED] |
+| Prepared date | [MANUAL INPUT REQUIRED] |
+| Source type | Synthetic sample only |
+| Reviewer | [MANUAL INPUT REQUIRED] |
+| Review status | Deferred |
+
+```json
+{
+  "receiptPackageVersion": "sample-v1",
+  "preparedFor": "Phase 1I evidence review only",
+  "sourceType": "synthetic",
+  "containsProductionData": false,
+  "containsBankData": false,
+  "containsFinancialAmounts": false,
+  "containsProviderSecrets": false,
+  "containsFirestorePaths": false,
+  "reviewPurpose": "Prove sanitized receipt format can be reviewed",
+  "sampleReceipts": [
+    {
+      "receiptType": "schemaEvidence",
+      "status": "sample_only",
+      "notes": "No financial or tenant data included"
+    },
+    {
+      "receiptType": "indexEvidence",
+      "status": "sample_only",
+      "notes": "No infrastructure changes implied"
+    }
+  ]
+}
+```
+
+Warning: this sample does not authorize operator use, prove source authority, close a Phase 1H gap, or prove production or operational readiness.
+
+## 9. Retention/deletion plan sample
+
+### Scope
+
+Only approved non-sensitive governance evidence references and synthetic samples may be considered. Real receipt bodies, real outputs, personal data, provider data, bank data, credentials, paths, internal identifiers, and financial amounts are prohibited.
+
+### Storage
+
+- Store draft evidence only in an approved local review folder.
+- Do not email evidence files externally.
+- Do not upload evidence to production systems.
+- Do not store evidence in public or shared folders unless separately approved.
+- Do not assume editor history, clipboard, sync, backup, telemetry, indexing, cache, screenshot, chat, ticket, email, or CI storage is safe.
+
+### Retention
+
+- Retain draft evidence files only while the review is open and only for the approved period.
+- The retention period must be documented and independently reviewed before any manual evidence is handled.
+- No retention exception is implicit.
+
+### Deletion
+
+- Delete any accidentally supplied sensitive file immediately and stop the review.
+- The retention owner records the deletion date using non-sensitive metadata only.
+- A reviewer independently confirms deletion when sensitive content was found.
+- If deletion cannot be proven, the package remains deferred and the incident path applies.
+
+### Incident condition
+
+Discovery of sensitive data, financial amounts, credentials, paths, provider secrets, bank data, uncontrolled copies, failed deletion, or ambiguous custody requires the reviewer to stop, defer, document a non-sensitive incident category, and replace the evidence only after independent approval.
+
+### Manual confirmation fields
+
+| Field | Value |
+| --- | --- |
+| Retention owner | [MANUAL INPUT REQUIRED] |
+| Deletion reviewer | [MANUAL INPUT REQUIRED] |
+| Approved local review folder | [MANUAL INPUT REQUIRED] |
+| Retention period | [MANUAL INPUT REQUIRED] |
+| Deletion confirmation required | Yes |
+| Current status | [DRAFT] / Deferred |
+
+This sample plan is not proof that host, storage, retention, or deletion controls are implemented or effective.
+
+## 10. Escalation/incident contact roles
+
+| Incident type | Primary role | Backup role | Required action | Status |
+| --- | --- | --- | --- | --- |
+| Sensitive data found | Privacy-security reviewer | Operations governance reviewer | Stop, defer, document, and replace evidence | Deferred |
+| Bank data found | Privacy-security reviewer | Security incident owner | Stop, defer, document, and replace evidence | Deferred |
+| Financial amounts found | Accounting reviewer | Privacy-security reviewer | Stop, defer, document, and replace evidence | Deferred |
+| Provider secret found | Security incident owner | Privacy-security reviewer | Stop, defer, document, and replace evidence | Deferred |
+| Tool output contains financial data | Technical safety reviewer | Accounting reviewer | Stop, defer, document, and replace evidence | Deferred |
+| Unclear ownership/reviewer gap | Operations governance reviewer | Final decision owner role | Stop, defer, document, and replace evidence | Deferred |
+| Missing retention/deletion evidence | Privacy reviewer | Security reviewer | Stop, defer, document, and replace evidence | Deferred |
+| Audit trail incomplete | Governance records reviewer | Operations governance reviewer | Stop, defer, document, and replace evidence | Deferred |
+
+| Manual field | Value |
+| --- | --- |
+| Primary role assignment | [MANUAL INPUT REQUIRED] |
+| Backup role assignment | [MANUAL INPUT REQUIRED] |
+| Escalation status | Deferred |
+
+The package does not require or permit personal phone numbers, personal email addresses, or other personal contact details. Missing role assignments keep the package deferred.
+
+## 11. Audit-trail example
+
+This is a non-persistent sample template. Phase 1I does not approve an audit store or write path.
+
+| Field | Value |
+| --- | --- |
+| Review package | Phase 1I Receivables Operator Authorization Evidence Package |
+| Package version | v1 draft |
+| Review date | [MANUAL INPUT REQUIRED] |
+| Related PR | [MANUAL INPUT REQUIRED] |
+| Commit SHA | [MANUAL INPUT REQUIRED] |
+| Reviewer roles | [MANUAL INPUT REQUIRED] |
+| Evidence reviewed | [MANUAL INPUT REQUIRED] |
+| Decision | Deferred |
+| Reason | Evidence package is reviewable, but operator use remains unauthorized. |
+| Open gaps | [MANUAL INPUT REQUIRED] |
+| Retention/deletion confirmation | [MANUAL INPUT REQUIRED] |
+| Final status | Deferred |
+
+Any future real audit-trail posture requires the separate no-persistence or minimal-metadata decision and controls specified in Phase 1H.
+
+## 12. Sign-off package sample
+
+| Field | Value |
+| --- | --- |
+| Package name | Phase 1I Operator Authorization Evidence Review |
+| Default status | Deferred |
+| Final disposition | Deferred |
+| Reason | This package proves the review process can be evaluated. It does not authorize use. |
+
+Decision options available within this sample:
+
+- Deferred
+- Incomplete
+- Ready for next audit only
+
+`Ready for next audit only` does not authorize operator use or Stage 3. It only indicates that a separately approved docs-only audit may inspect the completed evidence package.
+
+Unavailable decisions:
+
+- Operator use authorized
+- Production ready
+- Operationally ready
+- Firestore access approved
+- Payment/PAD processing approved
+- Rotessa integration approved
+- Financial reporting approved
+
+Required attachments:
+
+- Reviewer assignment table
+- Evidence owner table
+- Sanitized receipt provenance sample
+- Retention/deletion plan
+- Escalation/incident contact roles
+- Audit-trail example
+- Gap reviewability table
+
+Any missing, placeholder-only, stale, conflicting, unsafe, or self-approved attachment preserves the final disposition `Deferred`.
+
+## 13. Gap reviewability table
+
+| Gap | Evidence artifact | Owner | Reviewer | Reviewable? | Current status | Decision |
+| --- | --- | --- | --- | --- | --- | --- |
+| Reviewer assignments | Reviewer assignment table | [UNASSIGNED] | [UNASSIGNED] | No | Draft / Incomplete | Defer |
+| Evidence owners | Evidence owner table | [UNASSIGNED] | [UNASSIGNED] | No | Draft / Incomplete | Defer |
+| Sanitized receipt provenance | Synthetic provenance sample | [UNASSIGNED] | [UNASSIGNED] | Sample only | Sample only / Deferred | Defer |
+| Retention/deletion plan | Plan sample and future control evidence | [UNASSIGNED] | [UNASSIGNED] | No | Draft / Incomplete | Defer |
+| Escalation contacts | Role-based contact table | [UNASSIGNED] | [UNASSIGNED] | No | Draft / Incomplete | Defer |
+| Audit trail | Non-persistent audit example | [UNASSIGNED] | [UNASSIGNED] | Sample only | Sample only / Deferred | Defer |
+| Sign-off package | Sign-off page sample | [UNASSIGNED] | [UNASSIGNED] | Sample only | Sample only / Deferred | Defer |
+| Non-sensitive proof | Non-sensitive proof summary | [UNASSIGNED] | [UNASSIGNED] | Draft only | Draft / Deferred | Defer |
+
+If any row is not reviewable, Phase 1I cannot proceed to a Stage 3 review. `Sample only` and `Draft only` are not complete or passing states.
+
+## 14. Non-sensitive proof summary
+
+The governance package can be structured without exposing sensitive or financial information:
+
+- No real tenant data is required.
+- No bank data is required.
+- No rent or payment amounts are required.
+- No provider IDs or secrets are required.
+- No Firestore or storage paths are required.
+- No production credentials or environment values are required.
+- No raw internal identifiers or scope keys are required.
+- Evidence can remain role-based, synthetic, redacted, or non-sensitive.
+
+This proves only that the package format can be reviewed without prohibited content. It does not prove that organizational roles are assigned, controls are enforced, evidence is authoritative, Phase 1H gaps are closed, or an authorization process is ready.
+
+## 15. Final package status
+
+Final package status: **Reviewable but deferred.**
+
+This package shows that the governance gaps can be organized for review using non-sensitive evidence. It does not authorize operator use, execution commands, Firestore access, production data, payment/PAD processing, Rotessa integration, financial output, production readiness, or operational readiness.
+
+The current package contains placeholders and samples rather than independently reviewed gap-closure evidence. Stage 2 remains in progress and Stage 3 review remains deferred.
+
+## 16. Conditions that keep operator use deferred
+
+Operator use and authorization review remain deferred when any of the following applies:
+
+- Any reviewer role is unassigned.
+- Any evidence owner or independent reviewer is missing.
+- Sanitized receipt provenance is not reviewed.
+- The retention/deletion plan is not approved and independently tested.
+- Escalation contacts or backup roles are missing.
+- The audit trail decision or evidence is incomplete.
+- The sign-off package is incomplete.
+- Any sensitive data, real source data, financial amount, bank data, provider secret, credential, path, or raw identifier is discovered.
+- Any execution command, package script, CLI instruction, or operator procedure is requested.
+- Any Firestore, environment, runtime, production-data, route, job, scheduler, or UI access is requested.
+- Any financial output or financial-reporting behavior is requested.
+- Any production-readiness, operational-readiness, authorization, gap-closure, or Stage 3 approval claim is requested without a separate approved process and sufficient evidence.
+
+All conditions currently apply in whole or in part. The decision remains `Deferred`.
+
+## 17. Recommended next step
+
+No implementation PR is recommended from this evidence package.
+
+A future Phase 1I evidence review may occur only after this package is filled in with independently reviewable, non-sensitive evidence for every Phase 1H gap.
+
+Potential future branch, only after evidence exists:
+
+`audit/phase-1i-receivables-operator-authorization-readiness-evidence-review-v1`
+
+That future work must remain docs-only and may classify each gap as closed, incomplete, blocked, or deferred. It must keep operator use unauthorized unless a later, separately approved authorization process is explicitly established.
+
+## 18. Non-goals
+
+- No execution commands.
+- No package scripts or CLI instructions.
+- No operator-use authorization or authorization-review approval.
+- No runtime invocation or registration.
+- No Firestore, environment, production-data, credential, provider, or payment access.
+- No routes, jobs, schedulers, or UI.
+- No financial output or financial reporting.
+- No production or operational readiness claim.
+- No authorized or ready status.
+- No provider, payment, PAD, or Rotessa integration.
+- No bank data or money movement.
+- No RC1 behavior changes.
+- Tenant rent is not RentChain revenue.
+- No RentChain-held funds, pooled rent accounts, trust custody, landlord payout liabilities, or settlement float.
+
+## 19. Risks and guardrails
+
+| Risk | Guardrail |
+| --- | --- |
+| Evidence package is mistaken for approval | Default every approval and decision to Deferred and repeat the non-authorization boundary |
+| Sanitized sample accidentally includes sensitive data | Permit synthetic, redacted, role-based, or non-sensitive evidence only; stop on discovery |
+| Output is interpreted as financial readiness | Prohibit financial output and state that samples are not books, balances, or accounting assurance |
+| Reviewer roles remain unassigned | Mark assignments `[UNASSIGNED]` and block Stage 3 review |
+| Retention/deletion is documented but not enforced | Treat the sample as draft and require independent control evidence |
+| Pressure builds to add execution commands too early | Keep commands, scripts, CLI instructions, procedures, and runtime registration prohibited |
+| Sample evidence is mistaken for gap closure | Label every sample `Sample only` and every gap decision `Defer` |
+| Reviewable is mistaken for ready | Define reviewability as package-format inspectability only and preserve Stage 2 in progress |
+| Accounting governance drifts into payment execution | Preserve direct settlement, landlord revenue, and no custody or money movement |
+
+Phase 1I therefore provides only a draft, non-sensitive evidence-package structure. Operator use remains unauthorized, authorization review remains deferred, and no runtime behavior changes.


### PR DESCRIPTION
## Summary
- creates the Phase 1I draft operator authorization evidence package
- adds manual-input placeholders for reviewer assignments, evidence owners, provenance, retention/deletion, escalation, audit trail, sign-off, and gap reviewability
- includes a synthetic non-sensitive JSON receipt sample only
- defaults every approval to Deferred and every gap decision to Defer
- keeps Stage 2 in progress and Stage 3 review deferred

## Boundaries
- operator use remains unauthorized and authorization review remains deferred
- no execution commands, package scripts, CLI instructions, or operator procedure
- no Firestore, environment, production-data, runtime, route, job, scheduler, or UI access
- no financial output or production/operational readiness claim
- no real tenant, payment, bank, provider, credential, path, or internal-identifier data
- Rotessa, PAD, provider integration, payment processing, and money movement remain out of scope
- direct settlement and the landlord-revenue boundary are preserved
- no RC1 behavior changes

## Validation
- docs-only one-file scope confirmed
- all 19 required sections present
- all required manual-placeholder classes present
- git diff --check passed
- git diff --cached --check passed
- competitor-name scan passed
- execution-command pattern scan passed
- protected-scope scan passed
- no runtime behavior changed
- manual QA not required