### PR TITLE
Add Operational Credits decision records

### DIFF
--- a/docs/strategy/certn-commercial-allocation-strategy-v1.md
+++ b/docs/strategy/certn-commercial-allocation-strategy-v1.md
@@ -1,0 +1,118 @@
+# Certn Commercial and Allocation Strategy v1
+
+## Status
+
+Strategic negotiation preparation only. Certn is not represented here as integrated, contracted, commercially approved, or production-ready.
+
+## Context
+
+Draft PR #1431 identifies Certn as a preferred launch candidate while preserving a provider-neutral ledger and catalogue. Current code includes provider-neutral screening concepts and TransUnion-oriented paths; those do not establish Certn readiness. No confirmed Certn pricing, allocation, funding, API, webhook, support, geographic, consent, or marketing terms were found in the audited repository.
+
+## Decision
+
+Use a **staged pay-as-you-go wholesale relationship with pre-negotiated volume tiers and a capped co-funded onboarding pilot** as the preferred opening position.
+
+Do not accept an exclusivity obligation, large annual minimum, customer-facing “free checks” promise, or hardcoded product economics before real demand, completion, failure, refund, and support data exist. After a bounded pilot, consider an annual commitment only if the discount exceeds the risk-adjusted unused commitment and preserves target margin.
+
+Any Certn offering maps through the universal service catalogue and provider adapter. Certn product identifiers, prices, failures, and webhooks never become core ledger semantics.
+
+## Commercial questions to resolve
+
+- setup, certification, sandbox, or implementation fees;
+- per-product wholesale prices, currency, tax, and price-change notice;
+- minimum commitments, monthly minimums, tiers, overages, and included volume;
+- promotional units, marketing-development funds, or co-funded onboarding;
+- charges for failed, incomplete, duplicate, cancelled, retried, or expired checks;
+- refund/credit-note rules and invoice dispute process;
+- API, sandbox, webhook, idempotency, rate-limit, uptime, incident, and support terms;
+- usage/invoice reports and reconciliation identifiers;
+- data retention, deletion, residency, subprocessors, consent, and permissible purpose;
+- branded/white-label reports, geographic/product availability, contract term, renewal, termination, exclusivity, and marketing permissions.
+
+## Alternatives considered
+
+The principal partnership structures are:
+
+| Option | Advantage | Risk | Posture |
+| --- | --- | --- | --- |
+| RentChain-funded launch credits | Full control | Highest CAC and margin risk | Use only as capped experiment |
+| Certn-funded promotion | Lowers CAC | Availability and messaging depend on contract | Seek as first preference |
+| Shared-cost onboarding incentive | Aligns both parties | Requires exact attribution/reconciliation | Recommended bounded pilot |
+| Volume-discount model | Improves margin with usage | Forecast risk | Negotiate tiers without premature commitment |
+| Annual commitment with included volume | Best unit cost if volume is proven | Breakage/unused commitment | Defer until pilot data |
+| Pay-as-you-go wholesale | Low commitment risk | Higher initial unit cost | Recommended launch base |
+| Enterprise-specific bundles | Supports large contracts | Custom complexity and concentration | Offer only with signed enterprise demand |
+
+## Rationale
+
+The hybrid opening position increases Certn transaction opportunity while capping RentChain CAC and preserving optionality. It produces real redemption and support evidence before RentChain accepts fixed commitments or publishes an incentive.
+
+## Consequences
+
+- Pilot funding, maximum organization grants, eligible products, dates, and attribution must be explicit.
+- Provider invoices and usage reports must reconcile to partner transactions and credit redemptions.
+- Customer credit quantities remain configurable and need not equal reports or provider dollars.
+- Volume-tier evaluation uses completed/chargeable outcomes under the contract, not raw requests.
+- A provider outage or failed check must follow agreed reservation release/reversal rules.
+
+## Risks
+
+- Wholesale price or product changes could create negative-margin redemptions.
+- Minimums or exclusivity could reduce provider portability.
+- Co-marketing language could overstate integration or “free” value.
+- Failed-check charging and incomplete webhooks could create unreconciled cost.
+- Provider reporting may expose sensitive applicant information if not purpose-limited.
+
+## Open questions
+
+- Which product and jurisdictions are suitable for a bounded launch?
+- Who pays for incomplete, cancelled, duplicate, retried, or provider-failed requests?
+- What margin floor and CAC cap must every incentive preserve?
+- What pilot size provides useful evidence without material liability?
+- Can partner funding be credited directly on invoices rather than represented as customer cash value?
+- What termination/export/deletion support exists if RentChain changes providers?
+
+## Dependencies
+
+- approved classification, organization authority, and catalogue decisions;
+- legal/privacy/security provider diligence;
+- confirmed screening consent and permissible-purpose workflow;
+- reservation/redemption and partner reconciliation design;
+- financial model and target margin;
+- signed commercial terms and approved marketing language.
+
+## Legal or accounting review requirements
+
+Review resale/referral rights, promotional funding, taxes, refunds, data processing, consumer disclosures, liability, service failures, record retention, revenue/cost recognition, and contract termination.
+
+## Security implications
+
+Require secrets management, signed webhook verification, idempotency, least-privilege API access, audit-safe logging, incident contacts, rate-limit/outage behavior, and no raw reports in credit records.
+
+## Privacy implications
+
+Define controller/processor roles, consent, permissible purpose, minimization, retention/deletion, residency, subprocessors, report access, data-subject handling, and safe usage reporting before exchanging production data.
+
+## Enterprise implications
+
+Enterprise bundles require contract-specific catalogue policies, jurisdictions, volume bands, reporting, support, and governance. They must not force a global provider choice or cross-organization data sharing.
+
+## Implementation constraints
+
+- No Certn types in the ledger core.
+- No provider call before valid consent, service request, eligibility, and reservation.
+- Provider idempotency and reconciliation identifiers required.
+- No negotiated number hardcoded in code or public copy.
+- Provider replacement and suspension remain possible.
+
+## Explicit out of scope
+
+Certn outreach or contracting, API credentials, sandbox/live calls, webhook code, reports, customer grants, screening execution changes, public announcements, pricing changes, and production incentives.
+
+## Conditions required before implementation
+
+1. Signed commercial and data-processing terms resolve the listed questions.
+2. One product/jurisdiction is approved for a bounded pilot.
+3. Margin, CAC, funding cap, refund, and failed-check models pass review.
+4. Security/privacy, consent, sandbox, webhook, outage, and reconciliation tests pass.
+5. Customer claims and disclosures receive legal/commercial approval.

--- a/docs/strategy/founding-customer-pricing-incentive-strategy-v1.md
+++ b/docs/strategy/founding-customer-pricing-incentive-strategy-v1.md
@@ -1,0 +1,158 @@
+# Founding Customer Pricing and Annual Incentive Strategy v1
+
+## Status
+
+Scenario analysis and decision framework only. No price, plan name, unit cap, allocation, “free check,” entitlement, or public claim is approved.
+
+## Context
+
+Current public plan code presents Free, Starter at `$29/month`, Pro at `$49/month`, and Elite at `$79/month`, with yearly prices and pay-per-use screening. Existing enterprise strategy treats approximately `$30/unit/year` and enterprise minimums as planning references, not public commitments.
+
+This mission asks to evaluate working targets of approximately `$39/month` for Landlord/Operator, `$89/month` for Property Manager/Portfolio, approximately `$30/unit/year` for Institutional, a working `$249/month` institutional floor, and custom Enterprise contracts. These labels and numbers conflict with current public naming/pricing and therefore remain scenarios requiring a separate packaging/pricing decision. They must not be encoded or published from this record.
+
+## Decision
+
+The recommended founding incentive is a **small, capped annual-plan Operational Credit allocation activated after verified onboarding milestones**, not “10 free credit checks.”
+
+Use Operational Credit units rather than report counts, set an expiry window with approved disclosure, release the allocation once per organization/eligible annual subscription, and preserve pay-as-you-go screening outside the allocation. Consider a smaller staged release if fraud, breakage, or onboarding quality is uncertain.
+
+Final quantity must be solved from confirmed provider cost, expected redemption, support/refund cost, partner subsidy, plan gross-margin floor, and measured conversion lift. No quantity is recommended in this record.
+
+## Working packaging scenarios
+
+| Segment | Working scenario | Credit posture |
+| --- | --- | --- |
+| Free / Starter | `$0`, limited basic workflows | No recurring included allocation; eligible services transaction-priced subject to approval |
+| Landlord / Operator | Approximately `$39/month`; `$29/month` may remain founding price | Annual-only, milestone-activated capped allocation |
+| Property Manager / Portfolio | Approximately `$89/month`; current `$49/month` is a separate existing tier reference | Larger organization allocation only if unit cap, staff value, and margin support it |
+| Institutional | Approximately `$30/unit/year`, minimum ACV, working `$249/month` floor | Contract allocation with governance/reporting; validate floor against support cost |
+| Enterprise | Custom annual contract, possible implementation fee and minimum ACV | Negotiated allocation, catalogue, security, integration, and support terms |
+
+These are not a recommendation to rename current plans or change prices.
+
+## Sustainability model
+
+Define:
+
+```text
+expected incentive cost
+  = granted units
+  x expected redemption rate
+  x blended fulfilled-service cost per unit
+  + expected failed/refunded service cost
+  + incremental support and fraud cost
+  - confirmed partner subsidy
+
+incremental annual contribution
+  = annual plan revenue
+  - subscription delivery cost
+  - expected incentive cost
+  - payment/refund cost
+  - incremental support cost
+
+required conversion lift
+  = expected incentive cost / contribution margin per incremental annual customer
+```
+
+Model ARR, gross margin, Certn/other provider cost, redemption, expiry/breakage, annual conversion, renewal, churn, LTV, CAC, subsidy, support, tax, refund, and included-versus-purchased economics by cohort.
+
+### “10 free credit checks” test
+
+Ten checks are sustainable only if:
+
+```text
+10 x expected chargeable completion rate x all-in provider cost
++ failures/refunds/support/fraud
+- contractual partner subsidy
+<= approved incentive budget per converted annual customer
+```
+
+It must also preserve the plan’s gross-margin floor under high redemption and renewal scenarios. Without confirmed wholesale cost, subsidy, conversion lift, and unit economics, sustainability is unproven. The phrase hardcodes one service and overstates value; reject it as the initial architecture and marketing construct.
+
+## Alternatives considered
+
+| Alternative | Assessment |
+| --- | --- |
+| Ten free checks at signup | Highest activation simplicity but greatest fraud, margin, coupling, and claim risk; reject |
+| Ten Operational Credits | Provider-neutral but quantity still unsupported; retain only as a model scenario |
+| Partial screening discount | Limits cost but complicates price/credit interaction and disclosures |
+| Credits after onboarding | Best alignment with activation and abuse prevention; recommended |
+| Credits released over time | Reduces cost spike but adds lifecycle complexity; consider after launch evidence |
+| Applicant-paid screening | Protects landlord plan margin but requires legal/customer-experience review |
+| Certn-funded promotion | Best CAC economics if contractually confirmed; pursue in negotiation |
+| Annual-plan-only eligibility | Aligns incentive with conversion and cash commitment; recommended |
+| Expiring launch credits | Limits liability but requires lawful terms and clear notice; conditionally recommended |
+
+## Rationale
+
+A milestone-activated annual allocation rewards meaningful onboarding, ties cost to a higher-value commitment, reduces repeated-account abuse, remains provider-neutral, and allows a partner subsidy without promising a fixed number of reports.
+
+## Consequences
+
+- Monthly and free plans remain transaction-priced unless separately approved.
+- The entitlement event, milestone evidence, grant, expiry, and cancellation behavior need versioned rules.
+- Founding pricing and target pricing need cohort identifiers and cannot silently change existing customers.
+- Customer acquisition and redemption cohorts must be measured before increasing allocations.
+- Purchased credits remain deferred.
+
+## Risks
+
+- A generous allocation can create negative-margin annual plans.
+- A small or highly conditional incentive may not improve conversion.
+- Expiry or staged release may confuse customers or trigger legal disclosure requirements.
+- Founding-price grandfathering can create long-term packaging complexity.
+- Applicant-paid models may create jurisdictional or fairness concerns.
+
+## Open questions
+
+- What are confirmed provider costs by product, failure, refund, and jurisdiction?
+- What annual conversion lift and retention effect are realistically attributable to the incentive?
+- What gross-margin floor and maximum incentive CAC are approved by segment?
+- What unit caps, staff seats, support, and catalogue services define each proposed tier?
+- Are `$39`, `$89`, `$249`, and `$30/unit/year` compatible with current plan migration and customer expectations?
+- What expiry, cancellation, grandfathering, tax, and disclosure rules apply?
+
+## Dependencies
+
+- approved classification, organization authority, catalogue, and Certn strategy;
+- canonical subscription ownership and annual entitlement event;
+- cohort pricing/plan migration strategy;
+- legal/accounting review and customer terms;
+- confirmed provider economics and partner subsidy;
+- analytics definitions and experiment governance.
+
+## Legal or accounting review requirements
+
+Review price/discount disclosures, subscription bundling, expiry, cancellation, refunds, taxes, promotional terms, applicant-paid screening, revenue recognition, deferred revenue, grandfathering, and partner subsidy treatment.
+
+## Security implications
+
+Eligibility and milestones require authoritative server evidence, one-time semantic idempotency, organization isolation, campaign caps, abuse review, and no client-triggered grants.
+
+## Privacy implications
+
+Conversion and redemption analytics should use minimized cohort data. Do not use screening results or sensitive applicant attributes for marketing eligibility. Partner subsidy reporting must be purpose-limited.
+
+## Enterprise implications
+
+Institutional and enterprise allocations belong in contracts with unit definitions, true-up, service limits, reporting, support, security, and expiry terms. The `$249/month` floor may be too low for implementation or governance cost and needs cost-to-serve validation.
+
+## Implementation constraints
+
+- No hardcoded prices, quantities, plan mappings, or provider costs.
+- No grant before canonical annual entitlement and onboarding evidence.
+- No balance/UI claim before ledger and projection authority.
+- Experiment variants and cohorts must be versioned and reviewable.
+- High-redemption and no-subsidy scenarios must pass margin gates.
+
+## Explicit out of scope
+
+Pricing changes, plan renaming, public copy, entitlements, checkout, billing, grants, onboarding automation, analytics implementation, Certn integration, purchased credits, UI, Firestore, or RC1 behavior.
+
+## Conditions required before implementation
+
+1. Finance approves segment contribution-margin floors and maximum incentive CAC.
+2. Provider costs/subsidies and chargeable outcomes are contractually confirmed.
+3. Legal/accounting approve promotion, expiry, cancellation, tax, and disclosure treatment.
+4. Product approves plan naming, unit caps, annual entitlement, milestones, and experiment design.
+5. A bounded pilot has explicit stop-loss, cohort, review, and rollback criteria.

--- a/docs/strategy/operational-credit-classification-decision-v1.md
+++ b/docs/strategy/operational-credit-classification-decision-v1.md
@@ -1,0 +1,119 @@
+# Operational Credit Classification Decision v1
+
+## Status
+
+Proposed for review. Not legally approved, accounting-approved, commercially agreed, or authorized for implementation.
+
+## Context
+
+The governing architecture in draft PR #1431 defines RentChain Operational Credits as a non-cash, organization-scoped right to consume approved services through an immutable ledger. RentChain has no production Operational Credit account, balance, grant, purchase, reservation, or redemption system today.
+
+Classification must prevent promotional language from creating an unintended cash, deposit, stored-value, gift-card, or transferable-property promise. It must also keep Operational Credits separate from rent, security deposits, PAD, landlord receivables, payment processing, and the existing lease credit-allocation workflow.
+
+## Decision
+
+The proposed initial release classification is **promotional or subscription-included service credits owned by a RentChain customer organization**.
+
+For the initial release, Operational Credits would:
+
+- be redeemable only for versioned, approved RentChain operational services;
+- remain non-transferable between organizations and not become personal property of users;
+- have no cash redemption, withdrawal, external exchange, peer transfer, or bank payout;
+- be unusable for rent, security deposits, tenant payments, or other money movement;
+- have no blockchain representation and no cryptocurrency, investment, appreciation, or ownership language;
+- not be purchasable until separate legal, accounting, tax, refund, and consumer-protection approval exists.
+
+This is an architectural recommendation, not a legal conclusion.
+
+### Classification by source
+
+| Source | Proposed treatment | Initial-release posture |
+| --- | --- | --- |
+| Promotional credits | Conditional service rights granted without separate purchase, subject to disclosed eligibility and expiry | Candidate after legal/commercial approval |
+| Subscription-included credits | Service rights arising from a versioned annual plan or contract entitlement; subscription access remains separate | Preferred initial grant source |
+| Partner-funded credits | Promotional/service rights with attributable partner funding and contract-specific restrictions | Deferred until partner agreement and accounting treatment |
+| Purchased credits | Prepaid service rights acquired for consideration | Deferred; not in initial release |
+| Administrative adjustments | Governed corrections or exceptional grants/debits; not a customer product category | Protected operational tool only after controls exist |
+
+## Alternatives considered
+
+1. **Cash-equivalent wallet:** rejected because it increases payments, custody, consumer-protection, and accounting risk.
+2. **One credit equals one screening report:** rejected because it couples the platform to one product/provider.
+3. **User-owned balances:** rejected because subscription, commercial liability, and enterprise authority belong at organization scope.
+4. **Discount coupons only:** rejected because coupons cannot support reservations, multiple services, reversals, or enterprise allocation cleanly.
+5. **Purchased credits at launch:** deferred because refund, tax, expiry, revenue-recognition, and prepaid-service treatment are unresolved.
+
+## Rationale
+
+The service-credit classification supports annual subscription incentives and provider-funded campaigns without representing customer deposits or money held by RentChain. It preserves a reusable catalogue while keeping legal and accounting questions visible rather than embedding assumptions in code or marketing.
+
+## Consequences
+
+- Each grant lot needs its source, policy version, disclosure version, funding source, eligibility, and expiry terms.
+- Customer language must describe eligible services and units, not cash value.
+- Subscription cancellation, service failure, expiry, and reversal need explicit terms.
+- Purchased credits require a separate decision and cannot be activated by configuration alone.
+- Accounting projections may need to distinguish promotional, subscription-included, partner-funded, and purchased lots.
+
+## Risks
+
+- A regulator, court, auditor, tax authority, or customer contract may classify some credits differently.
+- Displaying monetary value or broad redemption promises could undermine the intended classification.
+- Expiration, breakage, partner funding, or subscription bundling may create liabilities or disclosure duties.
+- Inconsistent marketing could imply property ownership or guaranteed value.
+
+## Open questions
+
+- When, if ever, does a grant create deferred revenue or a contract liability?
+- When is revenue recognized for subscription-included, partner-funded, or purchased credits?
+- Which sales taxes apply to grants, purchases, redemptions, and bundled services?
+- What expiry periods and notices are lawful and commercially acceptable?
+- What refund or restoration is required after service failure or cancellation?
+- Do gift-card, prepaid-service, consumer-protection, or unclaimed-property rules apply?
+- What happens to unused credits on subscription termination or organization closure?
+- Can enterprise contracts override default expiry or allocation terms?
+
+## Dependencies
+
+- approved organization authority model;
+- versioned universal service catalogue;
+- legal/accounting/tax memorandum by customer type and jurisdiction;
+- subscription-entitlement ownership and lifecycle design;
+- immutable ledger, lot, expiry, reversal, and reconciliation design;
+- approved customer terms and disclosure language.
+
+## Legal or accounting review requirements
+
+Counsel and accounting reviewers must address deferred revenue, revenue recognition, sales tax, expiry, refund, cancellation, disclosures, prepaid-service/gift-card treatment, unclaimed property, partner-funded credits, subscription termination, enterprise contracts, and record retention before implementation.
+
+## Security implications
+
+Classification does not reduce the need for transactional double-spend prevention, immutable audit evidence, protected adjustments, exact organization scope, and fail-closed reconciliation.
+
+## Privacy implications
+
+Credit records should reference only the minimum organization, service, workflow, actor, and partner evidence required. Screening reports, consent payloads, provider payloads, bank data, and unrelated tenant PII must remain outside the credit ledger.
+
+## Enterprise implications
+
+Enterprise contracts may define allocation, expiry, funding, and catalogue terms, but must not convert credits into transferable employee property or cross-organization cash value. Contract exceptions require versioned policy and audit evidence.
+
+## Implementation constraints
+
+- Integer operational units only; no floating monetary representation.
+- Source-specific lots and deterministic consumption ordering.
+- No mutable balance as sole truth.
+- No purchase, checkout, transfer, or cash-value API in the initial implementation.
+- No customer claim before legal/commercial copy approval.
+
+## Explicit out of scope
+
+Runtime accounts, grants, balances, purchasing, checkout, refunds, redemption, Certn transactions, pricing changes, billing changes, Firestore changes, UI, marketing claims, PAD, rent, deposits, and money movement.
+
+## Conditions required before implementation
+
+1. Legal and accounting reviewers document the accepted initial classification and jurisdiction scope.
+2. Product and commercial owners approve source types, expiry/refund posture, and disclosures.
+3. Purchased credits remain explicitly disabled.
+4. Organization authority and catalogue decisions are approved.
+5. Security and reconciliation designs pass separate review.

--- a/docs/strategy/operational-credit-organization-authority-decision-v1.md
+++ b/docs/strategy/operational-credit-organization-authority-decision-v1.md
@@ -1,0 +1,119 @@
+# Operational Credit Organization Authority Decision v1
+
+## Status
+
+Proposed target architecture. Operator use and runtime implementation are not authorized.
+
+## Context
+
+Current RentChain authorization commonly resolves a landlord scope through `landlordId`, with some legacy paths falling back to the authenticated user ID. Landlord, admin, tenant, contractor, delegated-access, property-manager, and institutional patterns exist, but the audit does not establish a single canonical organization membership and subscription-ownership authority suitable for a financial-style service-credit account.
+
+Operational Credits need durable ownership beyond a particular user while still supporting independent landlords, property managers, portfolio operators, institutions, enterprises, multi-office businesses, and government/housing-authority programmes.
+
+## Decision
+
+Operational Credits belong to the **canonical RentChain organization**. Users act only as authorized representatives.
+
+An independent landlord is represented by a one-member organization rather than a personal wallet. A future credit account references a canonical `organizationId`; `landlordId`, user ID, email, alias, property ownership, or client-provided scope is insufficient authority by itself.
+
+### Authority model
+
+| Capability | Required authority |
+| --- | --- |
+| View balance/activity | Organization membership plus `operational_credits.read` |
+| Reserve/redeem | Membership, service permission, budget/limit availability, and valid workflow authority |
+| Allocate staff/office budget | `operational_credits.allocate` plus scope and threshold controls |
+| Grant or debit adjustment | Dedicated protected permission, reason, case reference, and approval rule |
+| Reverse redemption | Protected permission plus original transaction/service evidence |
+| Export usage | Audience-specific export permission and safe projection |
+| Configure enterprise rules | Contract/governance role with separation of duties where required |
+
+Admin status alone does not authorize credit mutation. Impersonation sessions must not perform grants, redemptions, reversals, or adjustments.
+
+### Lifecycle rules
+
+- Removing a user removes their authority but does not move or delete organization credits.
+- Subscription cancellation changes entitlement/grant policy according to approved terms; it does not transfer credits to users.
+- Organization closure freezes new use, preserves audit evidence, and applies approved expiry/refund rules.
+- Ownership disputes freeze mutation and enter a governed review; support cannot silently reassign balances.
+- Parent/subsidiary organizations retain distinct accounts. Central budgets are allocations from an explicitly contracted parent pool, not implicit cross-organization access.
+
+## Alternatives considered
+
+1. **User-owned wallet:** rejected because users change roles/employers and cannot own an enterprise entitlement personally.
+2. **Landlord ID as permanent owner:** rejected as a near-term alias that does not fully express multi-entity organizations.
+3. **Property-level accounts:** rejected as the primary model; too fragmented for subscriptions and central governance.
+4. **One global enterprise account across legal entities:** rejected without explicit contract and governed allocation relationships.
+5. **Subscription owner equals credit owner automatically:** rejected until subscription ownership is canonical and lifecycle-safe.
+
+## Rationale
+
+Organization ownership aligns the credit liability, subscription/contract, staff permissions, enterprise reporting, and service consumption. It prevents personal transferability and preserves continuity when staff change.
+
+## Consequences
+
+- A canonical organization and membership authority must precede persistence.
+- Subscription events require an adapter that proves the entitled organization.
+- Every ledger entry must record organization, account, actor, role, permission context, and audit evidence.
+- Budget allocation affects spending authority, not economic ownership or total units.
+- Parent/subsidiary and multi-office access require explicit relationship records and exact scope.
+
+## Risks
+
+- Reusing `landlordId` fallback behavior could permit wrong-organization access.
+- Broad admin roles could enable unauthorized adjustments.
+- Ambiguous mergers, closures, or ownership disputes could strand or misassign credits.
+- Complex enterprise allocation can accidentally duplicate credits if modeled as new grants.
+
+## Open questions
+
+- What collection/service is the canonical organization and membership authority?
+- How are current landlord records migrated to one-member organizations?
+- Which actor owns existing subscriptions and future enterprise contracts?
+- What delegated roles and approval thresholds are required at launch?
+- Are central pools permitted across distinct legal entities, and under what contract?
+- What happens to active reservations during user removal, subscription cancellation, or organization freeze?
+
+## Dependencies
+
+- canonical organization/member/relationship model;
+- subscription ownership and contract mapping;
+- permission registry and server-side authorization pattern;
+- operational-credit classification and catalogue decisions;
+- append-safe audit and organization closure/dispute procedures.
+
+## Legal or accounting review requirements
+
+Review organization ownership, agency authority, contract-party treatment, account closure, unused-credit treatment, enterprise legal entities, government programme constraints, and dispute handling.
+
+## Security implications
+
+Every read/write must resolve organization authority server-side and fail closed. Exact permissions, budget limits, approval thresholds, version checks, organization isolation tests, and immutable attribution are mandatory.
+
+## Privacy implications
+
+Customer projections should use organization/service display labels and omit raw IDs, membership internals, actor emails, provider references, and support metadata. Staff activity visibility must follow role and employment/privacy policy.
+
+## Enterprise implications
+
+The model supports offices, departments, regions, cost centres, per-user limits, approval thresholds, contract-specific catalogues, and institutional exports while retaining legal-entity isolation.
+
+## Implementation constraints
+
+- No user-owned wallet or personal transferable balance.
+- No client-supplied `organizationId` trusted without server resolution.
+- No alias-only or post-read filtering as ownership proof.
+- Allocations are control projections, not ledger grants.
+- All organization lifecycle actions are append-safe and reviewable.
+
+## Explicit out of scope
+
+Organization schema migration, membership runtime changes, permissions, routes, Firestore rules, account creation, balances, staff UI, enterprise hierarchy UI, subscription mutation, and credit operations.
+
+## Conditions required before implementation
+
+1. Canonical organization, membership, and subscription authority are documented and proven.
+2. Launch roles and permissions are approved.
+3. Closure, removal, cancellation, dispute, and parent/subsidiary rules are approved.
+4. Organization isolation and impersonation-write tests are specified.
+5. PR #1431 and the classification decision are approved dependencies.

--- a/docs/strategy/operational-service-catalogue-decision-v1.md
+++ b/docs/strategy/operational-service-catalogue-decision-v1.md
@@ -1,0 +1,156 @@
+# Operational Service Catalogue Decision v1
+
+## Status
+
+Proposed provider-neutral architecture. No service, provider, credit quantity, price, or regional availability is approved.
+
+## Context
+
+RentChain has screening packages, pay-per-use monetization, consent workflows, provider-neutral components, and provider-specific operational paths. It does not have a universal catalogue authority connecting Operational Credit quantities to approved services. Directly embedding Certn products or current provider assumptions in a ledger would block provider replacement and future services.
+
+## Decision
+
+Create a versioned universal service catalogue that separates six concerns:
+
+1. stable operational service definition;
+2. provider offering and fulfilment adapter;
+3. Operational Credit cost policy;
+4. provider monetary/commercial cost;
+5. customer eligibility and subscription entitlement;
+6. availability/version/effective-date controls.
+
+### Proposed records
+
+```ts
+type OperationalServiceDefinition = {
+  serviceKey: string;
+  version: string;
+  displayName: string;
+  category: string;
+  fulfilmentRequirementsVersion: string;
+  status: "draft" | "active" | "suspended" | "retired";
+  effectiveFrom: string;
+  effectiveTo: string | null;
+};
+
+type ServiceProviderOffering = {
+  offeringKey: string;
+  serviceKey: string;
+  serviceVersion: string;
+  providerKey: string;
+  providerProductKey: string;
+  regions: string[];
+  status: "draft" | "active" | "suspended" | "retired";
+  commercialTermsVersion: string;
+  effectiveFrom: string;
+  effectiveTo: string | null;
+};
+
+type ServiceCreditPolicy = {
+  policyKey: string;
+  serviceKey: string;
+  customerSegmentOrContractKey: string;
+  requiredUnits: number;
+  eligibilityPolicyKey: string;
+  fundingPolicyKey: string | null;
+  effectiveFrom: string;
+  effectiveTo: string | null;
+};
+```
+
+Provider wholesale cost belongs in a protected commercial record and must not be exposed through customer catalogue DTOs. Subscription access and credit quantity are policy overlays, not fields that redefine the service.
+
+### Candidate services
+
+- tenant credit report;
+- identity verification;
+- background check;
+- employment verification;
+- income verification;
+- supervised AI-assisted lease review;
+- premium evidence export;
+- future contractor service;
+- future legal-service referral;
+- future insurance service.
+
+These are examples only. Inclusion does not establish availability, legality, provider readiness, or an approved credit cost.
+
+## Alternatives considered
+
+1. **Certn product table as catalogue:** rejected because it couples core service identity to one provider.
+2. **One credit per service:** rejected because costs and value differ.
+3. **Plan-specific duplicate catalogue items:** rejected; use versioned eligibility/credit-policy overlays.
+4. **Provider monetary price stored on customer item:** rejected because it leaks commercial terms and conflates units with money.
+5. **Mutable current-price fields:** rejected because historical redemptions require effective-dated versions.
+
+## Rationale
+
+Separating service, provider, credit policy, commercial cost, and eligibility allows provider replacement, regional restrictions, temporary suspension, contract pricing, partner funding, and enterprise-specific availability without rewriting the ledger.
+
+## Consequences
+
+- Reservations pin service, offering, and credit-policy versions.
+- A provider can be suspended without changing the stable service definition.
+- Multiple providers may fulfil the same service under deterministic selection/approval rules.
+- Historical receipts retain display-safe snapshots of the version used.
+- Plan or contract differences are explicit policy, never hidden provider logic.
+
+## Risks
+
+- Excessive policy combinations could become hard to explain and reconcile.
+- Provider substitution may change consent, disclosures, data residency, or fulfilment semantics.
+- Incorrect effective-date handling could quote one quantity and redeem another.
+- Calling AI, legal, insurance, or contractor referrals “services” may create unsupported expectations without careful scope text.
+
+## Open questions
+
+- Which service is the bounded launch candidate after approvals?
+- Who owns catalogue, commercial offering, eligibility, and credit policy review?
+- Are plan-specific credit costs commercially desirable or unnecessarily complex?
+- How are provider selection, substitution consent, outage fallback, taxes, and regional rules represented?
+- Which catalogue fields may appear in landlord, admin, enterprise, and export projections?
+
+## Dependencies
+
+- Operational Credit classification and organization authority decisions;
+- provider adapter and reconciliation contracts;
+- consent/permissible-purpose requirements per service;
+- commercial terms registry and secrets boundary;
+- subscription/contract entitlement authority;
+- safe DTO and audit snapshot rules.
+
+## Legal or accounting review requirements
+
+Review service characterization, provider resale/referral restrictions, customer disclosures, taxes, regional availability, refund/cancellation, data retention, AI/legal/insurance disclaimers, and partner-funded treatment.
+
+## Security implications
+
+Only approved server-side catalogue versions can be reserved. Commercial cost and provider product identifiers require protected access. Suspension and effective-date transitions must fail closed without invalidating historical evidence.
+
+## Privacy implications
+
+Each service version defines minimum required data, consent, retention, provider disclosure, region, and customer projection. The catalogue must not contain raw provider payloads or tenant records.
+
+## Enterprise implications
+
+Enterprise-specific policies may limit catalogue entries by contract, entity, region, office, cost centre, approval threshold, or funding source while preserving the universal service definition.
+
+## Implementation constraints
+
+- Provider-neutral service keys.
+- Immutable/effective-dated versions.
+- Integer credit quantities separate from monetary cost.
+- Safe customer projection and protected commercial projection.
+- No automatic provider substitution when consent or service semantics differ.
+
+## Explicit out of scope
+
+Catalogue persistence, admin UI, public catalogue, provider adapters, Certn execution, prices, credit quantities, subscription changes, reservations, redemptions, routes, Firestore, or customer claims.
+
+## Conditions required before implementation
+
+1. Catalogue ownership and version lifecycle are approved.
+2. Initial service semantics and provider-neutral contract are accepted.
+3. Commercial cost and customer projection boundaries are reviewed.
+4. Effective-date, suspension, substitution, consent, and regional rules are specified.
+5. No service is activated until its provider, legal, privacy, security, and reconciliation gates pass.


### PR DESCRIPTION
## Summary

Adds the five docs-only decision records required before any Operational Credits backend implementation:

1. classification: proposes organization-owned promotional or subscription-included service credits; purchased credits remain deferred
2. organization authority: adopts canonical organization ownership as the target while blocking implementation until organization, membership, and subscription authority are proven
3. service catalogue: separates service identity, provider offering, Operational Credit policy, monetary cost, eligibility, region, and version
4. Certn strategy: recommends pay-as-you-go wholesale with negotiated volume tiers and a capped co-funded onboarding pilot; no confirmed commercial terms are assumed
5. founding incentive: recommends a small annual-plan allocation activated after verified onboarding rather than ten free checks; final quantity remains subject to margin and legal/accounting gates

## Governing dependency

Draft PR #1431 is the governing strategic architecture for this package. These records do not authorize implementation and should not be treated as final if #1431 changes materially during review.

## Material open gates

- canonical organization, membership, and subscription ownership authority
- legal/accounting classification, tax, expiry, cancellation, refund, prepaid-service, and unclaimed-property treatment
- confirmed Certn products, wholesale economics, failed-check/refund rules, data terms, and partner subsidy
- plan naming, unit caps, contribution-margin floor, CAC limit, and founding-price migration
- provider-neutral catalogue ownership, consent, regional, suspension, and effective-date rules

## Boundaries

- docs-only planning; no runtime implementation
- no pricing, billing, subscription, entitlement, Firestore, screening execution, Certn integration, payment, PAD, frontend, public marketing, or RC1 behavior changes
- no customer balance, grant, purchase, reservation, redemption, or production claim
- tenant rent and lease credit allocation remain separate from Operational Credits

## Validation

- five-file docs-only scope confirmed
- all required decision-record sections present in every file
- `git diff --check` passed
- `git diff --cached --check` passed before commit
- execution-command pattern scan passed
- unexpected competitor-name scan passed
- link/path scan passed; no Markdown links added
- protected-scope scan passed
- manual QA not required because no runtime behavior changed

## Review focus

- whether organization ownership should remain the target despite current landlord/user-scoped legacy patterns
- whether the initial classification adequately avoids cash, deposit, wallet, and prepaid-service overclaims
- whether the Certn opening position limits CAC and commitment risk
- whether the proposed annual incentive can be evaluated without changing current public tiers

No backend implementation should begin from this PR without separate authorization after PR #1431 and these records are approved.