### PR TITLE
infra: establish Phase B B2 Preview technical foundation

### DIFF
--- a/docs/strategy/preview-infrastructure/phase-b-b2-technical-foundation-evidence.md
+++ b/docs/strategy/preview-infrastructure/phase-b-b2-technical-foundation-evidence.md
@@ -1,0 +1,64 @@
+# Phase B B2 Technical Foundation Evidence
+
+## Executive summary
+
+Phase B B2 now has a repository-defined, isolated Terraform foundation mapped to the dedicated HCP Terraform workspace. No Terraform apply occurred, no API was enabled by this change, and no cloud resource, identity, workload, data service, or Vercel configuration was created.
+
+Current classification: **B2 awaiting controlled keyless Terraform identity**.
+
+## Verified starting baseline
+
+The Founder supplied and Codex reconfirmed the following before implementation:
+
+- active account `admin@rentchain.ai` and configuration `rentchain-preview`;
+- project `rentchain-preview`, number `501298948635`, lifecycle active, billing enabled;
+- approved Preview labels and CAD 100 monthly planning ceiling;
+- no custom service accounts, buckets, Cloud Run workload, Artifact Registry repository, or Phase B workload API intentionally enabled;
+- HCP Terraform organization `Rentchain`, project `RentChain Preview`, workspace `rentchain-preview-foundation`;
+- CLI-driven remote execution, zero resources/configuration, no production state or VCS connection, and auto-apply/auto-destroy off.
+
+New Google projects contain default Google-managed services. They are not represented as Phase B workload enablement or managed by this root. The B2 allowlist concerns only services intentionally proposed by this configuration.
+
+## Repository and state boundary
+
+The isolated root is `infra/environments/preview-foundation`. Its cloud block fixes the HCP organization and workspace. It does not read production remote state and does not reuse the repository-root Terraform configuration, which contains production-oriented workloads and unsafe Preview assumptions.
+
+Required inputs have no defaults. Plan-time validations require the exact Preview project ID, project number, environment, label baseline, and monthly ceiling. The known production project ID is denied explicitly.
+
+## Proposed API plan
+
+| Proposed resource address | Service | Justification |
+| --- | --- | --- |
+| `google_project_service.approved_management["cloudresourcemanager.googleapis.com"]` | Cloud Resource Manager | Bounded project foundation management |
+| `google_project_service.approved_management["iam.googleapis.com"]` | Identity and Access Management | Prerequisite for later separately authorized keyless identity work |
+| `google_project_service.approved_management["serviceusage.googleapis.com"]` | Service Usage | Explicit management API allowlist |
+
+No API has been enabled by this PR. IAM Credentials and Security Token Service remain excluded until a keyless authentication design is separately authorized. No workload or data API appears in the proposal.
+
+## Authentication status
+
+The root contains no static credential path or cloud identity resource. HCP Terraform has no authorized Google identity in this stage, so no cloud-backed remote plan or apply is permitted. The next dependency is a separately authorized, least-privilege, keyless Terraform planning identity design and exact IAM review.
+
+## Apply and destroy controls
+
+- Remote auto-apply and auto-destroy are off.
+- Founder — Paul must explicitly approve an exact captured plan.
+- The project target and resource addresses must be reviewed before apply.
+- API resources use `prevent_destroy` and retain services on state removal.
+- Production state and remote-state dependencies are prohibited.
+- No local state may become authoritative.
+- No automatic or undocumented destroy is allowed.
+
+## Cost impact
+
+Repository implementation and the un-applied API proposal have CAD 0 cloud-resource cost. Enabling the three management APIs has no direct enablement charge, but later use of billable services is not authorized. The existing CAD 100 monthly planning ceiling and CAD 15 daily anomaly threshold remain unchanged.
+
+## Residual resources and rollback
+
+Exact resources created by this implementation: **none**.
+
+Rollback before apply is deletion or reversion of the isolated root and documentation, with the empty HCP workspace retained for audit unless separately approved for removal. After any future apply, rollback requires a separately reviewed plan because `prevent_destroy` intentionally blocks automatic service removal.
+
+## Stage boundary
+
+B3 is not authorized. No service account, IAM binding, WIF resource, Cloud Run service, Artifact Registry repository, Cloud Build resource, Firebase/Firestore/Storage resource, application configuration, fixture, provider integration, or Vercel setting was created. PR #1435 remains unchanged and on hold pending authenticated Preview infrastructure.

--- a/docs/strategy/preview-infrastructure/phase-b-b2-technical-foundation-evidence.md
+++ b/docs/strategy/preview-infrastructure/phase-b-b2-technical-foundation-evidence.md
@@ -15,7 +15,7 @@ The Founder supplied and Codex reconfirmed the following before implementation:
 - approved Preview labels and CAD 100 monthly planning ceiling;
 - no custom service accounts, buckets, Cloud Run workload, Artifact Registry repository, or Phase B workload API intentionally enabled;
 - HCP Terraform organization `Rentchain`, project `RentChain Preview`, workspace `rentchain-preview-foundation`;
-- CLI-driven remote execution, zero resources/configuration, no production state or VCS connection, and auto-apply/auto-destroy off.
+- CLI-driven remote execution, zero resources/state objects, no uploaded configuration, no production state or VCS connection, no Google credentials, and auto-apply/auto-destroy off.
 
 New Google projects contain default Google-managed services. They are not represented as Phase B workload enablement or managed by this root. The B2 allowlist concerns only services intentionally proposed by this configuration.
 
@@ -37,7 +37,9 @@ No API has been enabled by this PR. IAM Credentials and Security Token Service r
 
 ## Authentication status
 
-The root contains no static credential path or cloud identity resource. HCP Terraform has no authorized Google identity in this stage, so no cloud-backed remote plan or apply is permitted. The next dependency is a separately authorized, least-privilege, keyless Terraform planning identity design and exact IAM review.
+The root contains no static credential path or cloud identity resource. HCP Terraform has no authorized Google identity in this stage, so remote initialization, provider-backed validation, planning, and apply remain blocked.
+
+The preferred future authentication model is HCP Terraform workload identity → Google Workload Identity Federation → a narrowly scoped Preview Terraform planning/apply identity → short-lived credentials. The next dependency is a separately authorized design and exact IAM review for that bounded path. No service-account JSON key, production credential, wildcard federation, production project access, or automatic apply is permitted.
 
 ## Apply and destroy controls
 

--- a/infra/environments/preview-foundation/README.md
+++ b/infra/environments/preview-foundation/README.md
@@ -10,6 +10,11 @@ This is the isolated Phase B B2 Terraform root for the permanent `rentchain-prev
 - Workflow: CLI-driven
 - Execution mode: Remote
 - State: isolated from production
+- Resources/state objects: zero
+- Configuration uploaded: none
+- VCS connection: none
+- Google credentials: none
+- Production-state connection: none
 - Auto-apply: off
 - Auto-destroy: off
 - Apply and destroy authority: Founder — Paul, with explicit confirmation
@@ -30,7 +35,9 @@ IAM Credentials and Security Token Service are excluded because no keyless Terra
 
 ## Authentication and execution boundary
 
-No Google credentials, service account, IAM binding, Workload Identity pool/provider, key, or environment-derived fallback is configured. HCP Terraform therefore cannot create a cloud-backed plan or apply until a separately authorized keyless planning identity exists.
+No Google credentials, service account, IAM binding, Workload Identity pool/provider, key, or environment-derived fallback is configured. HCP Terraform therefore cannot complete remote initialization, provider-backed validation, planning, or apply until a separately authorized keyless planning identity exists.
+
+The preferred future authentication model is HCP Terraform workload identity → Google Workload Identity Federation → a narrowly scoped Preview Terraform planning/apply identity → short-lived credentials. That path is a separate mission and is not implemented here. Service-account JSON keys, production credentials, wildcard federation, production project access, and automatic apply are prohibited.
 
 Static credentials are prohibited. Local state must never become authoritative. Plans and applies belong only to the fixed HCP workspace. Auto-apply and auto-destroy remain off.
 

--- a/infra/environments/preview-foundation/README.md
+++ b/infra/environments/preview-foundation/README.md
@@ -1,0 +1,45 @@
+# Preview Foundation Terraform Root
+
+This is the isolated Phase B B2 Terraform root for the permanent `rentchain-preview` non-production project. It is intentionally independent from the repository-root Terraform configuration and has no production remote-state dependency.
+
+## HCP Terraform mapping
+
+- Organization: `Rentchain`
+- Project: `RentChain Preview`
+- Workspace: `rentchain-preview-foundation`
+- Workflow: CLI-driven
+- Execution mode: Remote
+- State: isolated from production
+- Auto-apply: off
+- Auto-destroy: off
+- Apply and destroy authority: Founder — Paul, with explicit confirmation
+
+The cloud block fixes the organization and workspace. Project variables have no defaults, and validations bind the root to project `rentchain-preview`, project number `501298948635`, and environment `preview`. The production project `project-0d9658de-af29-4dc0-a99` is explicitly denied.
+
+## Proposed resources
+
+No resource has been applied. A future explicitly approved B2 apply would manage only three `google_project_service` resources:
+
+| API | B2 purpose | Owner | Expected direct cost | Retention decision |
+| --- | --- | --- | --- | --- |
+| Cloud Resource Manager | Validate and manage the bounded project target | Founder — Paul | No direct enablement charge | Retain while Terraform manages the foundation |
+| Service Usage | Manage the explicit service allowlist | Founder — Paul | No direct enablement charge | Retain while Terraform manages APIs |
+| Identity and Access Management | Foundation prerequisite for later separately authorized keyless identity work | Founder — Paul | No direct enablement charge | Retain pending later identity authorization |
+
+IAM Credentials and Security Token Service are excluded because no keyless Terraform identity is authorized in B2. All workload, data, build, registry, secret, messaging, compute, and Firebase services remain outside this root.
+
+## Authentication and execution boundary
+
+No Google credentials, service account, IAM binding, Workload Identity pool/provider, key, or environment-derived fallback is configured. HCP Terraform therefore cannot create a cloud-backed plan or apply until a separately authorized keyless planning identity exists.
+
+Static credentials are prohibited. Local state must never become authoritative. Plans and applies belong only to the fixed HCP workspace. Auto-apply and auto-destroy remain off.
+
+## Apply, drift, and destroy governance
+
+Before any apply, capture the exact remote plan, verify the project identity and three-resource allowlist, confirm zero production or workload addresses, document cost, and obtain Founder approval for that exact plan. Plan drift is reviewed against the B1 evidence before approval.
+
+The API resources use `prevent_destroy` and do not disable services on destroy. Removal requires a separately approved change that first documents dependencies, evidence retention, rollback impact, and the exact manual or Terraform action. No automatic destroy is permitted.
+
+## Current classification
+
+B2 is awaiting a controlled keyless Terraform identity. B3 is not authorized. PR #1435 remains unchanged and on hold pending authenticated Preview infrastructure.

--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -1,0 +1,21 @@
+check "preview_project_identity" {
+  assert {
+    condition = (
+      var.project_id == "rentchain-preview" &&
+      var.project_number == "501298948635" &&
+      var.environment == "preview"
+    )
+    error_message = "Preview project identity is inconsistent with the approved B1 evidence."
+  }
+}
+
+check "management_api_boundary" {
+  assert {
+    condition = local.approved_management_services == toset([
+      "cloudresourcemanager.googleapis.com",
+      "iam.googleapis.com",
+      "serviceusage.googleapis.com",
+    ])
+    error_message = "The B2 management API allowlist has changed."
+  }
+}

--- a/infra/environments/preview-foundation/outputs.tf
+++ b/infra/environments/preview-foundation/outputs.tf
@@ -1,0 +1,16 @@
+output "foundation_target" {
+  description = "Non-sensitive identity of the isolated Preview foundation."
+  value = {
+    environment    = var.environment
+    project_id     = var.project_id
+    project_number = var.project_number
+    workspace      = "rentchain-preview-foundation"
+  }
+  sensitive = false
+}
+
+output "proposed_management_services" {
+  description = "Management APIs proposed for a separately authorized B2 apply."
+  value       = sort(tolist(local.approved_management_services))
+  sensitive   = false
+}

--- a/infra/environments/preview-foundation/providers.tf
+++ b/infra/environments/preview-foundation/providers.tf
@@ -1,0 +1,3 @@
+provider "google" {
+  project = var.project_id
+}

--- a/infra/environments/preview-foundation/services.tf
+++ b/infra/environments/preview-foundation/services.tf
@@ -1,0 +1,20 @@
+locals {
+  approved_management_services = toset([
+    "cloudresourcemanager.googleapis.com",
+    "iam.googleapis.com",
+    "serviceusage.googleapis.com",
+  ])
+}
+
+resource "google_project_service" "approved_management" {
+  for_each = local.approved_management_services
+
+  project                    = var.project_id
+  service                    = each.value
+  disable_dependent_services = false
+  disable_on_destroy         = false
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/infra/environments/preview-foundation/terraform.tfvars.example
+++ b/infra/environments/preview-foundation/terraform.tfvars.example
@@ -1,0 +1,14 @@
+project_id     = "rentchain-preview"
+project_number = "501298948635"
+environment    = "preview"
+
+baseline_labels = {
+  environment = "preview"
+  lifecycle   = "permanent"
+  managed-by  = "terraform"
+  owner       = "founder"
+  platform    = "rentchain"
+  purpose     = "shared-preview"
+}
+
+monthly_planning_ceiling_cad = 100

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+expected_resources="google_project_service"
+actual_resources="$(rg -No 'resource "[^"]+"' "$root_dir" --glob '*.tf' | sed -E 's/.*resource "([^"]+)"/\1/' | sort -u)"
+test "$actual_resources" = "$expected_resources"
+
+test "$(rg -No 'service\s*=\s*"[^"]+\.googleapis\.com"' "$root_dir/services.tf" | wc -l | tr -d ' ')" = "0"
+test "$(rg -No '"(cloudresourcemanager|iam|serviceusage)\.googleapis\.com"' "$root_dir/services.tf" | sort -u | wc -l | tr -d ' ')" = "3"
+
+rg -q 'organization = "Rentchain"' "$root_dir/versions.tf"
+rg -q 'name = "rentchain-preview-foundation"' "$root_dir/versions.tf"
+rg -q 'var\.project_id == "rentchain-preview"' "$root_dir/variables.tf"
+rg -q 'var\.project_number == "501298948635"' "$root_dir/variables.tf"
+rg -q 'var\.environment == "preview"' "$root_dir/variables.tf"
+rg -q 'var\.project_id != "project-0d9658de-af29-4dc0-a99"' "$root_dir/variables.tf"
+
+if rg -n 'credentials\s*=|credentials_file|GOOGLE_APPLICATION_CREDENTIALS|service_account_key|private_key' "$root_dir" --glob '*.tf'; then
+  echo "Static credential reference found" >&2
+  exit 1
+fi
+
+if rg -n 'allUsers|allAuthenticatedUsers|google_.*_iam|google_cloud_run|google_artifact_registry|google_storage_bucket|google_firestore|google_compute|google_container' "$root_dir" --glob '*.tf'; then
+  echo "Public IAM or workload resource found" >&2
+  exit 1
+fi
+
+echo "Preview foundation scope validation passed"

--- a/infra/environments/preview-foundation/variables.tf
+++ b/infra/environments/preview-foundation/variables.tf
@@ -1,0 +1,66 @@
+variable "project_id" {
+  description = "Immutable Google Cloud project ID for the isolated Preview foundation."
+  type        = string
+  nullable    = false
+
+  validation {
+    condition     = var.project_id == "rentchain-preview"
+    error_message = "project_id must be the approved isolated Preview project: rentchain-preview."
+  }
+
+  validation {
+    condition     = var.project_id != "project-0d9658de-af29-4dc0-a99"
+    error_message = "The production project ID is prohibited in the Preview foundation root."
+  }
+}
+
+variable "project_number" {
+  description = "Immutable project number used to cross-check the approved Preview target."
+  type        = string
+  nullable    = false
+
+  validation {
+    condition     = var.project_number == "501298948635"
+    error_message = "project_number must match the approved RentChain Preview project."
+  }
+}
+
+variable "environment" {
+  description = "Environment classification for this isolated foundation."
+  type        = string
+  nullable    = false
+
+  validation {
+    condition     = var.environment == "preview"
+    error_message = "environment must be preview. Production and unspecified environments are prohibited."
+  }
+}
+
+variable "baseline_labels" {
+  description = "Approved B1 project labels recorded for drift comparison; this root does not mutate project labels."
+  type        = map(string)
+  nullable    = false
+
+  validation {
+    condition = var.baseline_labels == {
+      environment = "preview"
+      lifecycle   = "permanent"
+      managed-by  = "terraform"
+      owner       = "founder"
+      platform    = "rentchain"
+      purpose     = "shared-preview"
+    }
+    error_message = "baseline_labels must exactly match the approved B1 Preview label set."
+  }
+}
+
+variable "monthly_planning_ceiling_cad" {
+  description = "Approved B1 monthly planning ceiling reference; this root does not manage billing or budgets."
+  type        = number
+  nullable    = false
+
+  validation {
+    condition     = var.monthly_planning_ceiling_cad == 100
+    error_message = "monthly_planning_ceiling_cad must remain CAD 100."
+  }
+}

--- a/infra/environments/preview-foundation/versions.tf
+++ b/infra/environments/preview-foundation/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = "= 1.15.8"
+
+  cloud {
+    organization = "Rentchain"
+
+    workspaces {
+      name = "rentchain-preview-foundation"
+    }
+  }
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- add an isolated Terraform root at `infra/environments/preview-foundation`
- bind HCP Terraform to `Rentchain/rentchain-preview-foundation` with remote isolated state
- require exact Preview project, project number, environment, label baseline, and CAD 100 planning ceiling
- explicitly deny the known production project and all default project fallback
- propose only Cloud Resource Manager, Service Usage, and IAM management APIs
- document apply, drift, destroy, cost, rollback, identity, and B3 boundaries

## Infrastructure changes

Exact resources created: **none**.

Exact resources proposed for a future controlled plan/apply:
- `google_project_service.approved_management["cloudresourcemanager.googleapis.com"]`
- `google_project_service.approved_management["iam.googleapis.com"]`
- `google_project_service.approved_management["serviceusage.googleapis.com"]`

No API was enabled by this PR. No service account, IAM binding, WIF resource, workload, registry, data service, Vercel setting, or application configuration was created.

## Terraform and authentication status

- Terraform v1.15.8 confirmed
- HCP workspace mapping fixed to `Rentchain/rentchain-preview-foundation`
- `terraform fmt -check -recursive`: passed
- source-level Preview scope validation: passed
- `terraform init`: stopped with `Required token could not be found` before configuration upload
- `terraform validate`: blocked because the Google provider could not be installed without successful initialization
- plan/apply: not run

Current classification: **B2 awaiting controlled keyless Terraform identity**. Static credentials remain prohibited.

## Cost impact

- current PR and un-applied proposal: CAD 0 cloud-resource cost
- proposed API enablement: no direct enablement charge
- CAD 100 monthly planning ceiling and CAD 15 daily anomaly threshold unchanged

## Rollback

Before apply, revert/remove the isolated root and evidence while retaining the empty HCP workspace for audit unless its removal is separately approved. After any future apply, use a separately reviewed plan; `prevent_destroy` blocks automatic API removal.

## Validation

- `git diff --check`: passed
- staged diff check: passed
- exact protected-scope check: passed
- production Terraform root untouched: passed
- Markdown structure: passed
- internal links: passed
- secret-pattern scan: passed
- Terraform formatting: passed
- source scope tests for workspace, project/environment validation, production deny, API allowlist, static credentials, public IAM, and workload resources: passed

## Boundaries

B3 is not authorized. PR #1435 remains unchanged and on hold pending authenticated Preview infrastructure. This PR must not be merged or applied without separate authorization and exact-plan review.