### PR TITLE
infra: establish bounded HCP Terraform keyless Preview identity

### DIFF
--- a/docs/strategy/preview-infrastructure/phase-b-hcp-terraform-keyless-identity-evidence.md
+++ b/docs/strategy/preview-infrastructure/phase-b-hcp-terraform-keyless-identity-evidence.md
@@ -2,9 +2,9 @@
 
 ## Executive summary
 
-The bounded HCP Terraform plan-phase identity bootstrap was created in the isolated `rentchain-preview` project. HCP Terraform initialization succeeded, but Terraform validation failed on the existing `baseline_labels` validation in the merged B2 root. The mission stopped immediately: no plan or apply ran and the three-service B2 proposal was not applied.
+The bounded HCP Terraform plan-phase identity is validated in the isolated `rentchain-preview` project. After a narrow correction to the `baseline_labels` type comparison, focused tests and Terraform validation passed and one remote keyless plan completed. The plan contains exactly the three approved project-service resources. No apply ran and the three-service B2 proposal remains unapplied.
 
-Final classification: **keyless Terraform identity requires revision**.
+Final classification: **keyless Terraform planning identity validated**.
 
 ## Approved target
 
@@ -17,7 +17,7 @@ Final classification: **keyless Terraform identity requires revision**.
 | HCP workspace | `rentchain-preview-foundation` / `ws-ebtKQ2gkLZuoRis4` |
 | Terraform root | `infra/environments/preview-foundation` |
 
-The workspace remained remote, CLI-driven, auto-apply off, and at zero state resources after the stopped validation. No production credential, state, project, or command target was used.
+The workspace remained remote, CLI-driven, auto-apply off, and at zero state resources after the plan. No production credential, state, project, or command target was used.
 
 ## Bootstrap method and enabled APIs
 
@@ -103,16 +103,54 @@ No run or apply service-account variable, JSON credential, token, key, or produc
 
 `terraform init` succeeded from the isolated root and installed `hashicorp/google` v6.50.0. The generated dependency lock file is committed with this evidence.
 
-`terraform validate` did not pass. It stopped with:
+### Validation diagnosis and correction
+
+The original validation compared `var.baseline_labels`, declared as `map(string)`, directly with an object literal:
 
 ```text
-Invalid value for variable baseline_labels
-baseline_labels must exactly match the approved B1 Preview label set.
+var.baseline_labels == { ... }
 ```
 
-The failure points to the equality validation in `variables.tf`. No retry, source fix, IAM change, remote plan, or apply followed the error.
+Terraform equality requires values with compatible types. A converted `map(string)` and an object literal are not equal merely because they contain the same string keys and values. This was an object-versus-map mismatch, not a map-ordering, null, missing-key, or cross-variable problem.
 
-Remote plan result: **not run**. Exact plan summary: **none**. B2 project-service resources applied: **zero**.
+The merged B1/B2 policy requires an exact map: all six approved labels are mandatory and additional labels are prohibited. The correction preserves that policy by normalizing the literal before comparison:
+
+```text
+var.baseline_labels == tomap({ ... })
+```
+
+No label, project, environment, API, provider, IAM, or identity safeguard was weakened.
+
+### Focused tests and validation
+
+Terraform native tests use a mocked Google provider and require no cloud credentials. Results: **12 passed, 0 failed**.
+
+- exact approved labels pass;
+- an additional label fails;
+- missing environment, lifecycle, platform, purpose, or `managed-by` fails;
+- production environment, wrong purpose, and wrong owner fail;
+- the production project ID fails;
+- a wrong project number fails.
+
+`terraform fmt -check -recursive`, the repository scope validation, and `terraform validate` passed after the correction.
+
+### Remote plan
+
+HCP run `run-Z9oirF7PaGDkSGJq` authenticated successfully with the plan-only dynamic identity. Exact summary:
+
+```text
+Plan: 3 to add, 0 to change, 0 to destroy.
+```
+
+The only planned addresses are:
+
+- `google_project_service.approved_management["cloudresourcemanager.googleapis.com"]`;
+- `google_project_service.approved_management["iam.googleapis.com"]`;
+- `google_project_service.approved_management["serviceusage.googleapis.com"]`.
+
+Cloud Resource Manager and IAM were enabled manually for identity bootstrap, and Service Usage was already enabled. Because these enabled services are not yet represented in Terraform state, the provider reports all three as creates; a future apply would adopt/manage the existing service configuration rather than recreate a workload. No import or apply was attempted. No drift or unexpected resource appeared.
+
+Apply result: **not run**. B2 project-service resources applied: **zero**. HCP state resources after plan: **zero**.
 
 ## Negative-test evidence
 
@@ -123,15 +161,15 @@ Remote plan result: **not run**. Exact plan summary: **none**. B2 project-servic
 | Wrong workspace | Denied by immutable provider condition and exact subject binding; configuration verified |
 | Production workspace | No trust or binding exists; configuration verified |
 | Apply phase | Denied by `terraform_run_phase=='plan'`; no apply identity variable exists |
-| Missing or malformed token | No unauthenticated path exists; active exchange test not reached |
-| Wrong audience | Google default canonical audience enforced; active exchange test not reached |
+| Missing or malformed token | No unauthenticated path exists; unsupported synthetic token testing was not attempted |
+| Wrong audience | Google default canonical audience enforced; unsupported synthetic token testing was not attempted |
 | Static service-account keys | Zero |
 | Wildcard federation | Zero |
 | Project-level Workload Identity User | Zero |
 | Auto-apply | Off |
 | Apply confirmation | None |
 
-Token-bearing negative requests were not fabricated after the validation stop. No JWT, access token, ID token, authorization header, or credential was captured.
+The successful remote plan proves the exact HCP plan identity exchange. Token-bearing negative requests were not fabricated because HCP does not expose a safe supported mechanism for those tests. No JWT, access token, ID token, authorization header, or credential was captured.
 
 ## Production isolation and cost
 
@@ -149,6 +187,7 @@ Expected incremental cost for the pool, provider, service account, IAM bindings,
 - one project-level custom-role binding;
 - one service-account-level exact-subject Workload Identity User binding;
 - four non-sensitive HCP workspace environment variables;
+- one completed plan-only HCP run containing exactly three approved service resources;
 - zero HCP state resources;
 - zero Terraform applies.
 
@@ -168,4 +207,4 @@ Do not execute rollback against production or infer deletion authorization from 
 
 ## Stage boundary
 
-B3 did not begin. PR #1435 remains unchanged and on hold. The next action is a narrow correction and review of the B2 `baseline_labels` validation, followed by a separately authorized validation retry and plan-only run. No apply is authorized.
+B3 did not begin. PR #1435 remains unchanged and on hold. The keyless planning identity is validated, but the captured three-service plan remains unapplied. Any apply requires a separate exact-plan authorization.

--- a/docs/strategy/preview-infrastructure/phase-b-hcp-terraform-keyless-identity-evidence.md
+++ b/docs/strategy/preview-infrastructure/phase-b-hcp-terraform-keyless-identity-evidence.md
@@ -1,0 +1,171 @@
+# Phase B HCP Terraform Keyless Planning Identity Evidence
+
+## Executive summary
+
+The bounded HCP Terraform plan-phase identity bootstrap was created in the isolated `rentchain-preview` project. HCP Terraform initialization succeeded, but Terraform validation failed on the existing `baseline_labels` validation in the merged B2 root. The mission stopped immediately: no plan or apply ran and the three-service B2 proposal was not applied.
+
+Final classification: **keyless Terraform identity requires revision**.
+
+## Approved target
+
+| Item | Value |
+| --- | --- |
+| Google project | `rentchain-preview` |
+| Google project number | `501298948635` |
+| HCP organization | `Rentchain` / `org-DQu8qPHc6zr3hBmB` |
+| HCP project | `RentChain Preview` / `prj-aN9g8NbTvdnZbXTr` |
+| HCP workspace | `rentchain-preview-foundation` / `ws-ebtKQ2gkLZuoRis4` |
+| Terraform root | `infra/environments/preview-foundation` |
+
+The workspace remained remote, CLI-driven, auto-apply off, and at zero state resources after the stopped validation. No production credential, state, project, or command target was used.
+
+## Bootstrap method and enabled APIs
+
+Founder-authenticated `gcloud` commands created the bootstrap identity. No service-account key or static Google credential was used.
+
+Exactly four identity-bootstrap APIs were enabled:
+
+- `cloudresourcemanager.googleapis.com`
+- `iam.googleapis.com`
+- `iamcredentials.googleapis.com`
+- `sts.googleapis.com`
+
+This did not apply the three `google_project_service` resources proposed by B2. No workload, build, registry, Firebase, Firestore, Storage, Vercel, or application API was enabled by this mission.
+
+## Workload Identity Federation
+
+| Resource | Value |
+| --- | --- |
+| Pool | `projects/501298948635/locations/global/workloadIdentityPools/hcp-terraform-preview` |
+| Provider | `projects/501298948635/locations/global/workloadIdentityPools/hcp-terraform-preview/providers/hcp-terraform` |
+| Issuer | `https://app.terraform.io` |
+| Audience | Google canonical provider audience (default audience) |
+| Provider state | Active |
+
+Attribute mappings:
+
+```text
+google.subject=assertion.terraform_workspace_id
+attribute.terraform_organization_id=assertion.terraform_organization_id
+attribute.terraform_project_id=assertion.terraform_project_id
+attribute.terraform_workspace_id=assertion.terraform_workspace_id
+attribute.terraform_run_phase=assertion.terraform_run_phase
+```
+
+Exact provider condition:
+
+```text
+assertion.terraform_organization_id=='org-DQu8qPHc6zr3hBmB' && assertion.terraform_project_id=='prj-aN9g8NbTvdnZbXTr' && assertion.terraform_workspace_id=='ws-ebtKQ2gkLZuoRis4' && assertion.terraform_run_phase=='plan'
+```
+
+Mutable names are not used in the trust decision. Apply-phase tokens, other organizations, other HCP projects, other workspaces, and organization-level tokens fail the condition.
+
+## Service account, role, and bindings
+
+Dedicated service account:
+
+`hcp-terraform-preview@rentchain-preview.iam.gserviceaccount.com`
+
+User-managed key count: **zero**.
+
+Custom project role:
+
+`projects/rentchain-preview/roles/hcpTerraformPreviewPlanViewer`
+
+Exact permissions:
+
+- `resourcemanager.projects.get`
+- `serviceusage.services.get`
+- `serviceusage.services.list`
+
+The custom role is bound to the dedicated service account in `rentchain-preview` only. The only `roles/iam.workloadIdentityUser` binding is on the service account and uses this exact subject:
+
+```text
+principal://iam.googleapis.com/projects/501298948635/locations/global/workloadIdentityPools/hcp-terraform-preview/subject/ws-ebtKQ2gkLZuoRis4
+```
+
+No wildcard or `principalSet` federation exists. No project-level Workload Identity User binding exists. No Token Creator role was granted.
+
+## HCP Terraform variables
+
+Four non-sensitive workspace environment variables were configured:
+
+| Variable | Scope | Purpose |
+| --- | --- | --- |
+| `TFC_GCP_PROVIDER_AUTH` | Workspace | Enable HCP dynamic GCP credentials |
+| `TFC_GCP_PRINCIPAL_TYPE` | Workspace | Require service-account impersonation |
+| `TFC_GCP_WORKLOAD_PROVIDER_NAME` | Workspace | Select the canonical Preview provider |
+| `TFC_GCP_PLAN_SERVICE_ACCOUNT_EMAIL` | Workspace | Select the plan-only Preview service account |
+
+No run or apply service-account variable, JSON credential, token, key, or production variable was configured.
+
+## Terraform execution evidence
+
+`terraform init` succeeded from the isolated root and installed `hashicorp/google` v6.50.0. The generated dependency lock file is committed with this evidence.
+
+`terraform validate` did not pass. It stopped with:
+
+```text
+Invalid value for variable baseline_labels
+baseline_labels must exactly match the approved B1 Preview label set.
+```
+
+The failure points to the equality validation in `variables.tf`. No retry, source fix, IAM change, remote plan, or apply followed the error.
+
+Remote plan result: **not run**. Exact plan summary: **none**. B2 project-service resources applied: **zero**.
+
+## Negative-test evidence
+
+| Test | Result |
+| --- | --- |
+| Wrong organization | Denied by immutable provider condition; configuration verified |
+| Wrong HCP project | Denied by immutable provider condition; configuration verified |
+| Wrong workspace | Denied by immutable provider condition and exact subject binding; configuration verified |
+| Production workspace | No trust or binding exists; configuration verified |
+| Apply phase | Denied by `terraform_run_phase=='plan'`; no apply identity variable exists |
+| Missing or malformed token | No unauthenticated path exists; active exchange test not reached |
+| Wrong audience | Google default canonical audience enforced; active exchange test not reached |
+| Static service-account keys | Zero |
+| Wildcard federation | Zero |
+| Project-level Workload Identity User | Zero |
+| Auto-apply | Off |
+| Apply confirmation | None |
+
+Token-bearing negative requests were not fabricated after the validation stop. No JWT, access token, ID token, authorization header, or credential was captured.
+
+## Production isolation and cost
+
+Every modifying Google command explicitly targeted `rentchain-preview`. Production access was prohibited and no production command or credential was used. A production IAM read/diff was intentionally not performed; command-target evidence shows no production mutation.
+
+Expected incremental cost for the pool, provider, service account, IAM bindings, and custom role is approximately CAD 0. API and audit logging remain subject to Google pricing, while the existing CAD 100 monthly ceiling and CAD 15 anomaly threshold remain unchanged.
+
+## Residual resources
+
+- four enabled identity-bootstrap APIs;
+- one workload identity pool;
+- one OIDC provider;
+- one dedicated service account with zero user-managed keys;
+- one three-permission custom role;
+- one project-level custom-role binding;
+- one service-account-level exact-subject Workload Identity User binding;
+- four non-sensitive HCP workspace environment variables;
+- zero HCP state resources;
+- zero Terraform applies.
+
+## Rollback sequence
+
+Rollback requires separate authorization and must proceed in reverse order:
+
+1. Delete the four HCP workspace variables by their HCP variable IDs.
+2. Remove the exact service-account-level `roles/iam.workloadIdentityUser` binding.
+3. Remove the custom project-role binding from the dedicated service account.
+4. Delete custom role `hcpTerraformPreviewPlanViewer`.
+5. Delete service account `hcp-terraform-preview` after reconfirming zero keys and dependencies.
+6. Delete provider `hcp-terraform`, then pool `hcp-terraform-preview`.
+7. Disable only the four bootstrap APIs after confirming no remaining dependency.
+
+Do not execute rollback against production or infer deletion authorization from this document.
+
+## Stage boundary
+
+B3 did not begin. PR #1435 remains unchanged and on hold. The next action is a narrow correction and review of the B2 `baseline_labels` validation, followed by a separately authorized validation retry and plan-only run. No apply is authorized.

--- a/infra/environments/preview-foundation/.terraform.lock.hcl
+++ b/infra/environments/preview-foundation/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:79CwMTsp3Ud1nOl5hFS5mxQHyT0fGVye7pqpU0PPlHI=",
+    "zh:1f3513fcfcbf7ca53d667a168c5067a4dd91a4d4cccd19743e248ff31065503c",
+    "zh:3da7db8fc2c51a77dd958ea8baaa05c29cd7f829bd8941c26e2ea9cb3aadc1e5",
+    "zh:3e09ac3f6ca8111cbb659d38c251771829f4347ab159a12db195e211c76068bb",
+    "zh:7bb9e41c568df15ccf1a8946037355eefb4dfb4e35e3b190808bb7c4abae547d",
+    "zh:81e5d78bdec7778e6d67b5c3544777505db40a826b6eb5abe9b86d4ba396866b",
+    "zh:8d309d020fb321525883f5c4ea864df3d5942b6087f6656d6d8b3a1377f340fc",
+    "zh:93e112559655ab95a523193158f4a4ac0f2bfed7eeaa712010b85ebb551d5071",
+    "zh:d3efe589ffd625b300cef5917c4629513f77e3a7b111c9df65075f76a46a63c7",
+    "zh:d4a4d672bbef756a870d8f32b35925f8ce2ef4f6bbd5b71a3cb764f1b6c85421",
+    "zh:e13a86bca299ba8a118e80d5f84fbdd708fe600ecdceea1a13d4919c068379fe",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fec30c095647b583a246c39d557704947195a1b7d41f81e369ba377d997faef6",
+  ]
+}

--- a/infra/environments/preview-foundation/tests/baseline_labels.tftest.hcl
+++ b/infra/environments/preview-foundation/tests/baseline_labels.tftest.hcl
@@ -1,0 +1,194 @@
+mock_provider "google" {}
+
+variables {
+  project_id     = "rentchain-preview"
+  project_number = "501298948635"
+  environment    = "preview"
+  baseline_labels = {
+    environment = "preview"
+    lifecycle   = "permanent"
+    managed-by  = "terraform"
+    owner       = "founder"
+    platform    = "rentchain"
+    purpose     = "shared-preview"
+  }
+  monthly_planning_ceiling_cad = 100
+}
+
+run "exact_approved_labels_pass" {
+  command = plan
+
+  assert {
+    condition     = length(google_project_service.approved_management) == 3
+    error_message = "The approved baseline must retain exactly three proposed management services."
+  }
+}
+
+run "additional_label_fails" {
+  command = plan
+
+  variables {
+    baseline_labels = {
+      environment = "preview"
+      lifecycle   = "permanent"
+      managed-by  = "terraform"
+      owner       = "founder"
+      platform    = "rentchain"
+      purpose     = "shared-preview"
+      extra       = "not-approved"
+    }
+  }
+
+  expect_failures = [var.baseline_labels]
+}
+
+run "missing_environment_label_fails" {
+  command = plan
+
+  variables {
+    baseline_labels = {
+      lifecycle  = "permanent"
+      managed-by = "terraform"
+      owner      = "founder"
+      platform   = "rentchain"
+      purpose    = "shared-preview"
+    }
+  }
+
+  expect_failures = [var.baseline_labels]
+}
+
+run "production_environment_label_fails" {
+  command = plan
+
+  variables {
+    baseline_labels = {
+      environment = "production"
+      lifecycle   = "permanent"
+      managed-by  = "terraform"
+      owner       = "founder"
+      platform    = "rentchain"
+      purpose     = "shared-preview"
+    }
+  }
+
+  expect_failures = [var.baseline_labels]
+}
+
+run "wrong_purpose_fails" {
+  command = plan
+
+  variables {
+    baseline_labels = {
+      environment = "preview"
+      lifecycle   = "permanent"
+      managed-by  = "terraform"
+      owner       = "founder"
+      platform    = "rentchain"
+      purpose     = "production"
+    }
+  }
+
+  expect_failures = [var.baseline_labels]
+}
+
+run "wrong_owner_fails" {
+  command = plan
+
+  variables {
+    baseline_labels = {
+      environment = "preview"
+      lifecycle   = "permanent"
+      managed-by  = "terraform"
+      owner       = "unknown"
+      platform    = "rentchain"
+      purpose     = "shared-preview"
+    }
+  }
+
+  expect_failures = [var.baseline_labels]
+}
+
+run "missing_managed_by_fails" {
+  command = plan
+
+  variables {
+    baseline_labels = {
+      environment = "preview"
+      lifecycle   = "permanent"
+      owner       = "founder"
+      platform    = "rentchain"
+      purpose     = "shared-preview"
+    }
+  }
+
+  expect_failures = [var.baseline_labels]
+}
+
+run "missing_lifecycle_fails" {
+  command = plan
+
+  variables {
+    baseline_labels = {
+      environment = "preview"
+      managed-by  = "terraform"
+      owner       = "founder"
+      platform    = "rentchain"
+      purpose     = "shared-preview"
+    }
+  }
+
+  expect_failures = [var.baseline_labels]
+}
+
+run "missing_platform_fails" {
+  command = plan
+
+  variables {
+    baseline_labels = {
+      environment = "preview"
+      lifecycle   = "permanent"
+      managed-by  = "terraform"
+      owner       = "founder"
+      purpose     = "shared-preview"
+    }
+  }
+
+  expect_failures = [var.baseline_labels]
+}
+
+run "missing_purpose_fails" {
+  command = plan
+
+  variables {
+    baseline_labels = {
+      environment = "preview"
+      lifecycle   = "permanent"
+      managed-by  = "terraform"
+      owner       = "founder"
+      platform    = "rentchain"
+    }
+  }
+
+  expect_failures = [var.baseline_labels]
+}
+
+run "production_project_fails" {
+  command = plan
+
+  variables {
+    project_id = "project-0d9658de-af29-4dc0-a99"
+  }
+
+  expect_failures = [var.project_id]
+}
+
+run "wrong_project_number_fails" {
+  command = plan
+
+  variables {
+    project_number = "000000000000"
+  }
+
+  expect_failures = [var.project_number]
+}

--- a/infra/environments/preview-foundation/variables.tf
+++ b/infra/environments/preview-foundation/variables.tf
@@ -42,14 +42,14 @@ variable "baseline_labels" {
   nullable    = false
 
   validation {
-    condition = var.baseline_labels == {
+    condition = var.baseline_labels == tomap({
       environment = "preview"
       lifecycle   = "permanent"
       managed-by  = "terraform"
       owner       = "founder"
       platform    = "rentchain"
       purpose     = "shared-preview"
-    }
+    })
     error_message = "baseline_labels must exactly match the approved B1 Preview label set."
   }
 }


### PR DESCRIPTION
## Summary

- record the bounded plan-only HCP Terraform identity bootstrap
- add the generated Google provider dependency lock file
- document exact WIF claims, IAM, HCP variables, negative evidence, residual resources, and rollback
- preserve the stop after Terraform validation failed on the existing `baseline_labels` rule

## Cloud resources created

- identity APIs: IAM, Cloud Resource Manager, IAM Service Account Credentials, STS
- one pool: `hcp-terraform-preview`
- one provider: `hcp-terraform`, immutable org/project/workspace IDs and plan phase only
- one service account: `hcp-terraform-preview`, zero user-managed keys
- one custom role with exactly `resourcemanager.projects.get`, `serviceusage.services.get`, and `serviceusage.services.list`
- one project custom-role binding to the dedicated account
- one exact-subject `roles/iam.workloadIdentityUser` binding on that account only
- four approved non-sensitive HCP workspace environment variables

No wildcard federation, project-level Workload Identity User, Token Creator, production role, workload, B3 identity, or service-account key was created.

## Terraform results

- `terraform init`: passed; HCP initialized and Google provider v6.50.0 locked
- `terraform validate`: **failed**, not passed, on the existing `baseline_labels` equality validation
- remote plan: not run
- apply: not run
- B2 three-service proposal: not applied
- HCP state resources: zero

Per the mission stop rule, no retry, source correction, IAM change, plan, or apply followed the validation error.

## Validation

- Terraform formatting: passed
- Preview source/scope safeguard test: passed
- Markdown and diff checks: passed
- token/secret scan: passed
- exact two-file repository scope: passed
- zero keys, zero wildcard federation, zero project-level Workload Identity User: confirmed
- HCP workspace remote, auto-apply off, resource count zero: confirmed

## Cost and rollback

Expected incremental identity cost is approximately CAD 0. The evidence document provides the exact reverse-order rollback sequence; rollback is not authorized by this PR.

## Classification and boundaries

Final classification: **keyless Terraform identity requires revision**.

B3 did not begin. PR #1435 remains unchanged and on hold. This PR must not merge automatically, request an override, retry validation, run a plan, or apply infrastructure.