### PR TITLE
infra: establish B3 keyless Preview deployment identity

### DIFF
--- a/.github/workflows/preview-deployment-identity-validation.yml
+++ b/.github/workflows/preview-deployment-identity-validation.yml
@@ -1,0 +1,41 @@
+name: Preview deployment identity validation
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  validate-preview-identity:
+    if: >-
+      github.repository == 'rentchaincanada/rentchain' &&
+      github.ref == 'refs/heads/main' &&
+      github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Authenticate to the isolated Preview project
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: projects/501298948635/locations/global/workloadIdentityPools/github-preview-deploy/providers/github
+          service_account: github-preview-deploy@rentchain-preview.iam.gserviceaccount.com
+          create_credentials_file: true
+          export_environment_variables: true
+
+      - name: Set up Google Cloud CLI
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
+
+      - name: Verify inspection-only Preview access
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "${GITHUB_REPOSITORY}" = "rentchaincanada/rentchain"
+          test "${GITHUB_REF}" = "refs/heads/main"
+          test "${GITHUB_EVENT_NAME}" = "workflow_dispatch"
+          gcloud projects describe rentchain-preview \
+            --format='value(projectId,projectNumber)'
+          gcloud services list \
+            --enabled \
+            --project=rentchain-preview \
+            --format='value(config.name)'

--- a/docs/strategy/preview-infrastructure/phase-b-b3-keyless-deployment-identity-plan.md
+++ b/docs/strategy/preview-infrastructure/phase-b-b3-keyless-deployment-identity-plan.md
@@ -152,17 +152,17 @@ This PR supplies configuration proof only. It does not manufacture a JWT or clai
 
 ## Terraform plan evidence
 
-The immutable Terraform source commit is:
+The reviewed Terraform source commit is:
 
-`997144d239e34dbe7d7d87c65a4d0178d905ff1c`
+`4ff3f2f023ebbf7598e80b87503890d1d569abce`
 
 The exact confirmable HCP plan is:
 
 | Evidence | Value |
 | --- | --- |
-| Run | `run-ccC8nZHromtvHT6i` |
-| Configuration version | `cv-dTzxEtbX1jAZKXgv` |
-| Plan | `plan-BhfLLoGjGf4xQFUq` |
+| Run | `run-pbmPLZcFQzN7jC5m` |
+| Configuration version | `cv-5FvrwG2ZoeABVAnJ` |
+| Plan | `plan-Gwt7aQDuvekMj4Qf` |
 | Workspace | `rentchain-preview-foundation` / `ws-ebtKQ2gkLZuoRis4` |
 | Status | `planned` and confirmable |
 | Auto-apply | Off |
@@ -181,7 +181,7 @@ google_service_account_iam_member.github_preview_deploy_federation
 
 The existing three `google_project_service.approved_management` addresses are no-ops. Every planned resource targets `rentchain-preview`; no API, workload, billing, production, broad-IAM, key, change, destroy, or import action appears.
 
-A preceding CLI validation run, `run-4kMm7ZhzWy1fMYgm`, produced the same six-resource plan but was speculative and non-confirmable. It is not eligible for approval or apply. No state or cloud resource resulted from that validation run.
+A preceding CLI validation run, `run-4kMm7ZhzWy1fMYgm`, produced the same six-resource plan but was speculative and non-confirmable. The previous confirmable run, `run-ccC8nZHromtvHT6i`, was discarded unapplied after the reviewed permission-evidence source superseded it. Neither run is eligible for approval or apply. No state or cloud resource resulted from either preceding run.
 
 No apply is authorized by this document or PR.
 
@@ -206,7 +206,7 @@ The existing four apply permissions are preserved. The exact 12-permission addit
 - `resourcemanager.projects.getIamPolicy`; and
 - `resourcemanager.projects.setIamPolicy`.
 
-The resulting custom role has exactly the 16 permissions recorded in `infra/environments/preview-foundation/tests/hcp_apply_permissions.txt`.
+The resulting custom role has exactly the 16 permissions recorded in `infra/environments/preview-foundation/tests/hcp_apply_permissions.txt`. The administrative update changed only `projects/rentchain-preview/roles/hcpTerraformPreviewApply`; it added no predefined role, binding, service account, federation member, or Terraform state resource.
 
 | Terraform resource | Permission | Purpose and phase | Scope | Residual privilege and narrower-alternative assessment |
 | --- | --- | --- | --- | --- |
@@ -244,8 +244,8 @@ Any B3-only API removal would require a dependency review, but B3 proposes no AP
 
 ## Blockers and approval boundary
 
-- The exact HCP plan passed and contains only the six proposed B3 resources.
-- The previous exact HCP run predates the reviewed permission-evidence commit and is not eligible for apply approval.
+- The fresh exact HCP plan passed and contains only the six proposed B3 resources.
+- The previous exact HCP run was discarded unapplied and is not eligible for apply approval.
 - The HCP apply custom role expansion is an external administrative prerequisite, not a Terraform-managed B3 resource. It must remain exact, apply-phase restricted, and bound only to `hcp-terraform-preview-apply@rentchain-preview.iam.gserviceaccount.com` on `rentchain-preview`.
 - A fresh plan from the reviewed source head must remain exactly six creates, with no change, destroy, import, API, workload, billing, key, public-access, or production action.
 - Founder approval must name the exact immutable HCP run and configuration version.
@@ -254,6 +254,6 @@ Any B3-only API removal would require a dependency review, but B3 proposes no AP
 
 ## Classification
 
-**B3 permission expansion under validation.** The exact permission model is documented and statically enforced. B3 remains unapplied and cannot advance until the administrative role update, fresh exact plan, and post-change isolation checks succeed.
+**B3 exact apply awaiting Founder approval.** The apply role is exact, the fresh confirmable plan contains only six approved creates, auto-apply is off, and state remains at the three B2 service resources. This document and PR do not authorize apply.
 
 No workload was deployed. B4 did not begin. PR #1435 remains unchanged, draft, and on hold.

--- a/docs/strategy/preview-infrastructure/phase-b-b3-keyless-deployment-identity-plan.md
+++ b/docs/strategy/preview-infrastructure/phase-b-b3-keyless-deployment-identity-plan.md
@@ -152,7 +152,36 @@ This PR supplies configuration proof only. It does not manufacture a JWT or clai
 
 ## Terraform plan evidence
 
-To be recorded after the exact HCP plan is generated. The expected change is six additions, zero changes, and zero destroys. Any API, workload, billing, production, broad-IAM, key, change, destroy, or import action blocks B3.
+The immutable Terraform source commit is:
+
+`997144d239e34dbe7d7d87c65a4d0178d905ff1c`
+
+The exact confirmable HCP plan is:
+
+| Evidence | Value |
+| --- | --- |
+| Run | `run-ccC8nZHromtvHT6i` |
+| Configuration version | `cv-dTzxEtbX1jAZKXgv` |
+| Plan | `plan-BhfLLoGjGf4xQFUq` |
+| Workspace | `rentchain-preview-foundation` / `ws-ebtKQ2gkLZuoRis4` |
+| Status | `planned` and confirmable |
+| Auto-apply | Off |
+| Result | `6 to add, 0 to change, 0 to destroy, 0 to import` |
+
+The six create actions are exactly:
+
+```text
+google_iam_workload_identity_pool.github_preview_deploy
+google_iam_workload_identity_pool_provider.github
+google_project_iam_custom_role.github_preview_deployment_inspector
+google_project_iam_member.github_preview_deployment_inspector
+google_service_account.github_preview_deploy
+google_service_account_iam_member.github_preview_deploy_federation
+```
+
+The existing three `google_project_service.approved_management` addresses are no-ops. Every planned resource targets `rentchain-preview`; no API, workload, billing, production, broad-IAM, key, change, destroy, or import action appears.
+
+A preceding CLI validation run, `run-4kMm7ZhzWy1fMYgm`, produced the same six-resource plan but was speculative and non-confirmable. It is not eligible for approval or apply. No state or cloud resource resulted from that validation run.
 
 No apply is authorized by this document or PR.
 
@@ -178,14 +207,15 @@ Any B3-only API removal would require a dependency review, but B3 proposes no AP
 
 ## Blockers and approval boundary
 
-- The exact HCP plan must pass and contain only the six proposed B3 resources.
-- The HCP apply identity requires separately verified least-privilege permissions for those exact resource types before an apply can be authorized.
+- The exact HCP plan passed and contains only the six proposed B3 resources.
+- The current HCP apply custom role contains only project inspection and Service Usage permissions. It cannot create the planned WIF, service-account, custom-role, or IAM-member resources.
+- A separately authorized least-privilege HCP plan/apply role expansion must be designed, reviewed, and validated before this run can be considered for apply approval. It must not add Owner, Editor, IAM Admin, wildcard, production, workload-deployment, or static-key capability.
 - Founder approval must name the exact immutable HCP run and configuration version.
 - Runtime validation and negative runtime evidence occur only after apply.
 - B4 deployment permissions and workload resources remain separately unauthorized.
 
 ## Classification
 
-Pending exact-plan verification: **B3 awaiting controlled apply** if the plan matches; otherwise **B3 identity requires revision** or **B3 blocked**.
+**B3 blocked** pending a separately authorized least-privilege HCP Terraform plan/apply permission expansion. The B3 deployment identity configuration and exact plan are valid, but the exact run must not be applied with the current HCP apply role.
 
 No workload was deployed. B4 did not begin. PR #1435 remains unchanged, draft, and on hold.

--- a/docs/strategy/preview-infrastructure/phase-b-b3-keyless-deployment-identity-plan.md
+++ b/docs/strategy/preview-infrastructure/phase-b-b3-keyless-deployment-identity-plan.md
@@ -6,9 +6,9 @@
 
 GitHub Actions is the selected owner of future Preview backend deployment authentication. B3 proposes a dedicated GitHub OIDC to Google Workload Identity Federation path that is separate from production Cloud Build, HCP Terraform plan/apply identities, the retired Vercel spike identity, and all future runtime identities.
 
-The proposed identity is inspection-only. It can authenticate, describe `rentchain-preview`, and inspect enabled services. It cannot deploy Cloud Run, push images, run Cloud Build, mutate IAM, impersonate a runtime identity, access application data, or reach production.
+The applied identity is inspection-only. It can authenticate, describe `rentchain-preview`, and inspect enabled services. It cannot deploy Cloud Run, push images, run Cloud Build, mutate IAM, impersonate a runtime identity, access application data, or reach production.
 
-No workload is deployed by this change. Terraform apply remains blocked until the Founder separately approves the exact HCP run. B4 is not authorized, and PR #1435 remains unchanged, draft, and on hold.
+Founder-authorized HCP run `run-pbmPLZcFQzN7jC5m` applied exactly the six B3 identity resources. No workload was deployed. Runtime GitHub OIDC validation remains incomplete because GitHub rejected the manual dispatch before execution: the new validation workflow is not present on the default branch while PR #1449 remains draft. B4 is not authorized, and PR #1435 remains unchanged, draft, and on hold.
 
 ## Audit findings
 
@@ -164,9 +164,10 @@ The exact confirmable HCP plan is:
 | Configuration version | `cv-5FvrwG2ZoeABVAnJ` |
 | Plan | `plan-Gwt7aQDuvekMj4Qf` |
 | Workspace | `rentchain-preview-foundation` / `ws-ebtKQ2gkLZuoRis4` |
-| Status | `planned` and confirmable |
+| Status | `applied` |
 | Auto-apply | Off |
 | Result | `6 to add, 0 to change, 0 to destroy, 0 to import` |
+| Apply | `apply-2NsX8YBNBPBdwX4L` |
 
 The six create actions are exactly:
 
@@ -183,7 +184,7 @@ The existing three `google_project_service.approved_management` addresses are no
 
 A preceding CLI validation run, `run-4kMm7ZhzWy1fMYgm`, produced the same six-resource plan but was speculative and non-confirmable. The previous confirmable run, `run-ccC8nZHromtvHT6i`, was discarded unapplied after the reviewed permission-evidence source superseded it. Neither run is eligible for approval or apply. No state or cloud resource resulted from either preceding run.
 
-No apply is authorized by this document or PR.
+The Founder separately authorized only this exact run, configuration version, plan, source head, workspace, project, and six-resource create set. It applied successfully without retry, variable change, source change, or IAM broadening.
 
 ## HCP apply permission audit
 
@@ -222,6 +223,29 @@ List, update, delete, and undelete permissions are excluded because provider 6.5
 
 Explicitly absent permissions include service-account key creation or upload, access-token generation, signing, Cloud Run, Artifact Registry, Cloud Build, Storage, Firebase, Firestore, billing, organization IAM, project deletion, production access, and all B3 update/delete/undelete operations. No broad predefined role is granted.
 
+## Post-apply evidence
+
+HCP reported the exact run as `applied` with apply ID `apply-2NsX8YBNBPBdwX4L`. The apply-phase keyless identity authenticated successfully at runtime. Terraform state now contains exactly nine resources: the three existing B2 services and the six authorized B3 addresses. No additional address entered state.
+
+Live Google Cloud verification confirmed:
+
+- pool `github-preview-deploy` is active;
+- provider `github` is active and uses issuer `https://token.actions.githubusercontent.com`;
+- provider mappings remain limited to subject, repository, immutable repository ID, repository owner, immutable owner ID, ref, event, and workflow reference;
+- the provider condition fixes repository `rentchaincanada/rentchain`, repository ID `1103977082`, owner `rentchaincanada`, owner ID `246115482`, ref `refs/heads/main`, event `workflow_dispatch`, the exact validation workflow on `main`, and the exact main-branch subject;
+- service account `github-preview-deploy@rentchain-preview.iam.gserviceaccount.com` exists with zero user-managed keys;
+- its only federation member is the exact main-branch subject principal with `roles/iam.workloadIdentityUser` on that service account;
+- no project-level Workload Identity User binding exists;
+- custom role `githubPreviewDeploymentInspector` contains only `resourcemanager.projects.get`, `serviceusage.services.get`, and `serviceusage.services.list`;
+- the custom role is bound only to the deployment service account in `rentchain-preview`;
+- HCP plan and apply service accounts retain zero user-managed keys;
+- Cloud Run, Artifact Registry, Cloud Build, Firebase, and Firestore workload APIs remain disabled or absent; and
+- Storage buckets remain zero.
+
+The single authorized manual workflow dispatch targeted `main`. GitHub rejected it with HTTP 404 because `preview-deployment-identity-validation.yml` is not on the default branch. No workflow job started, no GitHub OIDC token was requested, no credential exchange occurred, and no runtime or negative OIDC test executed. The provider condition was not weakened and the dispatch was not retried.
+
+The mission required an immediate stop after runtime validation failure. Therefore no post-apply HCP plan was generated. No missing plan-role read permission was observed because refresh was not attempted. Zero-drift remains unproven and requires a later, separately authorized sequence after the workflow becomes available on the default branch.
+
 ## Cost impact
 
 Workload Identity Federation, service accounts, and IAM policy configuration have no expected direct incremental charge. One manually dispatched validation workflow consumes a small amount of GitHub Actions time. No billable workload or storage is created. Expected incremental Google Cloud cost is approximately CAD 0.
@@ -244,16 +268,16 @@ Any B3-only API removal would require a dependency review, but B3 proposes no AP
 
 ## Blockers and approval boundary
 
-- The fresh exact HCP plan passed and contains only the six proposed B3 resources.
+- The fresh exact HCP plan passed and applied only the six proposed B3 resources.
 - The previous exact HCP run was discarded unapplied and is not eligible for apply approval.
 - The HCP apply custom role expansion is an external administrative prerequisite, not a Terraform-managed B3 resource. It must remain exact, apply-phase restricted, and bound only to `hcp-terraform-preview-apply@rentchain-preview.iam.gserviceaccount.com` on `rentchain-preview`.
-- A fresh plan from the reviewed source head must remain exactly six creates, with no change, destroy, import, API, workload, billing, key, public-access, or production action.
-- Founder approval must name the exact immutable HCP run and configuration version.
-- Runtime validation and negative runtime evidence occur only after apply.
+- Runtime validation is blocked until the approved workflow exists on the default branch. No alternate ref, temporary workflow, condition relaxation, or rerun is authorized.
+- Zero-drift validation was not attempted after the runtime stop condition.
+- Future authorization must decide the safe ordering between merging the evidence/configuration PR and executing the main-only validation workflow.
 - B4 deployment permissions and workload resources remain separately unauthorized.
 
 ## Classification
 
-**B3 exact apply awaiting Founder approval.** The apply role is exact, the fresh confirmable plan contains only six approved creates, auto-apply is off, and state remains at the three B2 service resources. This document and PR do not authorize apply.
+**B3 applied; validation incomplete.** The exact six-resource identity apply succeeded and state contains nine expected resources, but GitHub OIDC runtime validation and post-apply zero-drift validation remain incomplete. Neither full identity-foundation validation nor a missing-read-permission classification can be claimed yet.
 
 No workload was deployed. B4 did not begin. PR #1435 remains unchanged, draft, and on hold.

--- a/docs/strategy/preview-infrastructure/phase-b-b3-keyless-deployment-identity-plan.md
+++ b/docs/strategy/preview-infrastructure/phase-b-b3-keyless-deployment-identity-plan.md
@@ -185,6 +185,43 @@ A preceding CLI validation run, `run-4kMm7ZhzWy1fMYgm`, produced the same six-re
 
 No apply is authorized by this document or PR.
 
+## HCP apply permission audit
+
+The locked HashiCorp Google provider version is `6.50.0`. Its exact create paths for the six planned resources were inspected before changing IAM. The provider creates each resource and then reads it. The two IAM member resources use read-modify-write policy operations. The custom-role create path also reads the requested role ID first so it can distinguish absence from a soft-deleted role.
+
+The target pool, deployment service account, and deployment-inspector role were independently confirmed absent before the permission change. That absence makes update and undelete branches inapplicable to this exact plan. Provider source inspection found no list call in any exact create/read path.
+
+The existing four apply permissions are preserved. The exact 12-permission addition is:
+
+- `iam.googleapis.com/workloadIdentityPools.create`;
+- `iam.googleapis.com/workloadIdentityPools.get`;
+- `iam.googleapis.com/workloadIdentityPoolProviders.create`;
+- `iam.googleapis.com/workloadIdentityPoolProviders.get`;
+- `iam.serviceAccounts.create`;
+- `iam.serviceAccounts.get`;
+- `iam.serviceAccounts.getIamPolicy`;
+- `iam.serviceAccounts.setIamPolicy`;
+- `iam.roles.create`;
+- `iam.roles.get`;
+- `resourcemanager.projects.getIamPolicy`; and
+- `resourcemanager.projects.setIamPolicy`.
+
+The resulting custom role has exactly the 16 permissions recorded in `infra/environments/preview-foundation/tests/hcp_apply_permissions.txt`.
+
+| Terraform resource | Permission | Purpose and phase | Scope | Residual privilege and narrower-alternative assessment |
+| --- | --- | --- | --- | --- |
+| `google_iam_workload_identity_pool` | `iam.googleapis.com/workloadIdentityPools.create`, `iam.googleapis.com/workloadIdentityPools.get` | Create and post-create read during apply | `rentchain-preview`, global location | Can create/read another pool in Preview while the apply-phase credential exists. IAM cannot restrict these permissions to one future pool ID; exact HCP trust, exact plan review, and manual confirmation are the operational boundary. |
+| `google_iam_workload_identity_pool_provider` | `iam.googleapis.com/workloadIdentityPoolProviders.create`, `iam.googleapis.com/workloadIdentityPoolProviders.get` | Create and post-create read during apply | `github-preview-deploy` pool in `rentchain-preview` | Can create/read another provider under a Preview pool. No narrower custom-role permission exists; exact-plan review is required. |
+| `google_service_account` | `iam.serviceAccounts.create`, `iam.serviceAccounts.get` | Create and post-create read during apply | `rentchain-preview` | Can create/read another Preview service account. Key, token, signing, update, disable, and delete permissions remain absent. |
+| `google_service_account_iam_member` | `iam.serviceAccounts.getIamPolicy`, `iam.serviceAccounts.setIamPolicy` | Read-modify-write the new service account policy during apply | Preview service accounts | Policy setters are sensitive and cannot be constrained to the future account in a project custom role. The exact plan must contain only the exact-subject Workload Identity User member. |
+| `google_project_iam_custom_role` | `iam.roles.get`, `iam.roles.create` | Absence check, create, and post-create read during apply | Project custom roles in `rentchain-preview` | Can create another Preview project role, but cannot update, delete, or undelete one. Exact-plan review is the narrowest available operational constraint. |
+| `google_project_iam_member` | `resourcemanager.projects.getIamPolicy`, `resourcemanager.projects.setIamPolicy` | Read-modify-write the Preview project policy during apply | `rentchain-preview` project | This pair can modify Preview project IAM and is the largest residual capability. Google exposes no role-specific setter for this Terraform resource. It is permitted only for the phase-restricted apply identity and a manually confirmed exact plan. |
+| Existing B2 services | `resourcemanager.projects.get`, `serviceusage.services.get`, `serviceusage.services.list`, `serviceusage.services.enable` | Preserve existing project and managed-service apply behavior | `rentchain-preview` project | No new API is planned by B3; these permissions are unchanged from B2. |
+
+List, update, delete, and undelete permissions are excluded because provider 6.50.0 does not invoke them for the exact absent-resource create path. They would be required only for a separately reviewed configuration update or rollback. The plan identity remains unchanged. A later zero-drift plan after B3 creation may require a separately authorized read-only plan-role expansion; this apply-role mission does not grant it pre-emptively.
+
+Explicitly absent permissions include service-account key creation or upload, access-token generation, signing, Cloud Run, Artifact Registry, Cloud Build, Storage, Firebase, Firestore, billing, organization IAM, project deletion, production access, and all B3 update/delete/undelete operations. No broad predefined role is granted.
+
 ## Cost impact
 
 Workload Identity Federation, service accounts, and IAM policy configuration have no expected direct incremental charge. One manually dispatched validation workflow consumes a small amount of GitHub Actions time. No billable workload or storage is created. Expected incremental Google Cloud cost is approximately CAD 0.
@@ -208,14 +245,15 @@ Any B3-only API removal would require a dependency review, but B3 proposes no AP
 ## Blockers and approval boundary
 
 - The exact HCP plan passed and contains only the six proposed B3 resources.
-- The current HCP apply custom role contains only project inspection and Service Usage permissions. It cannot create the planned WIF, service-account, custom-role, or IAM-member resources.
-- A separately authorized least-privilege HCP plan/apply role expansion must be designed, reviewed, and validated before this run can be considered for apply approval. It must not add Owner, Editor, IAM Admin, wildcard, production, workload-deployment, or static-key capability.
+- The previous exact HCP run predates the reviewed permission-evidence commit and is not eligible for apply approval.
+- The HCP apply custom role expansion is an external administrative prerequisite, not a Terraform-managed B3 resource. It must remain exact, apply-phase restricted, and bound only to `hcp-terraform-preview-apply@rentchain-preview.iam.gserviceaccount.com` on `rentchain-preview`.
+- A fresh plan from the reviewed source head must remain exactly six creates, with no change, destroy, import, API, workload, billing, key, public-access, or production action.
 - Founder approval must name the exact immutable HCP run and configuration version.
 - Runtime validation and negative runtime evidence occur only after apply.
 - B4 deployment permissions and workload resources remain separately unauthorized.
 
 ## Classification
 
-**B3 blocked** pending a separately authorized least-privilege HCP Terraform plan/apply permission expansion. The B3 deployment identity configuration and exact plan are valid, but the exact run must not be applied with the current HCP apply role.
+**B3 permission expansion under validation.** The exact permission model is documented and statically enforced. B3 remains unapplied and cannot advance until the administrative role update, fresh exact plan, and post-change isolation checks succeed.
 
 No workload was deployed. B4 did not begin. PR #1435 remains unchanged, draft, and on hold.

--- a/docs/strategy/preview-infrastructure/phase-b-b3-keyless-deployment-identity-plan.md
+++ b/docs/strategy/preview-infrastructure/phase-b-b3-keyless-deployment-identity-plan.md
@@ -1,0 +1,191 @@
+<!-- markdownlint-disable MD013 -->
+
+# Phase B B3 keyless Preview deployment identity plan
+
+## Executive summary
+
+GitHub Actions is the selected owner of future Preview backend deployment authentication. B3 proposes a dedicated GitHub OIDC to Google Workload Identity Federation path that is separate from production Cloud Build, HCP Terraform plan/apply identities, the retired Vercel spike identity, and all future runtime identities.
+
+The proposed identity is inspection-only. It can authenticate, describe `rentchain-preview`, and inspect enabled services. It cannot deploy Cloud Run, push images, run Cloud Build, mutate IAM, impersonate a runtime identity, access application data, or reach production.
+
+No workload is deployed by this change. Terraform apply remains blocked until the Founder separately approves the exact HCP run. B4 is not authorized, and PR #1435 remains unchanged, draft, and on hold.
+
+## Audit findings
+
+The merged Phase B sequence through PR #1448 establishes an isolated project, isolated HCP workspace, phase-separated keyless Terraform identities, exactly three managed service resources, and zero drift.
+
+Repository and live-project inspection found:
+
+- `.github/workflows/` contains CI and review automation but no backend deployment workflow;
+- `rentchain-api/cloudbuild.yaml` is production-oriented, targets the production service defaults, and is not safe to reuse for Preview identity ownership;
+- no Preview deployment service account exists;
+- no `github-preview-deploy` pool or provider exists;
+- only the HCP plan/apply service accounts and HCP pool exist in Preview;
+- Artifact Registry, Cloud Build, and Cloud Run Admin APIs remain disabled;
+- no Artifact Registry repository, Cloud Build trigger, Preview Cloud Run service, Storage bucket, Firebase resource, or Firestore resource exists; and
+- active local Google configuration targets only `rentchain-preview` / `501298948635` as `admin@rentchain.ai`.
+
+Production credentials, IAM, state, and resources were not inspected because production access is prohibited. No production identity is reused: the B3 service account, pool, provider, role, workflow, and state addresses are Preview-specific.
+
+## Deployment identity source decision
+
+GitHub Actions is preferred over Cloud Build and HCP Terraform:
+
+- GitHub supplies short-lived OIDC claims for the exact repository and workflow invocation;
+- repository, owner, event, ref, workflow, and subject restrictions are evaluated before token exchange;
+- the manual workflow produces an auditable GitHub run without a static secret;
+- federation can be revoked by disabling one provider or removing one service-account member;
+- HCP Terraform remains the owner of durable infrastructure and IAM, not application deployment execution; and
+- the current Cloud Build configuration is coupled to production defaults and would require a broader B4 build foundation.
+
+Vercel is excluded because its permanent role is authenticated frontend-to-backend invocation, not backend deployment. The bounded spike identity was deleted and is not reused.
+
+## Proposed identity resources
+
+| Resource | Exact identifier | Boundary |
+| --- | --- | --- |
+| Workload Identity Pool | `github-preview-deploy` | Preview project only |
+| OIDC provider | `github` | GitHub Actions issuer only |
+| Deployment service account | `github-preview-deploy@rentchain-preview.iam.gserviceaccount.com` | Authentication and inspection only |
+| Custom role | `githubPreviewDeploymentInspector` | Three non-mutating permissions |
+| Federation member | Exact GitHub `main` branch subject | Service-account policy only |
+| Inspection grant | Custom role to deployment service account | Preview project only |
+
+The Terraform plan must add exactly six B3 identity resources while retaining the three existing B2 service resources unchanged.
+
+## Issuer, audience, and attribute mapping
+
+Issuer:
+
+`https://token.actions.githubusercontent.com`
+
+The provider does not add a custom audience allowlist. Google therefore requires the OIDC audience to equal the provider's full canonical resource name, with or without the HTTPS prefix. The Google authentication action uses that exact provider resource as its audience. A different audience is rejected.
+
+Mappings:
+
+| Google attribute | GitHub assertion |
+| --- | --- |
+| `google.subject` | `assertion.sub` |
+| `attribute.repository` | `assertion.repository` |
+| `attribute.repository_id` | `assertion.repository_id` |
+| `attribute.repository_owner` | `assertion.repository_owner` |
+| `attribute.repository_owner_id` | `assertion.repository_owner_id` |
+| `attribute.ref` | `assertion.ref` |
+| `attribute.event_name` | `assertion.event_name` |
+| `attribute.job_workflow_ref` | `assertion.job_workflow_ref` |
+
+The service-account policy member is the exact subject principal:
+
+`principal://iam.googleapis.com/projects/501298948635/locations/global/workloadIdentityPools/github-preview-deploy/subject/repo:rentchaincanada/rentchain:ref:refs/heads/main`
+
+No pool-wide, provider-wide, repository-wide, organization-wide, wildcard, or project-level Workload Identity User binding is proposed.
+
+## Attribute condition
+
+The provider accepts a token only when all claims match:
+
+- repository: `rentchaincanada/rentchain`;
+- immutable repository ID: `1103977082`;
+- repository owner: `rentchaincanada`;
+- immutable owner ID: `246115482`;
+- ref: `refs/heads/main`;
+- event: `workflow_dispatch`;
+- workflow: `rentchaincanada/rentchain/.github/workflows/preview-deployment-identity-validation.yml@refs/heads/main`; and
+- subject: `repo:rentchaincanada/rentchain:ref:refs/heads/main`.
+
+Forks cannot satisfy the immutable repository and owner claims. Pull-request events, Dependabot events, other automation, other branches, tags, reusable workflows, renamed workflow paths, and arbitrary repositories fail closed. Actor identity is not trusted as an authorization claim because repository access is the governed control and actor membership is mutable. A future deployment environment approval belongs to B4 and requires separate authorization.
+
+## IAM role and scope
+
+The custom role contains exactly:
+
+- `resourcemanager.projects.get`;
+- `serviceusage.services.get`; and
+- `serviceusage.services.list`.
+
+The deployment identity receives no Cloud Run, Artifact Registry, Cloud Build, IAM mutation, Service Account User, Token Creator, Storage, Firebase, Firestore, billing, secret, or production permission.
+
+## Required API posture
+
+The APIs needed for federation are already enabled:
+
+- `cloudresourcemanager.googleapis.com`;
+- `iam.googleapis.com`;
+- `iamcredentials.googleapis.com`;
+- `serviceusage.googleapis.com`; and
+- `sts.googleapis.com`.
+
+B3 proposes no API enablement. Cloud Run Admin, Artifact Registry, Cloud Build, Firebase, Firestore, and Secret Manager remain disabled.
+
+## Validation workflow
+
+`.github/workflows/preview-deployment-identity-validation.yml` is manual-dispatch only. It grants only `contents: read` and `id-token: write`, pins the official Google authentication and CLI setup actions to immutable commits, and fails closed unless repository, ref, and event match the approved context.
+
+After a separately authorized apply, the workflow may:
+
+1. exchange the GitHub OIDC token for short-lived credentials;
+2. describe only the `rentchain-preview` project; and
+3. list enabled services in that project.
+
+It prints no token, uploads no credential, deploys nothing, and mutates nothing. The ephemeral credentials file created by the supported authentication action is runner-local and removed by the action cleanup step; it is not a service-account key or repository secret.
+
+The workflow must not be dispatched before the B3 apply completes. Runtime success is not claimed in this PR.
+
+## Negative-test plan
+
+| Case | Proof before apply | Runtime proof after apply |
+| --- | --- | --- |
+| Exact trusted workflow | Terraform contract and workflow scan | Manual dispatch succeeds |
+| Wrong repository or fork | Immutable repository/owner condition | Token exchange denied |
+| Wrong workflow | Exact `job_workflow_ref` condition | Token exchange denied |
+| Wrong ref or event | Exact ref/event/subject condition | Job guard or exchange denied |
+| Missing token | Workflow permission and auth step contract | Authentication fails closed |
+| Wrong audience | Default canonical-provider audience rule | STS exchange denied |
+| User-managed key | Static scan prohibits key resource | Key inventory remains zero |
+| Wildcard federation | Exact principal and scan | Service-account policy remains exact |
+| Production access | Project validations and role scope | Production remains unqueried |
+| Cloud Run deploy | No permission or resource | Permission denied; no service created |
+| Artifact Registry push | No API, repository, or permission | Permission denied; no artifact created |
+| IAM mutation | No IAM mutation permission | Permission denied |
+
+This PR supplies configuration proof only. It does not manufacture a JWT or claim runtime proof before apply.
+
+## Terraform plan evidence
+
+To be recorded after the exact HCP plan is generated. The expected change is six additions, zero changes, and zero destroys. Any API, workload, billing, production, broad-IAM, key, change, destroy, or import action blocks B3.
+
+No apply is authorized by this document or PR.
+
+## Cost impact
+
+Workload Identity Federation, service accounts, and IAM policy configuration have no expected direct incremental charge. One manually dispatched validation workflow consumes a small amount of GitHub Actions time. No billable workload or storage is created. Expected incremental Google Cloud cost is approximately CAD 0.
+
+## Audit and revocation
+
+Evidence consists of the exact Terraform configuration/version/run/plan, state inventory, GitHub workflow run, provider condition, service-account policy, custom-role permissions, zero-key inventory, enabled-service inventory, and zero-drift plan. Tokens and credential files must never be retained.
+
+Before apply, revocation is achieved by discarding the HCP run. After apply, emergency access revocation disables the provider or removes the exact service-account federation member. Full rollback requires separate authorization and proceeds in reverse order:
+
+1. disable or remove the validation workflow;
+2. remove the exact service-account federation member;
+3. remove the project inspection-role member;
+4. delete the deployment service account;
+5. delete the custom inspection role;
+6. delete the OIDC provider; and
+7. delete the Workload Identity Pool.
+
+Any B3-only API removal would require a dependency review, but B3 proposes no API addition. Terraform `prevent_destroy` guards require an explicitly reviewed rollback change before destruction.
+
+## Blockers and approval boundary
+
+- The exact HCP plan must pass and contain only the six proposed B3 resources.
+- The HCP apply identity requires separately verified least-privilege permissions for those exact resource types before an apply can be authorized.
+- Founder approval must name the exact immutable HCP run and configuration version.
+- Runtime validation and negative runtime evidence occur only after apply.
+- B4 deployment permissions and workload resources remain separately unauthorized.
+
+## Classification
+
+Pending exact-plan verification: **B3 awaiting controlled apply** if the plan matches; otherwise **B3 identity requires revision** or **B3 blocked**.
+
+No workload was deployed. B4 did not begin. PR #1435 remains unchanged, draft, and on hold.

--- a/infra/environments/preview-foundation/README.md
+++ b/infra/environments/preview-foundation/README.md
@@ -1,6 +1,6 @@
 # Preview Foundation Terraform Root
 
-This is the isolated Phase B B2 Terraform root for the permanent `rentchain-preview` non-production project. It is intentionally independent from the repository-root Terraform configuration and has no production remote-state dependency.
+This is the isolated Phase B Terraform root for the permanent `rentchain-preview` non-production project. It is intentionally independent from the repository-root Terraform configuration and has no production remote-state dependency. B2 manages only the three approved management APIs. B3 proposes a separate GitHub Actions keyless inspection identity; it does not authorize or create an application workload.
 
 ## HCP Terraform mapping
 
@@ -10,8 +10,8 @@ This is the isolated Phase B B2 Terraform root for the permanent `rentchain-prev
 - Workflow: CLI-driven
 - Execution mode: Remote
 - State: isolated from production
-- Resources/state objects: zero
-- Configuration uploaded: none
+- Resources/state objects: three B2 management-service resources
+- Configuration uploaded: B2 applied; B3 plan requires separate review and exact-run approval
 - VCS connection: none
 - Google credentials: none
 - Production-state connection: none
@@ -21,9 +21,9 @@ This is the isolated Phase B B2 Terraform root for the permanent `rentchain-prev
 
 The cloud block fixes the organization and workspace. Project variables have no defaults, and validations bind the root to project `rentchain-preview`, project number `501298948635`, and environment `preview`. The production project `project-0d9658de-af29-4dc0-a99` is explicitly denied.
 
-## Proposed resources
+## Managed and proposed resources
 
-No resource has been applied. A future explicitly approved B2 apply would manage only three `google_project_service` resources:
+The completed B2 apply manages only three `google_project_service` resources:
 
 | API | B2 purpose | Owner | Expected direct cost | Retention decision |
 | --- | --- | --- | --- | --- |
@@ -31,22 +31,33 @@ No resource has been applied. A future explicitly approved B2 apply would manage
 | Service Usage | Manage the explicit service allowlist | Founder — Paul | No direct enablement charge | Retain while Terraform manages APIs |
 | Identity and Access Management | Foundation prerequisite for later separately authorized keyless identity work | Founder — Paul | No direct enablement charge | Retain pending later identity authorization |
 
-IAM Credentials and Security Token Service are excluded because no keyless Terraform identity is authorized in B2. All workload, data, build, registry, secret, messaging, compute, and Firebase services remain outside this root.
+IAM Credentials and Security Token Service were enabled during the separately governed keyless HCP identity bootstrap and remain enabled. B3 does not add or enable APIs.
+
+The proposed B3 deployment-identity foundation contains only:
+
+- one `github-preview-deploy` Workload Identity Pool;
+- one `github` OIDC provider for `https://token.actions.githubusercontent.com`;
+- one `github-preview-deploy` service account with zero user-managed keys;
+- one three-permission project-inspection custom role;
+- one exact-subject Workload Identity User member on that service account; and
+- one project IAM member granting the inspection role to that service account.
+
+The provider requires the immutable GitHub repository ID `1103977082`, owner ID `246115482`, exact repository, exact `main` ref, `workflow_dispatch`, exact workflow file/ref, and exact branch subject. Forks, other repositories, other workflows, other events, other refs, and other subjects fail closed.
+
+All workload, data, build, registry, secret, messaging, compute, and Firebase services remain outside this root. B3 grants no Cloud Run, Artifact Registry, Cloud Build, IAM mutation, Service Account User, Token Creator, Storage, Firebase, or production permission.
 
 ## Authentication and execution boundary
 
-No Google credentials, service account, IAM binding, Workload Identity pool/provider, key, or environment-derived fallback is configured. HCP Terraform therefore cannot complete remote initialization, provider-backed validation, planning, or apply until a separately authorized keyless planning identity exists.
-
-The preferred future authentication model is HCP Terraform workload identity → Google Workload Identity Federation → a narrowly scoped Preview Terraform planning/apply identity → short-lived credentials. That path is a separate mission and is not implemented here. Service-account JSON keys, production credentials, wildcard federation, production project access, and automatic apply are prohibited.
+HCP Terraform uses the separately validated phase-specific plan and apply identities with short-lived workload identity credentials. The B3 GitHub deployment identity is distinct from both HCP identities and cannot be used by Terraform, Vercel, a browser, or a runtime workload.
 
 Static credentials are prohibited. Local state must never become authoritative. Plans and applies belong only to the fixed HCP workspace. Auto-apply and auto-destroy remain off.
 
 ## Apply, drift, and destroy governance
 
-Before any apply, capture the exact remote plan, verify the project identity and three-resource allowlist, confirm zero production or workload addresses, document cost, and obtain Founder approval for that exact plan. Plan drift is reviewed against the B1 evidence before approval.
+Before any apply, capture the exact remote plan, verify the project identity and complete resource allowlist, confirm zero production or workload addresses, document cost, and obtain Founder approval for that exact plan. Plan drift is reviewed against the B1 and B2 evidence before approval.
 
 The API resources use `prevent_destroy` and do not disable services on destroy. Removal requires a separately approved change that first documents dependencies, evidence retention, rollback impact, and the exact manual or Terraform action. No automatic destroy is permitted.
 
 ## Current classification
 
-B2 is awaiting a controlled keyless Terraform identity. B3 is not authorized. PR #1435 remains unchanged and on hold pending authenticated Preview infrastructure.
+B2 controlled apply is complete. B3 code and exact-plan review are authorized, but B3 apply is not. No workload deployment is authorized, B4 has not begun, and PR #1435 remains unchanged and on hold pending authenticated Preview infrastructure.

--- a/infra/environments/preview-foundation/README.md
+++ b/infra/environments/preview-foundation/README.md
@@ -60,4 +60,4 @@ The API resources use `prevent_destroy` and do not disable services on destroy. 
 
 ## Current classification
 
-B2 controlled apply is complete. B3 code and exact-plan review are authorized, but B3 apply is not. No workload deployment is authorized, B4 has not begun, and PR #1435 remains unchanged and on hold pending authenticated Preview infrastructure.
+B2 controlled apply is complete. The B3 exact plan proposes only the six bounded identity resources, but B3 is blocked because the current HCP apply role cannot create those resource types. A separately authorized least-privilege HCP plan/apply permission expansion is required before apply approval. No workload deployment is authorized, B4 has not begun, and PR #1435 remains unchanged and on hold pending authenticated Preview infrastructure.

--- a/infra/environments/preview-foundation/README.md
+++ b/infra/environments/preview-foundation/README.md
@@ -60,4 +60,4 @@ The API resources use `prevent_destroy` and do not disable services on destroy. 
 
 ## Current classification
 
-B2 controlled apply is complete. The B3 exact plan proposes only the six bounded identity resources, but B3 is blocked because the current HCP apply role cannot create those resource types. A separately authorized least-privilege HCP plan/apply permission expansion is required before apply approval. No workload deployment is authorized, B4 has not begun, and PR #1435 remains unchanged and on hold pending authenticated Preview infrastructure.
+B2 controlled apply is complete. The bounded HCP apply-role expansion is documented and validated, and the fresh B3 plan proposes only the six approved identity resources. B3 remains unapplied and awaits separate Founder authorization naming the exact run and configuration version. No workload deployment is authorized, B4 has not begun, and PR #1435 remains unchanged and on hold pending authenticated Preview infrastructure.

--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -19,3 +19,28 @@ check "management_api_boundary" {
     error_message = "The B2 management API allowlist has changed."
   }
 }
+
+check "github_preview_deployment_identity_boundary" {
+  assert {
+    condition = (
+      local.github_repository == "rentchaincanada/rentchain" &&
+      local.github_repository_id == "1103977082" &&
+      local.github_repository_owner == "rentchaincanada" &&
+      local.github_repository_owner_id == "246115482" &&
+      local.github_trusted_ref == "refs/heads/main" &&
+      local.github_trusted_event == "workflow_dispatch" &&
+      local.github_trusted_workflow == "rentchaincanada/rentchain/.github/workflows/preview-deployment-identity-validation.yml@refs/heads/main" &&
+      local.github_expected_subject == "repo:rentchaincanada/rentchain:ref:refs/heads/main"
+    )
+    error_message = "The B3 GitHub repository, owner, ref, event, workflow, or subject boundary has changed."
+  }
+
+  assert {
+    condition = local.github_deployment_inspection_permissions == toset([
+      "resourcemanager.projects.get",
+      "serviceusage.services.get",
+      "serviceusage.services.list",
+    ])
+    error_message = "The B3 deployment identity permission set has changed."
+  }
+}

--- a/infra/environments/preview-foundation/deployment_identity.tf
+++ b/infra/environments/preview-foundation/deployment_identity.tf
@@ -1,0 +1,110 @@
+locals {
+  github_repository          = "rentchaincanada/rentchain"
+  github_repository_id       = "1103977082"
+  github_repository_owner    = "rentchaincanada"
+  github_repository_owner_id = "246115482"
+  github_trusted_ref         = "refs/heads/main"
+  github_trusted_event       = "workflow_dispatch"
+  github_trusted_workflow    = "rentchaincanada/rentchain/.github/workflows/preview-deployment-identity-validation.yml@refs/heads/main"
+  github_expected_subject    = "repo:rentchaincanada/rentchain:ref:refs/heads/main"
+
+  github_deployment_inspection_permissions = toset([
+    "resourcemanager.projects.get",
+    "serviceusage.services.get",
+    "serviceusage.services.list",
+  ])
+
+  github_provider_condition = join(" && ", [
+    "assertion.repository == '${local.github_repository}'",
+    "assertion.repository_id == '${local.github_repository_id}'",
+    "assertion.repository_owner == '${local.github_repository_owner}'",
+    "assertion.repository_owner_id == '${local.github_repository_owner_id}'",
+    "assertion.ref == '${local.github_trusted_ref}'",
+    "assertion.event_name == '${local.github_trusted_event}'",
+    "assertion.job_workflow_ref == '${local.github_trusted_workflow}'",
+    "assertion.sub == '${local.github_expected_subject}'",
+  ])
+
+  github_federated_member = "principal://iam.googleapis.com/projects/${var.project_number}/locations/global/workloadIdentityPools/github-preview-deploy/subject/${local.github_expected_subject}"
+}
+
+resource "google_iam_workload_identity_pool" "github_preview_deploy" {
+  project                   = var.project_id
+  workload_identity_pool_id = "github-preview-deploy"
+  display_name              = "GitHub Preview Deploy"
+  description               = "Keyless identity pool for the exact trusted RentChain Preview deployment workflow."
+  disabled                  = false
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_iam_workload_identity_pool_provider" "github" {
+  project                            = var.project_id
+  workload_identity_pool_id          = google_iam_workload_identity_pool.github_preview_deploy.workload_identity_pool_id
+  workload_identity_pool_provider_id = "github"
+  display_name                       = "GitHub"
+  description                        = "Exact-repository and exact-workflow GitHub Actions trust for Preview deployment validation."
+  disabled                           = false
+
+  attribute_mapping = {
+    "google.subject"                = "assertion.sub"
+    "attribute.repository"          = "assertion.repository"
+    "attribute.repository_id"       = "assertion.repository_id"
+    "attribute.repository_owner"    = "assertion.repository_owner"
+    "attribute.repository_owner_id" = "assertion.repository_owner_id"
+    "attribute.ref"                 = "assertion.ref"
+    "attribute.event_name"          = "assertion.event_name"
+    "attribute.job_workflow_ref"    = "assertion.job_workflow_ref"
+  }
+
+  attribute_condition = local.github_provider_condition
+
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_service_account" "github_preview_deploy" {
+  project      = var.project_id
+  account_id   = "github-preview-deploy"
+  display_name = "GitHub Preview Deploy"
+  description  = "Keyless inspection-only identity for the trusted Preview deployment workflow."
+  disabled     = false
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_project_iam_custom_role" "github_preview_deployment_inspector" {
+  project     = var.project_id
+  role_id     = "githubPreviewDeploymentInspector"
+  title       = "GitHub Preview Deployment Inspector"
+  description = "Non-mutating project and service inspection for B3 identity validation."
+  permissions = local.github_deployment_inspection_permissions
+  stage       = "GA"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_service_account_iam_member" "github_preview_deploy_federation" {
+  service_account_id = google_service_account.github_preview_deploy.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = local.github_federated_member
+
+  depends_on = [google_iam_workload_identity_pool_provider.github]
+}
+
+resource "google_project_iam_member" "github_preview_deployment_inspector" {
+  project = var.project_id
+  role    = google_project_iam_custom_role.github_preview_deployment_inspector.name
+  member  = google_service_account.github_preview_deploy.member
+}

--- a/infra/environments/preview-foundation/outputs.tf
+++ b/infra/environments/preview-foundation/outputs.tf
@@ -14,3 +14,14 @@ output "proposed_management_services" {
   value       = sort(tolist(local.approved_management_services))
   sensitive   = false
 }
+
+output "github_preview_deployment_identity" {
+  description = "Non-sensitive identifiers for the B3 keyless Preview deployment identity."
+  value = {
+    workload_identity_provider = google_iam_workload_identity_pool_provider.github.name
+    service_account_email      = google_service_account.github_preview_deploy.email
+    trusted_repository         = local.github_repository
+    trusted_workflow           = local.github_trusted_workflow
+  }
+  sensitive = false
+}

--- a/infra/environments/preview-foundation/tests/deployment_identity.tftest.hcl
+++ b/infra/environments/preview-foundation/tests/deployment_identity.tftest.hcl
@@ -1,0 +1,85 @@
+mock_provider "google" {}
+
+variables {
+  project_id     = "rentchain-preview"
+  project_number = "501298948635"
+  environment    = "preview"
+  baseline_labels = {
+    environment = "preview"
+    lifecycle   = "permanent"
+    managed-by  = "terraform"
+    owner       = "founder"
+    platform    = "rentchain"
+    purpose     = "shared-preview"
+  }
+  monthly_planning_ceiling_cad = 100
+}
+
+run "exact_b3_identity_contract_passes" {
+  command = plan
+
+  assert {
+    condition     = google_iam_workload_identity_pool.github_preview_deploy.workload_identity_pool_id == "github-preview-deploy"
+    error_message = "The B3 workload identity pool ID must remain exact."
+  }
+
+  assert {
+    condition     = google_iam_workload_identity_pool_provider.github.workload_identity_pool_provider_id == "github"
+    error_message = "The B3 provider ID must remain exact."
+  }
+
+  assert {
+    condition     = google_iam_workload_identity_pool_provider.github.oidc[0].issuer_uri == "https://token.actions.githubusercontent.com"
+    error_message = "The B3 provider must trust only the GitHub Actions issuer."
+  }
+
+  assert {
+    condition     = google_service_account.github_preview_deploy.account_id == "github-preview-deploy"
+    error_message = "The B3 deployment service account ID must remain exact."
+  }
+
+  assert {
+    condition     = google_project_iam_custom_role.github_preview_deployment_inspector.permissions == local.github_deployment_inspection_permissions
+    error_message = "The B3 custom role must remain inspection-only."
+  }
+
+  assert {
+    condition     = google_service_account_iam_member.github_preview_deploy_federation.member == "principal://iam.googleapis.com/projects/501298948635/locations/global/workloadIdentityPools/github-preview-deploy/subject/repo:rentchaincanada/rentchain:ref:refs/heads/main"
+    error_message = "Federation must bind only the exact trusted GitHub subject."
+  }
+
+  assert {
+    condition     = google_service_account_iam_member.github_preview_deploy_federation.role == "roles/iam.workloadIdentityUser"
+    error_message = "Federation must grant only Workload Identity User on the deployment service account."
+  }
+}
+
+run "wrong_project_fails_closed" {
+  command = plan
+
+  variables {
+    project_id = "project-0d9658de-af29-4dc0-a99"
+  }
+
+  expect_failures = [var.project_id]
+}
+
+run "wrong_project_number_fails_closed" {
+  command = plan
+
+  variables {
+    project_number = "000000000000"
+  }
+
+  expect_failures = [var.project_number]
+}
+
+run "wrong_environment_fails_closed" {
+  command = plan
+
+  variables {
+    environment = "production"
+  }
+
+  expect_failures = [var.environment]
+}

--- a/infra/environments/preview-foundation/tests/hcp_apply_permissions.txt
+++ b/infra/environments/preview-foundation/tests/hcp_apply_permissions.txt
@@ -1,0 +1,16 @@
+iam.googleapis.com/workloadIdentityPoolProviders.create
+iam.googleapis.com/workloadIdentityPoolProviders.get
+iam.googleapis.com/workloadIdentityPools.create
+iam.googleapis.com/workloadIdentityPools.get
+iam.roles.create
+iam.roles.get
+iam.serviceAccounts.create
+iam.serviceAccounts.get
+iam.serviceAccounts.getIamPolicy
+iam.serviceAccounts.setIamPolicy
+resourcemanager.projects.get
+resourcemanager.projects.getIamPolicy
+resourcemanager.projects.setIamPolicy
+serviceusage.services.enable
+serviceusage.services.get
+serviceusage.services.list

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -2,6 +2,8 @@
 set -euo pipefail
 
 root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+repo_dir="$(cd "$root_dir/../../.." && pwd)"
+workflow_file="$repo_dir/.github/workflows/preview-deployment-identity-validation.yml"
 
 expected_resources="$(cat <<'EOF'
 google_iam_workload_identity_pool
@@ -56,6 +58,21 @@ test "$(rg -No '"(resourcemanager.projects.get|serviceusage.services.get|service
 
 if rg -n 'roles/(owner|editor|run\.admin|artifactregistry\.writer|cloudbuild\.builds\.editor|iam\.serviceAccountTokenCreator|iam\.serviceAccountUser|storage\.admin)|google_service_account_key|principalSet://.*/workloadIdentityPools/github-preview-deploy/\*' "$root_dir" --glob '*.tf'; then
   echo "Broad deployment permission, static key, or wildcard federation found" >&2
+  exit 1
+fi
+
+rg -q '^  workflow_dispatch:$' "$workflow_file"
+rg -q '^  contents: read$' "$workflow_file"
+rg -q '^  id-token: write$' "$workflow_file"
+rg -q "github.repository == 'rentchaincanada/rentchain'" "$workflow_file"
+rg -q "github.ref == 'refs/heads/main'" "$workflow_file"
+rg -q "github.event_name == 'workflow_dispatch'" "$workflow_file"
+rg -q 'workload_identity_provider: projects/501298948635/locations/global/workloadIdentityPools/github-preview-deploy/providers/github' "$workflow_file"
+rg -q 'service_account: github-preview-deploy@rentchain-preview.iam.gserviceaccount.com' "$workflow_file"
+rg -q 'gcloud projects describe rentchain-preview' "$workflow_file"
+
+if rg -n '^  (push|pull_request|schedule):|gcloud (run|builds|artifacts|iam|projects add-iam-policy-binding)|docker (build|push)|terraform (apply|destroy)' "$workflow_file"; then
+  echo "Untrusted trigger or mutation command found in B3 validation workflow" >&2
   exit 1
 fi
 

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 repo_dir="$(cd "$root_dir/../../.." && pwd)"
 workflow_file="$repo_dir/.github/workflows/preview-deployment-identity-validation.yml"
+apply_permissions_file="$root_dir/tests/hcp_apply_permissions.txt"
 
 expected_resources="$(cat <<'EOF'
 google_iam_workload_identity_pool
@@ -55,6 +56,38 @@ rg -q 'assertion.job_workflow_ref ==' "$root_dir/deployment_identity.tf"
 rg -q 'principal://iam.googleapis.com/projects/.*subject/' "$root_dir/deployment_identity.tf"
 
 test "$(rg -No '"(resourcemanager.projects.get|serviceusage.services.get|serviceusage.services.list)"' "$root_dir/deployment_identity.tf" | sort -u | wc -l | tr -d ' ')" = "3"
+
+expected_apply_permissions="$(cat <<'EOF'
+iam.googleapis.com/workloadIdentityPoolProviders.create
+iam.googleapis.com/workloadIdentityPoolProviders.get
+iam.googleapis.com/workloadIdentityPools.create
+iam.googleapis.com/workloadIdentityPools.get
+iam.roles.create
+iam.roles.get
+iam.serviceAccounts.create
+iam.serviceAccounts.get
+iam.serviceAccounts.getIamPolicy
+iam.serviceAccounts.setIamPolicy
+resourcemanager.projects.get
+resourcemanager.projects.getIamPolicy
+resourcemanager.projects.setIamPolicy
+serviceusage.services.enable
+serviceusage.services.get
+serviceusage.services.list
+EOF
+)"
+test "$(sort -u "$apply_permissions_file")" = "$expected_apply_permissions"
+test "$(wc -l < "$apply_permissions_file" | tr -d ' ')" = "16"
+
+if rg -n '(delete|undelete|update|workloadIdentityPools\.list|workloadIdentityPoolProviders\.list|serviceAccounts\.list|roles\.list|serviceAccountKeys|signBlob|signJwt|getAccessToken|generateAccessToken|run\.|artifactregistry\.|cloudbuild\.|storage\.|firebase|firestore|billing|setOrgPolicy)' "$apply_permissions_file"; then
+  echo "Forbidden HCP apply permission found" >&2
+  exit 1
+fi
+
+if rg -n 'project-0d9658de-af29-4dc0-a99|production' "$apply_permissions_file"; then
+  echo "Production reference found in HCP apply permission allowlist" >&2
+  exit 1
+fi
 
 if rg -n 'roles/(owner|editor|run\.admin|artifactregistry\.writer|cloudbuild\.builds\.editor|iam\.serviceAccountTokenCreator|iam\.serviceAccountUser|storage\.admin)|google_service_account_key|principalSet://.*/workloadIdentityPools/github-preview-deploy/\*' "$root_dir" --glob '*.tf'; then
   echo "Broad deployment permission, static key, or wildcard federation found" >&2

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -3,9 +3,20 @@ set -euo pipefail
 
 root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-expected_resources="google_project_service"
+expected_resources="$(cat <<'EOF'
+google_iam_workload_identity_pool
+google_iam_workload_identity_pool_provider
+google_project_iam_custom_role
+google_project_iam_member
+google_project_service
+google_service_account
+google_service_account_iam_member
+EOF
+)"
 actual_resources="$(rg -No 'resource "[^"]+"' "$root_dir" --glob '*.tf' | sed -E 's/.*resource "([^"]+)"/\1/' | sort -u)"
 test "$actual_resources" = "$expected_resources"
+
+test "$(rg -No '^resource "[^"]+"' "$root_dir" --glob '*.tf' | wc -l | tr -d ' ')" = "7"
 
 test "$(rg -No 'service\s*=\s*"[^"]+\.googleapis\.com"' "$root_dir/services.tf" | wc -l | tr -d ' ')" = "0"
 test "$(rg -No '"(cloudresourcemanager|iam|serviceusage)\.googleapis\.com"' "$root_dir/services.tf" | sort -u | wc -l | tr -d ' ')" = "3"
@@ -22,8 +33,29 @@ if rg -n 'credentials\s*=|credentials_file|GOOGLE_APPLICATION_CREDENTIALS|servic
   exit 1
 fi
 
-if rg -n 'allUsers|allAuthenticatedUsers|google_.*_iam|google_cloud_run|google_artifact_registry|google_storage_bucket|google_firestore|google_compute|google_container' "$root_dir" --glob '*.tf'; then
+if rg -n 'allUsers|allAuthenticatedUsers|google_cloud_run|google_artifact_registry|google_storage_bucket|google_firestore|google_compute|google_container|google_cloudbuild' "$root_dir" --glob '*.tf'; then
   echo "Public IAM or workload resource found" >&2
+  exit 1
+fi
+
+rg -q 'workload_identity_pool_id = "github-preview-deploy"' "$root_dir/deployment_identity.tf"
+rg -q 'workload_identity_pool_provider_id = "github"' "$root_dir/deployment_identity.tf"
+rg -q 'issuer_uri = "https://token.actions.githubusercontent.com"' "$root_dir/deployment_identity.tf"
+rg -q 'account_id   = "github-preview-deploy"' "$root_dir/deployment_identity.tf"
+rg -q 'github_repository_id       = "1103977082"' "$root_dir/deployment_identity.tf"
+rg -q 'github_repository_owner_id = "246115482"' "$root_dir/deployment_identity.tf"
+rg -q 'github_trusted_event       = "workflow_dispatch"' "$root_dir/deployment_identity.tf"
+rg -q 'github_trusted_workflow    = "rentchaincanada/rentchain/.github/workflows/preview-deployment-identity-validation.yml@refs/heads/main"' "$root_dir/deployment_identity.tf"
+rg -q 'assertion.repository_id ==' "$root_dir/deployment_identity.tf"
+rg -q 'assertion.repository_owner_id ==' "$root_dir/deployment_identity.tf"
+rg -q 'assertion.event_name ==' "$root_dir/deployment_identity.tf"
+rg -q 'assertion.job_workflow_ref ==' "$root_dir/deployment_identity.tf"
+rg -q 'principal://iam.googleapis.com/projects/.*subject/' "$root_dir/deployment_identity.tf"
+
+test "$(rg -No '"(resourcemanager.projects.get|serviceusage.services.get|serviceusage.services.list)"' "$root_dir/deployment_identity.tf" | sort -u | wc -l | tr -d ' ')" = "3"
+
+if rg -n 'roles/(owner|editor|run\.admin|artifactregistry\.writer|cloudbuild\.builds\.editor|iam\.serviceAccountTokenCreator|iam\.serviceAccountUser|storage\.admin)|google_service_account_key|principalSet://.*/workloadIdentityPools/github-preview-deploy/\*' "$root_dir" --glob '*.tf'; then
+  echo "Broad deployment permission, static key, or wildcard federation found" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- selects GitHub Actions OIDC as the isolated Preview deployment identity source
- adds a dedicated `github-preview-deploy` pool, provider, service account, inspection role, and exact IAM members to the isolated Preview Terraform root
- restricts trust by immutable repository and owner IDs, exact repository, exact manual event, exact `main` ref, exact workflow path/ref, and exact subject
- adds a manual, inspection-only validation workflow with pinned Google actions
- records architecture, negative-test, cost, revocation, rollback, and exact HCP plan evidence

## Exact HCP plan

- source commit: `997144d239e34dbe7d7d87c65a4d0178d905ff1c`
- run: `run-ccC8nZHromtvHT6i`
- configuration version: `cv-dTzxEtbX1jAZKXgv`
- plan: `plan-BhfLLoGjGf4xQFUq`
- result: 6 to add, 0 to change, 0 to destroy, 0 to import
- auto-apply: off
- state remains unchanged at three B2 resources
- apply: not authorized

The six additions are only the B3 pool, provider, deployment service account, three-permission custom role, exact service-account federation member, and inspection-role project member. Existing B2 services are no-ops.

## Security boundary

- no static keys or credentials
- no wildcard or project-level federation
- no production identity or access
- no Cloud Run, Artifact Registry, Cloud Build, Firebase, Firestore, Storage, Vercel, billing, public-access, or application resource
- no Cloud Run deploy, image push, IAM mutation, Service Account User, Token Creator, Owner, or Editor permission
- no workload deployed
- B4 not started
- PR #1435 unchanged and on hold

## Validation

- `terraform fmt -check -recursive`
- `terraform validate`
- `terraform test`: 16 passed, 0 failed
- focused scope and workflow guard scan passed
- workflow YAML parse passed
- secret/static-key scan passed
- production-target scan passed
- `git diff --check` passed
- exact HCP plan JSON reviewed

## Blocker

The B3 configuration and exact plan are valid, but the current HCP apply custom role contains only project inspection and Service Usage permissions. It cannot create the planned IAM/WIF resources. A separately authorized, least-privilege HCP plan/apply permission expansion is required before this run can be considered for apply approval.

Final classification: **B3 blocked** pending that bounded apply-permission prerequisite.
