### PR TITLE
fix: reconcile tenant lease ending and occupancy state

### DIFF
--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -2143,6 +2143,44 @@ describe("leaseRoutes GET /active", () => {
     );
   });
 
+  it("does not commit lease end when atomic occupancy reconciliation fails", async () => {
+    seedDoc("properties", "prop-rollback", {
+      landlordId: "landlord-1",
+      units: [{ id: "unit-rollback", unitNumber: "201", status: "occupied" }],
+    });
+    seedDoc("leases", "lease-rollback", {
+      landlordId: "landlord-1",
+      propertyId: "prop-rollback",
+      tenantId: "tenant-rollback",
+      unitId: "unit-rollback",
+      unitNumber: "201",
+      status: "active",
+      endDate: null,
+    });
+    seedDoc("units", "unit-rollback", {
+      landlordId: "landlord-1",
+      propertyId: "prop-rollback",
+      unitNumber: "201",
+      status: "occupied",
+      occupancyStatus: "occupied",
+      tenantId: "tenant-rollback",
+      leaseId: "lease-rollback",
+    });
+    vi.spyOn(fakeDb, "runTransaction").mockRejectedValueOnce(new Error("synthetic transaction failure"));
+
+    const router = (await import("../leaseRoutes")).default;
+    const res = await invokeRouter(router, { method: "POST", url: "/lease-rollback/end", body: {} });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual({ ok: false, error: "lease_end_occupancy_reconciliation_failed" });
+    expect((await fakeDb.collection("leases").doc("lease-rollback").get()).data()).toEqual(
+      expect.objectContaining({ status: "active", endDate: null })
+    );
+    expect((await fakeDb.collection("units").doc("unit-rollback").get()).data()).toEqual(
+      expect.objectContaining({ status: "occupied", leaseId: "lease-rollback" })
+    );
+  });
+
   it("restores an ended firestore lease and marks the matched unit occupied", async () => {
     seedDoc("properties", "prop-1", {
       landlordId: "landlord-1",

--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -2304,6 +2304,87 @@ describe("leaseRoutes GET /active", () => {
     expect((await fakeDb.collection("tenants").doc("tenant-old").get()).data()).toEqual(beforeTenant);
   });
 
+  it("rejects ambiguous standalone unit aliases before attempting any lease-end write", async () => {
+    seedDoc("properties", "prop-ambiguous", {
+      landlordId: "landlord-1",
+      units: [{
+        id: "unit-logical",
+        unitNumber: "QA-E",
+        status: "occupied",
+        occupancyStatus: "occupied",
+        tenantId: "tenant-ambiguous",
+        currentTenantId: "tenant-ambiguous",
+        leaseId: "lease-ambiguous",
+        currentLeaseId: "lease-ambiguous",
+      }],
+    });
+    seedDoc("leases", "lease-ambiguous", {
+      landlordId: "landlord-1",
+      propertyId: "prop-ambiguous",
+      tenantId: "tenant-ambiguous",
+      unitId: "unit-logical",
+      unitNumber: "QA-E",
+      status: "active",
+      endDate: null,
+    });
+    seedDoc("tenants", "tenant-ambiguous", {
+      landlordId: "landlord-1",
+      currentLeaseId: "lease-ambiguous",
+    });
+    seedDoc("units", "unit-ambiguous-1", {
+      id: "unit-ambiguous-1",
+      unitId: "unit-logical",
+      unitNumber: "QA-E-1",
+      landlordId: "landlord-1",
+      propertyId: "prop-ambiguous",
+      status: "occupied",
+      occupancyStatus: "occupied",
+      tenantId: "tenant-ambiguous",
+      leaseId: "lease-ambiguous",
+      currentLeaseId: "lease-ambiguous",
+    });
+    seedDoc("units", "unit-ambiguous-2", {
+      id: "unit-ambiguous-2",
+      unitId: "unit-logical",
+      unitNumber: "QA-E-2",
+      landlordId: "landlord-1",
+      propertyId: "prop-ambiguous",
+      status: "occupied",
+      occupancyStatus: "occupied",
+      tenantId: "tenant-ambiguous",
+      leaseId: "lease-ambiguous",
+      currentLeaseId: "lease-ambiguous",
+    });
+
+    const beforeProperty = structuredClone((await fakeDb.collection("properties").doc("prop-ambiguous").get()).data());
+    const beforeLease = structuredClone((await fakeDb.collection("leases").doc("lease-ambiguous").get()).data());
+    const beforeTenant = structuredClone((await fakeDb.collection("tenants").doc("tenant-ambiguous").get()).data());
+    const beforeUnit1 = structuredClone((await fakeDb.collection("units").doc("unit-ambiguous-1").get()).data());
+    const beforeUnit2 = structuredClone((await fakeDb.collection("units").doc("unit-ambiguous-2").get()).data());
+    const transactionSet = vi.fn();
+    vi.spyOn(fakeDb, "runTransaction").mockImplementationOnce(async (callback: any) =>
+      callback({
+        get: async (ref: any) => ref.get(),
+        set: async (ref: any, value: any, options?: any) => {
+          transactionSet(ref, value, options);
+          return ref.set(value, options);
+        },
+      })
+    );
+
+    const router = (await import("../leaseRoutes")).default;
+    const res = await invokeRouter(router, { method: "POST", url: "/lease-ambiguous/end", body: {} });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual({ ok: false, error: "lease_end_occupancy_reconciliation_failed" });
+    expect(transactionSet).not.toHaveBeenCalled();
+    expect((await fakeDb.collection("properties").doc("prop-ambiguous").get()).data()).toEqual(beforeProperty);
+    expect((await fakeDb.collection("leases").doc("lease-ambiguous").get()).data()).toEqual(beforeLease);
+    expect((await fakeDb.collection("tenants").doc("tenant-ambiguous").get()).data()).toEqual(beforeTenant);
+    expect((await fakeDb.collection("units").doc("unit-ambiguous-1").get()).data()).toEqual(beforeUnit1);
+    expect((await fakeDb.collection("units").doc("unit-ambiguous-2").get()).data()).toEqual(beforeUnit2);
+  });
+
   it("does not commit lease end when atomic occupancy reconciliation fails", async () => {
     seedDoc("properties", "prop-rollback", {
       landlordId: "landlord-1",

--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -35,7 +35,7 @@ const { fakeDb, listDocs, resetFakeDb, seedDoc } = vi.hoisted(() => {
         const col = ensureCollection(name);
         const docs = Array.from(col.values())
           .filter((doc) => matches(doc, filters))
-          .map((doc) => ({ id: doc.id, exists: true, data: () => doc.data }));
+          .map((doc) => ({ id: doc.id, exists: true, data: () => doc.data, ref: makeDoc(name, doc.id) }));
         return { docs, empty: docs.length === 0, forEach: (fn: any) => docs.forEach(fn), size: docs.length };
       },
       doc: (id?: string) => makeDoc(name, id),
@@ -2089,7 +2089,15 @@ describe("leaseRoutes GET /active", () => {
       landlordId: "landlord-1",
       name: "Harbour View",
       units: [
-        { id: "unit-1", unitNumber: "101", status: "occupied" },
+        {
+          id: "unit-1",
+          unitNumber: "101",
+          status: "occupied",
+          tenantId: "tenant-1",
+          currentTenantId: "tenant-1",
+          leaseId: "lease-1",
+          currentLeaseId: "lease-1",
+        },
         { id: "unit-2", unitNumber: "102", status: "occupied" },
       ],
     });
@@ -2141,6 +2149,159 @@ describe("leaseRoutes GET /active", () => {
         occupancySource: "lease_end",
       })
     );
+  });
+
+  it("treats an already-ended lease as an idempotent no-op when no replacement linkage exists", async () => {
+    seedDoc("properties", "prop-ended", {
+      landlordId: "landlord-1",
+      units: [{ id: "unit-ended", unitNumber: "301", status: "vacant", leaseId: null, currentLeaseId: null }],
+    });
+    seedDoc("leases", "lease-ended", {
+      landlordId: "landlord-1",
+      propertyId: "prop-ended",
+      tenantId: "tenant-ended",
+      unitId: "unit-ended",
+      unitNumber: "301",
+      status: "ended",
+      endDate: "2026-07-01T00:00:00.000Z",
+    });
+    seedDoc("units", "unit-ended", {
+      landlordId: "landlord-1",
+      propertyId: "prop-ended",
+      unitNumber: "301",
+      status: "vacant",
+      occupancyStatus: "vacant",
+      leaseId: null,
+      currentLeaseId: null,
+    });
+
+    const beforeProperty = structuredClone((await fakeDb.collection("properties").doc("prop-ended").get()).data());
+    const beforeUnit = structuredClone((await fakeDb.collection("units").doc("unit-ended").get()).data());
+    const beforeLease = structuredClone((await fakeDb.collection("leases").doc("lease-ended").get()).data());
+    const router = (await import("../leaseRoutes")).default;
+    const res = await invokeRouter(router, { method: "POST", url: "/lease-ended/end", body: {} });
+
+    expect(res.status).toBe(200);
+    expect((await fakeDb.collection("properties").doc("prop-ended").get()).data()).toEqual(beforeProperty);
+    expect((await fakeDb.collection("units").doc("unit-ended").get()).data()).toEqual(beforeUnit);
+    expect((await fakeDb.collection("leases").doc("lease-ended").get()).data()).toEqual(beforeLease);
+  });
+
+  it("rejects a repeated end when the standalone unit is linked to a replacement lease", async () => {
+    seedDoc("properties", "prop-replaced", {
+      landlordId: "landlord-1",
+      units: [{
+        id: "unit-replaced",
+        unitNumber: "302",
+        status: "occupied",
+        tenantId: "tenant-old",
+        currentTenantId: "tenant-old",
+        leaseId: "lease-old",
+        currentLeaseId: "lease-old",
+      }],
+    });
+    seedDoc("leases", "lease-old", {
+      landlordId: "landlord-1",
+      propertyId: "prop-replaced",
+      tenantId: "tenant-old",
+      unitId: "unit-replaced",
+      unitNumber: "302",
+      status: "active",
+      endDate: null,
+    });
+    seedDoc("tenants", "tenant-old", { landlordId: "landlord-1", currentLeaseId: "lease-old" });
+    seedDoc("units", "unit-replaced", {
+      landlordId: "landlord-1",
+      propertyId: "prop-replaced",
+      unitNumber: "302",
+      status: "occupied",
+      occupancyStatus: "occupied",
+      tenantId: "tenant-old",
+      currentTenantId: "tenant-old",
+      leaseId: "lease-old",
+      currentLeaseId: "lease-old",
+    });
+
+    const router = (await import("../leaseRoutes")).default;
+    const first = await invokeRouter(router, { method: "POST", url: "/lease-old/end", body: {} });
+    expect(first.status).toBe(200);
+
+    seedDoc("leases", "lease-replacement", { landlordId: "landlord-1", status: "active" });
+    seedDoc("tenants", "tenant-old", { landlordId: "landlord-1", currentLeaseId: "lease-replacement" });
+    seedDoc("units", "unit-replaced", {
+      landlordId: "landlord-1",
+      propertyId: "prop-replaced",
+      unitNumber: "302",
+      status: "occupied",
+      occupancyStatus: "occupied",
+      tenantId: "tenant-new",
+      currentTenantId: "tenant-new",
+      leaseId: "lease-replacement",
+      currentLeaseId: "lease-replacement",
+    });
+
+    const beforeProperty = structuredClone((await fakeDb.collection("properties").doc("prop-replaced").get()).data());
+    const beforeUnit = structuredClone((await fakeDb.collection("units").doc("unit-replaced").get()).data());
+    const beforeLease = structuredClone((await fakeDb.collection("leases").doc("lease-old").get()).data());
+    const beforeTenant = structuredClone((await fakeDb.collection("tenants").doc("tenant-old").get()).data());
+    const res = await invokeRouter(router, { method: "POST", url: "/lease-old/end", body: {} });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual({ ok: false, error: "lease_end_occupancy_reconciliation_failed" });
+    expect((await fakeDb.collection("properties").doc("prop-replaced").get()).data()).toEqual(beforeProperty);
+    expect((await fakeDb.collection("units").doc("unit-replaced").get()).data()).toEqual(beforeUnit);
+    expect((await fakeDb.collection("leases").doc("lease-old").get()).data()).toEqual(beforeLease);
+    expect((await fakeDb.collection("tenants").doc("tenant-old").get()).data()).toEqual(beforeTenant);
+    expect((await fakeDb.collection("leases").doc("lease-replacement").get()).data()).toEqual({
+      landlordId: "landlord-1",
+      status: "active",
+    });
+  });
+
+  it("rejects lease end when the embedded property unit is linked to a replacement lease", async () => {
+    seedDoc("properties", "prop-embedded-replaced", {
+      landlordId: "landlord-1",
+      units: [{
+        id: "unit-embedded-replaced",
+        unitNumber: "303",
+        status: "occupied",
+        tenantId: "tenant-new",
+        currentTenantId: "tenant-new",
+        leaseId: "lease-replacement",
+        currentLeaseId: "lease-replacement",
+      }],
+    });
+    seedDoc("leases", "lease-stale", {
+      landlordId: "landlord-1",
+      propertyId: "prop-embedded-replaced",
+      tenantId: "tenant-old",
+      unitId: "unit-embedded-replaced",
+      unitNumber: "303",
+      status: "active",
+      endDate: null,
+    });
+    seedDoc("units", "unit-embedded-replaced", {
+      landlordId: "landlord-1",
+      propertyId: "prop-embedded-replaced",
+      unitNumber: "303",
+      status: "occupied",
+      occupancyStatus: "occupied",
+    });
+    seedDoc("tenants", "tenant-old", { landlordId: "landlord-1", currentLeaseId: "lease-stale" });
+
+    const beforeProperty = structuredClone((await fakeDb.collection("properties").doc("prop-embedded-replaced").get()).data());
+    const beforeUnit = structuredClone((await fakeDb.collection("units").doc("unit-embedded-replaced").get()).data());
+    const beforeLease = structuredClone((await fakeDb.collection("leases").doc("lease-stale").get()).data());
+    const beforeTenant = structuredClone((await fakeDb.collection("tenants").doc("tenant-old").get()).data());
+    const router = (await import("../leaseRoutes")).default;
+    const res = await invokeRouter(router, { method: "POST", url: "/lease-stale/end", body: {} });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual({ ok: false, error: "lease_end_occupancy_reconciliation_failed" });
+    expect((await fakeDb.collection("properties").doc("prop-embedded-replaced").get()).data()).toEqual(beforeProperty);
+    expect((await fakeDb.collection("units").doc("unit-embedded-replaced").get()).data()).toEqual(beforeUnit);
+    expect((await fakeDb.collection("leases").doc("lease-stale").get()).data()).toEqual(beforeLease);
+    expect((await fakeDb.collection("tenants").doc("tenant-old").get()).data()).toEqual(beforeTenant);
   });
 
   it("does not commit lease end when atomic occupancy reconciliation fails", async () => {

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -389,6 +389,85 @@ async function reconcilePropertyUnitVacancyForLeaseEnd(lease: any) {
   }
 }
 
+/**
+ * Ends a Firestore lease and reconciles every denormalized occupancy projection
+ * in one transaction.  The previous implementation committed the lease first
+ * and reconciled the property/unit projections afterwards, leaving a durable
+ * ended lease when the second write failed.
+ */
+async function endFirestoreLeaseAtomically(leaseId: string, lease: any, endDate: string) {
+  const propertyId = String(lease?.propertyId || "").trim();
+  const unitReference = String(lease?.unitId || lease?.unitNumber || lease?.unit || "").trim();
+  const tenantId = String(lease?.tenantId || lease?.primaryTenantId || "").trim();
+  if (!propertyId || !unitReference) throw new Error("lease_end_missing_property_or_unit");
+
+  // Lightweight route fakes used by unit tests do not implement transactions;
+  // retain their existing reconciliation path while real Firestore always uses
+  // the atomic branch below.
+  if (typeof (db as any).runTransaction !== "function") {
+    await db.collection("leases").doc(leaseId).set({ status: "ended", endDate, updatedAt: new Date().toISOString() }, { merge: true });
+    await reconcilePropertyUnitVacancyForLeaseEnd({ id: leaseId, ...lease });
+    return;
+  }
+
+  try {
+    await (db as any).runTransaction(async (transaction: any) => {
+    const leaseRef = db.collection("leases").doc(leaseId);
+    const propertyRef = db.collection("properties").doc(propertyId);
+    const tenantRef = tenantId ? db.collection("tenants").doc(tenantId) : null;
+    const [leaseSnap, propertySnap, tenantSnap, unitSnap] = await Promise.all([
+      transaction.get(leaseRef),
+      transaction.get(propertyRef),
+      tenantRef ? transaction.get(tenantRef) : Promise.resolve(null),
+      transaction.get(db.collection("units").where("propertyId", "==", propertyId)),
+    ]);
+    if (!leaseSnap.exists) throw new Error("lease_end_lease_not_found");
+    if (!propertySnap.exists) throw new Error("lease_end_property_not_found");
+
+    const nowIso = new Date().toISOString();
+    const propertyData = propertySnap.data() || {};
+    const embeddedUnits = Array.isArray(propertyData.units) ? propertyData.units : [];
+    const matchingEmbedded = embeddedUnits
+      .map((unit: any, index: number) => ({ unit, index }))
+      .filter(({ unit }: any) => normalizeUnitReference(unit?.id || unit?.unitId || unit?.unitNumber || unit?.label || unit?.unit) === normalizeUnitReference(unitReference));
+    if (matchingEmbedded.length !== 1) throw new Error("lease_end_unit_not_found_or_ambiguous");
+
+    const unitDocs = (unitSnap?.docs || []).filter((doc: any) => {
+      const data = doc.data() || {};
+      return normalizeUnitReference(data.id || data.unitId || doc.id) === normalizeUnitReference(unitReference) ||
+        normalizeUnitReference(data.unitNumber || data.label || data.unit) === normalizeUnitReference(unitReference);
+    });
+    // Test doubles may return plain documents without transaction references.
+    // Fall back before issuing any transaction writes in that case.
+    if (unitDocs.length === 1 && !unitDocs[0].ref) throw new Error("lease_end_transaction_double_unsupported");
+
+    const nextEmbeddedUnits = embeddedUnits.map((unit: any, index: number) =>
+      index === matchingEmbedded[0].index
+        ? { ...unit, status: "vacant", occupancyStatus: "vacant", tenantId: null, currentTenantId: null, leaseId: null, currentLeaseId: null, occupancySource: "lease_end", occupancyUpdatedAt: nowIso, updatedAt: nowIso }
+        : unit
+    );
+    transaction.set(propertyRef, { units: nextEmbeddedUnits, updatedAt: nowIso }, { merge: true });
+
+    if (unitDocs.length > 1) throw new Error("lease_end_standalone_unit_ambiguous");
+    if (unitDocs.length === 1) {
+      transaction.set(unitDocs[0].ref, { status: "vacant", occupancyStatus: "vacant", tenantId: null, currentTenantId: null, leaseId: null, currentLeaseId: null, occupancySource: "lease_end", occupancyUpdatedAt: nowIso, updatedAt: nowIso }, { merge: true });
+    }
+
+    transaction.set(leaseRef, { status: "ended", endDate, updatedAt: nowIso }, { merge: true });
+    if (tenantRef && tenantSnap?.exists) {
+      const tenant = tenantSnap.data() || {};
+      if (String(tenant.currentLeaseId || "").trim() === leaseId) {
+        transaction.set(tenantRef, { currentLeaseId: null, updatedAt: nowIso }, { merge: true });
+      }
+    }
+    });
+  } catch (error: any) {
+    if (error?.message !== "lease_end_transaction_double_unsupported") throw error;
+    await db.collection("leases").doc(leaseId).set({ status: "ended", endDate, updatedAt: new Date().toISOString() }, { merge: true });
+    await reconcilePropertyUnitVacancyForLeaseEnd({ id: leaseId, ...lease });
+  }
+}
+
 async function resolveStandaloneUnitDocIdForLeaseEnd(lease: any): Promise<string | null> {
   const propertyId = String(lease?.propertyId || "").trim();
   const landlordId = String(lease?.landlordId || "").trim();
@@ -3678,16 +3757,8 @@ router.post("/:id/end", requireLandlord, async (req: any, res: Response) => {
       return res.status(leaseResult.status).json({ error: leaseResult.error });
     }
     if (leaseResult.source === "firestore") {
-      await db.collection("leases").doc(String(req.params?.id || "").trim()).set(
-        {
-          status: "ended",
-          endDate,
-          updatedAt: new Date().toISOString(),
-        },
-        { merge: true }
-      );
       try {
-        await reconcilePropertyUnitVacancyForLeaseEnd({ id: String(req.params?.id || "").trim(), ...(leaseResult.lease as any) });
+        await endFirestoreLeaseAtomically(String(req.params?.id || "").trim(), leaseResult.lease as any, endDate);
       } catch (reconcileErr: any) {
         console.error("[POST /api/leases/:id/end] occupancy reconciliation failed", {
           leaseId: String(req.params?.id || "").trim(),

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -441,6 +441,40 @@ async function endFirestoreLeaseAtomically(leaseId: string, lease: any, endDate:
     // Fall back before issuing any transaction writes in that case.
     if (unitDocs.length === 1 && !unitDocs[0].ref) throw new Error("lease_end_transaction_double_unsupported");
 
+    if (unitDocs.length > 1) throw new Error("lease_end_standalone_unit_ambiguous");
+
+    const standaloneUnit = unitDocs.length === 1 ? unitDocs[0].data() || {} : null;
+    const embeddedUnit = matchingEmbedded[0].unit || {};
+    const currentUnitRecords = [embeddedUnit, standaloneUnit].filter(Boolean);
+    const hasConflictingLeaseLink = currentUnitRecords.some((unit: any) =>
+      [unit.leaseId, unit.currentLeaseId].some((value) => {
+        const currentLeaseId = String(value || "").trim();
+        return Boolean(currentLeaseId) && currentLeaseId !== leaseId;
+      })
+    );
+    const hasConflictingTenantLink = currentUnitRecords.some((unit: any) =>
+      [unit.tenantId, unit.currentTenantId].some((value) => {
+        const currentTenantId = String(value || "").trim();
+        return Boolean(currentTenantId) && (!tenantId || currentTenantId !== tenantId);
+      })
+    );
+    const tenantCurrentLeaseId = tenantSnap?.exists
+      ? String((tenantSnap.data() || {}).currentLeaseId || "").trim()
+      : "";
+
+    if (
+      hasConflictingLeaseLink ||
+      hasConflictingTenantLink ||
+      (tenantCurrentLeaseId && tenantCurrentLeaseId !== leaseId)
+    ) {
+      throw new Error("lease_end_current_linkage_mismatch");
+    }
+
+    // A repeated request is idempotent only after proving that it cannot clear
+    // a replacement lease or tenancy. Do not fabricate another end transition
+    // or rewrite any occupancy projection for an already-ended lease.
+    if (normalizeStatus((leaseSnap.data() || {}).status) === "ended") return;
+
     const nextEmbeddedUnits = embeddedUnits.map((unit: any, index: number) =>
       index === matchingEmbedded[0].index
         ? { ...unit, status: "vacant", occupancyStatus: "vacant", tenantId: null, currentTenantId: null, leaseId: null, currentLeaseId: null, occupancySource: "lease_end", occupancyUpdatedAt: nowIso, updatedAt: nowIso }
@@ -448,7 +482,6 @@ async function endFirestoreLeaseAtomically(leaseId: string, lease: any, endDate:
     );
     transaction.set(propertyRef, { units: nextEmbeddedUnits, updatedAt: nowIso }, { merge: true });
 
-    if (unitDocs.length > 1) throw new Error("lease_end_standalone_unit_ambiguous");
     if (unitDocs.length === 1) {
       transaction.set(unitDocs[0].ref, { status: "vacant", occupancyStatus: "vacant", tenantId: null, currentTenantId: null, leaseId: null, currentLeaseId: null, occupancySource: "lease_end", occupancyUpdatedAt: nowIso, updatedAt: nowIso }, { merge: true });
     }

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -302,6 +302,14 @@ function normalizeUnitReference(value: any): string {
   return String(value || "").trim().toLowerCase();
 }
 
+function matchesUnitReference(unit: any, reference: string, documentId?: string): boolean {
+  const normalizedReference = normalizeUnitReference(reference);
+  if (!normalizedReference) return false;
+
+  return [unit?.id, unit?.unitId, documentId, unit?.unitNumber, unit?.label, unit?.unit]
+    .some((candidate) => normalizeUnitReference(candidate) === normalizedReference);
+}
+
 function normalizeUnitMatchToken(value: any): string {
   const raw = String(value || "").trim().toLowerCase();
   if (!raw) return "";
@@ -429,13 +437,12 @@ async function endFirestoreLeaseAtomically(leaseId: string, lease: any, endDate:
     const embeddedUnits = Array.isArray(propertyData.units) ? propertyData.units : [];
     const matchingEmbedded = embeddedUnits
       .map((unit: any, index: number) => ({ unit, index }))
-      .filter(({ unit }: any) => normalizeUnitReference(unit?.id || unit?.unitId || unit?.unitNumber || unit?.label || unit?.unit) === normalizeUnitReference(unitReference));
+      .filter(({ unit }: any) => matchesUnitReference(unit, unitReference));
     if (matchingEmbedded.length !== 1) throw new Error("lease_end_unit_not_found_or_ambiguous");
 
     const unitDocs = (unitSnap?.docs || []).filter((doc: any) => {
       const data = doc.data() || {};
-      return normalizeUnitReference(data.id || data.unitId || doc.id) === normalizeUnitReference(unitReference) ||
-        normalizeUnitReference(data.unitNumber || data.label || data.unit) === normalizeUnitReference(unitReference);
+      return matchesUnitReference(data, unitReference, doc.id);
     });
     // Test doubles may return plain documents without transaction references.
     // Fall back before issuing any transaction writes in that case.

--- a/rentchain-api/src/services/__tests__/tenantDetailsService.test.ts
+++ b/rentchain-api/src/services/__tests__/tenantDetailsService.test.ts
@@ -294,6 +294,49 @@ describe("getTenantDetailBundle", () => {
     });
   });
 
+  it.each([
+    ["missing lease document", null],
+    ["ended lease", { landlordId: "landlord-1", tenantId: "tenant-1", propertyId: "property-1", unitId: "unit-1", status: "ended" }],
+    ["another landlord lease", { landlordId: "landlord-2", tenantId: "tenant-1", propertyId: "property-1", unitId: "unit-1", status: "active" }],
+    ["another tenant lease", { landlordId: "landlord-1", tenantId: "tenant-2", propertyId: "property-1", unitId: "unit-1", status: "active" }],
+  ])("does not expose a canonical current lease for %s", async (_label, lease) => {
+    tenantDocs.set("tenant-1", {
+      landlordId: "landlord-1",
+      fullName: "Tenant One",
+      propertyId: "property-1",
+      unitId: "unit-1",
+      currentLeaseId: "lease-1",
+      status: "Current",
+    });
+    propertyDocs.set("property-1", { landlordId: "landlord-1", name: "Property" });
+    unitDocs.set("unit-1", {
+      landlordId: "landlord-1",
+      propertyId: "property-1",
+      unitNumber: "1",
+      status: "occupied",
+      occupancyStatus: "occupied",
+    });
+    if (lease) leaseDocs.set("lease-1", lease);
+
+    const { getTenantDetailBundle } = await import("../tenantDetailsService");
+    const bundle = await getTenantDetailBundle("tenant-1", { landlordId: "landlord-1" });
+
+    expect(bundle.currentLease).toBeNull();
+    expect(bundle.lease).toBeNull();
+    expect(bundle.stateCoherence?.occupancyState).toBe("review_required");
+  });
+
+  it("exposes only a valid landlord-owned lease for the matching tenant", async () => {
+    tenantDocs.set("tenant-1", { landlordId: "landlord-1", fullName: "Tenant One", currentLeaseId: "lease-1", status: "Current" });
+    propertyDocs.set("property-1", { landlordId: "landlord-1", name: "Property" });
+    unitDocs.set("unit-1", { landlordId: "landlord-1", propertyId: "property-1", unitNumber: "1", status: "occupied", occupancyStatus: "occupied" });
+    leaseDocs.set("lease-1", { landlordId: "landlord-1", tenantId: "tenant-1", propertyId: "property-1", unitId: "unit-1", status: "active", monthlyRent: 1800 });
+
+    const { getTenantDetailBundle } = await import("../tenantDetailsService");
+    const bundle = await getTenantDetailBundle("tenant-1", { landlordId: "landlord-1" });
+    expect(bundle.currentLease).toEqual(expect.objectContaining({ id: "lease-1", status: "active", monthlyRent: 1800 }));
+  });
+
   it("projects signed lease signing request state into tenant profile readiness and coherence", async () => {
     propertyDocs.set("property-1", {
       landlordId: "landlord-1",

--- a/rentchain-api/src/services/tenantDetailsService.ts
+++ b/rentchain-api/src/services/tenantDetailsService.ts
@@ -461,7 +461,10 @@ async function loadCurrentLeaseSnapshot(tenant: TenantRecord | null, landlordId?
 
     const currentEntries = Array.from(candidates.entries()).filter(([, raw]) => {
       const landlordMatch = !landlordId || String((raw as any)?.landlordId || "").trim() === String(landlordId);
-      return landlordMatch && isTenantProfileLeaseCandidate(raw);
+      const tenantMatch = Array.isArray((raw as any)?.tenantIds)
+        ? (raw as any).tenantIds.map((value: any) => String(value || "").trim()).includes(tenantId)
+        : String((raw as any)?.tenantId || (raw as any)?.primaryTenantId || "").trim() === tenantId;
+      return landlordMatch && tenantMatch && isTenantProfileLeaseCandidate(raw);
     });
     if (!currentEntries.length) return null;
 
@@ -701,6 +704,7 @@ async function loadApplicationRawById(applicationId: string | null | undefined) 
 
 async function hydrateTenantDisplayFields(tenant: TenantRecord, landlordId?: string | null): Promise<TenantRecord> {
   const hydrated: TenantRecord = { ...tenant };
+  const canonicalLease = await loadCurrentLeaseSnapshot(hydrated, landlordId);
   const property = await loadPropertyRecord(hydrated.propertyId || null);
   const unit = await loadUnitRecord(
     hydrated.propertyId || null,
@@ -720,10 +724,24 @@ async function hydrateTenantDisplayFields(tenant: TenantRecord, landlordId?: str
   );
   if (resolvedUnitLabel) hydrated.unit = resolvedUnitLabel;
 
+  if (canonicalLease) {
+    hydrated.currentLeaseId = canonicalLease.id;
+    hydrated.leaseStart = canonicalLease.leaseStartDate || null;
+    hydrated.leaseEnd = canonicalLease.leaseEndDate || null;
+    hydrated.monthlyRent = canonicalLease.currentRent ?? null;
+  } else {
+    hydrated.currentLeaseId = null;
+    hydrated.leaseStart = null;
+    hydrated.leaseEnd = null;
+    hydrated.monthlyRent = null;
+  }
+
   hydrated.lifecycle = deriveTenantLifecycle({
     tenantStatus: hydrated.status,
     applicationId: hydrated.applicationId,
-    currentLeaseId: hydrated.currentLeaseId,
+    leaseStatus: canonicalLease?.status || null,
+    currentLeaseId: canonicalLease?.id || null,
+    leaseId: canonicalLease?.id || null,
     source: hydrated.source,
     hiddenFromActiveLists: hydrated.hiddenFromActiveLists,
   });
@@ -788,23 +806,6 @@ export async function getTenantDetailBundle(tenantId: string, opts: TenantQueryO
         signedDocumentExpiresInSeconds: signedDocumentLink?.signedDocumentExpiresInSeconds ?? null,
         signedDocumentSource: signedDocumentLink?.signedDocumentSource || null,
       }
-    : tenant
-    ? {
-        tenantId: tenant.id,
-        propertyId: tenant.propertyId || null,
-        propertyName: property?.name || tenant.propertyName || "Unknown Property",
-        unitId: tenant.unitId || null,
-        unit: pickString(
-          unit?.unitNumber,
-          unit?.label,
-          unit?.name,
-          normalizeIdentityString(tenant.unit) !== normalizeIdentityString(tenant.unitId) ? tenant.unit : null
-        ) || "N/A",
-        leaseStart: tenant.leaseStart ?? null,
-        leaseEnd: tenant.leaseEnd ?? null,
-        monthlyRent: Number(tenant.monthlyRent ?? 0),
-        status: tenant.status ?? null,
-      }
     : null;
 
   if (tenant && lease) {
@@ -821,9 +822,9 @@ export async function getTenantDetailBundle(tenantId: string, opts: TenantQueryO
     tenantStatus: tenant?.status,
     applicantStatus: (applicationRaw as any)?.status,
     screeningStatus: (applicationRaw as any)?.screeningStatus,
-    leaseStatus: lease?.status || (currentLeaseRaw as any)?.status,
+    leaseStatus: lease?.status || null,
     occupancyStatus: currentTenancy?.status || unit?.occupancyStatus || unit?.status,
-    currentLeaseId: tenant?.currentLeaseId || lease?.id,
+    currentLeaseId: lease?.id || null,
     leaseId: lease?.id,
     applicationId: tenant?.applicationId || (applicationRaw as any)?.id,
     tenantId: tenant?.id,
@@ -869,12 +870,12 @@ export async function getTenantDetailBundle(tenantId: string, opts: TenantQueryO
         leaseId: currentLeaseRecord?.id || lease?.id || null,
         startDate: lease?.leaseStart || (currentLeaseRaw as any)?.startDate || (currentLeaseRaw as any)?.leaseStart,
         monthlyRent: lease?.monthlyRent ?? (currentLeaseRaw as any)?.monthlyRent ?? null,
-        status: lease?.status || (currentLeaseRaw as any)?.status,
+        status: lease?.status || null,
         raw: currentLeaseRaw,
       })
     : null;
   const stateCoherence = deriveLeaseOccupancyCoherence({
-    leaseStatus: lease?.status || (currentLeaseRaw as any)?.status,
+    leaseStatus: lease?.status || null,
     leaseExecutionStatus:
       leaseExecution?.executionStatus ||
       (currentLeaseRaw as any)?.leaseExecution?.executionStatus ||

--- a/rentchain-api/src/services/tenantReportService.ts
+++ b/rentchain-api/src/services/tenantReportService.ts
@@ -258,7 +258,6 @@ export async function buildTenantReportData(
   const currentLeaseId = String(
     bundle?.currentLease?.id ||
       bundle?.lease?.id ||
-      bundle?.tenant?.currentLeaseId ||
       ""
   ).trim();
   const landlordId = String(bundle?.tenant?.landlordId || "").trim() || null;

--- a/rentchain-frontend/src/components/layout/ResponsiveMasterDetail.css
+++ b/rentchain-frontend/src/components/layout/ResponsiveMasterDetail.css
@@ -6,6 +6,7 @@
   display: grid;
   grid-template-columns: minmax(280px, 360px) minmax(0, 1fr);
   gap: 16px;
+  height: 100%;
   min-height: 0;
   min-width: 0;
 }
@@ -17,6 +18,7 @@
   flex-direction: column;
   gap: 12px;
   min-width: 0;
+  overflow-y: hidden;
   overflow-x: hidden;
 }
 

--- a/rentchain-frontend/src/components/tenants/TenantAiInsightsPanel.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantAiInsightsPanel.tsx
@@ -89,7 +89,7 @@ export const TenantAiInsightsPanel: React.FC<TenantAiInsightsPanelProps> = ({
         display: "flex",
         flexDirection: "column",
         gap: "0.6rem",
-        height: "100%",
+        height: "auto",
       }}
     >
       {/* Header */}

--- a/rentchain-frontend/src/components/tenants/TenantDetailPanel.test.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantDetailPanel.test.tsx
@@ -298,6 +298,37 @@ describe("TenantDetailPanel", () => {
     await waitFor(() => expect(mocks.fetchTenantFinancialActivity).toHaveBeenCalledWith("tenant-1"));
   });
 
+  it("does not fabricate an active lease from stale tenant fields and labels active occupancy separately", async () => {
+    mocks.useTenantDetail.mockReturnValue({
+      loading: false,
+      error: null,
+      bundle: {
+        tenant: {
+          id: "tenant-1",
+          fullName: "Taylor Tenant",
+          currentLeaseId: "stale-lease",
+          leaseStatus: "active",
+          monthlyRent: 1850,
+        },
+        currentLease: null,
+        property: { id: "prop-1", name: "Harbour View" },
+        unit: { id: "unit-1", unitNumber: "101", status: "occupied" },
+        moveInReadiness: null,
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <TenantDetailPanel tenantId="tenant-1" />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Active occupant — no lease linked")).toBeInTheDocument();
+    expect(screen.queryByText("Lease Status Active")).not.toBeInTheDocument();
+    expect(screen.queryByText("Current lease rent")).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /Lease/i })).not.toBeInTheDocument();
+  });
+
   it("formats current lease date-only values without shifting to the previous day", async () => {
     mocks.useTenantDetail.mockReturnValue({
       loading: false,

--- a/rentchain-frontend/src/components/tenants/TenantDetailPanel.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantDetailPanel.tsx
@@ -169,6 +169,9 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityR
   const stateCoherence = bundle.stateCoherence || null;
   const property = bundle.property || null;
   const unit = bundle.unit || null;
+  const activeOccupantWithoutLease = !lease && [unit?.status, unit?.occupancyStatus].some((value) =>
+    String(value || "").trim().toLowerCase() === "occupied"
+  );
   const latestLeaseNoticeSummary = bundle.latestLeaseNoticeSummary || null;
   const credibilityInsights = bundle.credibilityInsights || null;
   const [moveInReadiness, setMoveInReadiness] = useState<MoveInReadiness | null>(bundle.moveInReadiness || null);
@@ -589,7 +592,10 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityR
               : "--"
           }
         />
-        <DetailField label="Lease Status" value={formatLeaseStatus(lease?.status)} />
+        <DetailField
+          label="Lease Status"
+          value={lease?.status ? formatLeaseStatus(lease.status) : activeOccupantWithoutLease ? "Active occupant — no lease linked" : "--"}
+        />
         <DetailField label="Lifecycle" value={lifecycle?.lifecycleLabel ?? "--"} />
         {stateCoherence ? (
           <DetailField

--- a/rentchain-frontend/src/components/tenants/TenantDetailPanel.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantDetailPanel.tsx
@@ -404,6 +404,7 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityR
 
   return (
     <div
+      className="rc-tenant-profile-content"
       style={{
         display: "flex",
         flexDirection: "column",
@@ -692,7 +693,6 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityR
             border: `1px solid ${tenantProfileTheme.border}`,
             background: tenantProfileTheme.card,
             boxShadow: shadows.sm,
-            overflow: "hidden",
           }}
         >
           <summary

--- a/rentchain-frontend/src/components/tenants/TenantLeasePanel.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantLeasePanel.tsx
@@ -31,6 +31,7 @@ function isNotFound(err: any): boolean {
 
 interface TenantLeasePanelProps {
   tenantId: string | null;
+  onLeaseEnded?: () => Promise<void> | void;
 }
 
 type TaskErrorState =
@@ -113,7 +114,7 @@ const AutomationMessageCard: React.FC<{
   </div>
 );
 
-export const TenantLeasePanel: React.FC<TenantLeasePanelProps> = ({ tenantId }) => {
+export const TenantLeasePanel: React.FC<TenantLeasePanelProps> = ({ tenantId, onLeaseEnded }) => {
   const [leases, setLeases] = useState<Lease[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -251,11 +252,14 @@ export const TenantLeasePanel: React.FC<TenantLeasePanelProps> = ({ tenantId }) 
   const handleEndLease = async (leaseId: string) => {
     try {
       setEndingLeaseId(leaseId);
+      setError(null);
       await endLease(leaseId, new Date().toISOString());
       await loadLeases();
+      await onLeaseEnded?.();
       setConfirmingLeaseId(null);
     } catch (err) {
       console.error("[TenantLeasePanel] Failed to end lease", err);
+      setError("Lease ending could not be reconciled. No partial update was kept; please retry.");
     } finally {
       setEndingLeaseId(null);
     }

--- a/rentchain-frontend/src/components/tenants/TenantLedgerPanel.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantLedgerPanel.tsx
@@ -137,9 +137,9 @@ export const TenantLedgerPanel: React.FC<TenantLedgerPanelProps> = ({
         flexDirection: "column",
         gap: "0.9rem",
         boxShadow: "0 18px 40px rgba(15,23,42,0.8)",
-        height: "100%",
+        height: "auto",
         minHeight: "260px",
-        overflow: "hidden",
+        overflow: "visible",
       }}
     >
       {/* Header */}
@@ -215,7 +215,7 @@ export const TenantLedgerPanel: React.FC<TenantLedgerPanelProps> = ({
             "linear-gradient(135deg, rgba(15,23,42,0.92), rgba(15,23,42,0.98))",
           border: "1px solid rgba(30,64,175,0.5)",
           padding: "0.75rem 0.75rem 0.5rem",
-          overflow: "hidden",
+          overflow: "visible",
           display: "flex",
           flexDirection: "column",
           gap: "0.5rem",

--- a/rentchain-frontend/src/pages/TenantsPage.css
+++ b/rentchain-frontend/src/pages/TenantsPage.css
@@ -56,6 +56,7 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
+  min-width: 0;
   min-height: 0;
 }
 
@@ -88,7 +89,10 @@
   overflow-y: auto;
   overflow-x: hidden;
   min-height: 0;
+  min-width: 0;
   flex: 1 1 auto;
+  width: 100%;
+  box-sizing: border-box;
   padding-bottom: 12px;
 }
 
@@ -126,6 +130,10 @@
   box-shadow: 0 6px 14px rgba(59, 44, 28, 0.06);
   min-height: 44px;
   height: auto;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
   flex: 0 0 auto;
   overflow: visible;
   transition:
@@ -142,11 +150,26 @@
   flex-shrink: 0;
   overflow: visible;
   align-self: stretch;
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+  position: static;
 }
 
 .rc-tenant-profile-content > * {
   flex: 0 0 auto;
-  min-height: max-content;
+  height: auto;
+  min-height: 0;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+  position: static;
+  overflow: visible;
+}
+
+.rc-tenant-profile-content > * > * {
+  min-width: 0;
 }
 
 .rc-tenants-list-item:hover {

--- a/rentchain-frontend/src/pages/TenantsPage.css
+++ b/rentchain-frontend/src/pages/TenantsPage.css
@@ -11,6 +11,8 @@
   position: relative;
   z-index: 0;
   box-sizing: border-box;
+  min-height: 0;
+  height: calc(100vh - var(--rc-landlord-sticky-shell-measured-height, var(--rc-landlord-sticky-shell-height, 120px)));
   padding: 20px;
   border: 1px solid rgba(91, 70, 48, 0.16);
   border-radius: 18px;
@@ -19,6 +21,24 @@
     linear-gradient(180deg, #fbf6ed 0%, #f7f1e7 100%);
   box-shadow: 0 12px 28px rgba(59, 44, 28, 0.1);
   scroll-margin-top: calc(var(--rc-landlord-sticky-shell-measured-height, var(--rc-landlord-sticky-shell-height, 120px)) + 24px);
+}
+
+@media (min-width: 769px) {
+  .rc-tenants-page {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .rc-tenants-page > .rc-tenants-header {
+    flex: 0 0 auto;
+  }
+
+  .rc-tenants-page > .rc-tenants-grid {
+    flex: 1 1 auto;
+    height: auto;
+    max-height: none;
+    min-height: 0;
+  }
 }
 
 .rc-tenants-header {
@@ -245,6 +265,11 @@
 }
 
 @media (max-width: 768px) {
+  .rc-tenants-page {
+    height: auto;
+    min-height: 0;
+  }
+
   .rc-tenants-grid {
     height: auto;
     max-height: none;

--- a/rentchain-frontend/src/pages/TenantsPage.css
+++ b/rentchain-frontend/src/pages/TenantsPage.css
@@ -125,11 +125,28 @@
   border-color: rgba(91, 70, 48, 0.18) !important;
   box-shadow: 0 6px 14px rgba(59, 44, 28, 0.06);
   min-height: 44px;
+  height: auto;
+  flex: 0 0 auto;
+  overflow: visible;
   transition:
     background-color 0.16s ease,
     border-color 0.16s ease,
     box-shadow 0.16s ease,
     transform 0.16s ease;
+}
+
+.rc-tenant-profile-content {
+  height: auto;
+  min-height: max-content;
+  flex: 0 0 auto;
+  flex-shrink: 0;
+  overflow: visible;
+  align-self: stretch;
+}
+
+.rc-tenant-profile-content > * {
+  flex: 0 0 auto;
+  min-height: max-content;
 }
 
 .rc-tenants-list-item:hover {
@@ -197,6 +214,10 @@
 
   .rc-tenants-detail {
     overflow: visible;
+  }
+
+  .rc-tenant-profile-content {
+    min-height: 0;
   }
 
   .rc-tenants-page {

--- a/rentchain-frontend/src/pages/TenantsPage.css
+++ b/rentchain-frontend/src/pages/TenantsPage.css
@@ -1,5 +1,6 @@
 .rc-tenants-grid {
   display: block;
+  box-sizing: border-box;
   height: min(760px, calc(100vh - 220px));
   max-height: calc(100vh - 220px);
   overflow: hidden;
@@ -86,6 +87,8 @@
   gap: 10px;
   overflow-y: auto;
   overflow-x: hidden;
+  min-height: 0;
+  flex: 1 1 auto;
   padding-bottom: 12px;
 }
 
@@ -96,6 +99,25 @@
   gap: 12px;
   overflow-y: auto;
   overflow-x: hidden;
+}
+
+/* Desktop split panes own their scroll independently; the search/title stay fixed. */
+@media (min-width: 769px) {
+  .rc-tenants-grid .rc-master-detail--desktop {
+    height: 100%;
+    min-height: 0;
+  }
+
+  .rc-tenants-grid .rc-master-detail-master {
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .rc-tenants-grid .rc-master-detail-detail {
+    min-height: 0;
+    overflow-y: auto;
+    overflow-x: hidden;
+  }
 }
 
 .rc-tenants-list-item {

--- a/rentchain-frontend/src/pages/TenantsPage.css
+++ b/rentchain-frontend/src/pages/TenantsPage.css
@@ -1,5 +1,8 @@
 .rc-tenants-grid {
   display: block;
+  height: min(760px, calc(100vh - 220px));
+  max-height: calc(100vh - 220px);
+  overflow: hidden;
   min-height: 0;
 }
 
@@ -82,6 +85,7 @@
   flex-direction: column;
   gap: 10px;
   overflow-y: auto;
+  overflow-x: hidden;
   padding-bottom: 12px;
 }
 
@@ -90,6 +94,8 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
 .rc-tenants-list-item {
@@ -161,6 +167,16 @@
 }
 
 @media (max-width: 768px) {
+  .rc-tenants-grid {
+    height: auto;
+    max-height: none;
+    overflow: visible;
+  }
+
+  .rc-tenants-detail {
+    overflow: visible;
+  }
+
   .rc-tenants-page {
     padding: 14px;
     border-radius: 14px;

--- a/rentchain-frontend/src/pages/TenantsPage.css
+++ b/rentchain-frontend/src/pages/TenantsPage.css
@@ -105,6 +105,22 @@
   overflow-x: hidden;
 }
 
+/* Top-level profile sections must occupy their natural height inside the
+ * independently scrolling detail pane; otherwise flex-shrink collapses one
+ * section underneath the next when the pane is bounded. */
+.rc-tenants-detail > * {
+  flex: 0 0 auto;
+  flex-shrink: 0;
+  height: auto;
+  min-height: 0;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+  position: static;
+  transform: none;
+}
+
 /* Desktop split panes own their scroll independently; the search/title stay fixed. */
 @media (min-width: 769px) {
   .rc-tenants-grid .rc-master-detail--desktop {

--- a/rentchain-frontend/src/pages/TenantsPage.test.tsx
+++ b/rentchain-frontend/src/pages/TenantsPage.test.tsx
@@ -77,10 +77,12 @@ vi.mock("../components/tenants/TenantPaymentsPanel", () => ({
 
 vi.mock("../components/layout/ResponsiveMasterDetail", () => ({
   ResponsiveMasterDetail: ({ master, detail, searchSlot }: ResponsiveMasterDetailProps) => (
-    <div>
-      {searchSlot}
-      {master}
-      {detail}
+    <div className="rc-master-detail rc-master-detail--desktop">
+      <div className="rc-master-detail-master">
+        {searchSlot}
+        {master}
+      </div>
+      <div className="rc-master-detail-detail">{detail}</div>
     </div>
   ),
 }));
@@ -152,6 +154,23 @@ describe("TenantsPage", () => {
       expect.objectContaining({ fallbackPath: "/pricing" })
     );
     expect(mocks.inviteTenantModalMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps tenant list and detail in separate desktop scroll regions", async () => {
+    mocks.fetchTenantsMock.mockResolvedValue([
+      { id: "tenant-1", name: "Tenant One", tenancies: [] },
+    ]);
+
+    render(
+      <MemoryRouter>
+        <TenantsPage />
+      </MemoryRouter>
+    );
+
+    const master = await screen.findByText("Tenant One");
+    expect(master.closest(".rc-master-detail-master")).toBeInTheDocument();
+    expect(document.querySelector(".rc-master-detail-detail")).toBeInTheDocument();
+    expect(document.querySelector(".rc-tenants-list-scroll")).toBeInTheDocument();
   });
 
   it("fails closed when cached invite capability is true but the authenticated plan is free", async () => {

--- a/rentchain-frontend/src/pages/TenantsPage.test.tsx
+++ b/rentchain-frontend/src/pages/TenantsPage.test.tsx
@@ -282,6 +282,21 @@ describe("TenantsPage", () => {
     mocks.fetchTenantTenanciesMock.mockResolvedValue([
       { id: "tenancy-1", tenantId: "tenant-1", status: "active", unitLabel: "Unit 4" },
     ]);
+    mocks.useTenantDetailMock.mockReturnValue({
+      loading: false,
+      error: null,
+      bundle: {
+        tenant: { id: "tenant-1", fullName: "Taylor Tenant" },
+        currentLease: {
+          id: "lease-1",
+          tenantId: "tenant-1",
+          propertyName: "Main Street",
+          unit: "Unit 4",
+          status: "active",
+        },
+        unit: { id: "unit-4", unitNumber: "Unit 4", status: "occupied" },
+      },
+    });
 
     render(
       <MemoryRouter initialEntries={["/tenants?tenantId=tenant-1"]}>

--- a/rentchain-frontend/src/pages/TenantsPage.tsx
+++ b/rentchain-frontend/src/pages/TenantsPage.tsx
@@ -172,7 +172,7 @@ function describeTenantLinkage(
   const activeTenancies = tenancies.filter((tenancy) => tenancy.status !== "inactive");
   const primaryProperty = tenant.propertyName || tenant.propertyId || "No property linked";
   const primaryUnit = tenant.unit || tenant.unitLabel || tenant.unitId || "No unit linked";
-  const currentLeaseId = String(currentLease?.id || tenant.currentLeaseId || "").trim();
+  const currentLeaseId = String(currentLease?.id || "").trim();
   const hasCurrentLeaseLink = Boolean(currentLeaseId);
   const leaseLabel = currentLeaseId
     ? [primaryProperty !== "No property linked" ? primaryProperty : null, primaryUnit !== "No unit linked" ? primaryUnit : null, "Lease"]
@@ -202,7 +202,7 @@ function getTenantCurrentLeaseId(
   tenant?: TenantApiModel | null,
   currentLease?: TenantLeaseSummary | null
 ): string {
-  return String(currentLease?.id || tenant?.currentLeaseId || "").trim();
+  return String(currentLease?.id || "").trim();
 }
 
 function buildTenantLeaseLink(

--- a/rentchain-frontend/src/pages/TenantsPage.tsx
+++ b/rentchain-frontend/src/pages/TenantsPage.tsx
@@ -440,6 +440,12 @@ const loadTenants = useCallback(async () => {
     }
   }, [authLoading, authStatus, canViewTenants, ready, showToast]);
 
+  const refreshAfterLeaseEnded = useCallback(async () => {
+    await loadTenants();
+    if (selectedTenantId) await refreshTenantTenancies(selectedTenantId);
+    setActivityRefreshKey((value) => value + 1);
+  }, [loadTenants, refreshTenantTenancies, selectedTenantId]);
+
   useEffect(() => {
     void loadTenants();
   }, [loadTenants]);
@@ -1203,7 +1209,10 @@ const loadTenants = useCallback(async () => {
               </Section>
 
               <Section style={tenantWorkspaceSectionStyle}>
-                <TenantLeasePanel tenantId={tenantExists ? selectedTenantId : null} />
+                <TenantLeasePanel
+                  tenantId={tenantExists ? selectedTenantId : null}
+                  onLeaseEnded={refreshAfterLeaseEnded}
+                />
               </Section>
 
               <Section style={tenantWorkspaceSectionStyle}>


### PR DESCRIPTION
## Summary\n- Make Firestore lease ending atomic across lease, property/unit occupancy projections, and stale tenant currentLeaseId.\n- Refresh tenant list/detail state after lease ending and surface reconciliation failures.\n- Bound desktop tenant panes with independent scrolling while preserving mobile stacking.\n\n## Validation\n- Backend focused lease-route tests: passed (44 tests).\n- Frontend TenantsPage tests: passed (15 tests).\n- Backend production build: passed under Node 20.20.2.\n- Frontend production build: passed under Node 20.20.2.\n- git diff --check: passed.\n\n## Scope\nNo production migration or data repair was run. Legacy inconsistent records require a separately authorized audit/dry-run before any mutation.

## Limited refresh — August 3, 2026

- Original head: `9bf23fd49e358cb84b521519eb42c84e730803b2`
- Rebased onto: `14d91a023c9f8f3765ae836c673ac3d86c17b5a5`
- Rebased pre-safety head: `2821e221ae89a479ae29e3e6a87f4190aabc9798`
- Final refreshed head: `0822687bd0bbfb0708ed2baa8f1397fcd989b8e7`
- Rebase completed without conflicts; range-diff confirmed all nine original commits are semantically unchanged.
- Added standalone and embedded unit current-linkage guards plus the current tenant-linkage guard. Replacement lease and replacement tenant links now prevent stale lease-end vacancy clearing. Safe already-ended requests are idempotent no-ops; unsafe mismatches preserve atomic `409 lease_end_occupancy_reconciliation_failed` behavior.
- Backend validation: lease routes 48/48, canonical tenant details 14/14, combined focused 62/62, fatal startup 5/5, and backend build passed with Node 20.11.1.
- Immutable-image runtime contract passed: rejected missing/wrong project startup, correct project listened on port 8080, and `/health` returned 200.
- Governance validation passed: human-admin pilot 87, release-control 20, build identity 20, source reader 20, legacy deployer 20, and Production governance 32.
- Frontend validation remains valid: focused 41/41, full 345/345 files and 1,647/1,647 tests, Production build passed in 2.47 seconds.
- Founder-confirmed manual responsive QA passed for desktop, narrow desktop/tablet, and mobile.
- Terraform init/validate and workflow YAML parsing passed; credential and mutation scans returned zero matches. No plan or apply ran.
- Production containment: `rentchain-landlord-api-candidate-dc4c0409` remains RoutesReady with 100% traffic, 1,074 revisions, digest `sha256:b063184b6527789f81e33cb853a0ff0a78f4665e0a44cd5b57a8017bd09da431`, and health 200/200/200.
- Preview containment: `rentchain-preview-backend-00003-42c` remains at 100% traffic on digest `sha256:270adb21de2b271eb468b28b1a591a3f27544aae162f1f028ad74c7bfd30960f`; `FIRESTORE_ENABLED=false`. No PR-head backend, seed, IAM, traffic, or environment mutation occurred.

Pre-merge Firestore reconciliation QA remains unavailable because Preview is not Firestore-enabled and no governed PR-head backend/test-data path exists. No Production data may be used.

## Live Firestore QA — Scenario E finding

- QA namespace: `qa-pr1453-0822687b-20260804T004252Z`
- Scenario A passed with HTTP 200 and the exact intended reconciliation.
- Scenario B passed with HTTP 200 and byte-for-byte idempotency.
- Scenario C passed with guarded HTTP 409 and zero mutation.
- Scenario D passed with guarded HTTP 409 and zero mutation.
- Scenario E unexpectedly returned HTTP 200: lease E ended, tenant E current lease cleared, and property E embedded unit became vacant; both standalone ambiguous unit records remained unchanged.
- Scenario E was not retried and cleanup was not executed.
- Root cause classification: mixed identity-resolution defect. The property-scoped standalone query returned both records, but first-truthy alias matching inspected each unique `id` and skipped the shared logical `unitId`, so the route saw zero standalone candidates and accepted the embedded unit.
- Correction: evaluate all unit identity aliases inside the transaction and reject non-unique standalone matches before any write.
- Regression coverage reproduces the live `id`/shared-`unitId` shape, expects `409 lease_end_occupancy_reconciliation_failed`, asserts no transaction writes, and proves byte-equivalent lease, tenant, property, and both standalone unit records.
- Refreshed PR head: `3398d13725d922b900318b787d906c6c7aa08b37`.

The current QA fixtures and temporary infrastructure remain preserved. A separately authorized new immutable image, one corrected QA revision, and a single Scenario E revalidation are still required before PR readiness.