### PR TITLE
Fix Preview backend runtime image validation contract

### DIFF
--- a/rentchain-api/Dockerfile
+++ b/rentchain-api/Dockerfile
@@ -2,7 +2,7 @@ FROM node:20.20.2-slim AS build
 
 WORKDIR /app
 
-COPY package*.json ./
+COPY package.json package-lock.json ./
 RUN npm ci
 
 COPY . .
@@ -12,7 +12,7 @@ FROM node:20.20.2-slim AS runtime
 
 WORKDIR /app
 
-COPY package*.json ./
+COPY package.json package-lock.json ./
 RUN npm ci --omit=dev && npm cache clean --force
 
 COPY --from=build /app/dist ./dist


### PR DESCRIPTION
## Summary\n- Makes runtime package metadata copies explicit in both Docker build stages.\n- Preserves the /app runtime contract required by the existing B5C validation.\n- No workflow, IAM, Terraform, Cloud Run, datastore, secret, or production changes.\n\n## Root cause\nThe exact B5C run built successfully but failed the runtime filesystem assertion for /app/package.json before authentication or publication. The Dockerfile contract requires package metadata at /app; explicit COPY removes wildcard ambiguity.\n\n## Validation\n- Backend TypeScript build passed on Node 20.20.2.\n- git diff --check passed.\n- Local Docker build unavailable because Docker is not installed in this environment; the image workflow must validate the correction after merge.\n- No image published and no B5C rerun performed.\n\nKeep this PR draft. A new Founder authorization is required for exactly one replacement B5C run after merge.