### PR TITLE
fix: make backend startup safe for Preview

### DIFF
--- a/.github/workflows/preview-image-runtime-validation.yml
+++ b/.github/workflows/preview-image-runtime-validation.yml
@@ -70,15 +70,47 @@ jobs:
           port="$(docker port "${name}" 8080/tcp | awk -F: 'NR == 1 { print $NF }')"
           [[ "${port}" =~ ^[0-9]+$ ]]
           ready=false
-          for attempt in $(seq 1 30); do
+          max_attempts=30
+          for attempt in $(seq 1 "${max_attempts}"); do
             if ! docker inspect "${name}" --format '{{.State.Running}}' | grep -qx true; then
               echo 'Container exited before readiness.' >&2
+              docker inspect "${name}" --format 'status={{.State.Status}} exit={{.State.ExitCode}}' >&2 || true
+              docker logs --tail 100 "${name}" >&2 || true
               exit 1
             fi
             ready_body="${RUNNER_TEMP}/preview-ready.json"
-            ready_status="$(curl --silent --show-error --output "${ready_body}" --write-out '%{http_code}' --max-time 2 "http://127.0.0.1:${port}/health/ready")"
+            ready_status=""
+            ready_curl_exit=0
+            if ready_status="$(curl --silent --show-error --output "${ready_body}" --write-out '%{http_code}' --max-time 2 "http://127.0.0.1:${port}/health/ready")"; then :; else ready_curl_exit=$?; fi
             if test "${ready_status}" = 503 && jq -e '.status == "fail" and .service == "rentchain-api" and .environment == "preview" and .mode == "foundation" and .checks.routes == "ok" and .checks.datastore == "deferred"' "${ready_body}" >/dev/null; then ready=true; break; fi
+            if test "${attempt}" = "${max_attempts}"; then
+              echo "Readiness probe failed: attempt=${attempt}/${max_attempts} curl_exit=${ready_curl_exit} http_status=${ready_status:-none} response_body=$(test -s "${ready_body}" && echo present || echo absent) url=http://127.0.0.1:${port}/health/ready" >&2
+              docker inspect "${name}" --format 'status={{.State.Status}} running={{.State.Running}} exit={{.State.ExitCode}}' >&2 || true
+              docker logs --tail 100 "${name}" >&2 || true
+              exit 1
+            fi
             sleep 1
           done
           test "${ready}" = true
-          curl --fail --silent --show-error --max-time 2 "http://127.0.0.1:${port}/health" | jq -e '.ok == true' >/dev/null
+          health=false
+          for attempt in $(seq 1 "${max_attempts}"); do
+            if ! docker inspect "${name}" --format '{{.State.Running}}' | grep -qx true; then
+              echo 'Container exited before liveness.' >&2
+              docker inspect "${name}" --format 'status={{.State.Status}} exit={{.State.ExitCode}}' >&2 || true
+              docker logs --tail 100 "${name}" >&2 || true
+              exit 1
+            fi
+            health_body="${RUNNER_TEMP}/preview-health.json"
+            health_status=""
+            health_curl_exit=0
+            if health_status="$(curl --silent --show-error --output "${health_body}" --write-out '%{http_code}' --max-time 2 "http://127.0.0.1:${port}/health")"; then :; else health_curl_exit=$?; fi
+            if test "${health_status}" = 200 && jq -e '.ok == true' "${health_body}" >/dev/null; then health=true; break; fi
+            if test "${attempt}" = "${max_attempts}"; then
+              echo "Liveness probe failed: attempt=${attempt}/${max_attempts} curl_exit=${health_curl_exit} http_status=${health_status:-none} response_body=$(test -s "${health_body}" && echo present || echo absent) url=http://127.0.0.1:${port}/health" >&2
+              docker inspect "${name}" --format 'status={{.State.Status}} running={{.State.Running}} exit={{.State.ExitCode}}' >&2 || true
+              docker logs --tail 100 "${name}" >&2 || true
+              exit 1
+            fi
+            sleep 1
+          done
+          test "${health}" = true

--- a/.github/workflows/preview-image-runtime-validation.yml
+++ b/.github/workflows/preview-image-runtime-validation.yml
@@ -66,7 +66,7 @@ jobs:
             docker rm -f "${name}" >/dev/null 2>&1 || true
           }
           trap dump_diagnostics EXIT
-          docker run --detach --name "${name}" --publish 127.0.0.1::8080 --env NODE_ENV=development --env PORT=8080 --env FIRESTORE_EMULATOR_HOST=127.0.0.1:65535 --env ALLOW_LOCAL_PROD_FIRESTORE=false "${image}" >/dev/null
+          docker run --detach --name "${name}" --publish 127.0.0.1::8080 --env APP_ENV=preview --env GOOGLE_CLOUD_PROJECT=rentchain-preview --env FIRESTORE_ENABLED=false --env NODE_ENV=production --env PORT=8080 "${image}" >/dev/null
           port="$(docker port "${name}" 8080/tcp | awk -F: 'NR == 1 { print $NF }')"
           [[ "${port}" =~ ^[0-9]+$ ]]
           ready=false
@@ -75,7 +75,9 @@ jobs:
               echo 'Container exited before readiness.' >&2
               exit 1
             fi
-            if curl --fail --silent --show-error --max-time 2 "http://127.0.0.1:${port}/health/ready" | jq -e '.status == "ok" and .checks.db == "skipped"' >/dev/null; then ready=true; break; fi
+            ready_body="${RUNNER_TEMP}/preview-ready.json"
+            ready_status="$(curl --silent --show-error --output "${ready_body}" --write-out '%{http_code}' --max-time 2 "http://127.0.0.1:${port}/health/ready")"
+            if test "${ready_status}" = 503 && jq -e '.status == "fail" and .service == "rentchain-api" and .environment == "preview" and .mode == "foundation" and .checks.routes == "ok" and .checks.datastore == "deferred"' "${ready_body}" >/dev/null; then ready=true; break; fi
             sleep 1
           done
           test "${ready}" = true

--- a/docs/strategy/phase-b-b6a-preview-safe-backend-startup-foundation.md
+++ b/docs/strategy/phase-b-b6a-preview-safe-backend-startup-foundation.md
@@ -1,0 +1,29 @@
+# Phase B B6A Preview-Safe Backend Startup Foundation
+
+## Status
+
+B6A establishes an explicit Preview startup contract. It does not deploy Cloud Run, provision Firestore or Secret Manager, create fixtures, configure Vercel routing, or authorize PR #1453 deployment.
+
+## Environment contract
+
+- `APP_ENV=preview` is required for Preview.
+- `GOOGLE_CLOUD_PROJECT=rentchain-preview` is required in Preview.
+- Preview rejects the production project `project-0d9658de-af29-4dc0-a99`.
+- Production remains strict and must use the approved production project.
+- Preview does not infer its identity from `NODE_ENV`, hostname, or missing secrets.
+
+## Datastore boundary
+
+Firestore is explicitly disabled while `FIRESTORE_ENABLED` is not `true`. Firebase Admin does not initialize credentials in this mode. Datastore-dependent routes must fail safely until a separately authorized isolated Preview datastore exists.
+
+The B6A change does not provision a datastore, grant runtime IAM, create secrets, or copy production credentials.
+
+## Health contract
+
+- `/health` is liveness: it reports that the process and routes are running, plus sanitized environment metadata.
+- `/health/ready` returns `503` with `datastore: deferred` when Preview Firestore is disabled.
+- Readiness must not claim datastore availability that has not been provisioned.
+
+## Remaining B6 prerequisites
+
+Before a Preview workload can be considered ready, a separately authorized mission must provide an isolated Preview datastore, approved Secret Manager configuration for any required secrets, least-privilege runtime IAM, and deployment verification. No production project, credential, provider secret, payment integration, screening integration, or fixture is in scope here.

--- a/rentchain-api/src/config/__tests__/firestoreEnvironmentGuard.test.ts
+++ b/rentchain-api/src/config/__tests__/firestoreEnvironmentGuard.test.ts
@@ -78,4 +78,18 @@ describe("firestoreEnvironmentGuard", () => {
       googleApplicationCredentialsPresent: true,
     });
   });
+
+  it("supports explicitly disabled Preview Firestore without initializing credentials", () => {
+    const result = assertSafeFirestoreEnvironment({
+      APP_ENV: "preview",
+      GOOGLE_CLOUD_PROJECT: "rentchain-preview",
+      FIRESTORE_ENABLED: "false",
+    });
+
+    expect(result).toMatchObject({
+      environment: "preview",
+      mode: "preview-disabled",
+      localProductionFirestoreOverride: false,
+    });
+  });
 });

--- a/rentchain-api/src/config/__tests__/requiredEnv.test.ts
+++ b/rentchain-api/src/config/__tests__/requiredEnv.test.ts
@@ -9,6 +9,8 @@ function resetEnv() {
 
 function setCommonRequiredEnv() {
   process.env.NODE_ENV = "production";
+  process.env.APP_ENV = "production";
+  process.env.GOOGLE_CLOUD_PROJECT = "project-0d9658de-af29-4dc0-a99";
   process.env.JWT_SECRET = "test_jwt";
   process.env.PUBLIC_APP_URL = "https://app.example.com";
   process.env.STRIPE_SECRET_KEY = "sk_test";
@@ -37,6 +39,8 @@ describe("requiredEnv provider-aware email requirements", () => {
     process.env = {
       ...ENV_BACKUP,
       NODE_ENV: "production",
+      APP_ENV: "production",
+      GOOGLE_CLOUD_PROJECT: "project-0d9658de-af29-4dc0-a99",
       FIRESTORE_EMULATOR_HOST: "127.0.0.1:8080",
       ALLOW_LOCAL_PROD_FIRESTORE: "false",
     };

--- a/rentchain-api/src/config/__tests__/runtimeEnvironment.test.ts
+++ b/rentchain-api/src/config/__tests__/runtimeEnvironment.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { assertRuntimeEnvironment, getConfiguredProjectId, getRuntimeEnvironment } from "../runtimeEnvironment";
+
+describe("runtime environment contract", () => {
+  it("requires the isolated Preview project", () => {
+    expect(() => assertRuntimeEnvironment({ APP_ENV: "preview" } as NodeJS.ProcessEnv)).toThrow(/requires GOOGLE_CLOUD_PROJECT/);
+    expect(() => assertRuntimeEnvironment({ APP_ENV: "preview", GOOGLE_CLOUD_PROJECT: "project-0d9658de-af29-4dc0-a99" } as NodeJS.ProcessEnv)).toThrow(/cannot target a production project/);
+    expect(assertRuntimeEnvironment({ APP_ENV: "preview", GOOGLE_CLOUD_PROJECT: "rentchain-preview" } as NodeJS.ProcessEnv)).toBe("preview");
+  });
+
+  it("does not infer Preview from NODE_ENV", () => {
+    expect(getRuntimeEnvironment({ NODE_ENV: "production" } as NodeJS.ProcessEnv)).toBe("production");
+    expect(getRuntimeEnvironment({ NODE_ENV: "development" } as NodeJS.ProcessEnv)).toBe("development");
+  });
+
+  it("uses only explicit project markers", () => {
+    expect(getConfiguredProjectId({ GOOGLE_CLOUD_PROJECT: "rentchain-preview" } as NodeJS.ProcessEnv)).toBe("rentchain-preview");
+    expect(getConfiguredProjectId({} as NodeJS.ProcessEnv)).toBe("");
+  });
+
+  it("requires the approved project explicitly in production", () => {
+    expect(() => assertRuntimeEnvironment({ APP_ENV: "production" } as NodeJS.ProcessEnv)).toThrow(/requires GOOGLE_CLOUD_PROJECT/);
+    expect(() => assertRuntimeEnvironment({ APP_ENV: "production", GOOGLE_CLOUD_PROJECT: "rentchain-preview" } as NodeJS.ProcessEnv)).toThrow(/approved production project/);
+    expect(assertRuntimeEnvironment({ APP_ENV: "production", GOOGLE_CLOUD_PROJECT: "project-0d9658de-af29-4dc0-a99" } as NodeJS.ProcessEnv)).toBe("production");
+  });
+});

--- a/rentchain-api/src/config/firestoreEnvironmentGuard.ts
+++ b/rentchain-api/src/config/firestoreEnvironmentGuard.ts
@@ -2,7 +2,7 @@ type FirestoreGuardEnv = NodeJS.ProcessEnv | Record<string, string | undefined>;
 
 export type FirestoreEnvironmentGuardResult = {
   environment: string;
-  mode: "production" | "emulator" | "local-prod-firestore-override";
+  mode: "production" | "preview-disabled" | "emulator" | "local-prod-firestore-override";
   emulatorHost: string | null;
   localProductionFirestoreOverride: boolean;
   googleApplicationCredentialsPresent: boolean;
@@ -15,7 +15,7 @@ function envValue(env: FirestoreGuardEnv, key: string): string {
 }
 
 function normalizedEnvironment(env: FirestoreGuardEnv): string {
-  return envValue(env, "NODE_ENV").toLowerCase() || "development";
+  return envValue(env, "APP_ENV").toLowerCase() || envValue(env, "NODE_ENV").toLowerCase() || "development";
 }
 
 function isTrue(value: string): boolean {
@@ -30,6 +30,16 @@ export function assertSafeFirestoreEnvironment(
   const emulatorHost = envValue(env, "FIRESTORE_EMULATOR_HOST");
   const googleApplicationCredentials = envValue(env, "GOOGLE_APPLICATION_CREDENTIALS");
   const localProductionFirestoreOverride = isTrue(envValue(env, "ALLOW_LOCAL_PROD_FIRESTORE"));
+
+  if (environment === "preview" && !isTrue(envValue(env, "FIRESTORE_ENABLED"))) {
+    return {
+      environment,
+      mode: "preview-disabled",
+      emulatorHost: emulatorHost || null,
+      localProductionFirestoreOverride: false,
+      googleApplicationCredentialsPresent: Boolean(googleApplicationCredentials),
+    };
+  }
 
   if (environment === "production") {
     return {

--- a/rentchain-api/src/config/requiredEnv.ts
+++ b/rentchain-api/src/config/requiredEnv.ts
@@ -1,4 +1,5 @@
 import { getPricingHealth } from "./planMatrix";
+import { assertRuntimeEnvironment, getRuntimeEnvironment } from "./runtimeEnvironment";
 
 type EnvRequirement =
   | { kind: "name"; name: string }
@@ -98,10 +99,16 @@ export function getEnvFlags() {
 }
 
 export function assertRequiredEnv(): void {
+  const runtime = assertRuntimeEnvironment();
+  if (runtime === "preview") {
+    if (process.env.FIRESTORE_ENABLED === "true") {
+      throw new Error("[boot] Preview Firestore requires a separately authorized datastore configuration.");
+    }
+    return;
+  }
   const missingHard = missingHardRequirements();
   const missingSoft = missingSoftRequirements();
-  const isProd =
-    String(process.env.NODE_ENV || "").trim().toLowerCase() === "production";
+  const isProd = getRuntimeEnvironment() === "production";
 
   if (missingHard.length > 0) {
     const message = `[boot] missing required env vars: ${missingHard.join(", ")}`;

--- a/rentchain-api/src/config/runtimeEnvironment.ts
+++ b/rentchain-api/src/config/runtimeEnvironment.ts
@@ -1,0 +1,52 @@
+export type RuntimeEnvironment = "production" | "preview" | "development" | "test";
+
+const PRODUCTION_PROJECT_ID = "project-0d9658de-af29-4dc0-a99";
+const PREVIEW_PROJECT_ID = "rentchain-preview";
+
+function value(env: NodeJS.ProcessEnv, key: string): string {
+  return String(env[key] || "").trim();
+}
+
+export function getRuntimeEnvironment(env: NodeJS.ProcessEnv = process.env): RuntimeEnvironment {
+  const configured = value(env, "APP_ENV").toLowerCase();
+  if (configured === "production" || configured === "preview" || configured === "development" || configured === "test") {
+    return configured;
+  }
+  const nodeEnv = value(env, "NODE_ENV").toLowerCase();
+  if (nodeEnv === "production") return "production";
+  if (nodeEnv === "test") return "test";
+  return "development";
+}
+
+export function getConfiguredProjectId(env: NodeJS.ProcessEnv = process.env): string {
+  return value(env, "GOOGLE_CLOUD_PROJECT") || value(env, "GCLOUD_PROJECT") || value(env, "FIREBASE_PROJECT_ID");
+}
+
+export function assertRuntimeEnvironment(env: NodeJS.ProcessEnv = process.env): RuntimeEnvironment {
+  const runtime = getRuntimeEnvironment(env);
+  const projectId = getConfiguredProjectId(env);
+
+  if (runtime === "preview") {
+    if (!projectId) throw new Error("[runtime-env] APP_ENV=preview requires GOOGLE_CLOUD_PROJECT=rentchain-preview.");
+    if (projectId !== PREVIEW_PROJECT_ID) {
+      throw new Error("[runtime-env] Preview must target rentchain-preview and cannot target a production project.");
+    }
+    if (value(env, "FIREBASE_PROJECT_ID") === PRODUCTION_PROJECT_ID) {
+      throw new Error("[runtime-env] Preview rejects the production Firebase project.");
+    }
+  }
+
+  if (runtime === "production") {
+    if (!projectId) {
+      throw new Error("[runtime-env] Production requires GOOGLE_CLOUD_PROJECT to be explicitly configured.");
+    }
+    if (projectId !== PRODUCTION_PROJECT_ID) {
+      throw new Error("[runtime-env] Production must target the approved production project.");
+    }
+  }
+
+  return runtime;
+}
+
+export const PREVIEW_PROJECT = PREVIEW_PROJECT_ID;
+export const PRODUCTION_PROJECT = PRODUCTION_PROJECT_ID;

--- a/rentchain-api/src/firebase/admin.ts
+++ b/rentchain-api/src/firebase/admin.ts
@@ -1,10 +1,27 @@
 import admin from "firebase-admin";
 import { assertSafeFirestoreEnvironment } from "../config/firestoreEnvironmentGuard";
 import { recordInitializationState } from "./initializationRegistry";
+import { assertRuntimeEnvironment, getConfiguredProjectId, PREVIEW_PROJECT, PRODUCTION_PROJECT } from "../config/runtimeEnvironment";
 
-export const PROJECT_ID = "project-0d9658de-af29-4dc0-a99";
+const runtime = assertRuntimeEnvironment();
+export const PROJECT_ID = getConfiguredProjectId() || (runtime === "production" ? PRODUCTION_PROJECT : "");
 
 const guard = assertSafeFirestoreEnvironment();
+
+let firestore: admin.firestore.Firestore;
+let db: admin.firestore.Firestore;
+const FieldValue = admin.firestore.FieldValue;
+
+if (runtime === "preview" && guard.mode === "preview-disabled") {
+  recordInitializationState({ guard, projectId: PREVIEW_PROJECT, caller: "rentchain-api/src/firebase/admin.ts" });
+  const unavailable = new Proxy({} as admin.firestore.Firestore, {
+    get() {
+      throw new Error("[firebase] Firestore is disabled in Preview until separately provisioned.");
+    },
+  });
+  firestore = unavailable;
+  db = unavailable;
+} else {
 
 if (!admin.apps.length) {
   admin.initializeApp({
@@ -22,9 +39,12 @@ recordInitializationState({
   caller: "rentchain-api/src/firebase/admin.ts",
 });
 
-export const firestore = firestoreInstance;
-export const db = firestoreInstance;
-export const FieldValue = admin.firestore.FieldValue;
+firestore = firestoreInstance;
+db = firestoreInstance;
+
+}
+
+export { firestore, db, FieldValue };
 
 console.log("[FIREBASE CONFIG LOADED]");
 console.log("[FIREBASE CONFIG] PROJECT_ID =", PROJECT_ID);

--- a/rentchain-api/src/firebase/initializationRegistry.ts
+++ b/rentchain-api/src/firebase/initializationRegistry.ts
@@ -33,7 +33,7 @@ export function recordInitializationState(input: {
 export function initializationState(): FirebaseInitializationState {
   if (currentState) return { ...currentState };
   return {
-    environment: String(process.env.NODE_ENV || "development").toLowerCase(),
+    environment: String(process.env.APP_ENV || process.env.NODE_ENV || "development").toLowerCase(),
     mode: "emulator",
     emulatorHost: String(process.env.FIRESTORE_EMULATOR_HOST || "").trim() || null,
     projectId: "",

--- a/rentchain-api/src/routes/healthRoutes.ts
+++ b/rentchain-api/src/routes/healthRoutes.ts
@@ -2,6 +2,7 @@ import express from "express";
 import { getVersion } from "../version";
 import { db, initializationState } from "../firebase";
 import { safeDiagnosticBuildMetadata } from "../middleware/diagnosticSurfaceGuard";
+import { getRuntimeEnvironment, getConfiguredProjectId } from "../config/runtimeEnvironment";
 
 const router = express.Router();
 
@@ -14,6 +15,8 @@ router.get("/", (_req, res) => {
     reportingEnabled: process.env.REPORTING_ENABLED === "true",
     reportingDryRun: process.env.REPORTING_DRY_RUN === "true",
     firebaseInitializationMode: firebaseState.mode,
+    environment: getRuntimeEnvironment(),
+    project: getConfiguredProjectId() || null,
   });
 });
 
@@ -30,6 +33,18 @@ router.get("/ready", async (_req, res) => {
   const checks: Record<string, string> = {
     routes: "ok",
   };
+
+  if (getRuntimeEnvironment() === "preview" && firebaseState.mode === "preview-disabled") {
+    return res.status(503).json({
+      status: "fail",
+      service: "rentchain-api",
+      checks: { routes: "ok", datastore: "deferred" },
+      firebaseInitializationMode: firebaseState.mode,
+      environment: getRuntimeEnvironment(),
+      mode: "foundation",
+      message: "Preview datastore is not provisioned; readiness is deferred.",
+    });
+  }
 
   const hasDbCreds = Boolean(process.env.GOOGLE_APPLICATION_CREDENTIALS || process.env.FIREBASE_CONFIG);
   if (!hasDbCreds) {


### PR DESCRIPTION
B6A Preview-safe backend startup foundation.

- Adds explicit APP_ENV/project validation.
- Prevents Preview from targeting production.
- Disables Firebase initialization when Preview Firestore is not authorized/provisioned.
- Makes /health liveness-only and /health/ready truthfully defer datastore readiness.
- Preserves strict production environment validation.
- Adds focused tests and startup contract documentation.

No Terraform, IAM, Cloud Run, Firestore, Secret Manager, Vercel, fixture, production, PR #1453, or PR #1435 changes.