### PR TITLE
Implement B6 Preview backend Cloud Run foundation

### DIFF
--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -75,6 +75,22 @@ check "github_preview_deployment_identity_boundary" {
   }
 }
 
+check "b6_preview_backend_boundary" {
+  assert {
+    condition = (
+      local.preview_backend_service_name == "rentchain-preview-backend" &&
+      local.preview_backend_image_digest == "northamerica-northeast1-docker.pkg.dev/rentchain-preview/rentchain-preview/backend@sha256:3a7de2792511786d9f984de5f99ee19b5466ad8336d9ec4e307702c9dedd8cfd" &&
+      local.preview_backend_source_sha == "d28c61991131e9a76874d5eb92adceac048f9417" &&
+      google_cloud_run_v2_service.preview_backend.project == "rentchain-preview" &&
+      google_cloud_run_v2_service.preview_backend.location == "northamerica-northeast1" &&
+      google_cloud_run_v2_service.preview_backend.ingress == "INGRESS_TRAFFIC_ALL" &&
+      google_cloud_run_v2_service.preview_backend.template[0].service_account == google_service_account.preview_backend_runtime.email &&
+      google_cloud_run_v2_service.preview_backend.template[0].containers[0].image == local.preview_backend_image_digest
+    )
+    error_message = "B6 Preview backend Cloud Run foundation changed outside the approved private digest-pinned design."
+  }
+}
+
 check "b5_image_delivery_boundary" {
   assert {
     condition = local.github_preview_image_publisher_permissions == toset([

--- a/infra/environments/preview-foundation/cloud_run.tf
+++ b/infra/environments/preview-foundation/cloud_run.tf
@@ -1,0 +1,79 @@
+locals {
+  preview_backend_service_name = "rentchain-preview-backend"
+  preview_backend_image_digest = "northamerica-northeast1-docker.pkg.dev/rentchain-preview/rentchain-preview/backend@sha256:3a7de2792511786d9f984de5f99ee19b5466ad8336d9ec4e307702c9dedd8cfd"
+  preview_backend_source_sha   = "d28c61991131e9a76874d5eb92adceac048f9417"
+}
+
+resource "google_cloud_run_v2_service" "preview_backend" {
+  project  = var.project_id
+  name     = local.preview_backend_service_name
+  location = local.preview_deployment_region
+  ingress  = "INGRESS_TRAFFIC_ALL"
+
+  labels = {
+    environment = "preview"
+    managed-by  = "terraform"
+    purpose     = "backend"
+  }
+
+  template {
+    service_account = google_service_account.preview_backend_runtime.email
+
+    scaling {
+      min_instance_count = 0
+      max_instance_count = 1
+    }
+
+    timeout = "60s"
+
+    max_instance_request_concurrency = 40
+
+    containers {
+      image = local.preview_backend_image_digest
+
+      ports {
+        container_port = 8080
+      }
+
+      resources {
+        limits = {
+          cpu    = "1"
+          memory = "512Mi"
+        }
+      }
+
+      env {
+        name  = "APP_ENV"
+        value = "preview"
+      }
+
+      env {
+        name  = "GOOGLE_CLOUD_PROJECT"
+        value = var.project_id
+      }
+
+      env {
+        name  = "FIRESTORE_ENABLED"
+        value = "false"
+      }
+
+      env {
+        name  = "APP_GIT_SHA"
+        value = local.preview_backend_source_sha
+      }
+
+      env {
+        name  = "APP_IMAGE_DIGEST"
+        value = "sha256:3a7de2792511786d9f984de5f99ee19b5466ad8336d9ec4e307702c9dedd8cfd"
+      }
+    }
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  depends_on = [
+    google_project_service.approved_management["run.googleapis.com"],
+  ]
+}

--- a/infra/environments/preview-foundation/outputs.tf
+++ b/infra/environments/preview-foundation/outputs.tf
@@ -37,3 +37,15 @@ output "preview_deployment_foundation" {
   }
   sensitive = false
 }
+
+output "preview_backend_service" {
+  description = "Non-sensitive identifiers for the private Preview backend service foundation."
+  value = {
+    name         = google_cloud_run_v2_service.preview_backend.name
+    region       = google_cloud_run_v2_service.preview_backend.location
+    uri          = google_cloud_run_v2_service.preview_backend.uri
+    image_digest = local.preview_backend_image_digest
+    source_sha   = local.preview_backend_source_sha
+    ingress      = google_cloud_run_v2_service.preview_backend.ingress
+  }
+}


### PR DESCRIPTION
## Summary
- Add one private, digest-pinned Cloud Run v2 Preview backend foundation.
- Configure the merged B6A Preview startup contract and non-secret deployment metadata.
- Keep invocation private with no invoker IAM binding; no apply is authorized by this PR.

## Proposed foundation
- Service: `rentchain-preview-backend`
- Region: `northamerica-northeast1`
- Image: approved B6A digest `sha256:3a7de2792511786d9f984de5f99ee19b5466ad8336d9ec4e307702c9dedd8cfd`
- Runtime identity: `preview-backend-runtime@rentchain-preview.iam.gserviceaccount.com`
- Ingress: `INGRESS_TRAFFIC_ALL`, with unauthenticated invocation denied by absence of public IAM
- Scaling: 0-1 instances, 1 vCPU, 512MiB, 40 concurrency, 60s timeout

## Validation
- `terraform fmt` passed
- `terraform validate` passed
- Preview scope safeguards passed
- Speculative HCP plan: `1 to add, 0 to change, 0 to destroy`
- Proposed resource: only `google_cloud_run_v2_service.preview_backend`
- No apply, Cloud Run service, Firestore, Secret Manager, Vercel, fixture, production, or B7 changes

A separate Founder authorization is required before any Terraform apply.