### PR TITLE
Grant least-privilege Preview Cloud Run deployer IAM

### DIFF
--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -91,6 +91,34 @@ check "b6_preview_backend_boundary" {
   }
 }
 
+check "b6_cloud_run_deployer_iam_boundary" {
+  assert {
+    condition = (
+      google_project_iam_custom_role.terraform_preview_cloud_run_deployer.project == "rentchain-preview" &&
+      google_project_iam_custom_role.terraform_preview_cloud_run_deployer.role_id == "terraformPreviewCloudRunDeployer" &&
+      local.terraform_preview_cloud_run_deployer_permissions == toset([
+        "run.locations.get",
+        "run.operations.get",
+        "run.services.create",
+        "run.services.delete",
+        "run.services.get",
+        "run.services.update",
+      ])
+    )
+    error_message = "The B6 Cloud Run deployer role must remain Preview-scoped and lifecycle-only."
+  }
+
+  assert {
+    condition = (
+      google_project_iam_member.terraform_preview_cloud_run_deployer.member == local.hcp_terraform_apply_member &&
+      google_service_account_iam_member.terraform_preview_runtime_act_as.service_account_id == google_service_account.preview_backend_runtime.name &&
+      google_service_account_iam_member.terraform_preview_runtime_act_as.member == local.hcp_terraform_apply_member &&
+      google_service_account_iam_member.terraform_preview_runtime_act_as.role == "roles/iam.serviceAccountUser"
+    )
+    error_message = "B6 deployer access must use the exact HCP apply principal and runtime-account actAs binding."
+  }
+}
+
 check "b5_image_delivery_boundary" {
   assert {
     condition = local.github_preview_image_publisher_permissions == toset([

--- a/infra/environments/preview-foundation/iam.tf
+++ b/infra/environments/preview-foundation/iam.tf
@@ -1,0 +1,45 @@
+locals {
+  hcp_terraform_apply_member = "serviceAccount:hcp-terraform-preview-apply@rentchain-preview.iam.gserviceaccount.com"
+
+  terraform_preview_cloud_run_deployer_permissions = toset([
+    "run.locations.get",
+    "run.operations.get",
+    "run.services.create",
+    "run.services.delete",
+    "run.services.get",
+    "run.services.update",
+  ])
+}
+
+resource "google_project_iam_custom_role" "terraform_preview_cloud_run_deployer" {
+  project     = var.project_id
+  role_id     = "terraformPreviewCloudRunDeployer"
+  title       = "Terraform Preview Cloud Run Deployer"
+  description = "Least-privilege lifecycle access for the single approved Preview backend service."
+  permissions = local.terraform_preview_cloud_run_deployer_permissions
+  stage       = "GA"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_project_iam_member" "terraform_preview_cloud_run_deployer" {
+  project = var.project_id
+  role    = google_project_iam_custom_role.terraform_preview_cloud_run_deployer.name
+  member  = local.hcp_terraform_apply_member
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_service_account_iam_member" "terraform_preview_runtime_act_as" {
+  service_account_id = google_service_account.preview_backend_runtime.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = local.hcp_terraform_apply_member
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -56,8 +56,12 @@ rg -q 'keep_recent_tagged_count = 15' "$root_dir/deployment_foundation.tf"
 rg -q 'delete_untagged_after    = "604800s"' "$root_dir/deployment_foundation.tf"
 rg -q 'account_id   = "preview-backend-runtime"' "$root_dir/deployment_foundation.tf"
 
-if rg -n 'preview_backend_runtime.*(role|member|iam)|roles/iam\.serviceAccountUser' "$root_dir" --glob '*.tf'; then
-  echo "The future Preview runtime identity must remain role-less and non-delegable" >&2
+rg -q 'role               = "roles/iam\.serviceAccountUser"' "$root_dir/iam.tf"
+rg -q 'service_account_id = google_service_account\.preview_backend_runtime\.name' "$root_dir/iam.tf"
+rg -q 'member             = local\.hcp_terraform_apply_member' "$root_dir/iam.tf"
+
+if rg -n 'roles/iam\.serviceAccountUser' "$root_dir" --glob '*.tf' | rg -v '/iam\.tf:'; then
+  echo "Service Account User must remain limited to the B6 exact runtime binding" >&2
   exit 1
 fi
 
@@ -151,10 +155,22 @@ if rg -n 'project-0d9658de-af29-4dc0-a99|production' "$apply_permissions_file"; 
   exit 1
 fi
 
-if rg -n 'roles/(owner|editor|run\.admin|artifactregistry\.writer|cloudbuild\.builds\.editor|iam\.serviceAccountTokenCreator|iam\.serviceAccountUser|storage\.admin)|google_service_account_key|principalSet://.*/workloadIdentityPools/github-preview-deploy/\*' "$root_dir" --glob '*.tf'; then
+if rg -n 'roles/(owner|editor|run\.admin|artifactregistry\.writer|cloudbuild\.builds\.editor|iam\.serviceAccountTokenCreator|storage\.admin)|google_service_account_key|principalSet://.*/workloadIdentityPools/github-preview-deploy/\*' "$root_dir" --glob '*.tf'; then
   echo "Broad deployment permission, static key, or wildcard federation found" >&2
   exit 1
 fi
+
+expected_cloud_run_permissions="$(cat <<'EOF'
+run.locations.get
+run.operations.get
+run.services.create
+run.services.delete
+run.services.get
+run.services.update
+EOF
+)"
+actual_cloud_run_permissions="$(rg -No '"run\.[^"]+"' "$root_dir/iam.tf" | tr -d '"' | sort -u)"
+test "$actual_cloud_run_permissions" = "$expected_cloud_run_permissions"
 
 rg -q '^  workflow_dispatch:$' "$workflow_file"
 rg -q '^  contents: read$' "$workflow_file"


### PR DESCRIPTION
## Summary
- Add a Preview-scoped custom Cloud Run lifecycle role for the exact HCP Terraform apply identity.
- Add exact runtime-service-account `roles/iam.serviceAccountUser` binding only.
- Preserve all existing image-publisher, GitHub, runtime, production, and public-invocation boundaries.

## Audit
- Apply identity: `hcp-terraform-preview-apply@rentchain-preview.iam.gserviceaccount.com`
- Failed permission: `run.services.create`
- Runtime account actAs was absent and is now modeled only as an exact service-account binding.

## Permissions
- `run.locations.get`
- `run.operations.get`
- `run.services.create`
- `run.services.delete`
- `run.services.get`
- `run.services.update`

## Validation
- Terraform fmt/validate passed.
- Scope checks passed.
- git diff --check passed.
- Speculative HCP plan: 4 to add, 0 to change, 0 to destroy: the existing reviewed Cloud Run service plus exactly three IAM resources.
- No apply, retry, manual IAM change, Cloud Run deployment, or production change.

IAM must be separately applied and verified before retrying the Cloud Run apply.