### PR TITLE
Sequence Preview Cloud Run IAM before service deployment

### DIFF
--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -81,11 +81,13 @@ check "b6_preview_backend_boundary" {
       local.preview_backend_service_name == "rentchain-preview-backend" &&
       local.preview_backend_image_digest == "northamerica-northeast1-docker.pkg.dev/rentchain-preview/rentchain-preview/backend@sha256:3a7de2792511786d9f984de5f99ee19b5466ad8336d9ec4e307702c9dedd8cfd" &&
       local.preview_backend_source_sha == "d28c61991131e9a76874d5eb92adceac048f9417" &&
-      google_cloud_run_v2_service.preview_backend.project == "rentchain-preview" &&
-      google_cloud_run_v2_service.preview_backend.location == "northamerica-northeast1" &&
-      google_cloud_run_v2_service.preview_backend.ingress == "INGRESS_TRAFFIC_ALL" &&
-      google_cloud_run_v2_service.preview_backend.template[0].service_account == google_service_account.preview_backend_runtime.email &&
-      google_cloud_run_v2_service.preview_backend.template[0].containers[0].image == local.preview_backend_image_digest
+      !var.enable_preview_backend_service || (
+        google_cloud_run_v2_service.preview_backend[0].project == "rentchain-preview" &&
+        google_cloud_run_v2_service.preview_backend[0].location == "northamerica-northeast1" &&
+        google_cloud_run_v2_service.preview_backend[0].ingress == "INGRESS_TRAFFIC_ALL" &&
+        google_cloud_run_v2_service.preview_backend[0].template[0].service_account == google_service_account.preview_backend_runtime.email &&
+        google_cloud_run_v2_service.preview_backend[0].template[0].containers[0].image == local.preview_backend_image_digest
+      )
     )
     error_message = "B6 Preview backend Cloud Run foundation changed outside the approved private digest-pinned design."
   }

--- a/infra/environments/preview-foundation/cloud_run.tf
+++ b/infra/environments/preview-foundation/cloud_run.tf
@@ -5,6 +5,7 @@ locals {
 }
 
 resource "google_cloud_run_v2_service" "preview_backend" {
+  count    = var.enable_preview_backend_service ? 1 : 0
   project  = var.project_id
   name     = local.preview_backend_service_name
   location = local.preview_deployment_region

--- a/infra/environments/preview-foundation/outputs.tf
+++ b/infra/environments/preview-foundation/outputs.tf
@@ -40,12 +40,12 @@ output "preview_deployment_foundation" {
 
 output "preview_backend_service" {
   description = "Non-sensitive identifiers for the private Preview backend service foundation."
-  value = {
-    name         = google_cloud_run_v2_service.preview_backend.name
-    region       = google_cloud_run_v2_service.preview_backend.location
-    uri          = google_cloud_run_v2_service.preview_backend.uri
+  value = var.enable_preview_backend_service ? {
+    name         = google_cloud_run_v2_service.preview_backend[0].name
+    region       = google_cloud_run_v2_service.preview_backend[0].location
+    uri          = google_cloud_run_v2_service.preview_backend[0].uri
     image_digest = local.preview_backend_image_digest
     source_sha   = local.preview_backend_source_sha
-    ingress      = google_cloud_run_v2_service.preview_backend.ingress
-  }
+    ingress      = google_cloud_run_v2_service.preview_backend[0].ingress
+  } : null
 }

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -12,6 +12,7 @@ b4_apply_delta_file="$root_dir/tests/hcp_b4_apply_permission_delta.txt"
 expected_resources="$(cat <<'EOF'
 google_artifact_registry_repository
 google_artifact_registry_repository_iam_member
+google_cloud_run_v2_service
 google_iam_workload_identity_pool
 google_iam_workload_identity_pool_provider
 google_project_iam_custom_role
@@ -24,7 +25,7 @@ EOF
 actual_resources="$(rg -No 'resource "[^"]+"' "$root_dir" --glob '*.tf' | sed -E 's/.*resource "([^"]+)"/\1/' | sort -u)"
 test "$actual_resources" = "$expected_resources"
 
-test "$(rg -No '^resource "[^"]+"' "$root_dir" --glob '*.tf' | wc -l | tr -d ' ')" = "11"
+test "$(rg -No '^resource "[^"]+"' "$root_dir" --glob '*.tf' | wc -l | tr -d ' ')" = "15"
 
 test "$(rg -No 'service\s*=\s*"[^"]+\.googleapis\.com"' "$root_dir/services.tf" | wc -l | tr -d ' ')" = "0"
 test "$(rg -No '"(artifactregistry|cloudresourcemanager|iam|run|serviceusage)\.googleapis\.com"' "$root_dir/services.tf" | sort -u | wc -l | tr -d ' ')" = "5"
@@ -35,13 +36,16 @@ rg -q 'var\.project_id == "rentchain-preview"' "$root_dir/variables.tf"
 rg -q 'var\.project_number == "501298948635"' "$root_dir/variables.tf"
 rg -q 'var\.environment == "preview"' "$root_dir/variables.tf"
 rg -q 'var\.project_id != "project-0d9658de-af29-4dc0-a99"' "$root_dir/variables.tf"
+rg -q 'variable "enable_preview_backend_service"' "$root_dir/variables.tf"
+rg -q 'default     = false' "$root_dir/variables.tf"
+rg -q 'count    = var\.enable_preview_backend_service \? 1 : 0' "$root_dir/cloud_run.tf"
 
 if rg -n 'credentials\s*=|credentials_file|GOOGLE_APPLICATION_CREDENTIALS|service_account_key|private_key' "$root_dir" --glob '*.tf'; then
   echo "Static credential reference found" >&2
   exit 1
 fi
 
-if rg -n 'allUsers|allAuthenticatedUsers|google_cloud_run|google_storage_bucket|google_firestore|google_compute|google_container|google_cloudbuild' "$root_dir" --glob '*.tf'; then
+if rg -n 'allUsers|allAuthenticatedUsers|google_storage_bucket|google_firestore|google_compute|google_container|google_cloudbuild' "$root_dir" --glob '*.tf'; then
   echo "Public IAM or workload resource found" >&2
   exit 1
 fi
@@ -60,7 +64,7 @@ rg -q 'role               = "roles/iam\.serviceAccountUser"' "$root_dir/iam.tf"
 rg -q 'service_account_id = google_service_account\.preview_backend_runtime\.name' "$root_dir/iam.tf"
 rg -q 'member             = local\.hcp_terraform_apply_member' "$root_dir/iam.tf"
 
-if rg -n 'roles/iam\.serviceAccountUser' "$root_dir" --glob '*.tf' | rg -v '/iam\.tf:'; then
+if rg -n 'roles/iam\.serviceAccountUser' "$root_dir" --glob '*.tf' | rg -v '/(iam|checks)\.tf:'; then
   echo "Service Account User must remain limited to the B6 exact runtime binding" >&2
   exit 1
 fi

--- a/infra/environments/preview-foundation/variables.tf
+++ b/infra/environments/preview-foundation/variables.tf
@@ -64,3 +64,9 @@ variable "monthly_planning_ceiling_cad" {
     error_message = "monthly_planning_ceiling_cad must remain CAD 100."
   }
 }
+
+variable "enable_preview_backend_service" {
+  description = "Explicit deployment-phase gate for the reviewed Preview Cloud Run service. Keep false for IAM-first sequencing."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Summary
- Add an explicit, default-false deployment-phase gate for the reviewed Cloud Run service.
- Keep the existing service configuration reusable when a later separately authorized phase enables it.
- Make the default IAM-first plan omit Cloud Run cleanly without targeted apply or unmanaged state.

## IAM-first result
- HCP workspace: `Rentchain/rentchain-preview-foundation`
- Speculative plan: `run-jqfwq6zsXmUUbFia`
- Result: `3 add, 0 change, 0 destroy`
- Proposed resources are exactly the custom Cloud Run deployer role, its project binding, and exact runtime-account `roles/iam.serviceAccountUser` binding.
- Cloud Run service is omitted by default.

## Validation
- Terraform fmt/validate passed.
- Preview scope safeguards passed.
- git diff --check passed.
- No apply, IAM mutation, Cloud Run creation, or production change.

A separate Founder authorization is required for the IAM-only Terraform apply.