### PR TITLE
Enable B6 Preview backend Cloud Run service

### DIFF
--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -37,7 +37,7 @@ rg -q 'var\.project_number == "501298948635"' "$root_dir/variables.tf"
 rg -q 'var\.environment == "preview"' "$root_dir/variables.tf"
 rg -q 'var\.project_id != "project-0d9658de-af29-4dc0-a99"' "$root_dir/variables.tf"
 rg -q 'variable "enable_preview_backend_service"' "$root_dir/variables.tf"
-rg -q 'default     = false' "$root_dir/variables.tf"
+rg -q 'default     = true' "$root_dir/variables.tf"
 rg -q 'count    = var\.enable_preview_backend_service \? 1 : 0' "$root_dir/cloud_run.tf"
 
 if rg -n 'credentials\s*=|credentials_file|GOOGLE_APPLICATION_CREDENTIALS|service_account_key|private_key' "$root_dir" --glob '*.tf'; then

--- a/infra/environments/preview-foundation/variables.tf
+++ b/infra/environments/preview-foundation/variables.tf
@@ -68,5 +68,5 @@ variable "monthly_planning_ceiling_cad" {
 variable "enable_preview_backend_service" {
   description = "Explicit deployment-phase gate for the reviewed Preview Cloud Run service. Keep false for IAM-first sequencing."
   type        = bool
-  default     = false
+  default     = true
 }


### PR DESCRIPTION
## Summary
- Enable the already-reviewed Preview Cloud Run service phase.
- Preserve the exact image digest, IAM, runtime identity, ingress, environment, sizing, and health contract.

## Validation
- Terraform fmt/validate passed.
- Scope safeguards passed.
- git diff --check passed.
- Speculative HCP plan `run-wU5NCfhDZ2AoTQNg`: `1 add, 0 change, 0 destroy`.
- Only proposed resource: `google_cloud_run_v2_service.preview_backend`.
- No IAM, Firestore, Secret Manager, Vercel, fixture, job, production, or mutable-tag changes.

A separate Founder authorization is required for the Terraform apply after this PR merges.