### PR TITLE
fix: grant bounded Preview image access for Cloud Run

### DIFF
--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -121,6 +121,21 @@ check "b6_cloud_run_deployer_iam_boundary" {
   }
 }
 
+check "b6_preview_artifact_reader_boundary" {
+  assert {
+    condition = (
+      google_project_iam_custom_role.terraform_preview_artifact_reader.project == "rentchain-preview" &&
+      google_project_iam_custom_role.terraform_preview_artifact_reader.role_id == "terraformPreviewArtifactReader" &&
+      local.terraform_preview_artifact_reader_permissions == toset([
+        "artifactregistry.repositories.downloadArtifacts",
+      ]) &&
+      google_artifact_registry_repository_iam_member.terraform_preview_artifact_reader.repository == google_artifact_registry_repository.preview_backend.repository_id &&
+      google_artifact_registry_repository_iam_member.terraform_preview_artifact_reader.member == local.terraform_preview_artifact_reader_member
+    )
+    error_message = "Preview Terraform image access must remain a single-permission repository-scoped binding for the exact HCP apply identity."
+  }
+}
+
 check "b5_image_delivery_boundary" {
   assert {
     condition = local.github_preview_image_publisher_permissions == toset([

--- a/infra/environments/preview-foundation/image_delivery.tf
+++ b/infra/environments/preview-foundation/image_delivery.tf
@@ -9,6 +9,37 @@ locals {
     "artifactregistry.tags.create",
     "artifactregistry.tags.get",
   ])
+
+  terraform_preview_artifact_reader_member = "serviceAccount:hcp-terraform-preview-apply@rentchain-preview.iam.gserviceaccount.com"
+
+  terraform_preview_artifact_reader_permissions = toset([
+    "artifactregistry.repositories.downloadArtifacts",
+  ])
+}
+
+resource "google_project_iam_custom_role" "terraform_preview_artifact_reader" {
+  project     = var.project_id
+  role_id     = "terraformPreviewArtifactReader"
+  title       = "Terraform Preview Artifact Reader"
+  description = "Repository deployment-time read access for the approved Preview backend image."
+  permissions = local.terraform_preview_artifact_reader_permissions
+  stage       = "GA"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_artifact_registry_repository_iam_member" "terraform_preview_artifact_reader" {
+  project    = var.project_id
+  location   = google_artifact_registry_repository.preview_backend.location
+  repository = google_artifact_registry_repository.preview_backend.repository_id
+  role       = google_project_iam_custom_role.terraform_preview_artifact_reader.name
+  member     = local.terraform_preview_artifact_reader_member
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "google_project_iam_custom_role" "github_preview_image_publisher" {

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -37,7 +37,7 @@ rg -q 'var\.project_number == "501298948635"' "$root_dir/variables.tf"
 rg -q 'var\.environment == "preview"' "$root_dir/variables.tf"
 rg -q 'var\.project_id != "project-0d9658de-af29-4dc0-a99"' "$root_dir/variables.tf"
 rg -q 'variable "enable_preview_backend_service"' "$root_dir/variables.tf"
-rg -q 'default     = true' "$root_dir/variables.tf"
+rg -q 'default     = false' "$root_dir/variables.tf"
 rg -q 'count    = var\.enable_preview_backend_service \? 1 : 0' "$root_dir/cloud_run.tf"
 
 if rg -n 'credentials\s*=|credentials_file|GOOGLE_APPLICATION_CREDENTIALS|service_account_key|private_key' "$root_dir" --glob '*.tf'; then
@@ -59,6 +59,15 @@ rg -q 'immutable_tags = true' "$root_dir/deployment_foundation.tf"
 rg -q 'keep_recent_tagged_count = 15' "$root_dir/deployment_foundation.tf"
 rg -q 'delete_untagged_after    = "604800s"' "$root_dir/deployment_foundation.tf"
 rg -q 'account_id   = "preview-backend-runtime"' "$root_dir/deployment_foundation.tf"
+
+rg -q 'role_id     = "terraformPreviewArtifactReader"' "$root_dir/image_delivery.tf"
+rg -q 'artifactregistry\.repositories\.downloadArtifacts' "$root_dir/image_delivery.tf"
+rg -q 'resource "google_artifact_registry_repository_iam_member" "terraform_preview_artifact_reader"' "$root_dir/image_delivery.tf"
+rg -q 'terraform_preview_artifact_reader_member = "serviceAccount:hcp-terraform-preview-apply@rentchain-preview\.iam\.gserviceaccount\.com"' "$root_dir/image_delivery.tf"
+if rg -n 'artifactregistry\.(repositories\.(uploadArtifacts|create|delete|setIamPolicy)|tags\.(create|delete|update))' "$root_dir/image_delivery.tf" | rg 'terraformPreviewArtifactReader|terraform_preview_artifact_reader'; then
+  echo "Terraform Preview artifact reader has write permissions" >&2
+  exit 1
+fi
 
 rg -q 'role               = "roles/iam\.serviceAccountUser"' "$root_dir/iam.tf"
 rg -q 'service_account_id = google_service_account\.preview_backend_runtime\.name' "$root_dir/iam.tf"

--- a/infra/environments/preview-foundation/variables.tf
+++ b/infra/environments/preview-foundation/variables.tf
@@ -68,5 +68,5 @@ variable "monthly_planning_ceiling_cad" {
 variable "enable_preview_backend_service" {
   description = "Explicit deployment-phase gate for the reviewed Preview Cloud Run service. Keep false for IAM-first sequencing."
   type        = bool
-  default     = true
+  default     = false
 }


### PR DESCRIPTION
B6 image-access IAM correction.

- Adds a dedicated custom role containing only artifactregistry.repositories.downloadArtifacts.
- Binds it only at the Preview Artifact Registry repository to the HCP Terraform apply identity.
- Keeps Cloud Run disabled for IAM-first sequencing.
- No apply, Cloud Run retry, manual IAM mutation, production, or runtime changes.

Speculative plan: 2 to add, 0 to change, 0 to destroy; Cloud Run service omitted.

Denied principal: hcp-terraform-preview-apply@rentchain-preview.iam.gserviceaccount.com
Denied permission: artifactregistry.repositories.downloadArtifacts