### PR TITLE
Re-enable B6 Preview backend Cloud Run service

### DIFF
--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -129,7 +129,7 @@ check "b6_preview_artifact_reader_boundary" {
       local.terraform_preview_artifact_reader_permissions == toset([
         "artifactregistry.repositories.downloadArtifacts",
       ]) &&
-      google_artifact_registry_repository_iam_member.terraform_preview_artifact_reader.repository == google_artifact_registry_repository.preview_backend.repository_id &&
+      google_artifact_registry_repository_iam_member.terraform_preview_artifact_reader.repository == "projects/${var.project_id}/locations/${google_artifact_registry_repository.preview_backend.location}/repositories/${google_artifact_registry_repository.preview_backend.repository_id}" &&
       google_artifact_registry_repository_iam_member.terraform_preview_artifact_reader.member == local.terraform_preview_artifact_reader_member
     )
     error_message = "Preview Terraform image access must remain a single-permission repository-scoped binding for the exact HCP apply identity."

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -37,7 +37,7 @@ rg -q 'var\.project_number == "501298948635"' "$root_dir/variables.tf"
 rg -q 'var\.environment == "preview"' "$root_dir/variables.tf"
 rg -q 'var\.project_id != "project-0d9658de-af29-4dc0-a99"' "$root_dir/variables.tf"
 rg -q 'variable "enable_preview_backend_service"' "$root_dir/variables.tf"
-rg -q 'default     = false' "$root_dir/variables.tf"
+rg -q 'default     = true' "$root_dir/variables.tf"
 rg -q 'count    = var\.enable_preview_backend_service \? 1 : 0' "$root_dir/cloud_run.tf"
 
 if rg -n 'credentials\s*=|credentials_file|GOOGLE_APPLICATION_CREDENTIALS|service_account_key|private_key' "$root_dir" --glob '*.tf'; then

--- a/infra/environments/preview-foundation/variables.tf
+++ b/infra/environments/preview-foundation/variables.tf
@@ -66,7 +66,7 @@ variable "monthly_planning_ceiling_cad" {
 }
 
 variable "enable_preview_backend_service" {
-  description = "Explicit deployment-phase gate for the reviewed Preview Cloud Run service. Keep false for IAM-first sequencing."
+  description = "Explicit deployment-phase gate for the reviewed Preview Cloud Run service."
   type        = bool
-  default     = false
+  default     = true
 }


### PR DESCRIPTION
Re-enables the reviewed Preview Cloud Run backend service gate and updates the canonical Artifact Registry repository-path safeguard. No Terraform apply is authorized.