### PR TITLE
Grant Preview plan identity Cloud Run read access

### DIFF
--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -121,6 +121,22 @@ check "b6_cloud_run_deployer_iam_boundary" {
   }
 }
 
+check "b6_cloud_run_plan_viewer_iam_boundary" {
+  assert {
+    condition = (
+      google_project_iam_custom_role.terraform_preview_cloud_run_viewer.project == "rentchain-preview" &&
+      google_project_iam_custom_role.terraform_preview_cloud_run_viewer.role_id == "hcpTerraformPreviewCloudRunViewer" &&
+      local.terraform_preview_cloud_run_viewer_permissions == toset([
+        "run.services.get",
+      ]) &&
+      google_project_iam_member.terraform_preview_cloud_run_viewer.project == "rentchain-preview" &&
+      google_project_iam_member.terraform_preview_cloud_run_viewer.member == local.hcp_terraform_plan_member &&
+      local.hcp_terraform_plan_member == "serviceAccount:hcp-terraform-preview@rentchain-preview.iam.gserviceaccount.com"
+    )
+    error_message = "The B6 plan viewer must remain a single-permission Preview-only binding for the exact HCP plan identity."
+  }
+}
+
 check "b6_preview_artifact_reader_boundary" {
   assert {
     condition = (

--- a/infra/environments/preview-foundation/cloud_run.tf
+++ b/infra/environments/preview-foundation/cloud_run.tf
@@ -72,6 +72,9 @@ resource "google_cloud_run_v2_service" "preview_backend" {
 
   lifecycle {
     prevent_destroy = true
+    ignore_changes = [
+      scaling,
+    ]
   }
 
   depends_on = [

--- a/infra/environments/preview-foundation/iam.tf
+++ b/infra/environments/preview-foundation/iam.tf
@@ -1,5 +1,10 @@
 locals {
+  hcp_terraform_plan_member  = "serviceAccount:hcp-terraform-preview@rentchain-preview.iam.gserviceaccount.com"
   hcp_terraform_apply_member = "serviceAccount:hcp-terraform-preview-apply@rentchain-preview.iam.gserviceaccount.com"
+
+  terraform_preview_cloud_run_viewer_permissions = toset([
+    "run.services.get",
+  ])
 
   terraform_preview_cloud_run_deployer_permissions = toset([
     "run.locations.get",
@@ -9,6 +14,29 @@ locals {
     "run.services.get",
     "run.services.update",
   ])
+}
+
+resource "google_project_iam_custom_role" "terraform_preview_cloud_run_viewer" {
+  project     = var.project_id
+  role_id     = "hcpTerraformPreviewCloudRunViewer"
+  title       = "HCP Terraform Preview Cloud Run Viewer"
+  description = "Plan-phase read access for the managed Preview backend service."
+  permissions = local.terraform_preview_cloud_run_viewer_permissions
+  stage       = "GA"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_project_iam_member" "terraform_preview_cloud_run_viewer" {
+  project = var.project_id
+  role    = google_project_iam_custom_role.terraform_preview_cloud_run_viewer.name
+  member  = local.hcp_terraform_plan_member
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "google_project_iam_custom_role" "terraform_preview_cloud_run_deployer" {

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -73,6 +73,19 @@ rg -q 'role               = "roles/iam\.serviceAccountUser"' "$root_dir/iam.tf"
 rg -q 'service_account_id = google_service_account\.preview_backend_runtime\.name' "$root_dir/iam.tf"
 rg -q 'member             = local\.hcp_terraform_apply_member' "$root_dir/iam.tf"
 
+rg -q 'role_id     = "hcpTerraformPreviewCloudRunViewer"' "$root_dir/iam.tf"
+rg -q 'terraform_preview_cloud_run_viewer_permissions = toset' "$root_dir/iam.tf"
+rg -q '"run\.services\.get"' "$root_dir/iam.tf"
+rg -q 'resource "google_project_iam_member" "terraform_preview_cloud_run_viewer"' "$root_dir/iam.tf"
+rg -q 'member  = local\.hcp_terraform_plan_member' "$root_dir/iam.tf"
+rg -q 'hcp_terraform_plan_member  = "serviceAccount:hcp-terraform-preview@rentchain-preview\.iam\.gserviceaccount\.com"' "$root_dir/iam.tf"
+actual_cloud_run_viewer_permissions="$(
+  sed -n '/terraform_preview_cloud_run_viewer_permissions = toset(/,/])/p' "$root_dir/iam.tf" \
+    | rg -No '"[^"]+"' \
+    | tr -d '"'
+)"
+test "$actual_cloud_run_viewer_permissions" = "run.services.get"
+
 if rg -n 'roles/iam\.serviceAccountUser' "$root_dir" --glob '*.tf' | rg -v '/(iam|checks)\.tf:'; then
   echo "Service Account User must remain limited to the B6 exact runtime binding" >&2
   exit 1

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -39,6 +39,9 @@ rg -q 'var\.project_id != "project-0d9658de-af29-4dc0-a99"' "$root_dir/variables
 rg -q 'variable "enable_preview_backend_service"' "$root_dir/variables.tf"
 rg -q 'default     = true' "$root_dir/variables.tf"
 rg -q 'count    = var\.enable_preview_backend_service \? 1 : 0' "$root_dir/cloud_run.tf"
+rg -U -q 'lifecycle \{\n    prevent_destroy = true\n    ignore_changes = \[\n      scaling,\n    \]\n  \}' "$root_dir/cloud_run.tf"
+test "$(rg -c 'ignore_changes' "$root_dir" --glob '*.tf')" = "1"
+rg -U -q 'template \{.*scaling \{\n      min_instance_count = 0\n      max_instance_count = 1\n    \}' "$root_dir/cloud_run.tf"
 
 if rg -n 'credentials\s*=|credentials_file|GOOGLE_APPLICATION_CREDENTIALS|service_account_key|private_key' "$root_dir" --glob '*.tf'; then
   echo "Static credential reference found" >&2


### PR DESCRIPTION
Adds a dedicated plan-only custom role containing exactly run.services.get and binds it only to the HCP Terraform plan identity. No Terraform apply or Cloud Run mutation is authorized.