### PR TITLE
Implement B7 Preview datastore and authentication foundation

### DIFF
--- a/docs/strategy/preview-infrastructure/phase-b-b7-datastore-auth-foundation.md
+++ b/docs/strategy/preview-infrastructure/phase-b-b7-datastore-auth-foundation.md
@@ -1,0 +1,170 @@
+# B7 Preview Datastore and Authentication Foundation
+
+## Decision
+
+B7 uses the Firestore Native-mode `(default)` database and Identity Platform in
+the isolated `rentchain-preview` project. The database location is
+`northamerica-northeast1`.
+
+This is a foundation-only change. It creates no user, document, fixture,
+production resource, frontend route, public Cloud Run binding, static
+credential, or Secret Manager secret.
+
+## Datastore boundary
+
+The backend already uses the Firebase Admin default Firestore instance. B7 makes
+that assumption explicit with:
+
+- `GOOGLE_CLOUD_PROJECT=rentchain-preview`
+- `FIREBASE_PROJECT_ID=rentchain-preview`
+- `FIRESTORE_DATABASE_ID=(default)`
+- `FIRESTORE_ENABLED=true`
+
+These values describe the later activation contract; B7 phase 1 does not change
+the deployed Cloud Run environment. The environment guard in the prepared
+runtime rejects a named database, production project, emulator endpoint, or
+static credential in deployed Preview.
+
+The runtime custom role is `previewBackendFirestoreRuntime` and contains exactly:
+
+- `datastore.databases.get`
+- `datastore.entities.create`
+- `datastore.entities.delete`
+- `datastore.entities.get`
+- `datastore.entities.list`
+- `datastore.entities.update`
+
+Its binding is conditional on the exact database resource
+`projects/rentchain-preview/databases/(default)` and applies only to
+`preview-backend-runtime@rentchain-preview.iam.gserviceaccount.com`.
+
+The database has API-level deletion protection and Terraform `prevent_destroy`.
+Its Firestore-specific Terraform deletion policy is `ABANDON`.
+It contains synthetic Preview data only. There is no startup migration, seed, or
+destructive cleanup routine.
+
+Existing composite-index definitions remain in
+`rentchain-api/firestore.indexes.json`. B7 does not deploy them because this
+mission authorizes no fixture or functional route. Required indexes must be
+selected from observed later QA paths and reviewed in that phase.
+
+## Authentication boundary
+
+Identity Platform is configured in `rentchain-preview` with:
+
+- email/password enabled and password required;
+- anonymous and phone providers disabled;
+- duplicate emails disabled;
+- public user signup disabled;
+- self-service user deletion disabled;
+- MFA disabled;
+- only `localhost` authorized until a separately reviewed frontend phase.
+
+The backend password-login path uses a Preview API key restricted to
+`identitytoolkit.googleapis.com`. A Firebase web API key identifies a client and
+is not a privileged server credential, but Terraform and HCP still treat its
+value as sensitive. It is injected directly into Cloud Run and is not output.
+Secret Manager is therefore not required. The API key remains in Terraform
+state, but it is not attached to Cloud Run in phase 1.
+
+The runtime role `previewBackendAuthReader` contains only
+`firebaseauth.users.get`. The existing login path needs this permission to read
+the authenticated user and enforce verified email. User creation, deletion,
+update, email delivery, token minting, and IAM administration are excluded.
+
+No Preview user is created by B7. A later fixture phase must separately
+authorize the synthetic landlord account and its deterministic cleanup.
+
+Under the locked Google provider, the Identity Platform configuration has no
+provider-level `ABANDON` deletion policy. Any removal or destruction requires a
+separately reviewed Terraform plan. B7 authorizes no teardown, and every
+authorized plan must contain zero destroy operations.
+
+## Readiness
+
+`/health` remains a liveness endpoint and returns HTTP 200 without exposing
+secrets.
+
+Before activation, `/health/ready` returns HTTP 503 with datastore and
+authentication deferred.
+
+After the later activation, readiness:
+
+1. confirms the exact Preview project and `(default)` database configuration;
+2. performs an ADC-backed Firestore `listCollections` probe;
+3. reports the isolated authentication boundary as `configured`;
+4. remains HTTP 503 until a later non-mutating token-boundary QA phase proves
+   issuer, audience, expiry, and production-token rejection.
+
+API-key presence is never reported as operational authentication readiness.
+
+The response exposes only safe capability labels, environment, mode, database
+ID, and redacted build-presence metadata.
+
+## Required APIs
+
+- `firestore.googleapis.com`
+- `identitytoolkit.googleapis.com`
+- `apikeys.googleapis.com`
+
+No Firebase Management, Secret Manager, Firestore Rules, Cloud Run Jobs, or
+production API is added.
+
+## Apply sequencing and bootstrap gate
+
+The B7 speculative plan is not apply authorization.
+
+Before the first apply, separately authorize and add only the permissions in:
+
+- `tests/hcp_b7_apply_permission_delta.txt` to
+  `projects/rentchain-preview/roles/hcpTerraformPreviewApply`;
+- `tests/hcp_b7_plan_permission_delta.txt` to
+  `projects/rentchain-preview/roles/hcpTerraformPreviewPlanViewer`.
+
+The plan-phase read delta must exist before resources are applied so the first
+post-apply refresh cannot deadlock. The apply delta must exist before the
+corresponding staged resource creation. Do not substitute the apply identity for
+the plan identity and do not widen Workload Identity Federation.
+
+The repository variable `b7_foundation_phase` is a governed phase gate:
+
+1. default phase 1 enables only the three APIs;
+2. phase 2 adds Firestore, Identity Platform, and the restricted API key;
+3. phase 3 adds the two exact runtime roles and bindings.
+
+The plan-phase read delta must be installed before phase 2 is applied. The
+apply-phase delta includes the exact long-running-operation reads needed while
+creating the database and API key. Existing IAM-management permissions cover
+phase 3.
+
+Cloud Run activation is deliberately absent from these phases. It requires a
+separately reviewed image built from the B7 runtime code, followed by the exact
+environment activation and operational authentication QA. Applying the current
+environment changes to the older pinned image would be incompatible.
+
+Use separate Founder-authorized phases:
+
+1. API enablement;
+2. exact HCP read/apply custom-role deltas, then datastore/auth resources;
+3. runtime IAM;
+4. separately published runtime image and Cloud Run environment activation;
+5. normal plan-identity zero-drift verification.
+
+Do not use targeted apply. If a phase cannot produce the reviewed scope, stop.
+
+## Cost and teardown
+
+At synthetic QA volume, the first Firestore database can remain within the
+project free quota. Email/password Identity Platform usage is consumption-based;
+phone/SMS is disabled. IAM and API enablement have no direct charge.
+
+Teardown is separately authorized and ordered:
+
+1. remove synthetic users and documents;
+2. return Cloud Run to deferred mode;
+3. remove runtime bindings and custom roles;
+4. remove the API key and Identity Platform configuration;
+5. disable APIs only after dependency checks;
+6. explicitly disable database deletion protection, then delete the database.
+
+Never copy data or identities to production during setup or teardown.

--- a/docs/strategy/preview-infrastructure/phase-b-b7-datastore-auth-foundation.md
+++ b/docs/strategy/preview-infrastructure/phase-b-b7-datastore-auth-foundation.md
@@ -114,28 +114,32 @@ production API is added.
 
 The B7 speculative plan is not apply authorization.
 
-Before the first apply, separately authorize and add only the permissions in:
+Phase 1 creates two dedicated B7 custom roles rather than broadening the
+existing Cloud Run roles:
 
-- `tests/hcp_b7_apply_permission_delta.txt` to
-  `projects/rentchain-preview/roles/hcpTerraformPreviewApply`;
-- `tests/hcp_b7_plan_permission_delta.txt` to
-  `projects/rentchain-preview/roles/hcpTerraformPreviewPlanViewer`.
+- `hcpTerraformPreviewB7Reader` contains exactly the four permissions in
+  `tests/hcp_b7_plan_permission_delta.txt` and is bound only to
+  `hcp-terraform-preview@rentchain-preview.iam.gserviceaccount.com`;
+- `terraformPreviewB7Manager` contains exactly the eight permissions in
+  `tests/hcp_b7_apply_permission_delta.txt` and is bound only to
+  `hcp-terraform-preview-apply@rentchain-preview.iam.gserviceaccount.com`.
 
-The plan-phase read delta must exist before resources are applied so the first
-post-apply refresh cannot deadlock. The apply delta must exist before the
-corresponding staged resource creation. Do not substitute the apply identity for
-the plan identity and do not widen Workload Identity Federation.
+The HCP apply identity already has the governed IAM role-management and project
+policy permissions needed to create these roles and bindings. Do not substitute
+the apply identity for the plan identity and do not widen Workload Identity
+Federation.
 
 The repository variable `b7_foundation_phase` is a governed phase gate:
 
-1. default phase 1 enables only the three APIs;
+1. default phase 1 enables the three APIs and creates the two B7 HCP roles and
+   their exact bindings;
 2. phase 2 adds Firestore, Identity Platform, and the restricted API key;
 3. phase 3 adds the two exact runtime roles and bindings.
 
-The plan-phase read delta must be installed before phase 2 is applied. The
-apply-phase delta includes the exact long-running-operation reads needed while
-creating the database and API key. Existing IAM-management permissions cover
-phase 3.
+The Phase 1 apply installs the plan and apply permissions before Phase 2 is
+selected. A later Phase 2 plan can therefore refresh the governed resource
+types, and its apply identity can create them, without manual IAM mutation or
+import. Existing IAM-management permissions cover Phase 3.
 
 Cloud Run activation is deliberately absent from these phases. It requires a
 separately reviewed image built from the B7 runtime code, followed by the exact
@@ -144,8 +148,8 @@ environment changes to the older pinned image would be incompatible.
 
 Use separate Founder-authorized phases:
 
-1. API enablement;
-2. exact HCP read/apply custom-role deltas, then datastore/auth resources;
+1. API enablement plus exact B7 HCP read/apply roles and bindings;
+2. datastore/auth resources;
 3. runtime IAM;
 4. separately published runtime image and Cloud Run environment activation;
 5. normal plan-identity zero-drift verification.

--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -93,6 +93,42 @@ check "b7_preview_authentication_boundary" {
   }
 }
 
+check "b7_hcp_bootstrap_iam_boundary" {
+  assert {
+    condition = (
+      google_project_iam_custom_role.hcp_terraform_preview_b7_reader.project == "rentchain-preview" &&
+      google_project_iam_custom_role.hcp_terraform_preview_b7_reader.role_id == "hcpTerraformPreviewB7Reader" &&
+      local.hcp_terraform_preview_b7_reader_permissions == toset([
+        "apikeys.keys.get",
+        "apikeys.keys.getKeyString",
+        "datastore.databases.getMetadata",
+        "firebaseauth.configs.get",
+      ]) &&
+      google_project_iam_member.hcp_terraform_preview_b7_reader.member == local.hcp_terraform_plan_member
+    )
+    error_message = "The B7 plan reader must remain the exact four-permission role bound only to the HCP plan identity."
+  }
+
+  assert {
+    condition = (
+      google_project_iam_custom_role.terraform_preview_b7_manager.project == "rentchain-preview" &&
+      google_project_iam_custom_role.terraform_preview_b7_manager.role_id == "terraformPreviewB7Manager" &&
+      local.terraform_preview_b7_manager_permissions == toset([
+        "apikeys.keys.create",
+        "apikeys.keys.get",
+        "apikeys.keys.getKeyString",
+        "datastore.databases.create",
+        "datastore.databases.getMetadata",
+        "firebaseauth.configs.create",
+        "firebaseauth.configs.get",
+        "firebaseauth.configs.update",
+      ]) &&
+      google_project_iam_member.terraform_preview_b7_manager.member == local.hcp_terraform_apply_member
+    )
+    error_message = "The B7 apply manager must remain the exact eight-permission role bound only to the HCP apply identity."
+  }
+}
+
 check "b4_deployment_foundation_boundary" {
   assert {
     condition = (

--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -12,13 +12,84 @@ check "preview_project_identity" {
 check "management_api_boundary" {
   assert {
     condition = local.approved_management_services == toset([
+      "apikeys.googleapis.com",
       "artifactregistry.googleapis.com",
       "cloudresourcemanager.googleapis.com",
+      "firestore.googleapis.com",
       "iam.googleapis.com",
+      "identitytoolkit.googleapis.com",
       "run.googleapis.com",
       "serviceusage.googleapis.com",
     ])
     error_message = "The B4 Preview foundation API allowlist has changed."
+  }
+}
+
+check "b7_preview_datastore_boundary" {
+  assert {
+    condition = var.b7_foundation_phase < 2 ? true : (
+      google_firestore_database.preview[0].project == "rentchain-preview" &&
+      google_firestore_database.preview[0].name == "(default)" &&
+      google_firestore_database.preview[0].location_id == "northamerica-northeast1" &&
+      google_firestore_database.preview[0].type == "FIRESTORE_NATIVE" &&
+      google_firestore_database.preview[0].delete_protection_state == "DELETE_PROTECTION_ENABLED" &&
+      google_firestore_database.preview[0].deletion_policy == "ABANDON"
+    )
+    error_message = "B7 Firestore must remain the protected Native-mode default database in the isolated Montreal Preview project."
+  }
+
+  assert {
+    condition = local.preview_runtime_firestore_permissions == toset([
+      "datastore.databases.get",
+      "datastore.entities.create",
+      "datastore.entities.delete",
+      "datastore.entities.get",
+      "datastore.entities.list",
+      "datastore.entities.update",
+    ])
+    error_message = "B7 Preview runtime Firestore permissions changed outside the exact data-plane set."
+  }
+
+  assert {
+    condition = var.b7_foundation_phase < 3 ? true : (
+      google_project_iam_custom_role.preview_runtime_firestore[0].role_id == "previewBackendFirestoreRuntime" &&
+      google_project_iam_member.preview_runtime_firestore[0].member == google_service_account.preview_backend_runtime.member &&
+      google_project_iam_member.preview_runtime_firestore[0].condition[0].expression == "resource.name == 'projects/rentchain-preview/databases/(default)'"
+    )
+    error_message = "B7 Firestore access must remain bound only to the Preview runtime identity and default Preview database."
+  }
+}
+
+check "b7_preview_authentication_boundary" {
+  assert {
+    condition = var.b7_foundation_phase < 2 ? true : (
+      google_identity_platform_config.preview[0].project == "rentchain-preview" &&
+      local.preview_identity_authorized_domains == toset(["localhost"]) &&
+      google_identity_platform_config.preview[0].sign_in[0].email[0].enabled &&
+      google_identity_platform_config.preview[0].sign_in[0].email[0].password_required &&
+      !google_identity_platform_config.preview[0].sign_in[0].anonymous[0].enabled &&
+      !google_identity_platform_config.preview[0].sign_in[0].phone_number[0].enabled &&
+      google_identity_platform_config.preview[0].client[0].permissions[0].disabled_user_signup &&
+      google_identity_platform_config.preview[0].client[0].permissions[0].disabled_user_deletion
+    )
+    error_message = "B7 Preview authentication must remain isolated, password-only, and closed to public signup."
+  }
+
+  assert {
+    condition = var.b7_foundation_phase < 3 ? true : (
+      local.preview_runtime_auth_permissions == toset(["firebaseauth.users.get"]) &&
+      google_project_iam_custom_role.preview_runtime_auth_reader[0].role_id == "previewBackendAuthReader" &&
+      google_project_iam_member.preview_runtime_auth_reader[0].member == google_service_account.preview_backend_runtime.member
+    )
+    error_message = "B7 Preview authentication runtime access must remain a single user-read permission for the exact runtime identity."
+  }
+
+  assert {
+    condition = var.b7_foundation_phase < 2 ? true : (
+      google_apikeys_key.preview_backend_auth[0].project == "rentchain-preview" &&
+      google_apikeys_key.preview_backend_auth[0].restrictions[0].api_targets[0].service == "identitytoolkit.googleapis.com"
+    )
+    error_message = "The Preview backend API key must remain isolated and restricted to Identity Toolkit."
   }
 }
 

--- a/infra/environments/preview-foundation/datastore_auth.tf
+++ b/infra/environments/preview-foundation/datastore_auth.tf
@@ -1,0 +1,171 @@
+locals {
+  preview_firestore_database_id = "(default)"
+  preview_firestore_location    = "northamerica-northeast1"
+
+  preview_runtime_member = google_service_account.preview_backend_runtime.member
+
+  preview_runtime_firestore_permissions = toset([
+    "datastore.databases.get",
+    "datastore.entities.create",
+    "datastore.entities.delete",
+    "datastore.entities.get",
+    "datastore.entities.list",
+    "datastore.entities.update",
+  ])
+
+  preview_runtime_auth_permissions = toset([
+    "firebaseauth.users.get",
+  ])
+
+  preview_identity_authorized_domains = toset([
+    "localhost",
+  ])
+}
+
+resource "google_firestore_database" "preview" {
+  count = var.b7_foundation_phase >= 2 ? 1 : 0
+
+  project     = var.project_id
+  name        = local.preview_firestore_database_id
+  location_id = local.preview_firestore_location
+  type        = "FIRESTORE_NATIVE"
+
+  delete_protection_state = "DELETE_PROTECTION_ENABLED"
+  deletion_policy         = "ABANDON"
+
+  depends_on = [
+    google_project_service.approved_management["firestore.googleapis.com"],
+  ]
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_identity_platform_config" "preview" {
+  count = var.b7_foundation_phase >= 2 ? 1 : 0
+
+  project = var.project_id
+
+  authorized_domains = sort(tolist(local.preview_identity_authorized_domains))
+
+  sign_in {
+    allow_duplicate_emails = false
+
+    email {
+      enabled           = true
+      password_required = true
+    }
+
+    anonymous {
+      enabled = false
+    }
+
+    phone_number {
+      enabled = false
+    }
+  }
+
+  client {
+    permissions {
+      disabled_user_signup   = true
+      disabled_user_deletion = true
+    }
+  }
+
+  mfa {
+    state = "DISABLED"
+  }
+
+  depends_on = [
+    google_project_service.approved_management["identitytoolkit.googleapis.com"],
+  ]
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_apikeys_key" "preview_backend_auth" {
+  count = var.b7_foundation_phase >= 2 ? 1 : 0
+
+  project      = var.project_id
+  name         = "preview-backend-auth"
+  display_name = "Preview Backend Identity Toolkit"
+
+  restrictions {
+    api_targets {
+      service = "identitytoolkit.googleapis.com"
+    }
+  }
+
+  depends_on = [
+    google_project_service.approved_management["apikeys.googleapis.com"],
+    google_project_service.approved_management["identitytoolkit.googleapis.com"],
+    google_identity_platform_config.preview[0],
+  ]
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_project_iam_custom_role" "preview_runtime_firestore" {
+  count = var.b7_foundation_phase >= 3 ? 1 : 0
+
+  project     = var.project_id
+  role_id     = "previewBackendFirestoreRuntime"
+  title       = "Preview Backend Firestore Runtime"
+  description = "Data-plane access to the isolated Preview Firestore database."
+  permissions = local.preview_runtime_firestore_permissions
+  stage       = "GA"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_project_iam_member" "preview_runtime_firestore" {
+  count = var.b7_foundation_phase >= 3 ? 1 : 0
+
+  project = var.project_id
+  role    = google_project_iam_custom_role.preview_runtime_firestore[0].name
+  member  = local.preview_runtime_member
+
+  condition {
+    title       = "preview_default_firestore_only"
+    description = "Restrict Preview runtime data access to the isolated default database."
+    expression  = "resource.name == 'projects/${var.project_id}/databases/${local.preview_firestore_database_id}'"
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_project_iam_custom_role" "preview_runtime_auth_reader" {
+  count = var.b7_foundation_phase >= 3 ? 1 : 0
+
+  project     = var.project_id
+  role_id     = "previewBackendAuthReader"
+  title       = "Preview Backend Authentication Reader"
+  description = "Read one Preview authentication user during verified password login."
+  permissions = local.preview_runtime_auth_permissions
+  stage       = "GA"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_project_iam_member" "preview_runtime_auth_reader" {
+  count = var.b7_foundation_phase >= 3 ? 1 : 0
+
+  project = var.project_id
+  role    = google_project_iam_custom_role.preview_runtime_auth_reader[0].name
+  member  = local.preview_runtime_member
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/infra/environments/preview-foundation/iam.tf
+++ b/infra/environments/preview-foundation/iam.tf
@@ -14,6 +14,70 @@ locals {
     "run.services.get",
     "run.services.update",
   ])
+
+  hcp_terraform_preview_b7_reader_permissions = toset([
+    "apikeys.keys.get",
+    "apikeys.keys.getKeyString",
+    "datastore.databases.getMetadata",
+    "firebaseauth.configs.get",
+  ])
+
+  terraform_preview_b7_manager_permissions = toset([
+    "apikeys.keys.create",
+    "apikeys.keys.get",
+    "apikeys.keys.getKeyString",
+    "datastore.databases.create",
+    "datastore.databases.getMetadata",
+    "firebaseauth.configs.create",
+    "firebaseauth.configs.get",
+    "firebaseauth.configs.update",
+  ])
+}
+
+resource "google_project_iam_custom_role" "hcp_terraform_preview_b7_reader" {
+  project     = var.project_id
+  role_id     = "hcpTerraformPreviewB7Reader"
+  title       = "HCP Terraform Preview B7 Reader"
+  description = "Plan-phase read access for the governed Preview datastore and authentication foundation."
+  permissions = local.hcp_terraform_preview_b7_reader_permissions
+  stage       = "GA"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_project_iam_member" "hcp_terraform_preview_b7_reader" {
+  project = var.project_id
+  role    = google_project_iam_custom_role.hcp_terraform_preview_b7_reader.name
+  member  = local.hcp_terraform_plan_member
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_project_iam_custom_role" "terraform_preview_b7_manager" {
+  project     = var.project_id
+  role_id     = "terraformPreviewB7Manager"
+  title       = "Terraform Preview B7 Manager"
+  description = "Apply-phase lifecycle access for the governed Preview datastore and authentication foundation."
+  permissions = local.terraform_preview_b7_manager_permissions
+  stage       = "GA"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_project_iam_member" "terraform_preview_b7_manager" {
+  project = var.project_id
+  role    = google_project_iam_custom_role.terraform_preview_b7_manager.name
+  member  = local.hcp_terraform_apply_member
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "google_project_iam_custom_role" "terraform_preview_cloud_run_viewer" {

--- a/infra/environments/preview-foundation/outputs.tf
+++ b/infra/environments/preview-foundation/outputs.tf
@@ -49,3 +49,16 @@ output "preview_backend_service" {
     ingress      = google_cloud_run_v2_service.preview_backend[0].ingress
   } : null
 }
+
+output "preview_datastore_auth_foundation" {
+  description = "Non-sensitive identifiers for the isolated B7 datastore and authentication foundation."
+  value = var.b7_foundation_phase >= 2 ? {
+    project_id              = var.project_id
+    database_id             = google_firestore_database.preview[0].name
+    firestore_location      = google_firestore_database.preview[0].location_id
+    authentication_project  = google_identity_platform_config.preview[0].project
+    authorized_domains      = sort(tolist(local.preview_identity_authorized_domains))
+    runtime_service_account = google_service_account.preview_backend_runtime.email
+  } : null
+  sensitive = false
+}

--- a/infra/environments/preview-foundation/services.tf
+++ b/infra/environments/preview-foundation/services.tf
@@ -1,8 +1,11 @@
 locals {
   approved_management_services = toset([
+    "apikeys.googleapis.com",
     "artifactregistry.googleapis.com",
     "cloudresourcemanager.googleapis.com",
+    "firestore.googleapis.com",
     "iam.googleapis.com",
+    "identitytoolkit.googleapis.com",
     "run.googleapis.com",
     "serviceusage.googleapis.com",
   ])

--- a/infra/environments/preview-foundation/tests/hcp_b7_apply_permission_delta.txt
+++ b/infra/environments/preview-foundation/tests/hcp_b7_apply_permission_delta.txt
@@ -3,8 +3,6 @@ apikeys.keys.get
 apikeys.keys.getKeyString
 datastore.databases.create
 datastore.databases.getMetadata
-datastore.operations.get
 firebaseauth.configs.create
 firebaseauth.configs.get
 firebaseauth.configs.update
-serviceusage.operations.get

--- a/infra/environments/preview-foundation/tests/hcp_b7_apply_permission_delta.txt
+++ b/infra/environments/preview-foundation/tests/hcp_b7_apply_permission_delta.txt
@@ -1,0 +1,10 @@
+apikeys.keys.create
+apikeys.keys.get
+apikeys.keys.getKeyString
+datastore.databases.create
+datastore.databases.getMetadata
+datastore.operations.get
+firebaseauth.configs.create
+firebaseauth.configs.get
+firebaseauth.configs.update
+serviceusage.operations.get

--- a/infra/environments/preview-foundation/tests/hcp_b7_plan_permission_delta.txt
+++ b/infra/environments/preview-foundation/tests/hcp_b7_plan_permission_delta.txt
@@ -1,0 +1,4 @@
+apikeys.keys.get
+apikeys.keys.getKeyString
+datastore.databases.getMetadata
+firebaseauth.configs.get

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -8,13 +8,18 @@ dockerfile="$repo_dir/rentchain-api/Dockerfile"
 dockerignore_file="$repo_dir/rentchain-api/.dockerignore"
 apply_permissions_file="$root_dir/tests/hcp_apply_permissions.txt"
 b4_apply_delta_file="$root_dir/tests/hcp_b4_apply_permission_delta.txt"
+b7_plan_delta_file="$root_dir/tests/hcp_b7_plan_permission_delta.txt"
+b7_apply_delta_file="$root_dir/tests/hcp_b7_apply_permission_delta.txt"
 
 expected_resources="$(cat <<'EOF'
+google_apikeys_key
 google_artifact_registry_repository
 google_artifact_registry_repository_iam_member
 google_cloud_run_v2_service
+google_firestore_database
 google_iam_workload_identity_pool
 google_iam_workload_identity_pool_provider
+google_identity_platform_config
 google_project_iam_custom_role
 google_project_iam_member
 google_project_service
@@ -25,10 +30,10 @@ EOF
 actual_resources="$(rg -No 'resource "[^"]+"' "$root_dir" --glob '*.tf' | sed -E 's/.*resource "([^"]+)"/\1/' | sort -u)"
 test "$actual_resources" = "$expected_resources"
 
-test "$(rg -No '^resource "[^"]+"' "$root_dir" --glob '*.tf' | wc -l | tr -d ' ')" = "15"
+test "$(rg -No '^resource "[^"]+"' "$root_dir" --glob '*.tf' | wc -l | tr -d ' ')" = "26"
 
 test "$(rg -No 'service\s*=\s*"[^"]+\.googleapis\.com"' "$root_dir/services.tf" | wc -l | tr -d ' ')" = "0"
-test "$(rg -No '"(artifactregistry|cloudresourcemanager|iam|run|serviceusage)\.googleapis\.com"' "$root_dir/services.tf" | sort -u | wc -l | tr -d ' ')" = "5"
+test "$(rg -No '"(apikeys|artifactregistry|cloudresourcemanager|firestore|iam|identitytoolkit|run|serviceusage)\.googleapis\.com"' "$root_dir/services.tf" | sort -u | wc -l | tr -d ' ')" = "8"
 
 rg -q 'organization = "Rentchain"' "$root_dir/versions.tf"
 rg -q 'name = "rentchain-preview-foundation"' "$root_dir/versions.tf"
@@ -38,20 +43,72 @@ rg -q 'var\.environment == "preview"' "$root_dir/variables.tf"
 rg -q 'var\.project_id != "project-0d9658de-af29-4dc0-a99"' "$root_dir/variables.tf"
 rg -q 'variable "enable_preview_backend_service"' "$root_dir/variables.tf"
 rg -q 'default     = true' "$root_dir/variables.tf"
+rg -q 'variable "b7_foundation_phase"' "$root_dir/variables.tf"
+grep -Fq 'condition     = contains([1, 2, 3], var.b7_foundation_phase)' "$root_dir/variables.tf"
 rg -q 'count    = var\.enable_preview_backend_service \? 1 : 0' "$root_dir/cloud_run.tf"
 rg -U -q 'lifecycle \{\n    prevent_destroy = true\n    ignore_changes = \[\n      scaling,\n    \]\n  \}' "$root_dir/cloud_run.tf"
-test "$(rg -c 'ignore_changes' "$root_dir" --glob '*.tf')" = "1"
-rg -U -q 'template \{.*scaling \{\n      min_instance_count = 0\n      max_instance_count = 1\n    \}' "$root_dir/cloud_run.tf"
+test "$(rg -No 'ignore_changes' "$root_dir" --glob '*.tf' | wc -l | tr -d ' ')" = "1"
+rg -U -q 'scaling \{\n      min_instance_count = 0\n      max_instance_count = 1\n    \}' "$root_dir/cloud_run.tf"
 
 if rg -n 'credentials\s*=|credentials_file|GOOGLE_APPLICATION_CREDENTIALS|service_account_key|private_key' "$root_dir" --glob '*.tf'; then
   echo "Static credential reference found" >&2
   exit 1
 fi
 
-if rg -n 'allUsers|allAuthenticatedUsers|google_storage_bucket|google_firestore|google_compute|google_container|google_cloudbuild' "$root_dir" --glob '*.tf'; then
+if rg -n 'allUsers|allAuthenticatedUsers|google_storage_bucket|google_firestore_(document|field|index)|google_compute|google_container|google_cloudbuild' "$root_dir" --glob '*.tf'; then
   echo "Public IAM or workload resource found" >&2
   exit 1
 fi
+
+rg -q 'name        = local\.preview_firestore_database_id' "$root_dir/datastore_auth.tf"
+rg -q 'preview_firestore_database_id = "\(default\)"' "$root_dir/datastore_auth.tf"
+rg -q 'preview_firestore_location    = "northamerica-northeast1"' "$root_dir/datastore_auth.tf"
+rg -q 'type        = "FIRESTORE_NATIVE"' "$root_dir/datastore_auth.tf"
+rg -q 'delete_protection_state = "DELETE_PROTECTION_ENABLED"' "$root_dir/datastore_auth.tf"
+rg -q 'deletion_policy         = "ABANDON"' "$root_dir/datastore_auth.tf"
+rg -q 'role_id     = "previewBackendFirestoreRuntime"' "$root_dir/datastore_auth.tf"
+grep -Fq "resource.name == 'projects/\${var.project_id}/databases/\${local.preview_firestore_database_id}'" "$root_dir/datastore_auth.tf"
+
+expected_runtime_firestore_permissions="$(cat <<'EOF'
+datastore.databases.get
+datastore.entities.create
+datastore.entities.delete
+datastore.entities.get
+datastore.entities.list
+datastore.entities.update
+EOF
+)"
+actual_runtime_firestore_permissions="$(
+  sed -n '/preview_runtime_firestore_permissions = toset(/,/])/p' "$root_dir/datastore_auth.tf" \
+    | rg -No '"[^"]+"' \
+    | tr -d '"' \
+    | sort -u
+)"
+test "$actual_runtime_firestore_permissions" = "$expected_runtime_firestore_permissions"
+
+rg -q 'resource "google_identity_platform_config" "preview"' "$root_dir/datastore_auth.tf"
+grep -Fq 'authorized_domains = sort(tolist(local.preview_identity_authorized_domains))' "$root_dir/datastore_auth.tf"
+rg -q 'preview_identity_authorized_domains = toset' "$root_dir/datastore_auth.tf"
+test "$(sed -n '/preview_identity_authorized_domains = toset(/,/])/p' "$root_dir/datastore_auth.tf" | rg -No '"[^"]+"' | tr -d '"')" = "localhost"
+rg -q 'disabled_user_signup   = true' "$root_dir/datastore_auth.tf"
+rg -q 'disabled_user_deletion = true' "$root_dir/datastore_auth.tf"
+rg -q 'role_id     = "previewBackendAuthReader"' "$root_dir/datastore_auth.tf"
+test "$(sed -n '/preview_runtime_auth_permissions = toset(/,/])/p' "$root_dir/datastore_auth.tf" | rg -No '"[^"]+"' | tr -d '"')" = "firebaseauth.users.get"
+rg -q 'service = "identitytoolkit.googleapis.com"' "$root_dir/datastore_auth.tf"
+
+if rg -n 'firebaseauth\.users\.(create|delete|update|sendEmail)|datastore\.(databases\.(delete|update)|indexes\.|operations\.)|roles/(datastore|firebase|identityplatform)' "$root_dir/datastore_auth.tf"; then
+  echo "B7 runtime IAM broadening or destructive datastore permission found" >&2
+  exit 1
+fi
+
+rg -U -q 'name  = "FIRESTORE_ENABLED"\n        value = "false"' "$root_dir/cloud_run.tf"
+if rg -n 'FIRESTORE_DATABASE_ID|PREVIEW_AUTH_ENABLED|FIREBASE_PROJECT_ID|FIREBASE_API_KEY|google_apikeys_key' "$root_dir/cloud_run.tf"; then
+  echo "B7 Cloud Run activation must remain deferred until the separately reviewed runtime-image phase" >&2
+  exit 1
+fi
+
+test "$(rg -No 'count = var\.b7_foundation_phase >= 2 \? 1 : 0' "$root_dir/datastore_auth.tf" | wc -l | tr -d ' ')" = "3"
+test "$(rg -No 'count = var\.b7_foundation_phase >= 3 \? 1 : 0' "$root_dir/datastore_auth.tf" | wc -l | tr -d ' ')" = "4"
 
 test "$(rg -No '^resource "google_artifact_registry_repository"' "$root_dir" --glob '*.tf' | wc -l | tr -d ' ')" = "1"
 rg -q 'project       = var\.project_id' "$root_dir/deployment_foundation.tf"
@@ -171,6 +228,37 @@ test "$(wc -l < "$b4_apply_delta_file" | tr -d ' ')" = "2"
 
 if rg -n '(delete|update|setIamPolicy|serviceusage\.services\.enable|serviceAccountKeys|signBlob|signJwt|getAccessToken|generateAccessToken|run\.|cloudbuild\.|storage\.|firebase|firestore|billing)' "$b4_apply_delta_file"; then
   echo "Forbidden B4 apply-permission delta found" >&2
+  exit 1
+fi
+
+expected_b7_plan_delta="$(cat <<'EOF'
+apikeys.keys.get
+apikeys.keys.getKeyString
+datastore.databases.getMetadata
+firebaseauth.configs.get
+EOF
+)"
+test "$(sort -u "$b7_plan_delta_file")" = "$expected_b7_plan_delta"
+test "$(wc -l < "$b7_plan_delta_file" | tr -d ' ')" = "4"
+
+expected_b7_apply_delta="$(cat <<'EOF'
+apikeys.keys.create
+apikeys.keys.get
+apikeys.keys.getKeyString
+datastore.databases.create
+datastore.databases.getMetadata
+datastore.operations.get
+firebaseauth.configs.create
+firebaseauth.configs.get
+firebaseauth.configs.update
+serviceusage.operations.get
+EOF
+)"
+test "$(sort -u "$b7_apply_delta_file")" = "$expected_b7_apply_delta"
+test "$(wc -l < "$b7_apply_delta_file" | tr -d ' ')" = "10"
+
+if rg -n '(delete|undelete|users\.(create|delete|update|sendEmail)|getSecret|getHashConfig|serviceAccountKeys|signBlob|signJwt|getAccessToken|generateAccessToken|run\.|storage\.|billing)' "$b7_plan_delta_file" "$b7_apply_delta_file"; then
+  echo "Forbidden B7 HCP permission delta found" >&2
   exit 1
 fi
 

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -30,7 +30,7 @@ EOF
 actual_resources="$(rg -No 'resource "[^"]+"' "$root_dir" --glob '*.tf' | sed -E 's/.*resource "([^"]+)"/\1/' | sort -u)"
 test "$actual_resources" = "$expected_resources"
 
-test "$(rg -No '^resource "[^"]+"' "$root_dir" --glob '*.tf' | wc -l | tr -d ' ')" = "26"
+test "$(rg -No '^resource "[^"]+"' "$root_dir" --glob '*.tf' | wc -l | tr -d ' ')" = "30"
 
 test "$(rg -No 'service\s*=\s*"[^"]+\.googleapis\.com"' "$root_dir/services.tf" | wc -l | tr -d ' ')" = "0"
 test "$(rg -No '"(apikeys|artifactregistry|cloudresourcemanager|firestore|iam|identitytoolkit|run|serviceusage)\.googleapis\.com"' "$root_dir/services.tf" | sort -u | wc -l | tr -d ' ')" = "8"
@@ -132,6 +132,58 @@ fi
 rg -q 'role               = "roles/iam\.serviceAccountUser"' "$root_dir/iam.tf"
 rg -q 'service_account_id = google_service_account\.preview_backend_runtime\.name' "$root_dir/iam.tf"
 rg -q 'member             = local\.hcp_terraform_apply_member' "$root_dir/iam.tf"
+
+rg -q 'role_id     = "hcpTerraformPreviewB7Reader"' "$root_dir/iam.tf"
+rg -q 'resource "google_project_iam_member" "hcp_terraform_preview_b7_reader"' "$root_dir/iam.tf"
+rg -q 'member  = local\.hcp_terraform_plan_member' "$root_dir/iam.tf"
+expected_b7_reader_permissions="$(cat <<'EOF'
+apikeys.keys.get
+apikeys.keys.getKeyString
+datastore.databases.getMetadata
+firebaseauth.configs.get
+EOF
+)"
+actual_b7_reader_permissions="$(
+  sed -n '/hcp_terraform_preview_b7_reader_permissions = toset(/,/])/p' "$root_dir/iam.tf" \
+    | rg -No '"[^"]+"' \
+    | tr -d '"' \
+    | sort -u
+)"
+test "$actual_b7_reader_permissions" = "$expected_b7_reader_permissions"
+
+rg -q 'role_id     = "terraformPreviewB7Manager"' "$root_dir/iam.tf"
+rg -q 'resource "google_project_iam_member" "terraform_preview_b7_manager"' "$root_dir/iam.tf"
+rg -q 'member  = local\.hcp_terraform_apply_member' "$root_dir/iam.tf"
+expected_b7_manager_permissions="$(cat <<'EOF'
+apikeys.keys.create
+apikeys.keys.get
+apikeys.keys.getKeyString
+datastore.databases.create
+datastore.databases.getMetadata
+firebaseauth.configs.create
+firebaseauth.configs.get
+firebaseauth.configs.update
+EOF
+)"
+actual_b7_manager_permissions="$(
+  sed -n '/terraform_preview_b7_manager_permissions = toset(/,/])/p' "$root_dir/iam.tf" \
+    | rg -No '"[^"]+"' \
+    | tr -d '"' \
+    | sort -u
+)"
+test "$actual_b7_manager_permissions" = "$expected_b7_manager_permissions"
+
+test "$(rg -No '^resource "google_project_iam_custom_role" "(hcp_terraform_preview_b7_reader|terraform_preview_b7_manager)"' "$root_dir/iam.tf" | wc -l | tr -d ' ')" = "2"
+test "$(rg -No '^resource "google_project_iam_member" "(hcp_terraform_preview_b7_reader|terraform_preview_b7_manager)"' "$root_dir/iam.tf" | wc -l | tr -d ' ')" = "2"
+if sed -n '/resource "google_project_iam_custom_role" "hcp_terraform_preview_b7_reader"/,/^}/p; /resource "google_project_iam_member" "hcp_terraform_preview_b7_reader"/,/^}/p; /resource "google_project_iam_custom_role" "terraform_preview_b7_manager"/,/^}/p; /resource "google_project_iam_member" "terraform_preview_b7_manager"/,/^}/p' "$root_dir/iam.tf" | rg -n 'count\s*=|for_each\s*='; then
+  echo "B7 bootstrap IAM resources must remain ungated in Phase 1" >&2
+  exit 1
+fi
+
+if printf '%s\n%s\n' "$actual_b7_reader_permissions" "$actual_b7_manager_permissions" | rg -n '(delete|users\.|token|run\.|storage\.|billing|secretmanager|firebase\.|identitytoolkit\.)'; then
+  echo "Forbidden permission found in B7 HCP bootstrap roles" >&2
+  exit 1
+fi
 
 rg -q 'role_id     = "hcpTerraformPreviewCloudRunViewer"' "$root_dir/iam.tf"
 rg -q 'terraform_preview_cloud_run_viewer_permissions = toset' "$root_dir/iam.tf"
@@ -247,15 +299,13 @@ apikeys.keys.get
 apikeys.keys.getKeyString
 datastore.databases.create
 datastore.databases.getMetadata
-datastore.operations.get
 firebaseauth.configs.create
 firebaseauth.configs.get
 firebaseauth.configs.update
-serviceusage.operations.get
 EOF
 )"
 test "$(sort -u "$b7_apply_delta_file")" = "$expected_b7_apply_delta"
-test "$(wc -l < "$b7_apply_delta_file" | tr -d ' ')" = "10"
+test "$(wc -l < "$b7_apply_delta_file" | tr -d ' ')" = "8"
 
 if rg -n '(delete|undelete|users\.(create|delete|update|sendEmail)|getSecret|getHashConfig|serviceAccountKeys|signBlob|signJwt|getAccessToken|generateAccessToken|run\.|storage\.|billing)' "$b7_plan_delta_file" "$b7_apply_delta_file"; then
   echo "Forbidden B7 HCP permission delta found" >&2

--- a/infra/environments/preview-foundation/variables.tf
+++ b/infra/environments/preview-foundation/variables.tf
@@ -70,3 +70,14 @@ variable "enable_preview_backend_service" {
   type        = bool
   default     = true
 }
+
+variable "b7_foundation_phase" {
+  description = "Governed B7 phase gate: 1=APIs only, 2=datastore/auth resources, 3=runtime IAM. Cloud Run activation is separately reviewed."
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = contains([1, 2, 3], var.b7_foundation_phase)
+    error_message = "b7_foundation_phase must be exactly 1, 2, or 3."
+  }
+}

--- a/rentchain-api/src/config/__tests__/firestoreEnvironmentGuard.test.ts
+++ b/rentchain-api/src/config/__tests__/firestoreEnvironmentGuard.test.ts
@@ -35,6 +35,7 @@ describe("firestoreEnvironmentGuard", () => {
       environment: "development",
       mode: "emulator",
       emulatorHost: "127.0.0.1:8080",
+      databaseId: "(default)",
       localProductionFirestoreOverride: false,
       googleApplicationCredentialsPresent: false,
     });
@@ -56,6 +57,7 @@ describe("firestoreEnvironmentGuard", () => {
       environment: "development",
       mode: "local-prod-firestore-override",
       emulatorHost: null,
+      databaseId: "(default)",
       localProductionFirestoreOverride: true,
       googleApplicationCredentialsPresent: true,
     });
@@ -74,6 +76,7 @@ describe("firestoreEnvironmentGuard", () => {
       environment: "production",
       mode: "production",
       emulatorHost: null,
+      databaseId: "(default)",
       localProductionFirestoreOverride: false,
       googleApplicationCredentialsPresent: true,
     });
@@ -91,5 +94,45 @@ describe("firestoreEnvironmentGuard", () => {
       mode: "preview-disabled",
       localProductionFirestoreOverride: false,
     });
+  });
+
+  it("enables only the explicit keyless Preview default database boundary", () => {
+    const result = assertSafeFirestoreEnvironment({
+      APP_ENV: "preview",
+      GOOGLE_CLOUD_PROJECT: "rentchain-preview",
+      FIRESTORE_ENABLED: "true",
+      FIRESTORE_DATABASE_ID: "(default)",
+    });
+
+    expect(result).toMatchObject({
+      environment: "preview",
+      mode: "preview-enabled",
+      databaseId: "(default)",
+      emulatorHost: null,
+      googleApplicationCredentialsPresent: false,
+    });
+  });
+
+  it("rejects a named Preview database", () => {
+    expect(() =>
+      assertSafeFirestoreEnvironment({
+        APP_ENV: "preview",
+        GOOGLE_CLOUD_PROJECT: "rentchain-preview",
+        FIRESTORE_ENABLED: "true",
+        FIRESTORE_DATABASE_ID: "preview",
+      })
+    ).toThrow(/FIRESTORE_DATABASE_ID=\(default\)/);
+  });
+
+  it("rejects static credentials in enabled Preview", () => {
+    expect(() =>
+      assertSafeFirestoreEnvironment({
+        APP_ENV: "preview",
+        GOOGLE_CLOUD_PROJECT: "rentchain-preview",
+        FIRESTORE_ENABLED: "true",
+        FIRESTORE_DATABASE_ID: "(default)",
+        GOOGLE_APPLICATION_CREDENTIALS: "/tmp/preview.json",
+      })
+    ).toThrow(/keyless Application Default Credentials/);
   });
 });

--- a/rentchain-api/src/config/__tests__/previewFoundationConfig.test.ts
+++ b/rentchain-api/src/config/__tests__/previewFoundationConfig.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { getPreviewFoundationConfig } from "../previewFoundationConfig";
+
+function preview(overrides: Record<string, string | undefined> = {}) {
+  return {
+    APP_ENV: "preview",
+    GOOGLE_CLOUD_PROJECT: "rentchain-preview",
+    FIRESTORE_ENABLED: "true",
+    FIRESTORE_DATABASE_ID: "(default)",
+    PREVIEW_AUTH_ENABLED: "true",
+    FIREBASE_PROJECT_ID: "rentchain-preview",
+    FIREBASE_API_KEY: "preview-only-key",
+    ...overrides,
+  };
+}
+
+describe("previewFoundationConfig", () => {
+  it("accepts the exact isolated Preview datastore and authentication boundary", () => {
+    expect(getPreviewFoundationConfig(preview())).toEqual({
+      environment: "preview",
+      datastoreEnabled: true,
+      authenticationEnabled: true,
+      authenticationConfigured: true,
+      authenticationOperationallyVerified: false,
+      projectId: "rentchain-preview",
+      databaseId: "(default)",
+      firebaseApiKeyPresent: true,
+    });
+  });
+
+  it("preserves the explicit deferred mode", () => {
+    expect(
+      getPreviewFoundationConfig(
+        preview({
+          FIRESTORE_ENABLED: "false",
+          FIRESTORE_DATABASE_ID: undefined,
+          PREVIEW_AUTH_ENABLED: "false",
+          FIREBASE_PROJECT_ID: undefined,
+          FIREBASE_API_KEY: undefined,
+        })
+      )
+    ).toMatchObject({
+      datastoreEnabled: false,
+      authenticationEnabled: false,
+      authenticationConfigured: false,
+      authenticationOperationallyVerified: false,
+    });
+  });
+
+  it("rejects production Firebase configuration", () => {
+    expect(() =>
+      getPreviewFoundationConfig(
+        preview({
+          FIREBASE_PROJECT_ID: "project-0d9658de-af29-4dc0-a99",
+        })
+      )
+    ).toThrow(/production Firebase project/);
+  });
+
+  it("rejects authentication without the exact Preview Firebase project", () => {
+    expect(() =>
+      getPreviewFoundationConfig(
+        preview({
+          FIREBASE_PROJECT_ID: "other-preview",
+        })
+      )
+    ).toThrow(/explicitly target rentchain-preview/);
+  });
+
+  it("rejects authentication without its Preview API key", () => {
+    expect(() =>
+      getPreviewFoundationConfig(
+        preview({
+          FIREBASE_API_KEY: undefined,
+        })
+      )
+    ).toThrow(/isolated FIREBASE_API_KEY/);
+  });
+
+  it("does not treat API-key presence alone as configured authentication", () => {
+    expect(
+      getPreviewFoundationConfig(
+        preview({
+          PREVIEW_AUTH_ENABLED: "false",
+        })
+      )
+    ).toMatchObject({
+      authenticationEnabled: false,
+      authenticationConfigured: false,
+      authenticationOperationallyVerified: false,
+      firebaseApiKeyPresent: true,
+    });
+  });
+});

--- a/rentchain-api/src/config/__tests__/requiredEnv.test.ts
+++ b/rentchain-api/src/config/__tests__/requiredEnv.test.ts
@@ -144,4 +144,36 @@ describe("requiredEnv provider-aware email requirements", () => {
     expect(flags.emailProvider).toBe("sendgrid");
     expect(flags.emailConfigured).toBe(true);
   });
+
+  it("accepts the exact isolated Preview datastore and authentication configuration", () => {
+    process.env = {
+      ...ENV_BACKUP,
+      APP_ENV: "preview",
+      NODE_ENV: "production",
+      GOOGLE_CLOUD_PROJECT: "rentchain-preview",
+      FIRESTORE_ENABLED: "true",
+      FIRESTORE_DATABASE_ID: "(default)",
+      PREVIEW_AUTH_ENABLED: "true",
+      FIREBASE_PROJECT_ID: "rentchain-preview",
+      FIREBASE_API_KEY: "preview-only-key",
+    };
+
+    expect(() => assertRequiredEnv()).not.toThrow();
+  });
+
+  it("rejects Preview authentication configured for production", () => {
+    process.env = {
+      ...ENV_BACKUP,
+      APP_ENV: "preview",
+      NODE_ENV: "production",
+      GOOGLE_CLOUD_PROJECT: "rentchain-preview",
+      FIRESTORE_ENABLED: "true",
+      FIRESTORE_DATABASE_ID: "(default)",
+      PREVIEW_AUTH_ENABLED: "true",
+      FIREBASE_PROJECT_ID: "project-0d9658de-af29-4dc0-a99",
+      FIREBASE_API_KEY: "production-key",
+    };
+
+    expect(() => assertRequiredEnv()).toThrow(/production Firebase project/);
+  });
 });

--- a/rentchain-api/src/config/firestoreEnvironmentGuard.ts
+++ b/rentchain-api/src/config/firestoreEnvironmentGuard.ts
@@ -2,8 +2,9 @@ type FirestoreGuardEnv = NodeJS.ProcessEnv | Record<string, string | undefined>;
 
 export type FirestoreEnvironmentGuardResult = {
   environment: string;
-  mode: "production" | "preview-disabled" | "emulator" | "local-prod-firestore-override";
+  mode: "production" | "preview-disabled" | "preview-enabled" | "emulator" | "local-prod-firestore-override";
   emulatorHost: string | null;
+  databaseId: string | null;
   localProductionFirestoreOverride: boolean;
   googleApplicationCredentialsPresent: boolean;
 };
@@ -30,14 +31,36 @@ export function assertSafeFirestoreEnvironment(
   const emulatorHost = envValue(env, "FIRESTORE_EMULATOR_HOST");
   const googleApplicationCredentials = envValue(env, "GOOGLE_APPLICATION_CREDENTIALS");
   const localProductionFirestoreOverride = isTrue(envValue(env, "ALLOW_LOCAL_PROD_FIRESTORE"));
+  const databaseId = envValue(env, "FIRESTORE_DATABASE_ID");
 
   if (environment === "preview" && !isTrue(envValue(env, "FIRESTORE_ENABLED"))) {
     return {
       environment,
       mode: "preview-disabled",
       emulatorHost: emulatorHost || null,
+      databaseId: databaseId || null,
       localProductionFirestoreOverride: false,
       googleApplicationCredentialsPresent: Boolean(googleApplicationCredentials),
+    };
+  }
+
+  if (environment === "preview") {
+    if (databaseId !== "(default)") {
+      throw new Error("[firestore-guard] Preview requires FIRESTORE_DATABASE_ID=(default).");
+    }
+    if (emulatorHost) {
+      throw new Error("[firestore-guard] Deployed Preview must not use FIRESTORE_EMULATOR_HOST.");
+    }
+    if (googleApplicationCredentials) {
+      throw new Error("[firestore-guard] Preview Cloud Run must use keyless Application Default Credentials.");
+    }
+    return {
+      environment,
+      mode: "preview-enabled",
+      emulatorHost: null,
+      databaseId,
+      localProductionFirestoreOverride: false,
+      googleApplicationCredentialsPresent: false,
     };
   }
 
@@ -46,6 +69,7 @@ export function assertSafeFirestoreEnvironment(
       environment,
       mode: "production",
       emulatorHost: emulatorHost || null,
+      databaseId: databaseId || "(default)",
       localProductionFirestoreOverride,
       googleApplicationCredentialsPresent: Boolean(googleApplicationCredentials),
     };
@@ -63,6 +87,7 @@ export function assertSafeFirestoreEnvironment(
       environment,
       mode: "local-prod-firestore-override",
       emulatorHost: emulatorHost || null,
+      databaseId: databaseId || "(default)",
       localProductionFirestoreOverride,
       googleApplicationCredentialsPresent: Boolean(googleApplicationCredentials),
     };
@@ -92,6 +117,7 @@ export function assertSafeFirestoreEnvironment(
     environment,
     mode: "emulator",
     emulatorHost,
+    databaseId: databaseId || "(default)",
     localProductionFirestoreOverride,
     googleApplicationCredentialsPresent: false,
   };

--- a/rentchain-api/src/config/previewFoundationConfig.ts
+++ b/rentchain-api/src/config/previewFoundationConfig.ts
@@ -1,0 +1,78 @@
+import { PREVIEW_PROJECT, PRODUCTION_PROJECT, getConfiguredProjectId, getRuntimeEnvironment } from "./runtimeEnvironment";
+
+type PreviewFoundationEnv = NodeJS.ProcessEnv | Record<string, string | undefined>;
+
+export type PreviewFoundationConfig = {
+  environment: string;
+  datastoreEnabled: boolean;
+  authenticationEnabled: boolean;
+  authenticationConfigured: boolean;
+  authenticationOperationallyVerified: false;
+  projectId: string;
+  databaseId: string;
+  firebaseApiKeyPresent: boolean;
+};
+
+function value(env: PreviewFoundationEnv, name: string): string {
+  return String(env[name] || "").trim();
+}
+
+function enabled(env: PreviewFoundationEnv, name: string): boolean {
+  return value(env, name).toLowerCase() === "true";
+}
+
+export function getPreviewFoundationConfig(
+  env: PreviewFoundationEnv = process.env
+): PreviewFoundationConfig {
+  const environment = getRuntimeEnvironment(env as NodeJS.ProcessEnv);
+  const projectId = getConfiguredProjectId(env as NodeJS.ProcessEnv);
+  const datastoreEnabled = enabled(env, "FIRESTORE_ENABLED");
+  const authenticationEnabled = enabled(env, "PREVIEW_AUTH_ENABLED");
+  const databaseId = value(env, "FIRESTORE_DATABASE_ID");
+  const firebaseProjectId = value(env, "FIREBASE_PROJECT_ID");
+
+  if (environment !== "preview") {
+    return {
+      environment,
+      datastoreEnabled,
+      authenticationEnabled,
+      authenticationConfigured: false,
+      authenticationOperationallyVerified: false,
+      projectId,
+      databaseId,
+      firebaseApiKeyPresent: Boolean(value(env, "FIREBASE_API_KEY")),
+    };
+  }
+
+  if (projectId !== PREVIEW_PROJECT) {
+    throw new Error("[preview-foundation] Preview must target rentchain-preview.");
+  }
+  if (firebaseProjectId === PRODUCTION_PROJECT) {
+    throw new Error("[preview-foundation] Preview rejects the production Firebase project.");
+  }
+  if (datastoreEnabled && databaseId !== "(default)") {
+    throw new Error("[preview-foundation] Preview Firestore database must be explicitly set to (default).");
+  }
+  if (authenticationEnabled) {
+    if (firebaseProjectId !== PREVIEW_PROJECT) {
+      throw new Error("[preview-foundation] Preview authentication must explicitly target rentchain-preview.");
+    }
+    if (!value(env, "FIREBASE_API_KEY")) {
+      throw new Error("[preview-foundation] Preview authentication requires its isolated FIREBASE_API_KEY.");
+    }
+  }
+
+  return {
+    environment,
+    datastoreEnabled,
+    authenticationEnabled,
+    authenticationConfigured:
+      authenticationEnabled &&
+      firebaseProjectId === PREVIEW_PROJECT &&
+      Boolean(value(env, "FIREBASE_API_KEY")),
+    authenticationOperationallyVerified: false,
+    projectId,
+    databaseId,
+    firebaseApiKeyPresent: Boolean(value(env, "FIREBASE_API_KEY")),
+  };
+}

--- a/rentchain-api/src/config/requiredEnv.ts
+++ b/rentchain-api/src/config/requiredEnv.ts
@@ -1,5 +1,6 @@
 import { getPricingHealth } from "./planMatrix";
 import { assertRuntimeEnvironment, getRuntimeEnvironment } from "./runtimeEnvironment";
+import { getPreviewFoundationConfig } from "./previewFoundationConfig";
 
 type EnvRequirement =
   | { kind: "name"; name: string }
@@ -101,9 +102,7 @@ export function getEnvFlags() {
 export function assertRequiredEnv(): void {
   const runtime = assertRuntimeEnvironment();
   if (runtime === "preview") {
-    if (process.env.FIRESTORE_ENABLED === "true") {
-      throw new Error("[boot] Preview Firestore requires a separately authorized datastore configuration.");
-    }
+    getPreviewFoundationConfig();
     return;
   }
   const missingHard = missingHardRequirements();

--- a/rentchain-api/src/firebase/admin.ts
+++ b/rentchain-api/src/firebase/admin.ts
@@ -2,11 +2,13 @@ import admin from "firebase-admin";
 import { assertSafeFirestoreEnvironment } from "../config/firestoreEnvironmentGuard";
 import { recordInitializationState } from "./initializationRegistry";
 import { assertRuntimeEnvironment, getConfiguredProjectId, PREVIEW_PROJECT, PRODUCTION_PROJECT } from "../config/runtimeEnvironment";
+import { getPreviewFoundationConfig } from "../config/previewFoundationConfig";
 
 const runtime = assertRuntimeEnvironment();
 export const PROJECT_ID = getConfiguredProjectId() || (runtime === "production" ? PRODUCTION_PROJECT : "");
 
 const guard = assertSafeFirestoreEnvironment();
+const previewFoundation = getPreviewFoundationConfig();
 
 let firestore: admin.firestore.Firestore;
 let db: admin.firestore.Firestore;
@@ -32,6 +34,13 @@ if (!admin.apps.length) {
 
 const firestoreInstance = admin.firestore();
 firestoreInstance.settings({ ignoreUndefinedProperties: true });
+
+if (runtime === "preview" && (
+  previewFoundation.projectId !== PREVIEW_PROJECT ||
+  previewFoundation.databaseId !== "(default)"
+)) {
+  throw new Error("[firebase] Preview Firestore initialization boundary is invalid.");
+}
 
 recordInitializationState({
   guard,

--- a/rentchain-api/src/firebase/initializationRegistry.ts
+++ b/rentchain-api/src/firebase/initializationRegistry.ts
@@ -7,6 +7,7 @@ export type FirebaseInitializationState = {
   mode: FirebaseInitializationMode;
   emulatorHost: string | null;
   projectId: string;
+  databaseId: string | null;
   timestamp: string;
   caller: string;
 };
@@ -24,6 +25,7 @@ export function recordInitializationState(input: {
     mode: input.guard.mode,
     emulatorHost: input.guard.emulatorHost,
     projectId: input.projectId,
+    databaseId: input.guard.databaseId,
     timestamp: input.timestamp || new Date().toISOString(),
     caller: input.caller,
   };
@@ -37,6 +39,7 @@ export function initializationState(): FirebaseInitializationState {
     mode: "emulator",
     emulatorHost: String(process.env.FIRESTORE_EMULATOR_HOST || "").trim() || null,
     projectId: "",
+    databaseId: null,
     timestamp: new Date(0).toISOString(),
     caller: "firebase_initialization_not_recorded",
   };

--- a/rentchain-api/src/routes/__tests__/healthRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/healthRoutes.test.ts
@@ -4,6 +4,15 @@ import healthRoutes from "../healthRoutes";
 
 const firebaseMock = vi.hoisted(() => ({
   listCollections: vi.fn(async () => []),
+  state: {
+    environment: "test",
+    mode: "emulator",
+    emulatorHost: "127.0.0.1:8080",
+    projectId: "project-0d9658de-af29-4dc0-a99",
+    databaseId: "(default)",
+    timestamp: "2026-06-03T00:00:00.000Z",
+    caller: "health-test",
+  },
 }));
 const originalNodeEnv = process.env.NODE_ENV;
 
@@ -11,14 +20,7 @@ vi.mock("../../firebase", () => ({
   db: {
     listCollections: firebaseMock.listCollections,
   },
-  initializationState: () => ({
-    environment: "test",
-    mode: "emulator",
-    emulatorHost: "127.0.0.1:8080",
-    projectId: "project-0d9658de-af29-4dc0-a99",
-    timestamp: "2026-06-03T00:00:00.000Z",
-    caller: "health-test",
-  }),
+  initializationState: () => ({ ...firebaseMock.state }),
 }));
 
 function buildApp() {
@@ -80,6 +82,20 @@ describe("healthRoutes", () => {
     delete process.env.VERCEL_GIT_COMMIT_SHA;
     delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
     delete process.env.FIREBASE_CONFIG;
+    delete process.env.APP_ENV;
+    delete process.env.GOOGLE_CLOUD_PROJECT;
+    delete process.env.FIRESTORE_ENABLED;
+    delete process.env.FIRESTORE_DATABASE_ID;
+    delete process.env.PREVIEW_AUTH_ENABLED;
+    delete process.env.FIREBASE_PROJECT_ID;
+    delete process.env.FIREBASE_API_KEY;
+    Object.assign(firebaseMock.state, {
+      environment: "test",
+      mode: "emulator",
+      emulatorHost: "127.0.0.1:8080",
+      projectId: "project-0d9658de-af29-4dc0-a99",
+      databaseId: "(default)",
+    });
   });
 
   it("keeps /health reachable while redacting exact revision and commit values", async () => {
@@ -135,6 +151,96 @@ describe("healthRoutes", () => {
       status: "skipped",
       firebaseInitializationMode: "emulator",
       message: "No DB credentials configured",
+    });
+  });
+
+  it("reports datastore ready but keeps Preview unready until auth is operationally verified", async () => {
+    process.env.APP_ENV = "preview";
+    process.env.GOOGLE_CLOUD_PROJECT = "rentchain-preview";
+    process.env.FIRESTORE_ENABLED = "true";
+    process.env.FIRESTORE_DATABASE_ID = "(default)";
+    process.env.PREVIEW_AUTH_ENABLED = "true";
+    process.env.FIREBASE_PROJECT_ID = "rentchain-preview";
+    process.env.FIREBASE_API_KEY = "preview-only-key";
+    Object.assign(firebaseMock.state, {
+      environment: "preview",
+      mode: "preview-enabled",
+      emulatorHost: null,
+      projectId: "rentchain-preview",
+      databaseId: "(default)",
+    });
+
+    const ready = await invokeApp(buildApp(), "GET", "/health/ready");
+
+    expect(ready.status).toBe(503);
+    expect(ready.body).toMatchObject({
+      status: "fail",
+      checks: {
+        routes: "ok",
+        db: "ok",
+        datastore: "ready",
+        authentication: "configured",
+      },
+      environment: "preview",
+      mode: "datastore-auth-foundation",
+      databaseId: "(default)",
+    });
+    expect(firebaseMock.listCollections).toHaveBeenCalledOnce();
+    expect(JSON.stringify(ready.body)).not.toContain("preview-only-key");
+  });
+
+  it("does not report authentication ready from API-key presence alone", async () => {
+    process.env.APP_ENV = "preview";
+    process.env.GOOGLE_CLOUD_PROJECT = "rentchain-preview";
+    process.env.FIRESTORE_ENABLED = "true";
+    process.env.FIRESTORE_DATABASE_ID = "(default)";
+    process.env.PREVIEW_AUTH_ENABLED = "false";
+    process.env.FIREBASE_PROJECT_ID = "rentchain-preview";
+    process.env.FIREBASE_API_KEY = "preview-only-key";
+    Object.assign(firebaseMock.state, {
+      environment: "preview",
+      mode: "preview-enabled",
+      emulatorHost: null,
+      projectId: "rentchain-preview",
+      databaseId: "(default)",
+    });
+
+    const ready = await invokeApp(buildApp(), "GET", "/health/ready");
+
+    expect(ready.status).toBe(503);
+    expect(ready.body).toMatchObject({
+      checks: {
+        datastore: "ready",
+        authentication: "deferred",
+      },
+      mode: "datastore-auth-foundation",
+    });
+    expect(JSON.stringify(ready.body)).not.toContain("preview-only-key");
+  });
+
+  it("fails Preview readiness when the datastore probe fails", async () => {
+    process.env.APP_ENV = "preview";
+    process.env.GOOGLE_CLOUD_PROJECT = "rentchain-preview";
+    process.env.FIRESTORE_ENABLED = "true";
+    process.env.FIRESTORE_DATABASE_ID = "(default)";
+    process.env.PREVIEW_AUTH_ENABLED = "true";
+    process.env.FIREBASE_PROJECT_ID = "rentchain-preview";
+    process.env.FIREBASE_API_KEY = "preview-only-key";
+    Object.assign(firebaseMock.state, {
+      environment: "preview",
+      mode: "preview-enabled",
+      emulatorHost: null,
+      projectId: "rentchain-preview",
+      databaseId: "(default)",
+    });
+    firebaseMock.listCollections.mockRejectedValueOnce(new Error("permission denied"));
+
+    const ready = await invokeApp(buildApp(), "GET", "/health/ready");
+
+    expect(ready.status).toBe(503);
+    expect(ready.body).toMatchObject({
+      status: "fail",
+      checks: { routes: "ok", db: "fail" },
     });
   });
 });

--- a/rentchain-api/src/routes/healthRoutes.ts
+++ b/rentchain-api/src/routes/healthRoutes.ts
@@ -3,6 +3,7 @@ import { getVersion } from "../version";
 import { db, initializationState } from "../firebase";
 import { safeDiagnosticBuildMetadata } from "../middleware/diagnosticSurfaceGuard";
 import { getRuntimeEnvironment, getConfiguredProjectId } from "../config/runtimeEnvironment";
+import { getPreviewFoundationConfig } from "../config/previewFoundationConfig";
 
 const router = express.Router();
 
@@ -30,6 +31,7 @@ router.get("/version", (_req, res) => {
 
 router.get("/ready", async (_req, res) => {
   const firebaseState = initializationState();
+  const previewFoundation = getPreviewFoundationConfig();
   const checks: Record<string, string> = {
     routes: "ok",
   };
@@ -38,7 +40,7 @@ router.get("/ready", async (_req, res) => {
     return res.status(503).json({
       status: "fail",
       service: "rentchain-api",
-      checks: { routes: "ok", datastore: "deferred" },
+      checks: { routes: "ok", datastore: "deferred", authentication: "deferred" },
       firebaseInitializationMode: firebaseState.mode,
       environment: getRuntimeEnvironment(),
       mode: "foundation",
@@ -46,8 +48,12 @@ router.get("/ready", async (_req, res) => {
     });
   }
 
-  const hasDbCreds = Boolean(process.env.GOOGLE_APPLICATION_CREDENTIALS || process.env.FIREBASE_CONFIG);
-  if (!hasDbCreds) {
+  const mustProbeDatastore =
+    firebaseState.mode === "production" ||
+    firebaseState.mode === "preview-enabled" ||
+    Boolean(process.env.GOOGLE_APPLICATION_CREDENTIALS || process.env.FIREBASE_CONFIG);
+
+  if (!mustProbeDatastore) {
     checks.db = "skipped";
   } else {
     try {
@@ -66,19 +72,43 @@ router.get("/ready", async (_req, res) => {
     }
   }
 
+  if (getRuntimeEnvironment() === "preview") {
+    checks.datastore = checks.db === "ok" ? "ready" : "fail";
+    checks.authentication = previewFoundation.authenticationConfigured ? "configured" : "deferred";
+
+    return res.status(503).json({
+      status: "fail",
+      service: "rentchain-api",
+      checks,
+      firebaseInitializationMode: firebaseState.mode,
+      environment: previewFoundation.environment,
+      mode: "datastore-auth-foundation",
+      databaseId: previewFoundation.databaseId || null,
+      message: previewFoundation.authenticationConfigured
+        ? "Preview authentication is configured but awaits operational token-boundary verification."
+        : "Preview authentication configuration is deferred.",
+    });
+  }
+
   res.json({
     status: "ok",
     service: "rentchain-api",
     checks,
     firebaseInitializationMode: firebaseState.mode,
+    environment: getRuntimeEnvironment(),
+    mode: firebaseState.mode,
+    databaseId: firebaseState.databaseId,
   });
 });
 
 // Optional: db detail endpoint; return skipped when not configured
 router.get("/db", async (_req, res) => {
   const firebaseState = initializationState();
-  const hasDbCreds = Boolean(process.env.GOOGLE_APPLICATION_CREDENTIALS || process.env.FIREBASE_CONFIG);
-  if (!hasDbCreds) {
+  const mustProbeDatastore =
+    firebaseState.mode === "production" ||
+    firebaseState.mode === "preview-enabled" ||
+    Boolean(process.env.GOOGLE_APPLICATION_CREDENTIALS || process.env.FIREBASE_CONFIG);
+  if (!mustProbeDatastore) {
     return res.json({
       status: "skipped",
       firebaseInitializationMode: firebaseState.mode,


### PR DESCRIPTION
## Summary

Implements the bounded B7 Preview datastore and authentication foundation.

### Firestore

- isolated `rentchain-preview` default Firestore database
- `northamerica-northeast1`
- Native mode
- deletion protection enabled
- Terraform deletion policy `ABANDON`
- no documents, fixtures, indexes, seed data, or production import

### Authentication

- isolated Identity Platform configuration in `rentchain-preview`
- email/password enabled
- password required
- anonymous, phone, and MFA disabled
- public signup disabled
- user deletion disabled
- authorized domain limited to `localhost`
- no users created

### Runtime IAM

Firestore permissions:

- `datastore.databases.get`
- `datastore.entities.create`
- `datastore.entities.delete`
- `datastore.entities.get`
- `datastore.entities.list`
- `datastore.entities.update`

Authentication permission:

- `firebaseauth.users.get`

No runtime user creation or update permission is granted.

### Activation boundary

- Cloud Run Terraform is unchanged
- `FIRESTORE_ENABLED=false` remains
- Firebase API key is not injected into Cloud Run
- authentication is reported as `configured`, never `ready`
- `/health/ready` remains HTTP 503 pending operational token-boundary QA

### Local validation

- `terraform fmt`: passed
- `terraform fmt -check`: passed
- `terraform init -backend=false`: passed
- `terraform validate`: passed
- Preview scope validation: passed
- focused backend tests: 4 files, 29 tests passed
- backend TypeScript build: passed
- no typecheck or lint scripts exist

### Scope

- 19 files
- no production mutation
- no public IAM
- no static credentials
- no Terraform apply
- no cloud mutation
- PR #1453 and PR #1435 untouched

This PR remains draft pending authoritative HCP Terraform speculative-plan review.
