### PR TITLE
Advance B7 Preview datastore and authentication foundation to Phase 2

### DIFF
--- a/docs/strategy/preview-infrastructure/phase-b-b7-datastore-auth-foundation.md
+++ b/docs/strategy/preview-infrastructure/phase-b-b7-datastore-auth-foundation.md
@@ -63,9 +63,9 @@ Identity Platform is configured in `rentchain-preview` with:
 The backend password-login path uses a Preview API key restricted to
 `identitytoolkit.googleapis.com`. A Firebase web API key identifies a client and
 is not a privileged server credential, but Terraform and HCP still treat its
-value as sensitive. It is injected directly into Cloud Run and is not output.
-Secret Manager is therefore not required. The API key remains in Terraform
-state, but it is not attached to Cloud Run in phase 1.
+value as sensitive. Phase 2 creates the key in Terraform state without exposing
+it through outputs or attaching it to Cloud Run. Delivery to Cloud Run requires
+a separately reviewed activation phase; Secret Manager remains absent.
 
 The runtime role `previewBackendAuthReader` contains only
 `firebaseauth.users.get`. The existing login path needs this permission to read
@@ -129,11 +129,13 @@ policy permissions needed to create these roles and bindings. Do not substitute
 the apply identity for the plan identity and do not widen Workload Identity
 Federation.
 
-The repository variable `b7_foundation_phase` is a governed phase gate:
+The repository variable `b7_foundation_phase` is a governed phase gate. Its
+default is advanced only through separately reviewed phase-transition PRs:
 
-1. default phase 1 enables the three APIs and creates the two B7 HCP roles and
-   their exact bindings;
-2. phase 2 adds Firestore, Identity Platform, and the restricted API key;
+1. phase 1 enables the three APIs and creates the two B7 HCP roles and their
+   exact bindings;
+2. the current default, phase 2, adds Firestore, Identity Platform, and the
+   restricted API key;
 3. phase 3 adds the two exact runtime roles and bindings.
 
 The Phase 1 apply installs the plan and apply permissions before Phase 2 is

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -44,6 +44,7 @@ rg -q 'var\.project_id != "project-0d9658de-af29-4dc0-a99"' "$root_dir/variables
 rg -q 'variable "enable_preview_backend_service"' "$root_dir/variables.tf"
 rg -q 'default     = true' "$root_dir/variables.tf"
 rg -q 'variable "b7_foundation_phase"' "$root_dir/variables.tf"
+rg -U -q 'variable "b7_foundation_phase" \{\n  description = "[^"]+"\n  type        = number\n  default     = 2' "$root_dir/variables.tf"
 grep -Fq 'condition     = contains([1, 2, 3], var.b7_foundation_phase)' "$root_dir/variables.tf"
 rg -q 'count    = var\.enable_preview_backend_service \? 1 : 0' "$root_dir/cloud_run.tf"
 rg -U -q 'lifecycle \{\n    prevent_destroy = true\n    ignore_changes = \[\n      scaling,\n    \]\n  \}' "$root_dir/cloud_run.tf"

--- a/infra/environments/preview-foundation/variables.tf
+++ b/infra/environments/preview-foundation/variables.tf
@@ -74,7 +74,7 @@ variable "enable_preview_backend_service" {
 variable "b7_foundation_phase" {
   description = "Governed B7 phase gate: 1=APIs only, 2=datastore/auth resources, 3=runtime IAM. Cloud Run activation is separately reviewed."
   type        = number
-  default     = 1
+  default     = 2
 
   validation {
     condition     = contains([1, 2, 3], var.b7_foundation_phase)


### PR DESCRIPTION
## Summary

Advances the governed B7 Preview foundation phase gate from Phase 1 to Phase 2.

### Expected Terraform resources

- `google_firestore_database.preview[0]`
- `google_identity_platform_config.preview[0]`
- `google_apikeys_key.preview_backend_auth[0]`

### Firestore

- project: `rentchain-preview`
- database: `(default)`
- location: `northamerica-northeast1`
- mode: `FIRESTORE_NATIVE`
- deletion protection enabled
- Terraform deletion policy `ABANDON`
- no documents, indexes, fixtures, imports, or production data

### Identity Platform

- project: `rentchain-preview`
- authorized domain limited to `localhost`
- email/password enabled
- password required
- anonymous, phone, and MFA disabled
- public signup disabled
- client-side deletion disabled
- no users or OAuth providers

### Restricted API key

- restricted to `identitytoolkit.googleapis.com`
- not exposed through outputs
- not delivered to Cloud Run
- no Secret Manager resource

### Activation boundary

- Cloud Run remains unchanged
- `FIRESTORE_ENABLED=false`
- no `PREVIEW_AUTH_ENABLED`
- no `FIREBASE_PROJECT_ID`
- no `FIREBASE_API_KEY`
- runtime IAM remains deferred to Phase 3

### Validation

- `terraform fmt`: passed
- `terraform fmt -check`: passed
- `terraform init -backend=false`: passed
- `terraform validate`: passed
- Preview scope safeguards: passed
- Terraform tests: report result in PR
- `git diff --check`: passed

This PR remains draft pending authoritative HCP speculative-plan review.

No Terraform apply or cloud mutation is authorized.
