### PR TITLE
Fix B7 Phase 2 Firebase project initialization IAM

### DIFF
--- a/docs/strategy/preview-infrastructure/phase-b-b7-datastore-auth-foundation.md
+++ b/docs/strategy/preview-infrastructure/phase-b-b7-datastore-auth-foundation.md
@@ -120,9 +120,18 @@ existing Cloud Run roles:
 - `hcpTerraformPreviewB7Reader` contains exactly the four permissions in
   `tests/hcp_b7_plan_permission_delta.txt` and is bound only to
   `hcp-terraform-preview@rentchain-preview.iam.gserviceaccount.com`;
-- `terraformPreviewB7Manager` contains exactly the eight permissions in
+- `terraformPreviewB7Manager` contains exactly the nine permissions in
   `tests/hcp_b7_apply_permission_delta.txt` and is bound only to
   `hcp-terraform-preview-apply@rentchain-preview.iam.gserviceaccount.com`.
+
+The first Phase 2 apply partially succeeded: the protected Firestore database is
+recorded in Terraform state, while Identity Platform and the restricted API key
+remain absent. During Identity Platform initialization, the Google provider
+invokes Firebase `AddFirebase` before creating the Identity Platform
+configuration. Audit logs proved that `firebase.projects.update` was the sole
+denied prerequisite permission; `firebaseauth.configs.create` was already
+granted. The apply manager therefore includes that one additional permission.
+No manual Firebase project association or Terraform import was performed.
 
 The HCP apply identity already has the governed IAM role-management and project
 policy permissions needed to create these roles and bindings. Do not substitute

--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -119,13 +119,14 @@ check "b7_hcp_bootstrap_iam_boundary" {
         "apikeys.keys.getKeyString",
         "datastore.databases.create",
         "datastore.databases.getMetadata",
+        "firebase.projects.update",
         "firebaseauth.configs.create",
         "firebaseauth.configs.get",
         "firebaseauth.configs.update",
       ]) &&
       google_project_iam_member.terraform_preview_b7_manager.member == local.hcp_terraform_apply_member
     )
-    error_message = "The B7 apply manager must remain the exact eight-permission role bound only to the HCP apply identity."
+    error_message = "The B7 apply manager must remain the exact nine-permission role bound only to the HCP apply identity."
   }
 }
 

--- a/infra/environments/preview-foundation/iam.tf
+++ b/infra/environments/preview-foundation/iam.tf
@@ -28,6 +28,7 @@ locals {
     "apikeys.keys.getKeyString",
     "datastore.databases.create",
     "datastore.databases.getMetadata",
+    "firebase.projects.update",
     "firebaseauth.configs.create",
     "firebaseauth.configs.get",
     "firebaseauth.configs.update",

--- a/infra/environments/preview-foundation/tests/hcp_b7_apply_permission_delta.txt
+++ b/infra/environments/preview-foundation/tests/hcp_b7_apply_permission_delta.txt
@@ -3,6 +3,7 @@ apikeys.keys.get
 apikeys.keys.getKeyString
 datastore.databases.create
 datastore.databases.getMetadata
+firebase.projects.update
 firebaseauth.configs.create
 firebaseauth.configs.get
 firebaseauth.configs.update

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -161,6 +161,7 @@ apikeys.keys.get
 apikeys.keys.getKeyString
 datastore.databases.create
 datastore.databases.getMetadata
+firebase.projects.update
 firebaseauth.configs.create
 firebaseauth.configs.get
 firebaseauth.configs.update
@@ -181,7 +182,7 @@ if sed -n '/resource "google_project_iam_custom_role" "hcp_terraform_preview_b7_
   exit 1
 fi
 
-if printf '%s\n%s\n' "$actual_b7_reader_permissions" "$actual_b7_manager_permissions" | rg -n '(delete|users\.|token|run\.|storage\.|billing|secretmanager|firebase\.|identitytoolkit\.)'; then
+if printf '%s\n%s\n' "$actual_b7_reader_permissions" "$actual_b7_manager_permissions" | rg -n '(delete|users\.|token|run\.|storage\.|billing|secretmanager|firebase\.projects\.(delete|get)|identitytoolkit\.)'; then
   echo "Forbidden permission found in B7 HCP bootstrap roles" >&2
   exit 1
 fi
@@ -306,7 +307,7 @@ firebaseauth.configs.update
 EOF
 )"
 test "$(sort -u "$b7_apply_delta_file")" = "$expected_b7_apply_delta"
-test "$(wc -l < "$b7_apply_delta_file" | tr -d ' ')" = "8"
+test "$(wc -l < "$b7_apply_delta_file" | tr -d ' ')" = "9"
 
 if rg -n '(delete|undelete|users\.(create|delete|update|sendEmail)|getSecret|getHashConfig|serviceAccountKeys|signBlob|signJwt|getAccessToken|generateAccessToken|run\.|storage\.|billing)' "$b7_plan_delta_file" "$b7_apply_delta_file"; then
   echo "Forbidden B7 HCP permission delta found" >&2


### PR DESCRIPTION
## Summary

Adds the single prerequisite permission proven necessary by the failed B7 Phase 2 apply:

- `firebase.projects.update`

The Google provider invokes Firebase Management API `AddFirebase` before initializing Identity Platform. Cloud Audit Logs confirmed:

- `firebase.projects.update`: denied
- `firebaseauth.configs.create`: granted

### Partial apply state

Already created and recorded:

- `google_firestore_database.preview[0]`

Still absent:

- `google_identity_platform_config.preview[0]`
- `google_apikeys_key.preview_backend_auth[0]`

Current Terraform state count:

- 31 resources

### IAM correction

Updates only the existing custom role:

- `terraformPreviewB7Manager`

Final exact permission count:

- 9

No broad predefined Firebase or Identity Platform role is added.

### Boundaries

- Firestore unchanged
- Cloud Run unchanged
- Phase 3 runtime IAM absent
- no manual Firebase association
- no users or fixtures
- no Terraform import
- no production mutation
- no Terraform apply authorized by this PR

### Validation

- `terraform fmt`: passed
- `terraform fmt -check`: passed
- `terraform init -backend=false`: passed
- `terraform validate`: passed
- Preview scope safeguards: passed
- `git diff --check`: passed

This PR remains draft pending authoritative HCP recovery-plan review.
