### PR TITLE
Add B7 custom-role updater bootstrap stage

### DIFF
--- a/docs/strategy/preview-infrastructure/phase-b-b7-datastore-auth-foundation.md
+++ b/docs/strategy/preview-infrastructure/phase-b-b7-datastore-auth-foundation.md
@@ -133,6 +133,16 @@ denied prerequisite permission; `firebaseauth.configs.create` was already
 granted. The apply manager therefore includes that one additional permission.
 No manual Firebase project association or Terraform import was performed.
 
+Phase 2 recovery uses a two-stage bootstrap because the HCP apply identity can
+create and bind project custom roles but cannot update an existing custom role.
+Recovery stage 1 creates `terraformPreviewCustomRoleUpdater`, containing only
+`iam.roles.update`, and binds it only to the HCP Preview apply identity. During
+that stage, `terraformPreviewB7Manager` retains its existing eight permissions,
+Firestore remains managed, and Identity Platform plus the API key are
+suppressed. Recovery stage 2 retains the updater role, adds only
+`firebase.projects.update` to the B7 manager, and resumes the two absent Phase 2
+resources. The recovery stage is a plan boundary, not apply authorization.
+
 The HCP apply identity already has the governed IAM role-management and project
 policy permissions needed to create these roles and bindings. Do not substitute
 the apply identity for the plan identity and do not widen Workload Identity

--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -62,7 +62,7 @@ check "b7_preview_datastore_boundary" {
 
 check "b7_preview_authentication_boundary" {
   assert {
-    condition = var.b7_foundation_phase < 2 ? true : (
+    condition = var.b7_foundation_phase < 2 || var.b7_phase2_recovery_stage < 2 ? true : (
       google_identity_platform_config.preview[0].project == "rentchain-preview" &&
       local.preview_identity_authorized_domains == toset(["localhost"]) &&
       google_identity_platform_config.preview[0].sign_in[0].email[0].enabled &&
@@ -85,7 +85,7 @@ check "b7_preview_authentication_boundary" {
   }
 
   assert {
-    condition = var.b7_foundation_phase < 2 ? true : (
+    condition = var.b7_foundation_phase < 2 || var.b7_phase2_recovery_stage < 2 ? true : (
       google_apikeys_key.preview_backend_auth[0].project == "rentchain-preview" &&
       google_apikeys_key.preview_backend_auth[0].restrictions[0].api_targets[0].service == "identitytoolkit.googleapis.com"
     )
@@ -113,20 +113,33 @@ check "b7_hcp_bootstrap_iam_boundary" {
     condition = (
       google_project_iam_custom_role.terraform_preview_b7_manager.project == "rentchain-preview" &&
       google_project_iam_custom_role.terraform_preview_b7_manager.role_id == "terraformPreviewB7Manager" &&
-      local.terraform_preview_b7_manager_permissions == toset([
+      local.terraform_preview_b7_manager_base_permissions == toset([
         "apikeys.keys.create",
         "apikeys.keys.get",
         "apikeys.keys.getKeyString",
         "datastore.databases.create",
         "datastore.databases.getMetadata",
-        "firebase.projects.update",
         "firebaseauth.configs.create",
         "firebaseauth.configs.get",
         "firebaseauth.configs.update",
       ]) &&
+      local.terraform_preview_b7_manager_permissions == setunion(
+        local.terraform_preview_b7_manager_base_permissions,
+        var.b7_phase2_recovery_stage >= 2 ? toset(["firebase.projects.update"]) : toset([]),
+      ) &&
       google_project_iam_member.terraform_preview_b7_manager.member == local.hcp_terraform_apply_member
     )
-    error_message = "The B7 apply manager must remain the exact nine-permission role bound only to the HCP apply identity."
+    error_message = "The B7 apply manager must remain at eight permissions in recovery stage 1 and add only firebase.projects.update in stage 2."
+  }
+
+  assert {
+    condition = (
+      google_project_iam_custom_role.terraform_preview_custom_role_updater.project == "rentchain-preview" &&
+      google_project_iam_custom_role.terraform_preview_custom_role_updater.role_id == "terraformPreviewCustomRoleUpdater" &&
+      local.terraform_preview_custom_role_updater_permissions == toset(["iam.roles.update"]) &&
+      google_project_iam_member.terraform_preview_custom_role_updater.member == local.hcp_terraform_apply_member
+    )
+    error_message = "The B7 recovery updater must remain the exact one-permission project role bound only to the HCP apply identity."
   }
 }
 

--- a/infra/environments/preview-foundation/datastore_auth.tf
+++ b/infra/environments/preview-foundation/datastore_auth.tf
@@ -43,7 +43,7 @@ resource "google_firestore_database" "preview" {
 }
 
 resource "google_identity_platform_config" "preview" {
-  count = var.b7_foundation_phase >= 2 ? 1 : 0
+  count = var.b7_foundation_phase >= 2 && var.b7_phase2_recovery_stage >= 2 ? 1 : 0
 
   project = var.project_id
 
@@ -87,7 +87,7 @@ resource "google_identity_platform_config" "preview" {
 }
 
 resource "google_apikeys_key" "preview_backend_auth" {
-  count = var.b7_foundation_phase >= 2 ? 1 : 0
+  count = var.b7_foundation_phase >= 2 && var.b7_phase2_recovery_stage >= 2 ? 1 : 0
 
   project      = var.project_id
   name         = "preview-backend-auth"

--- a/infra/environments/preview-foundation/iam.tf
+++ b/infra/environments/preview-foundation/iam.tf
@@ -22,16 +22,24 @@ locals {
     "firebaseauth.configs.get",
   ])
 
-  terraform_preview_b7_manager_permissions = toset([
+  terraform_preview_b7_manager_base_permissions = toset([
     "apikeys.keys.create",
     "apikeys.keys.get",
     "apikeys.keys.getKeyString",
     "datastore.databases.create",
     "datastore.databases.getMetadata",
-    "firebase.projects.update",
     "firebaseauth.configs.create",
     "firebaseauth.configs.get",
     "firebaseauth.configs.update",
+  ])
+
+  terraform_preview_b7_manager_permissions = setunion(
+    local.terraform_preview_b7_manager_base_permissions,
+    var.b7_phase2_recovery_stage >= 2 ? toset(["firebase.projects.update"]) : toset([]),
+  )
+
+  terraform_preview_custom_role_updater_permissions = toset([
+    "iam.roles.update",
   ])
 }
 
@@ -74,6 +82,29 @@ resource "google_project_iam_custom_role" "terraform_preview_b7_manager" {
 resource "google_project_iam_member" "terraform_preview_b7_manager" {
   project = var.project_id
   role    = google_project_iam_custom_role.terraform_preview_b7_manager.name
+  member  = local.hcp_terraform_apply_member
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_project_iam_custom_role" "terraform_preview_custom_role_updater" {
+  project     = var.project_id
+  role_id     = "terraformPreviewCustomRoleUpdater"
+  title       = "Terraform Preview Custom Role Updater"
+  description = "Allows the HCP Preview apply identity to update governed project custom-role definitions."
+  permissions = local.terraform_preview_custom_role_updater_permissions
+  stage       = "GA"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_project_iam_member" "terraform_preview_custom_role_updater" {
+  project = var.project_id
+  role    = google_project_iam_custom_role.terraform_preview_custom_role_updater.name
   member  = local.hcp_terraform_apply_member
 
   lifecycle {

--- a/infra/environments/preview-foundation/outputs.tf
+++ b/infra/environments/preview-foundation/outputs.tf
@@ -52,7 +52,7 @@ output "preview_backend_service" {
 
 output "preview_datastore_auth_foundation" {
   description = "Non-sensitive identifiers for the isolated B7 datastore and authentication foundation."
-  value = var.b7_foundation_phase >= 2 ? {
+  value = var.b7_foundation_phase >= 2 && var.b7_phase2_recovery_stage >= 2 ? {
     project_id              = var.project_id
     database_id             = google_firestore_database.preview[0].name
     firestore_location      = google_firestore_database.preview[0].location_id

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -30,7 +30,7 @@ EOF
 actual_resources="$(rg -No 'resource "[^"]+"' "$root_dir" --glob '*.tf' | sed -E 's/.*resource "([^"]+)"/\1/' | sort -u)"
 test "$actual_resources" = "$expected_resources"
 
-test "$(rg -No '^resource "[^"]+"' "$root_dir" --glob '*.tf' | wc -l | tr -d ' ')" = "30"
+test "$(rg -No '^resource "[^"]+"' "$root_dir" --glob '*.tf' | wc -l | tr -d ' ')" = "32"
 
 test "$(rg -No 'service\s*=\s*"[^"]+\.googleapis\.com"' "$root_dir/services.tf" | wc -l | tr -d ' ')" = "0"
 test "$(rg -No '"(apikeys|artifactregistry|cloudresourcemanager|firestore|iam|identitytoolkit|run|serviceusage)\.googleapis\.com"' "$root_dir/services.tf" | sort -u | wc -l | tr -d ' ')" = "8"
@@ -46,6 +46,8 @@ rg -q 'default     = true' "$root_dir/variables.tf"
 rg -q 'variable "b7_foundation_phase"' "$root_dir/variables.tf"
 rg -U -q 'variable "b7_foundation_phase" \{\n  description = "[^"]+"\n  type        = number\n  default     = 2' "$root_dir/variables.tf"
 grep -Fq 'condition     = contains([1, 2, 3], var.b7_foundation_phase)' "$root_dir/variables.tf"
+rg -U -q 'variable "b7_phase2_recovery_stage" \{\n  description = "[^"]+"\n  type        = number\n  default     = 1' "$root_dir/variables.tf"
+grep -Fq 'condition     = contains([1, 2], var.b7_phase2_recovery_stage)' "$root_dir/variables.tf"
 rg -q 'count    = var\.enable_preview_backend_service \? 1 : 0' "$root_dir/cloud_run.tf"
 rg -U -q 'lifecycle \{\n    prevent_destroy = true\n    ignore_changes = \[\n      scaling,\n    \]\n  \}' "$root_dir/cloud_run.tf"
 test "$(rg -No 'ignore_changes' "$root_dir" --glob '*.tf' | wc -l | tr -d ' ')" = "1"
@@ -108,7 +110,8 @@ if rg -n 'FIRESTORE_DATABASE_ID|PREVIEW_AUTH_ENABLED|FIREBASE_PROJECT_ID|FIREBAS
   exit 1
 fi
 
-test "$(rg -No 'count = var\.b7_foundation_phase >= 2 \? 1 : 0' "$root_dir/datastore_auth.tf" | wc -l | tr -d ' ')" = "3"
+test "$(rg -No 'count = var\.b7_foundation_phase >= 2 \? 1 : 0' "$root_dir/datastore_auth.tf" | wc -l | tr -d ' ')" = "1"
+test "$(rg -No 'count = var\.b7_foundation_phase >= 2 && var\.b7_phase2_recovery_stage >= 2 \? 1 : 0' "$root_dir/datastore_auth.tf" | wc -l | tr -d ' ')" = "2"
 test "$(rg -No 'count = var\.b7_foundation_phase >= 3 \? 1 : 0' "$root_dir/datastore_auth.tf" | wc -l | tr -d ' ')" = "4"
 
 test "$(rg -No '^resource "google_artifact_registry_repository"' "$root_dir" --glob '*.tf' | wc -l | tr -d ' ')" = "1"
@@ -155,34 +158,38 @@ test "$actual_b7_reader_permissions" = "$expected_b7_reader_permissions"
 rg -q 'role_id     = "terraformPreviewB7Manager"' "$root_dir/iam.tf"
 rg -q 'resource "google_project_iam_member" "terraform_preview_b7_manager"' "$root_dir/iam.tf"
 rg -q 'member  = local\.hcp_terraform_apply_member' "$root_dir/iam.tf"
-expected_b7_manager_permissions="$(cat <<'EOF'
+expected_b7_manager_base_permissions="$(cat <<'EOF'
 apikeys.keys.create
 apikeys.keys.get
 apikeys.keys.getKeyString
 datastore.databases.create
 datastore.databases.getMetadata
-firebase.projects.update
 firebaseauth.configs.create
 firebaseauth.configs.get
 firebaseauth.configs.update
 EOF
 )"
-actual_b7_manager_permissions="$(
-  sed -n '/terraform_preview_b7_manager_permissions = toset(/,/])/p' "$root_dir/iam.tf" \
+actual_b7_manager_base_permissions="$(
+  sed -n '/terraform_preview_b7_manager_base_permissions = toset(/,/])/p' "$root_dir/iam.tf" \
     | rg -No '"[^"]+"' \
     | tr -d '"' \
     | sort -u
 )"
-test "$actual_b7_manager_permissions" = "$expected_b7_manager_permissions"
+test "$actual_b7_manager_base_permissions" = "$expected_b7_manager_base_permissions"
+grep -Fq 'var.b7_phase2_recovery_stage >= 2 ? toset(["firebase.projects.update"]) : toset([])' "$root_dir/iam.tf"
 
-test "$(rg -No '^resource "google_project_iam_custom_role" "(hcp_terraform_preview_b7_reader|terraform_preview_b7_manager)"' "$root_dir/iam.tf" | wc -l | tr -d ' ')" = "2"
-test "$(rg -No '^resource "google_project_iam_member" "(hcp_terraform_preview_b7_reader|terraform_preview_b7_manager)"' "$root_dir/iam.tf" | wc -l | tr -d ' ')" = "2"
+rg -q 'role_id     = "terraformPreviewCustomRoleUpdater"' "$root_dir/iam.tf"
+test "$(sed -n '/terraform_preview_custom_role_updater_permissions = toset(/,/])/p' "$root_dir/iam.tf" | rg -No '"[^"]+"' | tr -d '"')" = "iam.roles.update"
+rg -q 'resource "google_project_iam_member" "terraform_preview_custom_role_updater"' "$root_dir/iam.tf"
+rg -q 'member  = local\.hcp_terraform_apply_member' "$root_dir/iam.tf"
+test "$(rg -No '^resource "google_project_iam_custom_role" "(hcp_terraform_preview_b7_reader|terraform_preview_b7_manager|terraform_preview_custom_role_updater)"' "$root_dir/iam.tf" | wc -l | tr -d ' ')" = "3"
+test "$(rg -No '^resource "google_project_iam_member" "(hcp_terraform_preview_b7_reader|terraform_preview_b7_manager|terraform_preview_custom_role_updater)"' "$root_dir/iam.tf" | wc -l | tr -d ' ')" = "3"
 if sed -n '/resource "google_project_iam_custom_role" "hcp_terraform_preview_b7_reader"/,/^}/p; /resource "google_project_iam_member" "hcp_terraform_preview_b7_reader"/,/^}/p; /resource "google_project_iam_custom_role" "terraform_preview_b7_manager"/,/^}/p; /resource "google_project_iam_member" "terraform_preview_b7_manager"/,/^}/p' "$root_dir/iam.tf" | rg -n 'count\s*=|for_each\s*='; then
   echo "B7 bootstrap IAM resources must remain ungated in Phase 1" >&2
   exit 1
 fi
 
-if printf '%s\n%s\n' "$actual_b7_reader_permissions" "$actual_b7_manager_permissions" | rg -n '(delete|users\.|token|run\.|storage\.|billing|secretmanager|firebase\.projects\.(delete|get)|identitytoolkit\.)'; then
+if printf '%s\n%s\n%s\n' "$actual_b7_reader_permissions" "$actual_b7_manager_base_permissions" "iam.roles.update" | rg -n '(delete|users\.|token|run\.|storage\.|billing|secretmanager|firebase\.projects\.(delete|get)|identitytoolkit\.)'; then
   echo "Forbidden permission found in B7 HCP bootstrap roles" >&2
   exit 1
 fi
@@ -301,6 +308,7 @@ apikeys.keys.get
 apikeys.keys.getKeyString
 datastore.databases.create
 datastore.databases.getMetadata
+firebase.projects.update
 firebaseauth.configs.create
 firebaseauth.configs.get
 firebaseauth.configs.update

--- a/infra/environments/preview-foundation/variables.tf
+++ b/infra/environments/preview-foundation/variables.tf
@@ -81,3 +81,14 @@ variable "b7_foundation_phase" {
     error_message = "b7_foundation_phase must be exactly 1, 2, or 3."
   }
 }
+
+variable "b7_phase2_recovery_stage" {
+  description = "B7 Phase 2 recovery gate: 1=custom-role updater bootstrap only, 2=resume manager update and Phase 2 resources."
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = contains([1, 2], var.b7_phase2_recovery_stage)
+    error_message = "b7_phase2_recovery_stage must be exactly 1 or 2."
+  }
+}


### PR DESCRIPTION
## Summary

Adds a narrowly staged bootstrap role so the HCP Preview apply identity can update governed project custom roles.

### Root cause

The B7 Phase 2 recovery apply failed because the apply identity lacked:

- `iam.roles.update`

That prevented Terraform from adding `firebase.projects.update` to `terraformPreviewB7Manager`.

### Bootstrap role

Creates:

- `google_project_iam_custom_role.terraform_preview_custom_role_updater`
- `google_project_iam_member.terraform_preview_custom_role_updater`

Exact permission:

- `iam.roles.update`

Exact principal:

- `hcp-terraform-preview-apply@rentchain-preview.iam.gserviceaccount.com`

### Recovery staging

Recovery stage defaults to `1`.

At stage 1:

- updater role and binding are created
- B7 manager remains at its existing eight permissions
- Identity Platform is suppressed
- restricted API key is suppressed
- Firestore remains managed and unchanged
- Phase 2 output is suppressed safely

At stage 2:

- `firebase.projects.update` is added to the B7 manager
- Identity Platform and the restricted API key may resume

### Boundaries

- no Firestore mutation
- no Cloud Run change
- no Phase 3 runtime IAM
- no users or fixtures
- no production change
- no broad IAM role
- no Terraform apply authorized by this PR

### Validation

- `terraform fmt`: passed
- `terraform fmt -check`: passed
- `terraform init -backend=false`: passed
- `terraform validate`: passed
- Preview scope safeguards: passed
- `git diff --check`: passed

This PR remains draft pending authoritative two-resource HCP plan review.
