### PR TITLE
Add B7 Firebase project read IAM

### DIFF
--- a/docs/strategy/preview-infrastructure/phase-b-b7-datastore-auth-foundation.md
+++ b/docs/strategy/preview-infrastructure/phase-b-b7-datastore-auth-foundation.md
@@ -117,12 +117,17 @@ The B7 speculative plan is not apply authorization.
 Phase 1 creates two dedicated B7 custom roles rather than broadening the
 existing Cloud Run roles:
 
-- `hcpTerraformPreviewB7Reader` contains exactly the four permissions in
+- `hcpTerraformPreviewB7Reader` contains exactly the five permissions in
   `tests/hcp_b7_plan_permission_delta.txt` and is bound only to
   `hcp-terraform-preview@rentchain-preview.iam.gserviceaccount.com`;
-- `terraformPreviewB7Manager` contains exactly the nine permissions in
+- `terraformPreviewB7Manager` contains exactly the ten permissions in
   `tests/hcp_b7_apply_permission_delta.txt` and is bound only to
   `hcp-terraform-preview-apply@rentchain-preview.iam.gserviceaccount.com`.
+
+Both roles include `firebase.projects.get` so Terraform can refresh an existing
+Preview Firebase project association during planning, ownership import, and
+post-import lifecycle checks. This is read-only Firebase project metadata
+access; no broad Firebase role or project-delete permission is granted.
 
 The first Phase 2 apply partially succeeded: the protected Firestore database is
 recorded in Terraform state, while Identity Platform and the restricted API key
@@ -137,7 +142,7 @@ Phase 2 recovery uses a two-stage bootstrap because the HCP apply identity can
 create and bind project custom roles but cannot update an existing custom role.
 Recovery stage 1 creates `terraformPreviewCustomRoleUpdater`, containing only
 `iam.roles.update`, and binds it only to the HCP Preview apply identity. During
-that stage, `terraformPreviewB7Manager` retains its existing eight permissions,
+that stage, `terraformPreviewB7Manager` retains its existing nine permissions,
 Firestore remains managed, and Identity Platform plus the API key are
 suppressed. The current default, recovery stage 2, retains the updater role, adds
 only `firebase.projects.update` to the B7 manager, and resumes the two absent

--- a/docs/strategy/preview-infrastructure/phase-b-b7-datastore-auth-foundation.md
+++ b/docs/strategy/preview-infrastructure/phase-b-b7-datastore-auth-foundation.md
@@ -144,10 +144,13 @@ Recovery stage 1 creates `terraformPreviewCustomRoleUpdater`, containing only
 `iam.roles.update`, and binds it only to the HCP Preview apply identity. During
 that stage, `terraformPreviewB7Manager` retains its existing nine permissions,
 Firestore remains managed, and Identity Platform plus the API key are
-suppressed. The current default, recovery stage 2, retains the updater role, adds
-only `firebase.projects.update` to the B7 manager, and resumes the two absent
-Phase 2 resources. The recovery stage is a plan boundary, not apply
-authorization.
+suppressed. The current default, recovery stage 2, retains the updater role and
+adds only `firebase.projects.update` to the B7 manager. A separate
+default-false `b7_identity_platform_activation` gate controls only Identity
+Platform, the restricted API key, and their non-sensitive output. This keeps the
+two resources suppressed while Firebase project read IAM is reviewed, without
+gating Firestore or either recovery IAM role. Both gates are plan boundaries,
+not apply authorization.
 
 The HCP apply identity already has the governed IAM role-management and project
 policy permissions needed to create these roles and bindings. Do not substitute

--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -62,7 +62,7 @@ check "b7_preview_datastore_boundary" {
 
 check "b7_preview_authentication_boundary" {
   assert {
-    condition = var.b7_foundation_phase < 2 || var.b7_phase2_recovery_stage < 2 ? true : (
+    condition = var.b7_foundation_phase < 2 || var.b7_phase2_recovery_stage < 2 || !var.b7_identity_platform_activation ? true : (
       google_identity_platform_config.preview[0].project == "rentchain-preview" &&
       local.preview_identity_authorized_domains == toset(["localhost"]) &&
       google_identity_platform_config.preview[0].sign_in[0].email[0].enabled &&
@@ -85,7 +85,7 @@ check "b7_preview_authentication_boundary" {
   }
 
   assert {
-    condition = var.b7_foundation_phase < 2 || var.b7_phase2_recovery_stage < 2 ? true : (
+    condition = var.b7_foundation_phase < 2 || var.b7_phase2_recovery_stage < 2 || !var.b7_identity_platform_activation ? true : (
       google_apikeys_key.preview_backend_auth[0].project == "rentchain-preview" &&
       google_apikeys_key.preview_backend_auth[0].restrictions[0].api_targets[0].service == "identitytoolkit.googleapis.com"
     )

--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -102,11 +102,12 @@ check "b7_hcp_bootstrap_iam_boundary" {
         "apikeys.keys.get",
         "apikeys.keys.getKeyString",
         "datastore.databases.getMetadata",
+        "firebase.projects.get",
         "firebaseauth.configs.get",
       ]) &&
       google_project_iam_member.hcp_terraform_preview_b7_reader.member == local.hcp_terraform_plan_member
     )
-    error_message = "The B7 plan reader must remain the exact four-permission role bound only to the HCP plan identity."
+    error_message = "The B7 plan reader must remain the exact five-permission role bound only to the HCP plan identity."
   }
 
   assert {
@@ -119,6 +120,7 @@ check "b7_hcp_bootstrap_iam_boundary" {
         "apikeys.keys.getKeyString",
         "datastore.databases.create",
         "datastore.databases.getMetadata",
+        "firebase.projects.get",
         "firebaseauth.configs.create",
         "firebaseauth.configs.get",
         "firebaseauth.configs.update",
@@ -129,7 +131,7 @@ check "b7_hcp_bootstrap_iam_boundary" {
       ) &&
       google_project_iam_member.terraform_preview_b7_manager.member == local.hcp_terraform_apply_member
     )
-    error_message = "The B7 apply manager must remain at eight permissions in recovery stage 1 and add only firebase.projects.update in stage 2."
+    error_message = "The B7 apply manager must remain at nine permissions in recovery stage 1 and add only firebase.projects.update in stage 2."
   }
 
   assert {

--- a/infra/environments/preview-foundation/datastore_auth.tf
+++ b/infra/environments/preview-foundation/datastore_auth.tf
@@ -43,7 +43,7 @@ resource "google_firestore_database" "preview" {
 }
 
 resource "google_identity_platform_config" "preview" {
-  count = var.b7_foundation_phase >= 2 && var.b7_phase2_recovery_stage >= 2 ? 1 : 0
+  count = var.b7_foundation_phase >= 2 && var.b7_phase2_recovery_stage >= 2 && var.b7_identity_platform_activation ? 1 : 0
 
   project = var.project_id
 
@@ -87,7 +87,7 @@ resource "google_identity_platform_config" "preview" {
 }
 
 resource "google_apikeys_key" "preview_backend_auth" {
-  count = var.b7_foundation_phase >= 2 && var.b7_phase2_recovery_stage >= 2 ? 1 : 0
+  count = var.b7_foundation_phase >= 2 && var.b7_phase2_recovery_stage >= 2 && var.b7_identity_platform_activation ? 1 : 0
 
   project      = var.project_id
   name         = "preview-backend-auth"

--- a/infra/environments/preview-foundation/iam.tf
+++ b/infra/environments/preview-foundation/iam.tf
@@ -19,6 +19,7 @@ locals {
     "apikeys.keys.get",
     "apikeys.keys.getKeyString",
     "datastore.databases.getMetadata",
+    "firebase.projects.get",
     "firebaseauth.configs.get",
   ])
 
@@ -28,6 +29,7 @@ locals {
     "apikeys.keys.getKeyString",
     "datastore.databases.create",
     "datastore.databases.getMetadata",
+    "firebase.projects.get",
     "firebaseauth.configs.create",
     "firebaseauth.configs.get",
     "firebaseauth.configs.update",

--- a/infra/environments/preview-foundation/outputs.tf
+++ b/infra/environments/preview-foundation/outputs.tf
@@ -52,7 +52,7 @@ output "preview_backend_service" {
 
 output "preview_datastore_auth_foundation" {
   description = "Non-sensitive identifiers for the isolated B7 datastore and authentication foundation."
-  value = var.b7_foundation_phase >= 2 && var.b7_phase2_recovery_stage >= 2 ? {
+  value = var.b7_foundation_phase >= 2 && var.b7_phase2_recovery_stage >= 2 && var.b7_identity_platform_activation ? {
     project_id              = var.project_id
     database_id             = google_firestore_database.preview[0].name
     firestore_location      = google_firestore_database.preview[0].location_id

--- a/infra/environments/preview-foundation/tests/hcp_b7_apply_permission_delta.txt
+++ b/infra/environments/preview-foundation/tests/hcp_b7_apply_permission_delta.txt
@@ -3,6 +3,7 @@ apikeys.keys.get
 apikeys.keys.getKeyString
 datastore.databases.create
 datastore.databases.getMetadata
+firebase.projects.get
 firebase.projects.update
 firebaseauth.configs.create
 firebaseauth.configs.get

--- a/infra/environments/preview-foundation/tests/hcp_b7_plan_permission_delta.txt
+++ b/infra/environments/preview-foundation/tests/hcp_b7_plan_permission_delta.txt
@@ -1,4 +1,5 @@
 apikeys.keys.get
 apikeys.keys.getKeyString
 datastore.databases.getMetadata
+firebase.projects.get
 firebaseauth.configs.get

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -48,6 +48,7 @@ rg -U -q 'variable "b7_foundation_phase" \{\n  description = "[^"]+"\n  type    
 grep -Fq 'condition     = contains([1, 2, 3], var.b7_foundation_phase)' "$root_dir/variables.tf"
 rg -U -q 'variable "b7_phase2_recovery_stage" \{\n  description = "[^"]+"\n  type        = number\n  default     = 2' "$root_dir/variables.tf"
 grep -Fq 'condition     = contains([1, 2], var.b7_phase2_recovery_stage)' "$root_dir/variables.tf"
+rg -U -q 'variable "b7_identity_platform_activation" \{\n  description = "[^"]+"\n  type        = bool\n  default     = false\n\}' "$root_dir/variables.tf"
 rg -q 'count    = var\.enable_preview_backend_service \? 1 : 0' "$root_dir/cloud_run.tf"
 rg -U -q 'lifecycle \{\n    prevent_destroy = true\n    ignore_changes = \[\n      scaling,\n    \]\n  \}' "$root_dir/cloud_run.tf"
 test "$(rg -No 'ignore_changes' "$root_dir" --glob '*.tf' | wc -l | tr -d ' ')" = "1"
@@ -111,7 +112,12 @@ if rg -n 'FIRESTORE_DATABASE_ID|PREVIEW_AUTH_ENABLED|FIREBASE_PROJECT_ID|FIREBAS
 fi
 
 test "$(rg -No 'count = var\.b7_foundation_phase >= 2 \? 1 : 0' "$root_dir/datastore_auth.tf" | wc -l | tr -d ' ')" = "1"
-test "$(rg -No 'count = var\.b7_foundation_phase >= 2 && var\.b7_phase2_recovery_stage >= 2 \? 1 : 0' "$root_dir/datastore_auth.tf" | wc -l | tr -d ' ')" = "2"
+test "$(rg -No 'count = var\.b7_foundation_phase >= 2 && var\.b7_phase2_recovery_stage >= 2 && var\.b7_identity_platform_activation \? 1 : 0' "$root_dir/datastore_auth.tf" | wc -l | tr -d ' ')" = "2"
+grep -Fq 'value = var.b7_foundation_phase >= 2 && var.b7_phase2_recovery_stage >= 2 && var.b7_identity_platform_activation ? {' "$root_dir/outputs.tf"
+if rg -n 'b7_identity_platform_activation' "$root_dir/cloud_run.tf" "$root_dir/iam.tf"; then
+  echo "The B7 Identity Platform activation gate must not control Cloud Run or IAM" >&2
+  exit 1
+fi
 test "$(rg -No 'count = var\.b7_foundation_phase >= 3 \? 1 : 0' "$root_dir/datastore_auth.tf" | wc -l | tr -d ' ')" = "4"
 
 test "$(rg -No '^resource "google_artifact_registry_repository"' "$root_dir" --glob '*.tf' | wc -l | tr -d ' ')" = "1"

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -144,6 +144,7 @@ expected_b7_reader_permissions="$(cat <<'EOF'
 apikeys.keys.get
 apikeys.keys.getKeyString
 datastore.databases.getMetadata
+firebase.projects.get
 firebaseauth.configs.get
 EOF
 )"
@@ -164,6 +165,7 @@ apikeys.keys.get
 apikeys.keys.getKeyString
 datastore.databases.create
 datastore.databases.getMetadata
+firebase.projects.get
 firebaseauth.configs.create
 firebaseauth.configs.get
 firebaseauth.configs.update
@@ -189,7 +191,7 @@ if sed -n '/resource "google_project_iam_custom_role" "hcp_terraform_preview_b7_
   exit 1
 fi
 
-if printf '%s\n%s\n%s\n' "$actual_b7_reader_permissions" "$actual_b7_manager_base_permissions" "iam.roles.update" | rg -n '(delete|users\.|token|run\.|storage\.|billing|secretmanager|firebase\.projects\.(delete|get)|identitytoolkit\.)'; then
+if printf '%s\n%s\n%s\n' "$actual_b7_reader_permissions" "$actual_b7_manager_base_permissions" "iam.roles.update" | rg -n '(delete|users\.|token|run\.|storage\.|billing|secretmanager|firebase\.projects\.delete|identitytoolkit\.)'; then
   echo "Forbidden permission found in B7 HCP bootstrap roles" >&2
   exit 1
 fi
@@ -296,11 +298,12 @@ expected_b7_plan_delta="$(cat <<'EOF'
 apikeys.keys.get
 apikeys.keys.getKeyString
 datastore.databases.getMetadata
+firebase.projects.get
 firebaseauth.configs.get
 EOF
 )"
 test "$(sort -u "$b7_plan_delta_file")" = "$expected_b7_plan_delta"
-test "$(wc -l < "$b7_plan_delta_file" | tr -d ' ')" = "4"
+test "$(wc -l < "$b7_plan_delta_file" | tr -d ' ')" = "5"
 
 expected_b7_apply_delta="$(cat <<'EOF'
 apikeys.keys.create
@@ -308,6 +311,7 @@ apikeys.keys.get
 apikeys.keys.getKeyString
 datastore.databases.create
 datastore.databases.getMetadata
+firebase.projects.get
 firebase.projects.update
 firebaseauth.configs.create
 firebaseauth.configs.get
@@ -315,7 +319,7 @@ firebaseauth.configs.update
 EOF
 )"
 test "$(sort -u "$b7_apply_delta_file")" = "$expected_b7_apply_delta"
-test "$(wc -l < "$b7_apply_delta_file" | tr -d ' ')" = "9"
+test "$(wc -l < "$b7_apply_delta_file" | tr -d ' ')" = "10"
 
 if rg -n '(delete|undelete|users\.(create|delete|update|sendEmail)|getSecret|getHashConfig|serviceAccountKeys|signBlob|signJwt|getAccessToken|generateAccessToken|run\.|storage\.|billing)' "$b7_plan_delta_file" "$b7_apply_delta_file"; then
   echo "Forbidden B7 HCP permission delta found" >&2

--- a/infra/environments/preview-foundation/variables.tf
+++ b/infra/environments/preview-foundation/variables.tf
@@ -92,3 +92,9 @@ variable "b7_phase2_recovery_stage" {
     error_message = "b7_phase2_recovery_stage must be exactly 1 or 2."
   }
 }
+
+variable "b7_identity_platform_activation" {
+  description = "Governed activation gate for Preview Identity Platform and the restricted backend API key."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Summary

Adds the exact Firebase project read permission required for governed Terraform ownership of the existing Preview Firebase project association.

### Plan identity

Adds only:

- `firebase.projects.get`

Final exact permission count:

- 5

### Apply identity

Adds only:

- `firebase.projects.get`

Final exact permission count:

- 10

The apply role retains:

- `firebase.projects.update`

### Boundaries

- no `google-beta` provider
- no Firebase project resource
- no import block
- no Identity Platform action
- no API-key action
- no Browser-key action
- no Firestore action
- no Cloud Run action
- no runtime IAM
- no production change
- no Terraform apply authorized by this PR

### Validation

- `terraform fmt`: passed
- `terraform fmt -check`: passed
- `terraform init -backend=false`: passed
- `terraform validate`: passed
- Preview scope safeguards: passed
- `git diff --check`: passed

This PR remains draft pending authoritative HCP plan review.
