### PR TITLE
Adopt Preview Firebase project into Terraform ownership

### DIFF
--- a/docs/strategy/preview-infrastructure/phase-b-b7-datastore-auth-foundation.md
+++ b/docs/strategy/preview-infrastructure/phase-b-b7-datastore-auth-foundation.md
@@ -134,6 +134,15 @@ when `user_project_override = true`. This does not grant API enablement,
 disablement, service discovery, billing administration, or a predefined Service
 Usage role.
 
+The active Firebase association for `rentchain-preview` is adopted through the
+`google-beta` 6.50.0 `google_firebase_project` resource and one declarative
+short-project-ID import. The resource uses `prevent_destroy` and manages only
+the existing Firebase project association. It does not manage the
+Firebase-created Browser key, any Firebase app, Hosting, analytics, Identity
+Platform, or the restricted backend key. The default-false Identity Platform
+activation gate remains unchanged, so this ownership adoption does not activate
+authentication or produce the datastore/auth output.
+
 The first Phase 2 apply partially succeeded: the protected Firestore database is
 recorded in Terraform state, while Identity Platform and the restricted API key
 remain absent. During Identity Platform initialization, the Google provider

--- a/infra/environments/preview-foundation/.terraform.lock.hcl
+++ b/infra/environments/preview-foundation/.terraform.lock.hcl
@@ -20,3 +20,23 @@ provider "registry.terraform.io/hashicorp/google" {
     "zh:fec30c095647b583a246c39d557704947195a1b7d41f81e369ba377d997faef6",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/google-beta" {
+  version     = "6.50.0"
+  constraints = "6.50.0"
+  hashes = [
+    "h1:P2GiUJM1frlPtBViwKn1A9V2dVBdGuWcX80w9TdH8ZE=",
+    "zh:18b442bd0a05321d39dda1e9e3f1bdede4e61bc2ac62cc7a67037a3864f75101",
+    "zh:2e387c51455862828bec923a3ec81abf63a4d998da470cf00e09003bda53d668",
+    "zh:3942e708fa84ebe54996086f4b1398cb747fe19cbcd0be07ace528291fb35dee",
+    "zh:496287dd48b34ae6197cb1f887abeafd07c33f389dbe431bb01e24846754cfdd",
+    "zh:6eca885419969ce5c2a706f34dce1f10bde9774757675f2d8a92d12e5a1be390",
+    "zh:710dbef826c3fe7f76f844dae47937e8e4c1279dd9205ec4610be04cf3327244",
+    "zh:777ebf44b24bfc7bdbf770dc089f1a72f143b4718fdedb8c6bd75983115a1ec2",
+    "zh:9c8703bba37b8c7ad857efc3513392c5a096c519397c1cb822d7612f38e4262f",
+    "zh:c4f1d3a73de2702277c99d5348ad6d374705bcfdd367ad964ff4cfd2cf06c281",
+    "zh:eca8df11af3f5a948492d5b8b5d01b4ec705aad10bc30ec1524205508ae28393",
+    "zh:f41e7fd5f2628e8fd6b8ea136366923858f54428d1729898925469b862c275c2",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -93,6 +93,16 @@ check "b7_preview_authentication_boundary" {
   }
 }
 
+check "b7_firebase_project_ownership_boundary" {
+  assert {
+    condition = (
+      google_firebase_project.preview.project == "rentchain-preview" &&
+      !var.b7_identity_platform_activation
+    )
+    error_message = "B7 Firebase ownership must remain limited to the existing Preview project while Identity Platform activation stays disabled."
+  }
+}
+
 check "b7_hcp_bootstrap_iam_boundary" {
   assert {
     condition = (

--- a/infra/environments/preview-foundation/firebase.tf
+++ b/infra/environments/preview-foundation/firebase.tf
@@ -1,0 +1,8 @@
+resource "google_firebase_project" "preview" {
+  provider = google-beta
+  project  = var.project_id
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/infra/environments/preview-foundation/imports.tf
+++ b/infra/environments/preview-foundation/imports.tf
@@ -1,0 +1,4 @@
+import {
+  to = google_firebase_project.preview
+  id = "rentchain-preview"
+}

--- a/infra/environments/preview-foundation/providers.tf
+++ b/infra/environments/preview-foundation/providers.tf
@@ -1,3 +1,8 @@
 provider "google" {
   project = var.project_id
 }
+
+provider "google-beta" {
+  project               = var.project_id
+  user_project_override = true
+}

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -16,6 +16,7 @@ google_apikeys_key
 google_artifact_registry_repository
 google_artifact_registry_repository_iam_member
 google_cloud_run_v2_service
+google_firebase_project
 google_firestore_database
 google_iam_workload_identity_pool
 google_iam_workload_identity_pool_provider
@@ -30,7 +31,7 @@ EOF
 actual_resources="$(rg -No 'resource "[^"]+"' "$root_dir" --glob '*.tf' | sed -E 's/.*resource "([^"]+)"/\1/' | sort -u)"
 test "$actual_resources" = "$expected_resources"
 
-test "$(rg -No '^resource "[^"]+"' "$root_dir" --glob '*.tf' | wc -l | tr -d ' ')" = "32"
+test "$(rg -No '^resource "[^"]+"' "$root_dir" --glob '*.tf' | wc -l | tr -d ' ')" = "33"
 
 test "$(rg -No 'service\s*=\s*"[^"]+\.googleapis\.com"' "$root_dir/services.tf" | wc -l | tr -d ' ')" = "0"
 test "$(rg -No '"(apikeys|artifactregistry|cloudresourcemanager|firestore|iam|identitytoolkit|run|serviceusage)\.googleapis\.com"' "$root_dir/services.tf" | sort -u | wc -l | tr -d ' ')" = "8"
@@ -49,6 +50,17 @@ grep -Fq 'condition     = contains([1, 2, 3], var.b7_foundation_phase)' "$root_d
 rg -U -q 'variable "b7_phase2_recovery_stage" \{\n  description = "[^"]+"\n  type        = number\n  default     = 2' "$root_dir/variables.tf"
 grep -Fq 'condition     = contains([1, 2], var.b7_phase2_recovery_stage)' "$root_dir/variables.tf"
 rg -U -q 'variable "b7_identity_platform_activation" \{\n  description = "[^"]+"\n  type        = bool\n  default     = false\n\}' "$root_dir/variables.tf"
+rg -U -q 'google-beta = \{\n      source  = "hashicorp/google-beta"\n      version = "6\.50\.0"\n    \}' "$root_dir/versions.tf"
+rg -U -q 'provider "google-beta" \{\n  project               = var\.project_id\n  user_project_override = true\n\}' "$root_dir/providers.tf"
+rg -U -q 'resource "google_firebase_project" "preview" \{\n  provider = google-beta\n  project  = var\.project_id\n\n  lifecycle \{\n    prevent_destroy = true\n  \}\n\}' "$root_dir/firebase.tf"
+rg -U -q 'import \{\n  to = google_firebase_project\.preview\n  id = "rentchain-preview"\n\}' "$root_dir/imports.tf"
+test "$(rg -No '^import \{' "$root_dir" --glob '*.tf' | wc -l | tr -d ' ')" = "1"
+test "$(rg -No 'provider = google-beta' "$root_dir" --glob '*.tf' | wc -l | tr -d ' ')" = "1"
+test "$(rg -No '^resource "google_firebase_project"' "$root_dir" --glob '*.tf' | wc -l | tr -d ' ')" = "1"
+if rg -n 'google_firebase_(web|android|apple)_app|google_firebase_hosting|google_firebase_app_hosting|google_firebase_extensions|google_firebase_database' "$root_dir" --glob '*.tf'; then
+  echo "Firebase ownership scope includes an app, Hosting, extension, or database resource" >&2
+  exit 1
+fi
 rg -q 'count    = var\.enable_preview_backend_service \? 1 : 0' "$root_dir/cloud_run.tf"
 rg -U -q 'lifecycle \{\n    prevent_destroy = true\n    ignore_changes = \[\n      scaling,\n    \]\n  \}' "$root_dir/cloud_run.tf"
 test "$(rg -No 'ignore_changes' "$root_dir" --glob '*.tf' | wc -l | tr -d ' ')" = "1"

--- a/infra/environments/preview-foundation/versions.tf
+++ b/infra/environments/preview-foundation/versions.tf
@@ -14,5 +14,10 @@ terraform {
       source  = "hashicorp/google"
       version = "~> 6.0"
     }
+
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "6.50.0"
+    }
   }
 }


### PR DESCRIPTION
## Summary

Adopts the existing active Firebase association for `rentchain-preview` into Terraform ownership.

### Provider

Adds only:

- `hashicorp/google-beta` v6.50.0

The beta provider is isolated to the Firebase project resource and uses:

- `user_project_override = true`

No existing stable Google resources are migrated.

### Ownership resource

Adds:

- `google_firebase_project.preview`

Target:

- `rentchain-preview`

Lifecycle:

- `prevent_destroy = true`

### Declarative import

Adds exactly one import:

- target: `google_firebase_project.preview`
- ID: `rentchain-preview`

### Boundaries

- Identity Platform remains suppressed
- restricted backend API key remains suppressed
- Firebase-created Browser key remains unmanaged and untouched
- Firestore remains unchanged
- IAM remains unchanged
- Cloud Run remains unchanged
- runtime IAM remains absent
- production remains untouched
- no apply or import is authorized by this PR

### Validation

- `terraform fmt`: passed
- `terraform fmt -check`: passed
- `terraform init -backend=false`: passed
- `terraform validate`: passed
- Preview scope safeguards: passed
- `git diff --check`: passed

### Expected speculative plan

Preferred:

- 1 import
- 0 add
- 0 change
- 0 destroy

Acceptable:

- 1 import
- 0 add
- 1 explained non-destructive reconciliation
- 0 destroy

This PR remains draft pending authoritative HCP import-plan review.
