### PR TITLE
Add B7 Firebase quota-project usage IAM

### DIFF
--- a/docs/strategy/preview-infrastructure/phase-b-b7-datastore-auth-foundation.md
+++ b/docs/strategy/preview-infrastructure/phase-b-b7-datastore-auth-foundation.md
@@ -117,10 +117,10 @@ The B7 speculative plan is not apply authorization.
 Phase 1 creates two dedicated B7 custom roles rather than broadening the
 existing Cloud Run roles:
 
-- `hcpTerraformPreviewB7Reader` contains exactly the five permissions in
+- `hcpTerraformPreviewB7Reader` contains exactly the six permissions in
   `tests/hcp_b7_plan_permission_delta.txt` and is bound only to
   `hcp-terraform-preview@rentchain-preview.iam.gserviceaccount.com`;
-- `terraformPreviewB7Manager` contains exactly the ten permissions in
+- `terraformPreviewB7Manager` contains exactly the eleven permissions in
   `tests/hcp_b7_apply_permission_delta.txt` and is bound only to
   `hcp-terraform-preview-apply@rentchain-preview.iam.gserviceaccount.com`.
 
@@ -128,6 +128,11 @@ Both roles include `firebase.projects.get` so Terraform can refresh an existing
 Preview Firebase project association during planning, ownership import, and
 post-import lifecycle checks. This is read-only Firebase project metadata
 access; no broad Firebase role or project-delete permission is granted.
+Both roles also include exactly `serviceusage.services.use`, allowing the
+isolated Google provider quota project to be charged for Firebase project reads
+when `user_project_override = true`. This does not grant API enablement,
+disablement, service discovery, billing administration, or a predefined Service
+Usage role.
 
 The first Phase 2 apply partially succeeded: the protected Firestore database is
 recorded in Terraform state, while Identity Platform and the restricted API key
@@ -142,7 +147,7 @@ Phase 2 recovery uses a two-stage bootstrap because the HCP apply identity can
 create and bind project custom roles but cannot update an existing custom role.
 Recovery stage 1 creates `terraformPreviewCustomRoleUpdater`, containing only
 `iam.roles.update`, and binds it only to the HCP Preview apply identity. During
-that stage, `terraformPreviewB7Manager` retains its existing nine permissions,
+that stage, `terraformPreviewB7Manager` retains its existing ten permissions,
 Firestore remains managed, and Identity Platform plus the API key are
 suppressed. The current default, recovery stage 2, retains the updater role and
 adds only `firebase.projects.update` to the B7 manager. A separate

--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -104,10 +104,11 @@ check "b7_hcp_bootstrap_iam_boundary" {
         "datastore.databases.getMetadata",
         "firebase.projects.get",
         "firebaseauth.configs.get",
+        "serviceusage.services.use",
       ]) &&
       google_project_iam_member.hcp_terraform_preview_b7_reader.member == local.hcp_terraform_plan_member
     )
-    error_message = "The B7 plan reader must remain the exact five-permission role bound only to the HCP plan identity."
+    error_message = "The B7 plan reader must remain the exact six-permission role bound only to the HCP plan identity."
   }
 
   assert {
@@ -124,6 +125,7 @@ check "b7_hcp_bootstrap_iam_boundary" {
         "firebaseauth.configs.create",
         "firebaseauth.configs.get",
         "firebaseauth.configs.update",
+        "serviceusage.services.use",
       ]) &&
       local.terraform_preview_b7_manager_permissions == setunion(
         local.terraform_preview_b7_manager_base_permissions,
@@ -131,7 +133,7 @@ check "b7_hcp_bootstrap_iam_boundary" {
       ) &&
       google_project_iam_member.terraform_preview_b7_manager.member == local.hcp_terraform_apply_member
     )
-    error_message = "The B7 apply manager must remain at nine permissions in recovery stage 1 and add only firebase.projects.update in stage 2."
+    error_message = "The B7 apply manager must remain at ten permissions in recovery stage 1 and add only firebase.projects.update in stage 2."
   }
 
   assert {

--- a/infra/environments/preview-foundation/iam.tf
+++ b/infra/environments/preview-foundation/iam.tf
@@ -21,6 +21,7 @@ locals {
     "datastore.databases.getMetadata",
     "firebase.projects.get",
     "firebaseauth.configs.get",
+    "serviceusage.services.use",
   ])
 
   terraform_preview_b7_manager_base_permissions = toset([
@@ -33,6 +34,7 @@ locals {
     "firebaseauth.configs.create",
     "firebaseauth.configs.get",
     "firebaseauth.configs.update",
+    "serviceusage.services.use",
   ])
 
   terraform_preview_b7_manager_permissions = setunion(

--- a/infra/environments/preview-foundation/tests/hcp_b7_apply_permission_delta.txt
+++ b/infra/environments/preview-foundation/tests/hcp_b7_apply_permission_delta.txt
@@ -8,3 +8,4 @@ firebase.projects.update
 firebaseauth.configs.create
 firebaseauth.configs.get
 firebaseauth.configs.update
+serviceusage.services.use

--- a/infra/environments/preview-foundation/tests/hcp_b7_plan_permission_delta.txt
+++ b/infra/environments/preview-foundation/tests/hcp_b7_plan_permission_delta.txt
@@ -3,3 +3,4 @@ apikeys.keys.getKeyString
 datastore.databases.getMetadata
 firebase.projects.get
 firebaseauth.configs.get
+serviceusage.services.use

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -152,6 +152,7 @@ apikeys.keys.getKeyString
 datastore.databases.getMetadata
 firebase.projects.get
 firebaseauth.configs.get
+serviceusage.services.use
 EOF
 )"
 actual_b7_reader_permissions="$(
@@ -175,6 +176,7 @@ firebase.projects.get
 firebaseauth.configs.create
 firebaseauth.configs.get
 firebaseauth.configs.update
+serviceusage.services.use
 EOF
 )"
 actual_b7_manager_base_permissions="$(
@@ -199,6 +201,11 @@ fi
 
 if printf '%s\n%s\n%s\n' "$actual_b7_reader_permissions" "$actual_b7_manager_base_permissions" "iam.roles.update" | rg -n '(delete|users\.|token|run\.|storage\.|billing|secretmanager|firebase\.projects\.delete|identitytoolkit\.)'; then
   echo "Forbidden permission found in B7 HCP bootstrap roles" >&2
+  exit 1
+fi
+
+if rg -n 'roles/serviceusage\.serviceUsageConsumer' "$root_dir" --glob '*.tf'; then
+  echo "Predefined Service Usage role found in Preview foundation" >&2
   exit 1
 fi
 
@@ -306,10 +313,11 @@ apikeys.keys.getKeyString
 datastore.databases.getMetadata
 firebase.projects.get
 firebaseauth.configs.get
+serviceusage.services.use
 EOF
 )"
 test "$(sort -u "$b7_plan_delta_file")" = "$expected_b7_plan_delta"
-test "$(wc -l < "$b7_plan_delta_file" | tr -d ' ')" = "5"
+test "$(wc -l < "$b7_plan_delta_file" | tr -d ' ')" = "6"
 
 expected_b7_apply_delta="$(cat <<'EOF'
 apikeys.keys.create
@@ -322,10 +330,11 @@ firebase.projects.update
 firebaseauth.configs.create
 firebaseauth.configs.get
 firebaseauth.configs.update
+serviceusage.services.use
 EOF
 )"
 test "$(sort -u "$b7_apply_delta_file")" = "$expected_b7_apply_delta"
-test "$(wc -l < "$b7_apply_delta_file" | tr -d ' ')" = "10"
+test "$(wc -l < "$b7_apply_delta_file" | tr -d ' ')" = "11"
 
 if rg -n '(delete|undelete|users\.(create|delete|update|sendEmail)|getSecret|getHashConfig|serviceAccountKeys|signBlob|signJwt|getAccessToken|generateAccessToken|run\.|storage\.|billing)' "$b7_plan_delta_file" "$b7_apply_delta_file"; then
   echo "Forbidden B7 HCP permission delta found" >&2


### PR DESCRIPTION
## Summary

Adds the exact quota-project usage permission required by the isolated `google-beta` provider when `user_project_override = true`.

Observed blocker in PR #1474:

- `USER_PROJECT_DENIED`
- missing `serviceusage.services.use`

### Plan identity

Adds only:

- `serviceusage.services.use`

Final exact permission count:

- 6

### Apply identity

Adds only:

- `serviceusage.services.use`

Final exact permission count:

- 11

### Boundaries

- no predefined Service Usage role
- no provider changes
- no Firebase project resource changes
- no import changes
- no Identity Platform activation
- no API-key action
- no Browser-key action
- no Firestore action
- no Cloud Run action
- no runtime IAM
- no production change
- PR #1474 remains draft and unchanged
- no Terraform apply authorized by this PR

### Validation

- `terraform fmt`: passed
- `terraform fmt -check`: passed
- `terraform init -backend=false`: passed
- `terraform validate`: passed
- Preview scope safeguards: passed
- `git diff --check`: passed

Expected authoritative plan:

- 0 add
- 2 change
- 0 destroy
- 0 import
