### PR TITLE
Initialize Preview Identity Platform

### DIFF
--- a/docs/strategy/preview-infrastructure/phase-b-b7-datastore-auth-foundation.md
+++ b/docs/strategy/preview-infrastructure/phase-b-b7-datastore-auth-foundation.md
@@ -55,7 +55,7 @@ Identity Platform is configured in `rentchain-preview` with:
 - email/password enabled and password required;
 - anonymous and phone providers disabled;
 - duplicate emails disabled;
-- public user signup disabled;
+- client-side user signup enabled for the later governed email/password flow;
 - self-service user deletion disabled;
 - MFA disabled;
 - only `localhost` authorized until a separately reviewed frontend phase.

--- a/docs/strategy/preview-infrastructure/phase-b-b7-datastore-auth-foundation.md
+++ b/docs/strategy/preview-infrastructure/phase-b-b7-datastore-auth-foundation.md
@@ -139,18 +139,18 @@ The active Firebase association for `rentchain-preview` is adopted through the
 short-project-ID import. The resource uses `prevent_destroy` and manages only
 the existing Firebase project association. It does not manage the
 Firebase-created Browser key, any Firebase app, Hosting, analytics, Identity
-Platform, or the restricted backend key. The default-false Identity Platform
-activation gate remains unchanged, so this ownership adoption does not activate
-authentication or produce the datastore/auth output.
+Platform, or the restricted backend key.
 
 The first Phase 2 apply partially succeeded: the protected Firestore database is
 recorded in Terraform state, while Identity Platform and the restricted API key
-remain absent. During Identity Platform initialization, the Google provider
-invokes Firebase `AddFirebase` before creating the Identity Platform
-configuration. Audit logs proved that `firebase.projects.update` was the sole
-denied prerequisite permission; `firebaseauth.configs.create` was already
-granted. The apply manager therefore includes that one additional permission.
-No manual Firebase project association or Terraform import was performed.
+remain absent. Firebase project ownership was subsequently adopted through the
+governed import above. The stable Google provider initializes Identity Platform
+by calling `POST projects/rentchain-preview/identityPlatform:initializeAuth`,
+then reconciles the configured fields. A successful speculative plan does not
+prove that this apply-time request will succeed: the prior
+`409 PROJECT_EXISTS` response may recur. A repeated 409 requires stopping and
+preserving the diagnostics; no automatic workaround or manual initialization is
+authorized.
 
 Phase 2 recovery uses a two-stage bootstrap because the HCP apply identity can
 create and bind project custom roles but cannot update an existing custom role.
@@ -159,12 +159,19 @@ Recovery stage 1 creates `terraformPreviewCustomRoleUpdater`, containing only
 that stage, `terraformPreviewB7Manager` retains its existing ten permissions,
 Firestore remains managed, and Identity Platform plus the API key are
 suppressed. The current default, recovery stage 2, retains the updater role and
-adds only `firebase.projects.update` to the B7 manager. A separate
-default-false `b7_identity_platform_activation` gate controls only Identity
-Platform, the restricted API key, and their non-sensitive output. This keeps the
-two resources suppressed while Firebase project read IAM is reviewed, without
-gating Firestore or either recovery IAM role. Both gates are plan boundaries,
-not apply authorization.
+adds only `firebase.projects.update` to the B7 manager.
+
+Identity Platform initialization and restricted API-key creation use independent
+governed gates. For the initialization stage,
+`b7_identity_platform_initialization` temporarily defaults to `true`, while
+`b7_restricted_api_key_activation` remains `false`. This permits only the
+Identity Platform configuration and keeps the Terraform-managed restricted key
+suppressed. The Identity Platform resource explicitly depends on the governed
+Firebase project resource as an ordering and documentation safeguard; that
+dependency is not a fix for the prior 409. After a successful apply and
+zero-drift verification, a separate stabilization mission must reassess or reset
+the temporary initialization default before API-key activation. Neither gate
+controls Firestore, recovery IAM, runtime IAM, or Cloud Run.
 
 The HCP apply identity already has the governed IAM role-management and project
 policy permissions needed to create these roles and bindings. Do not substitute

--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -62,7 +62,7 @@ check "b7_preview_datastore_boundary" {
 
 check "b7_preview_authentication_boundary" {
   assert {
-    condition = var.b7_foundation_phase < 2 || var.b7_phase2_recovery_stage < 2 || !var.b7_identity_platform_activation ? true : (
+    condition = var.b7_foundation_phase < 2 || var.b7_phase2_recovery_stage < 2 || !var.b7_identity_platform_initialization ? true : (
       google_identity_platform_config.preview[0].project == "rentchain-preview" &&
       local.preview_identity_authorized_domains == toset(["localhost"]) &&
       google_identity_platform_config.preview[0].sign_in[0].email[0].enabled &&
@@ -85,7 +85,7 @@ check "b7_preview_authentication_boundary" {
   }
 
   assert {
-    condition = var.b7_foundation_phase < 2 || var.b7_phase2_recovery_stage < 2 || !var.b7_identity_platform_activation ? true : (
+    condition = var.b7_foundation_phase < 2 || var.b7_phase2_recovery_stage < 2 || !var.b7_restricted_api_key_activation ? true : (
       google_apikeys_key.preview_backend_auth[0].project == "rentchain-preview" &&
       google_apikeys_key.preview_backend_auth[0].restrictions[0].api_targets[0].service == "identitytoolkit.googleapis.com"
     )
@@ -97,9 +97,10 @@ check "b7_firebase_project_ownership_boundary" {
   assert {
     condition = (
       google_firebase_project.preview.project == "rentchain-preview" &&
-      !var.b7_identity_platform_activation
+      var.b7_identity_platform_initialization &&
+      !var.b7_restricted_api_key_activation
     )
-    error_message = "B7 Firebase ownership must remain limited to the existing Preview project while Identity Platform activation stays disabled."
+    error_message = "B7 Firebase ownership must remain limited to the existing Preview project while only Identity Platform initialization is active."
   }
 }
 

--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -69,10 +69,10 @@ check "b7_preview_authentication_boundary" {
       google_identity_platform_config.preview[0].sign_in[0].email[0].password_required &&
       !google_identity_platform_config.preview[0].sign_in[0].anonymous[0].enabled &&
       !google_identity_platform_config.preview[0].sign_in[0].phone_number[0].enabled &&
-      google_identity_platform_config.preview[0].client[0].permissions[0].disabled_user_signup &&
+      !google_identity_platform_config.preview[0].client[0].permissions[0].disabled_user_signup &&
       google_identity_platform_config.preview[0].client[0].permissions[0].disabled_user_deletion
     )
-    error_message = "B7 Preview authentication must remain isolated, password-only, and closed to public signup."
+    error_message = "B7 Preview authentication must remain isolated, password-only, open to client signup, and closed to client deletion."
   }
 
   assert {

--- a/infra/environments/preview-foundation/datastore_auth.tf
+++ b/infra/environments/preview-foundation/datastore_auth.tf
@@ -68,7 +68,7 @@ resource "google_identity_platform_config" "preview" {
 
   client {
     permissions {
-      disabled_user_signup   = true
+      disabled_user_signup   = false
       disabled_user_deletion = true
     }
   }

--- a/infra/environments/preview-foundation/datastore_auth.tf
+++ b/infra/environments/preview-foundation/datastore_auth.tf
@@ -43,7 +43,7 @@ resource "google_firestore_database" "preview" {
 }
 
 resource "google_identity_platform_config" "preview" {
-  count = var.b7_foundation_phase >= 2 && var.b7_phase2_recovery_stage >= 2 && var.b7_identity_platform_activation ? 1 : 0
+  count = var.b7_foundation_phase >= 2 && var.b7_phase2_recovery_stage >= 2 && var.b7_identity_platform_initialization ? 1 : 0
 
   project = var.project_id
 
@@ -78,6 +78,7 @@ resource "google_identity_platform_config" "preview" {
   }
 
   depends_on = [
+    google_firebase_project.preview,
     google_project_service.approved_management["identitytoolkit.googleapis.com"],
   ]
 
@@ -87,7 +88,7 @@ resource "google_identity_platform_config" "preview" {
 }
 
 resource "google_apikeys_key" "preview_backend_auth" {
-  count = var.b7_foundation_phase >= 2 && var.b7_phase2_recovery_stage >= 2 && var.b7_identity_platform_activation ? 1 : 0
+  count = var.b7_foundation_phase >= 2 && var.b7_phase2_recovery_stage >= 2 && var.b7_restricted_api_key_activation ? 1 : 0
 
   project      = var.project_id
   name         = "preview-backend-auth"

--- a/infra/environments/preview-foundation/outputs.tf
+++ b/infra/environments/preview-foundation/outputs.tf
@@ -52,7 +52,7 @@ output "preview_backend_service" {
 
 output "preview_datastore_auth_foundation" {
   description = "Non-sensitive identifiers for the isolated B7 datastore and authentication foundation."
-  value = var.b7_foundation_phase >= 2 && var.b7_phase2_recovery_stage >= 2 && var.b7_identity_platform_activation ? {
+  value = var.b7_foundation_phase >= 2 && var.b7_phase2_recovery_stage >= 2 && var.b7_identity_platform_initialization ? {
     project_id              = var.project_id
     database_id             = google_firestore_database.preview[0].name
     firestore_location      = google_firestore_database.preview[0].location_id

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -49,7 +49,8 @@ rg -U -q 'variable "b7_foundation_phase" \{\n  description = "[^"]+"\n  type    
 grep -Fq 'condition     = contains([1, 2, 3], var.b7_foundation_phase)' "$root_dir/variables.tf"
 rg -U -q 'variable "b7_phase2_recovery_stage" \{\n  description = "[^"]+"\n  type        = number\n  default     = 2' "$root_dir/variables.tf"
 grep -Fq 'condition     = contains([1, 2], var.b7_phase2_recovery_stage)' "$root_dir/variables.tf"
-rg -U -q 'variable "b7_identity_platform_activation" \{\n  description = "[^"]+"\n  type        = bool\n  default     = false\n\}' "$root_dir/variables.tf"
+rg -U -q 'variable "b7_identity_platform_initialization" \{\n  description = "Governed stage activation for initializing Preview Identity Platform\."\n  type        = bool\n  default     = true\n\}' "$root_dir/variables.tf"
+rg -U -q 'variable "b7_restricted_api_key_activation" \{\n  description = "Governed activation for the Terraform-managed restricted Preview backend API key\."\n  type        = bool\n  default     = false\n\}' "$root_dir/variables.tf"
 rg -U -q 'google-beta = \{\n      source  = "hashicorp/google-beta"\n      version = "6\.50\.0"\n    \}' "$root_dir/versions.tf"
 rg -U -q 'provider "google-beta" \{\n  project               = var\.project_id\n  user_project_override = true\n\}' "$root_dir/providers.tf"
 rg -U -q 'resource "google_firebase_project" "preview" \{\n  provider = google-beta\n  project  = var\.project_id\n\n  lifecycle \{\n    prevent_destroy = true\n  \}\n\}' "$root_dir/firebase.tf"
@@ -124,10 +125,12 @@ if rg -n 'FIRESTORE_DATABASE_ID|PREVIEW_AUTH_ENABLED|FIREBASE_PROJECT_ID|FIREBAS
 fi
 
 test "$(rg -No 'count = var\.b7_foundation_phase >= 2 \? 1 : 0' "$root_dir/datastore_auth.tf" | wc -l | tr -d ' ')" = "1"
-test "$(rg -No 'count = var\.b7_foundation_phase >= 2 && var\.b7_phase2_recovery_stage >= 2 && var\.b7_identity_platform_activation \? 1 : 0' "$root_dir/datastore_auth.tf" | wc -l | tr -d ' ')" = "2"
-grep -Fq 'value = var.b7_foundation_phase >= 2 && var.b7_phase2_recovery_stage >= 2 && var.b7_identity_platform_activation ? {' "$root_dir/outputs.tf"
-if rg -n 'b7_identity_platform_activation' "$root_dir/cloud_run.tf" "$root_dir/iam.tf"; then
-  echo "The B7 Identity Platform activation gate must not control Cloud Run or IAM" >&2
+test "$(rg -No 'count = var\.b7_foundation_phase >= 2 && var\.b7_phase2_recovery_stage >= 2 && var\.b7_identity_platform_initialization \? 1 : 0' "$root_dir/datastore_auth.tf" | wc -l | tr -d ' ')" = "1"
+test "$(rg -No 'count = var\.b7_foundation_phase >= 2 && var\.b7_phase2_recovery_stage >= 2 && var\.b7_restricted_api_key_activation \? 1 : 0' "$root_dir/datastore_auth.tf" | wc -l | tr -d ' ')" = "1"
+grep -Fq 'value = var.b7_foundation_phase >= 2 && var.b7_phase2_recovery_stage >= 2 && var.b7_identity_platform_initialization ? {' "$root_dir/outputs.tf"
+rg -U -q '(?s)resource "google_identity_platform_config" "preview" \{.*depends_on = \[\n    google_firebase_project\.preview,\n    google_project_service\.approved_management\["identitytoolkit\.googleapis\.com"\],\n  \]' "$root_dir/datastore_auth.tf"
+if rg -n 'b7_identity_platform_initialization|b7_restricted_api_key_activation' "$root_dir/cloud_run.tf" "$root_dir/iam.tf"; then
+  echo "The B7 authentication activation gates must not control Cloud Run or IAM" >&2
   exit 1
 fi
 test "$(rg -No 'count = var\.b7_foundation_phase >= 3 \? 1 : 0' "$root_dir/datastore_auth.tf" | wc -l | tr -d ' ')" = "4"

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -107,7 +107,7 @@ rg -q 'resource "google_identity_platform_config" "preview"' "$root_dir/datastor
 grep -Fq 'authorized_domains = sort(tolist(local.preview_identity_authorized_domains))' "$root_dir/datastore_auth.tf"
 rg -q 'preview_identity_authorized_domains = toset' "$root_dir/datastore_auth.tf"
 test "$(sed -n '/preview_identity_authorized_domains = toset(/,/])/p' "$root_dir/datastore_auth.tf" | rg -No '"[^"]+"' | tr -d '"')" = "localhost"
-rg -q 'disabled_user_signup   = true' "$root_dir/datastore_auth.tf"
+rg -q 'disabled_user_signup   = false' "$root_dir/datastore_auth.tf"
 rg -q 'disabled_user_deletion = true' "$root_dir/datastore_auth.tf"
 rg -q 'role_id     = "previewBackendAuthReader"' "$root_dir/datastore_auth.tf"
 test "$(sed -n '/preview_runtime_auth_permissions = toset(/,/])/p' "$root_dir/datastore_auth.tf" | rg -No '"[^"]+"' | tr -d '"')" = "firebaseauth.users.get"

--- a/infra/environments/preview-foundation/variables.tf
+++ b/infra/environments/preview-foundation/variables.tf
@@ -93,8 +93,14 @@ variable "b7_phase2_recovery_stage" {
   }
 }
 
-variable "b7_identity_platform_activation" {
-  description = "Governed activation gate for Preview Identity Platform and the restricted backend API key."
+variable "b7_identity_platform_initialization" {
+  description = "Governed stage activation for initializing Preview Identity Platform."
+  type        = bool
+  default     = true
+}
+
+variable "b7_restricted_api_key_activation" {
+  description = "Governed activation for the Terraform-managed restricted Preview backend API key."
   type        = bool
   default     = false
 }


### PR DESCRIPTION
## Summary

Introduces a controlled Identity Platform-only activation stage for Preview.

### Activation

- `b7_identity_platform_initialization = true`
- `b7_restricted_api_key_activation = false`

This plans only:

- `google_identity_platform_config.preview[0]`

### Boundaries

- restricted backend API key remains suppressed
- Firebase ownership remains unchanged
- Firebase-created Browser key remains unmanaged and untouched
- Firestore remains unchanged
- IAM remains unchanged
- providers remain unchanged
- Cloud Run remains unchanged
- runtime IAM remains absent
- no users or fixtures
- production remains untouched
- no Terraform apply authorized

### Apply risk

The stable provider will call:

`POST projects/rentchain-preview/identityPlatform:initializeAuth`

The prior `409 PROJECT_EXISTS` may recur during apply. A successful speculative plan does not prove apply-time initialization will succeed. Any repeated 409 requires stopping without a manual workaround.

### Validation

Passed:

- `terraform fmt`
- `terraform fmt -check`
- Preview scope safeguards
- `git diff --check`

Provider-backed validation was blocked by the Codex execution-service failure and must be confirmed through HCP Terraform.
