### PR TITLE
Stabilize Preview Identity Platform multi-tenant defaults

### DIFF
--- a/docs/strategy/preview-infrastructure/phase-b-b7-datastore-auth-foundation.md
+++ b/docs/strategy/preview-infrastructure/phase-b-b7-datastore-auth-foundation.md
@@ -58,6 +58,7 @@ Identity Platform is configured in `rentchain-preview` with:
 - client-side user signup enabled for the later governed email/password flow;
 - self-service user deletion disabled;
 - MFA disabled;
+- multi-tenancy disabled with no default tenant location;
 - only `localhost` authorized until a separately reviewed frontend phase.
 
 The backend password-login path uses a Preview API key restricted to

--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -70,9 +70,11 @@ check "b7_preview_authentication_boundary" {
       !google_identity_platform_config.preview[0].sign_in[0].anonymous[0].enabled &&
       !google_identity_platform_config.preview[0].sign_in[0].phone_number[0].enabled &&
       !google_identity_platform_config.preview[0].client[0].permissions[0].disabled_user_signup &&
-      google_identity_platform_config.preview[0].client[0].permissions[0].disabled_user_deletion
+      google_identity_platform_config.preview[0].client[0].permissions[0].disabled_user_deletion &&
+      !google_identity_platform_config.preview[0].multi_tenant[0].allow_tenants &&
+      google_identity_platform_config.preview[0].multi_tenant[0].default_tenant_location == ""
     )
-    error_message = "B7 Preview authentication must remain isolated, password-only, open to client signup, and closed to client deletion."
+    error_message = "B7 Preview authentication must remain isolated, password-only, single-tenant, open to client signup, and closed to client deletion."
   }
 
   assert {

--- a/infra/environments/preview-foundation/datastore_auth.tf
+++ b/infra/environments/preview-foundation/datastore_auth.tf
@@ -77,6 +77,11 @@ resource "google_identity_platform_config" "preview" {
     state = "DISABLED"
   }
 
+  multi_tenant {
+    allow_tenants           = false
+    default_tenant_location = ""
+  }
+
   depends_on = [
     google_firebase_project.preview,
     google_project_service.approved_management["identitytoolkit.googleapis.com"],

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -109,6 +109,8 @@ rg -q 'preview_identity_authorized_domains = toset' "$root_dir/datastore_auth.tf
 test "$(sed -n '/preview_identity_authorized_domains = toset(/,/])/p' "$root_dir/datastore_auth.tf" | rg -No '"[^"]+"' | tr -d '"')" = "localhost"
 rg -q 'disabled_user_signup   = false' "$root_dir/datastore_auth.tf"
 rg -q 'disabled_user_deletion = true' "$root_dir/datastore_auth.tf"
+rg -U -q 'multi_tenant \{\n    allow_tenants           = false\n    default_tenant_location = ""\n  \}' "$root_dir/datastore_auth.tf"
+test "$(rg -No 'multi_tenant \{' "$root_dir/datastore_auth.tf" | wc -l | tr -d ' ')" = "1"
 rg -q 'role_id     = "previewBackendAuthReader"' "$root_dir/datastore_auth.tf"
 test "$(sed -n '/preview_runtime_auth_permissions = toset(/,/])/p' "$root_dir/datastore_auth.tf" | rg -No '"[^"]+"' | tr -d '"')" = "firebaseauth.users.get"
 rg -q 'service = "identitytoolkit.googleapis.com"' "$root_dir/datastore_auth.tf"


### PR DESCRIPTION
## Summary

Adds the exact multi-tenant defaults returned by the live Preview Identity Platform configuration:

```hcl
multi_tenant {
  allow_tenants           = false
  default_tenant_location = ""
}
```

This stabilizes Terraform against provider/API normalization after successful Identity Platform creation.

## Boundaries

- no Identity Platform recreation
- no restricted API-key creation
- no Firebase ownership change
- no Browser-key action
- no Firestore change
- no IAM change
- no Cloud Run change
- no runtime IAM
- no users or fixtures
- no production change
- no Terraform apply authorized by this PR

## Validation

- `terraform fmt`: passed
- `terraform fmt -check`: passed
- Preview scope safeguards: passed
- `git diff --check`: passed

## Expected authoritative plan

- 0 add
- 0 change
- 0 destroy
- 0 import
- 0 actions

The PR remains draft pending authoritative HCP zero-drift verification.
