### PR TITLE
Add Preview Secret Manager IAM foundation

### DIFF
--- a/docs/strategy/preview-infrastructure/phase-b-b7-datastore-auth-foundation.md
+++ b/docs/strategy/preview-infrastructure/phase-b-b7-datastore-auth-foundation.md
@@ -107,9 +107,13 @@ ID, and redacted build-presence metadata.
 - `firestore.googleapis.com`
 - `identitytoolkit.googleapis.com`
 - `apikeys.googleapis.com`
+- `secretmanager.googleapis.com`
 
-No Firebase Management, Secret Manager, Firestore Rules, Cloud Run Jobs, or
-production API is added.
+Secret Manager is enabled only as a management-plane prerequisite for a later
+governed, write-only backend-key delivery stage. This stage creates no secret,
+secret version, runtime accessor binding, or Cloud Run secret reference. No
+Firebase Management, Firestore Rules, Cloud Run Jobs, or production API is
+added.
 
 ## Apply sequencing and bootstrap gate
 
@@ -118,12 +122,19 @@ The B7 speculative plan is not apply authorization.
 Phase 1 creates two dedicated B7 custom roles rather than broadening the
 existing Cloud Run roles:
 
-- `hcpTerraformPreviewB7Reader` contains exactly the six permissions in
+- `hcpTerraformPreviewB7Reader` contains exactly the nine permissions in
   `tests/hcp_b7_plan_permission_delta.txt` and is bound only to
   `hcp-terraform-preview@rentchain-preview.iam.gserviceaccount.com`;
-- `terraformPreviewB7Manager` contains exactly the eleven permissions in
+- `terraformPreviewB7Manager` contains exactly the seventeen permissions in
   `tests/hcp_b7_apply_permission_delta.txt` and is bound only to
   `hcp-terraform-preview-apply@rentchain-preview.iam.gserviceaccount.com`.
+
+The Secret Manager additions are limited to secret and secret-version metadata
+reads for the plan identity and secret creation, version creation, and
+secret-scoped IAM policy management for the apply identity. Neither role has
+`secretmanager.versions.access`, secret deletion, version disabling or
+destruction, list access, or a predefined Secret Manager role. The runtime
+identity receives no Secret Manager permission in this prerequisite stage.
 
 Both roles include `firebase.projects.get` so Terraform can refresh an existing
 Preview Firebase project association during planning, ownership import, and
@@ -157,10 +168,11 @@ Phase 2 recovery uses a two-stage bootstrap because the HCP apply identity can
 create and bind project custom roles but cannot update an existing custom role.
 Recovery stage 1 creates `terraformPreviewCustomRoleUpdater`, containing only
 `iam.roles.update`, and binds it only to the HCP Preview apply identity. During
-that stage, `terraformPreviewB7Manager` retains its existing ten permissions,
-Firestore remains managed, and Identity Platform plus the API key are
-suppressed. The current default, recovery stage 2, retains the updater role and
-adds only `firebase.projects.update` to the B7 manager.
+that stage, `terraformPreviewB7Manager` has sixteen permissions after the
+Secret Manager prerequisite additions, Firestore remains managed, and Identity
+Platform plus the API key are suppressed. The current default, recovery stage
+2, retains the updater role and adds only `firebase.projects.update`, producing
+the exact seventeen-permission B7 manager.
 
 Identity Platform initialization and restricted API-key creation use independent
 governed gates. For the initialization stage,

--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -19,6 +19,7 @@ check "management_api_boundary" {
       "iam.googleapis.com",
       "identitytoolkit.googleapis.com",
       "run.googleapis.com",
+      "secretmanager.googleapis.com",
       "serviceusage.googleapis.com",
     ])
     error_message = "The B4 Preview foundation API allowlist has changed."
@@ -117,11 +118,14 @@ check "b7_hcp_bootstrap_iam_boundary" {
         "datastore.databases.getMetadata",
         "firebase.projects.get",
         "firebaseauth.configs.get",
+        "secretmanager.secrets.get",
+        "secretmanager.secrets.getIamPolicy",
+        "secretmanager.versions.get",
         "serviceusage.services.use",
       ]) &&
       google_project_iam_member.hcp_terraform_preview_b7_reader.member == local.hcp_terraform_plan_member
     )
-    error_message = "The B7 plan reader must remain the exact six-permission role bound only to the HCP plan identity."
+    error_message = "The B7 plan reader must remain the exact nine-permission role bound only to the HCP plan identity."
   }
 
   assert {
@@ -138,6 +142,12 @@ check "b7_hcp_bootstrap_iam_boundary" {
         "firebaseauth.configs.create",
         "firebaseauth.configs.get",
         "firebaseauth.configs.update",
+        "secretmanager.secrets.create",
+        "secretmanager.secrets.get",
+        "secretmanager.secrets.getIamPolicy",
+        "secretmanager.secrets.setIamPolicy",
+        "secretmanager.versions.add",
+        "secretmanager.versions.get",
         "serviceusage.services.use",
       ]) &&
       local.terraform_preview_b7_manager_permissions == setunion(
@@ -146,7 +156,7 @@ check "b7_hcp_bootstrap_iam_boundary" {
       ) &&
       google_project_iam_member.terraform_preview_b7_manager.member == local.hcp_terraform_apply_member
     )
-    error_message = "The B7 apply manager must remain at ten permissions in recovery stage 1 and add only firebase.projects.update in stage 2."
+    error_message = "The B7 apply manager must remain at sixteen permissions in recovery stage 1 and add only firebase.projects.update in stage 2."
   }
 
   assert {

--- a/infra/environments/preview-foundation/iam.tf
+++ b/infra/environments/preview-foundation/iam.tf
@@ -21,6 +21,9 @@ locals {
     "datastore.databases.getMetadata",
     "firebase.projects.get",
     "firebaseauth.configs.get",
+    "secretmanager.secrets.get",
+    "secretmanager.secrets.getIamPolicy",
+    "secretmanager.versions.get",
     "serviceusage.services.use",
   ])
 
@@ -34,6 +37,12 @@ locals {
     "firebaseauth.configs.create",
     "firebaseauth.configs.get",
     "firebaseauth.configs.update",
+    "secretmanager.secrets.create",
+    "secretmanager.secrets.get",
+    "secretmanager.secrets.getIamPolicy",
+    "secretmanager.secrets.setIamPolicy",
+    "secretmanager.versions.add",
+    "secretmanager.versions.get",
     "serviceusage.services.use",
   ])
 

--- a/infra/environments/preview-foundation/services.tf
+++ b/infra/environments/preview-foundation/services.tf
@@ -7,6 +7,7 @@ locals {
     "iam.googleapis.com",
     "identitytoolkit.googleapis.com",
     "run.googleapis.com",
+    "secretmanager.googleapis.com",
     "serviceusage.googleapis.com",
   ])
 }

--- a/infra/environments/preview-foundation/tests/hcp_b7_apply_permission_delta.txt
+++ b/infra/environments/preview-foundation/tests/hcp_b7_apply_permission_delta.txt
@@ -8,4 +8,10 @@ firebase.projects.update
 firebaseauth.configs.create
 firebaseauth.configs.get
 firebaseauth.configs.update
+secretmanager.secrets.create
+secretmanager.secrets.get
+secretmanager.secrets.getIamPolicy
+secretmanager.secrets.setIamPolicy
+secretmanager.versions.add
+secretmanager.versions.get
 serviceusage.services.use

--- a/infra/environments/preview-foundation/tests/hcp_b7_plan_permission_delta.txt
+++ b/infra/environments/preview-foundation/tests/hcp_b7_plan_permission_delta.txt
@@ -3,4 +3,7 @@ apikeys.keys.getKeyString
 datastore.databases.getMetadata
 firebase.projects.get
 firebaseauth.configs.get
+secretmanager.secrets.get
+secretmanager.secrets.getIamPolicy
+secretmanager.versions.get
 serviceusage.services.use

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -34,7 +34,7 @@ test "$actual_resources" = "$expected_resources"
 test "$(rg -No '^resource "[^"]+"' "$root_dir" --glob '*.tf' | wc -l | tr -d ' ')" = "33"
 
 test "$(rg -No 'service\s*=\s*"[^"]+\.googleapis\.com"' "$root_dir/services.tf" | wc -l | tr -d ' ')" = "0"
-test "$(rg -No '"(apikeys|artifactregistry|cloudresourcemanager|firestore|iam|identitytoolkit|run|serviceusage)\.googleapis\.com"' "$root_dir/services.tf" | sort -u | wc -l | tr -d ' ')" = "8"
+test "$(rg -No '"(apikeys|artifactregistry|cloudresourcemanager|firestore|iam|identitytoolkit|run|secretmanager|serviceusage)\.googleapis\.com"' "$root_dir/services.tf" | sort -u | wc -l | tr -d ' ')" = "9"
 
 rg -q 'organization = "Rentchain"' "$root_dir/versions.tf"
 rg -q 'name = "rentchain-preview-foundation"' "$root_dir/versions.tf"
@@ -169,6 +169,9 @@ apikeys.keys.getKeyString
 datastore.databases.getMetadata
 firebase.projects.get
 firebaseauth.configs.get
+secretmanager.secrets.get
+secretmanager.secrets.getIamPolicy
+secretmanager.versions.get
 serviceusage.services.use
 EOF
 )"
@@ -193,6 +196,12 @@ firebase.projects.get
 firebaseauth.configs.create
 firebaseauth.configs.get
 firebaseauth.configs.update
+secretmanager.secrets.create
+secretmanager.secrets.get
+secretmanager.secrets.getIamPolicy
+secretmanager.secrets.setIamPolicy
+secretmanager.versions.add
+secretmanager.versions.get
 serviceusage.services.use
 EOF
 )"
@@ -216,8 +225,18 @@ if sed -n '/resource "google_project_iam_custom_role" "hcp_terraform_preview_b7_
   exit 1
 fi
 
-if printf '%s\n%s\n%s\n' "$actual_b7_reader_permissions" "$actual_b7_manager_base_permissions" "iam.roles.update" | rg -n '(delete|users\.|token|run\.|storage\.|billing|secretmanager|firebase\.projects\.delete|identitytoolkit\.)'; then
+if printf '%s\n%s\n%s\n' "$actual_b7_reader_permissions" "$actual_b7_manager_base_permissions" "iam.roles.update" | rg -n '(delete|users\.|token|run\.|storage\.|billing|secretmanager\.versions\.(access|disable|destroy|list)|secretmanager\.secrets\.(delete|list)|firebase\.projects\.delete|identitytoolkit\.)'; then
   echo "Forbidden permission found in B7 HCP bootstrap roles" >&2
+  exit 1
+fi
+
+if rg -n 'roles/secretmanager\.' "$root_dir" --glob '*.tf'; then
+  echo "Predefined Secret Manager role found in Preview foundation Stage 1" >&2
+  exit 1
+fi
+
+if rg -n 'google_secret_manager_|FIREBASE_API_KEY' "$root_dir" --glob '*.tf'; then
+  echo "Secret resource, runtime binding, or Cloud Run secret injection found in Stage 1" >&2
   exit 1
 fi
 
@@ -330,11 +349,14 @@ apikeys.keys.getKeyString
 datastore.databases.getMetadata
 firebase.projects.get
 firebaseauth.configs.get
+secretmanager.secrets.get
+secretmanager.secrets.getIamPolicy
+secretmanager.versions.get
 serviceusage.services.use
 EOF
 )"
 test "$(sort -u "$b7_plan_delta_file")" = "$expected_b7_plan_delta"
-test "$(wc -l < "$b7_plan_delta_file" | tr -d ' ')" = "6"
+test "$(wc -l < "$b7_plan_delta_file" | tr -d ' ')" = "9"
 
 expected_b7_apply_delta="$(cat <<'EOF'
 apikeys.keys.create
@@ -347,13 +369,19 @@ firebase.projects.update
 firebaseauth.configs.create
 firebaseauth.configs.get
 firebaseauth.configs.update
+secretmanager.secrets.create
+secretmanager.secrets.get
+secretmanager.secrets.getIamPolicy
+secretmanager.secrets.setIamPolicy
+secretmanager.versions.add
+secretmanager.versions.get
 serviceusage.services.use
 EOF
 )"
 test "$(sort -u "$b7_apply_delta_file")" = "$expected_b7_apply_delta"
-test "$(wc -l < "$b7_apply_delta_file" | tr -d ' ')" = "11"
+test "$(wc -l < "$b7_apply_delta_file" | tr -d ' ')" = "17"
 
-if rg -n '(delete|undelete|users\.(create|delete|update|sendEmail)|getSecret|getHashConfig|serviceAccountKeys|signBlob|signJwt|getAccessToken|generateAccessToken|run\.|storage\.|billing)' "$b7_plan_delta_file" "$b7_apply_delta_file"; then
+if rg -n '(delete|undelete|users\.(create|delete|update|sendEmail)|getSecret|getHashConfig|serviceAccountKeys|signBlob|signJwt|getAccessToken|generateAccessToken|run\.|storage\.|billing|secretmanager\.versions\.(access|disable|destroy|list)|secretmanager\.secrets\.(delete|list))' "$b7_plan_delta_file" "$b7_apply_delta_file"; then
   echo "Forbidden B7 HCP permission delta found" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary

Adds the Stage 1 management-plane foundation required for later write-only delivery of the Preview backend Identity Toolkit API key.

### API

Enables only:

- `secretmanager.googleapis.com`

### Plan identity

Adds only:

- `secretmanager.secrets.get`
- `secretmanager.secrets.getIamPolicy`
- `secretmanager.versions.get`

Final exact permission count:

- 9

### Apply identity

Adds only:

- `secretmanager.secrets.create`
- `secretmanager.secrets.get`
- `secretmanager.secrets.getIamPolicy`
- `secretmanager.secrets.setIamPolicy`
- `secretmanager.versions.add`
- `secretmanager.versions.get`

Final exact permission count:

- 17

### Boundaries

- no `secretmanager.versions.access`
- no predefined Secret Manager role
- no secret resource
- no secret version
- no runtime accessor binding
- no API-key creation
- no Cloud Run change
- no Identity Platform change
- no Firebase ownership change
- no Firestore change
- no production change
- no Terraform apply authorized by this PR

### Validation

- `terraform fmt`: passed
- `terraform fmt -check`: passed
- `terraform validate`: passed locally
- Preview scope safeguards: passed
- `git diff --check`: passed

### Expected authoritative plan

- 1 add
- 2 change
- 0 destroy
- 0 import
- 0 actions

Exact add:

- `google_project_service.approved_management["secretmanager.googleapis.com"]`

Exact changes:

- `google_project_iam_custom_role.hcp_terraform_preview_b7_reader`
- `google_project_iam_custom_role.terraform_preview_b7_manager`

This PR remains draft pending authoritative HCP plan review.
