### PR TITLE
Create Preview backend auth key and write-only secret

### DIFF
--- a/docs/strategy/preview-infrastructure/phase-b-b7-datastore-auth-foundation.md
+++ b/docs/strategy/preview-infrastructure/phase-b-b7-datastore-auth-foundation.md
@@ -7,8 +7,8 @@ the isolated `rentchain-preview` project. The database location is
 `northamerica-northeast1`.
 
 This is a foundation-only change. It creates no user, document, fixture,
-production resource, frontend route, public Cloud Run binding, static
-credential, or Secret Manager secret.
+production resource, frontend route, public Cloud Run binding, or static
+credential.
 
 ## Datastore boundary
 
@@ -64,9 +64,12 @@ Identity Platform is configured in `rentchain-preview` with:
 The backend password-login path uses a Preview API key restricted to
 `identitytoolkit.googleapis.com`. A Firebase web API key identifies a client and
 is not a privileged server credential, but Terraform and HCP still treat its
-value as sensitive. Phase 2 creates the key in Terraform state without exposing
-it through outputs or attaching it to Cloud Run. Delivery to Cloud Run requires
-a separately reviewed activation phase; Secret Manager remains absent.
+value as sensitive. The governed backend-key stage creates the key in Terraform
+state without exposing it through outputs or attaching it to Cloud Run. Its
+value flows directly from the API Keys resource into a protected Secret Manager
+version through Terraform's write-only `secret_data_wo` argument. Ordinary
+`secret_data` is prohibited. Delivery from Secret Manager to Cloud Run requires
+a separately reviewed runtime activation phase.
 
 The runtime role `previewBackendAuthReader` contains only
 `firebaseauth.users.get`. The existing login path needs this permission to read
@@ -109,11 +112,13 @@ ID, and redacted build-presence metadata.
 - `apikeys.googleapis.com`
 - `secretmanager.googleapis.com`
 
-Secret Manager is enabled only as a management-plane prerequisite for a later
-governed, write-only backend-key delivery stage. This stage creates no secret,
-secret version, runtime accessor binding, or Cloud Run secret reference. No
-Firebase Management, Firestore Rules, Cloud Run Jobs, or production API is
-added.
+Secret Manager supports the governed write-only backend-key stage. That stage
+creates exactly `preview-backend-identity-toolkit-api-key` with automatic
+Google-managed replication, deletion protection, and Terraform
+`prevent_destroy`. Its one managed version uses `secret_data_wo`, write-only
+version `1`, deletion policy `DISABLE`, and `create_before_destroy`. It creates
+no runtime accessor binding or Cloud Run secret reference. No Firebase
+Management, Firestore Rules, Cloud Run Jobs, or production API is added.
 
 ## Apply sequencing and bootstrap gate
 
@@ -175,16 +180,14 @@ Platform plus the API key are suppressed. The current default, recovery stage
 the exact seventeen-permission B7 manager.
 
 Identity Platform initialization and restricted API-key creation use independent
-governed gates. For the initialization stage,
-`b7_identity_platform_initialization` temporarily defaults to `true`, while
-`b7_restricted_api_key_activation` remains `false`. This permits only the
-Identity Platform configuration and keeps the Terraform-managed restricted key
-suppressed. The Identity Platform resource explicitly depends on the governed
-Firebase project resource as an ordering and documentation safeguard; that
-dependency is not a fix for the prior 409. After a successful apply and
-zero-drift verification, a separate stabilization mission must reassess or reset
-the temporary initialization default before API-key activation. Neither gate
-controls Firestore, recovery IAM, runtime IAM, or Cloud Run.
+governed gates. `b7_identity_platform_initialization` remains active for the
+managed Identity Platform configuration. The current backend-key stage sets
+`b7_restricted_api_key_activation` to `true`, planning the restricted API key,
+protected Secret Manager secret, and write-only secret version together. The
+Identity Platform resource explicitly depends on the governed Firebase project
+resource as an ordering and documentation safeguard; that dependency is not a
+fix for the prior 409. Neither gate controls Firestore, recovery IAM, runtime
+IAM, or Cloud Run.
 
 The HCP apply identity already has the governed IAM role-management and project
 policy permissions needed to create these roles and bindings. Do not substitute

--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -100,10 +100,22 @@ check "b7_firebase_project_ownership_boundary" {
   assert {
     condition = (
       google_firebase_project.preview.project == "rentchain-preview" &&
-      var.b7_identity_platform_initialization &&
-      !var.b7_restricted_api_key_activation
+      var.b7_identity_platform_initialization
     )
-    error_message = "B7 Firebase ownership must remain limited to the existing Preview project while only Identity Platform initialization is active."
+    error_message = "B7 Firebase ownership must remain limited to the existing Preview project."
+  }
+}
+
+check "b7_backend_auth_secret_boundary" {
+  assert {
+    condition = var.b7_foundation_phase < 2 || var.b7_phase2_recovery_stage < 2 || !var.b7_restricted_api_key_activation ? true : (
+      google_secret_manager_secret.preview_backend_identity_toolkit[0].project == "rentchain-preview" &&
+      google_secret_manager_secret.preview_backend_identity_toolkit[0].secret_id == "preview-backend-identity-toolkit-api-key" &&
+      google_secret_manager_secret.preview_backend_identity_toolkit[0].deletion_protection &&
+      google_secret_manager_secret_version.preview_backend_identity_toolkit[0].secret_data_wo_version == 1 &&
+      google_secret_manager_secret_version.preview_backend_identity_toolkit[0].deletion_policy == "DISABLE"
+    )
+    error_message = "The Preview backend Identity Toolkit key must remain in the protected write-only Secret Manager boundary."
   }
 }
 

--- a/infra/environments/preview-foundation/secret_manager.tf
+++ b/infra/environments/preview-foundation/secret_manager.tf
@@ -1,0 +1,33 @@
+resource "google_secret_manager_secret" "preview_backend_identity_toolkit" {
+  count = var.b7_foundation_phase >= 2 && var.b7_phase2_recovery_stage >= 2 && var.b7_restricted_api_key_activation ? 1 : 0
+
+  project   = var.project_id
+  secret_id = "preview-backend-identity-toolkit-api-key"
+
+  replication {
+    auto {}
+  }
+
+  deletion_protection = true
+
+  depends_on = [
+    google_project_service.approved_management["secretmanager.googleapis.com"],
+  ]
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_secret_manager_secret_version" "preview_backend_identity_toolkit" {
+  count = var.b7_foundation_phase >= 2 && var.b7_phase2_recovery_stage >= 2 && var.b7_restricted_api_key_activation ? 1 : 0
+
+  secret                 = google_secret_manager_secret.preview_backend_identity_toolkit[0].id
+  secret_data_wo         = google_apikeys_key.preview_backend_auth[0].key_string
+  secret_data_wo_version = 1
+  deletion_policy        = "DISABLE"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -24,6 +24,8 @@ google_identity_platform_config
 google_project_iam_custom_role
 google_project_iam_member
 google_project_service
+google_secret_manager_secret
+google_secret_manager_secret_version
 google_service_account
 google_service_account_iam_member
 EOF
@@ -31,7 +33,7 @@ EOF
 actual_resources="$(rg -No 'resource "[^"]+"' "$root_dir" --glob '*.tf' | sed -E 's/.*resource "([^"]+)"/\1/' | sort -u)"
 test "$actual_resources" = "$expected_resources"
 
-test "$(rg -No '^resource "[^"]+"' "$root_dir" --glob '*.tf' | wc -l | tr -d ' ')" = "33"
+test "$(rg -No '^resource "[^"]+"' "$root_dir" --glob '*.tf' | wc -l | tr -d ' ')" = "35"
 
 test "$(rg -No 'service\s*=\s*"[^"]+\.googleapis\.com"' "$root_dir/services.tf" | wc -l | tr -d ' ')" = "0"
 test "$(rg -No '"(apikeys|artifactregistry|cloudresourcemanager|firestore|iam|identitytoolkit|run|secretmanager|serviceusage)\.googleapis\.com"' "$root_dir/services.tf" | sort -u | wc -l | tr -d ' ')" = "9"
@@ -50,7 +52,7 @@ grep -Fq 'condition     = contains([1, 2, 3], var.b7_foundation_phase)' "$root_d
 rg -U -q 'variable "b7_phase2_recovery_stage" \{\n  description = "[^"]+"\n  type        = number\n  default     = 2' "$root_dir/variables.tf"
 grep -Fq 'condition     = contains([1, 2], var.b7_phase2_recovery_stage)' "$root_dir/variables.tf"
 rg -U -q 'variable "b7_identity_platform_initialization" \{\n  description = "Governed stage activation for initializing Preview Identity Platform\."\n  type        = bool\n  default     = true\n\}' "$root_dir/variables.tf"
-rg -U -q 'variable "b7_restricted_api_key_activation" \{\n  description = "Governed activation for the Terraform-managed restricted Preview backend API key\."\n  type        = bool\n  default     = false\n\}' "$root_dir/variables.tf"
+rg -U -q 'variable "b7_restricted_api_key_activation" \{\n  description = "Governed activation for the Terraform-managed restricted Preview backend API key and write-only Secret Manager delivery\."\n  type        = bool\n  default     = true\n\}' "$root_dir/variables.tf"
 rg -U -q 'google-beta = \{\n      source  = "hashicorp/google-beta"\n      version = "6\.50\.0"\n    \}' "$root_dir/versions.tf"
 rg -U -q 'provider "google-beta" \{\n  project               = var\.project_id\n  user_project_override = true\n\}' "$root_dir/providers.tf"
 rg -U -q 'resource "google_firebase_project" "preview" \{\n  provider = google-beta\n  project  = var\.project_id\n\n  lifecycle \{\n    prevent_destroy = true\n  \}\n\}' "$root_dir/firebase.tf"
@@ -114,6 +116,9 @@ test "$(rg -No 'multi_tenant \{' "$root_dir/datastore_auth.tf" | wc -l | tr -d '
 rg -q 'role_id     = "previewBackendAuthReader"' "$root_dir/datastore_auth.tf"
 test "$(sed -n '/preview_runtime_auth_permissions = toset(/,/])/p' "$root_dir/datastore_auth.tf" | rg -No '"[^"]+"' | tr -d '"')" = "firebaseauth.users.get"
 rg -q 'service = "identitytoolkit.googleapis.com"' "$root_dir/datastore_auth.tf"
+rg -q 'name         = "preview-backend-auth"' "$root_dir/datastore_auth.tf"
+rg -q 'display_name = "Preview Backend Identity Toolkit"' "$root_dir/datastore_auth.tf"
+rg -U -q '(?s)resource "google_apikeys_key" "preview_backend_auth" \{.*lifecycle \{\n    prevent_destroy = true\n  \}' "$root_dir/datastore_auth.tf"
 
 if rg -n 'firebaseauth\.users\.(create|delete|update|sendEmail)|datastore\.(databases\.(delete|update)|indexes\.|operations\.)|roles/(datastore|firebase|identityplatform)' "$root_dir/datastore_auth.tf"; then
   echo "B7 runtime IAM broadening or destructive datastore permission found" >&2
@@ -129,6 +134,7 @@ fi
 test "$(rg -No 'count = var\.b7_foundation_phase >= 2 \? 1 : 0' "$root_dir/datastore_auth.tf" | wc -l | tr -d ' ')" = "1"
 test "$(rg -No 'count = var\.b7_foundation_phase >= 2 && var\.b7_phase2_recovery_stage >= 2 && var\.b7_identity_platform_initialization \? 1 : 0' "$root_dir/datastore_auth.tf" | wc -l | tr -d ' ')" = "1"
 test "$(rg -No 'count = var\.b7_foundation_phase >= 2 && var\.b7_phase2_recovery_stage >= 2 && var\.b7_restricted_api_key_activation \? 1 : 0' "$root_dir/datastore_auth.tf" | wc -l | tr -d ' ')" = "1"
+test "$(rg -No 'count = var\.b7_foundation_phase >= 2 && var\.b7_phase2_recovery_stage >= 2 && var\.b7_restricted_api_key_activation \? 1 : 0' "$root_dir/secret_manager.tf" | wc -l | tr -d ' ')" = "2"
 grep -Fq 'value = var.b7_foundation_phase >= 2 && var.b7_phase2_recovery_stage >= 2 && var.b7_identity_platform_initialization ? {' "$root_dir/outputs.tf"
 rg -U -q '(?s)resource "google_identity_platform_config" "preview" \{.*depends_on = \[\n    google_firebase_project\.preview,\n    google_project_service\.approved_management\["identitytoolkit\.googleapis\.com"\],\n  \]' "$root_dir/datastore_auth.tf"
 if rg -n 'b7_identity_platform_initialization|b7_restricted_api_key_activation' "$root_dir/cloud_run.tf" "$root_dir/iam.tf"; then
@@ -235,8 +241,23 @@ if rg -n 'roles/secretmanager\.' "$root_dir" --glob '*.tf'; then
   exit 1
 fi
 
-if rg -n 'google_secret_manager_|FIREBASE_API_KEY' "$root_dir" --glob '*.tf'; then
-  echo "Secret resource, runtime binding, or Cloud Run secret injection found in Stage 1" >&2
+test "$(rg -No '^resource "google_secret_manager_secret"' "$root_dir/secret_manager.tf" | wc -l | tr -d ' ')" = "1"
+test "$(rg -No '^resource "google_secret_manager_secret_version"' "$root_dir/secret_manager.tf" | wc -l | tr -d ' ')" = "1"
+rg -q 'secret_id = "preview-backend-identity-toolkit-api-key"' "$root_dir/secret_manager.tf"
+rg -U -q 'replication \{\n    auto \{\}\n  \}' "$root_dir/secret_manager.tf"
+rg -q 'deletion_protection = true' "$root_dir/secret_manager.tf"
+rg -U -q '(?s)resource "google_secret_manager_secret" "preview_backend_identity_toolkit" \{.*lifecycle \{\n    prevent_destroy = true\n  \}' "$root_dir/secret_manager.tf"
+grep -Fq 'secret_data_wo         = google_apikeys_key.preview_backend_auth[0].key_string' "$root_dir/secret_manager.tf"
+rg -q 'secret_data_wo_version = 1' "$root_dir/secret_manager.tf"
+rg -q 'deletion_policy        = "DISABLE"' "$root_dir/secret_manager.tf"
+rg -U -q '(?s)resource "google_secret_manager_secret_version" "preview_backend_identity_toolkit" \{.*lifecycle \{\n    create_before_destroy = true\n  \}' "$root_dir/secret_manager.tf"
+test "$(rg -No 'secret_data_wo\s*=' "$root_dir/secret_manager.tf" | wc -l | tr -d ' ')" = "1"
+if rg -n '(^|[[:space:]])secret_data[[:space:]]*=' "$root_dir" --glob '*.tf'; then
+  echo "Ordinary Secret Manager secret_data found; write-only delivery is required" >&2
+  exit 1
+fi
+if rg -n 'google_secret_manager_secret_iam_|roles/secretmanager\.secretAccessor|FIREBASE_API_KEY' "$root_dir" --glob '*.tf'; then
+  echo "Runtime Secret Manager IAM or Cloud Run secret injection found" >&2
   exit 1
 fi
 

--- a/infra/environments/preview-foundation/variables.tf
+++ b/infra/environments/preview-foundation/variables.tf
@@ -100,7 +100,7 @@ variable "b7_identity_platform_initialization" {
 }
 
 variable "b7_restricted_api_key_activation" {
-  description = "Governed activation for the Terraform-managed restricted Preview backend API key."
+  description = "Governed activation for the Terraform-managed restricted Preview backend API key and write-only Secret Manager delivery."
   type        = bool
-  default     = false
+  default     = true
 }


### PR DESCRIPTION
## Summary

Creates the governed Preview backend Identity Toolkit API key and stores it immediately in Secret Manager through Terraform's write-only secret-version argument.

## Resources

Adds exactly:

- `google_apikeys_key.preview_backend_auth[0]`
- `google_secret_manager_secret.preview_backend_identity_toolkit[0]`
- `google_secret_manager_secret_version.preview_backend_identity_toolkit[0]`

## API key

- Name: `preview-backend-auth`
- Display name: `Preview Backend Identity Toolkit`
- API target: `identitytoolkit.googleapis.com` only
- `prevent_destroy = true`

## Secret Manager

- Secret ID: `preview-backend-identity-toolkit-api-key`
- Automatic Google-managed replication
- Deletion protection enabled
- `prevent_destroy = true`

## Write-only secret version

Uses:

```hcl
secret_data_wo         = google_apikeys_key.preview_backend_auth[0].key_string
secret_data_wo_version = 1
```

Also uses:

- `deletion_policy = "DISABLE"`
- `create_before_destroy = true`

Ordinary `secret_data` is prohibited and absent.

## Boundaries

- no key string in outputs
- no runtime Secret Manager IAM
- no Cloud Run `FIREBASE_API_KEY` injection
- no API-key update or delete permissions
- no Firebase-created Browser-key action
- no Identity Platform change
- no Firebase ownership change
- no Firestore change
- no IAM change
- no Vercel change
- no production change
- no Terraform apply authorized by this PR

## Validation

- `terraform fmt`: passed
- `terraform fmt -check`: passed
- `terraform init -backend=false`: passed
- `terraform validate`: passed
- Preview scope safeguards: passed
- `git diff --check`: passed

## Expected authoritative plan

- 3 add
- 0 change
- 0 destroy
- 0 import
- 0 actions

This PR remains draft pending authoritative HCP plan review.
