### PR TITLE
Stabilize Preview runtime secret accessor check

### DIFF
--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -114,7 +114,7 @@ check "b7_backend_auth_secret_boundary" {
       google_secret_manager_secret.preview_backend_identity_toolkit[0].deletion_protection &&
       google_secret_manager_secret_version.preview_backend_identity_toolkit[0].secret_data_wo_version == 1 &&
       google_secret_manager_secret_version.preview_backend_identity_toolkit[0].deletion_policy == "DISABLE" &&
-      google_secret_manager_secret_iam_member.preview_backend_identity_toolkit_accessor[0].secret_id == google_secret_manager_secret.preview_backend_identity_toolkit[0].secret_id &&
+      google_secret_manager_secret_iam_member.preview_backend_identity_toolkit_accessor[0].secret_id == google_secret_manager_secret.preview_backend_identity_toolkit[0].id &&
       google_secret_manager_secret_iam_member.preview_backend_identity_toolkit_accessor[0].role == "roles/secretmanager.secretAccessor" &&
       google_secret_manager_secret_iam_member.preview_backend_identity_toolkit_accessor[0].member == google_service_account.preview_backend_runtime.member
     )

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -255,6 +255,7 @@ rg -q 'secret_data_wo_version = 1' "$root_dir/secret_manager.tf"
 rg -q 'deletion_policy        = "DISABLE"' "$root_dir/secret_manager.tf"
 rg -U -q '(?s)resource "google_secret_manager_secret_version" "preview_backend_identity_toolkit" \{.*lifecycle \{\n    create_before_destroy = true\n  \}' "$root_dir/secret_manager.tf"
 rg -U -q 'resource "google_secret_manager_secret_iam_member" "preview_backend_identity_toolkit_accessor" \{\n  count = var\.b7_foundation_phase >= 2 && var\.b7_phase2_recovery_stage >= 2 && var\.b7_restricted_api_key_activation \? 1 : 0\n\n  project   = var\.project_id\n  secret_id = google_secret_manager_secret\.preview_backend_identity_toolkit\[0\]\.secret_id\n  role      = "roles/secretmanager\.secretAccessor"\n  member    = google_service_account\.preview_backend_runtime\.member\n\}' "$root_dir/secret_manager.tf"
+grep -Fq 'google_secret_manager_secret_iam_member.preview_backend_identity_toolkit_accessor[0].secret_id == google_secret_manager_secret.preview_backend_identity_toolkit[0].id' "$root_dir/checks.tf"
 test "$(rg -No 'secret_data_wo\s*=' "$root_dir/secret_manager.tf" | wc -l | tr -d ' ')" = "1"
 if rg -n '(^|[[:space:]])secret_data[[:space:]]*=' "$root_dir" --glob '*.tf'; then
   echo "Ordinary Secret Manager secret_data found; write-only delivery is required" >&2


### PR DESCRIPTION
## Summary

Corrects the Preview runtime secret-accessor assertion to compare equivalent fully qualified Secret Manager identifiers.

The IAM member resource returns:

`projects/rentchain-preview/secrets/preview-backend-identity-toolkit-api-key`

The secret resource's `id` returns the same fully qualified path.

## Change

Replaces the invalid comparison against the short `secret_id` with:

`google_secret_manager_secret.preview_backend_identity_toolkit[0].id`

## Boundaries

- no IAM binding change
- no runtime permission change
- no API-key change
- no secret or secret-version change
- no Cloud Run change
- no `FIREBASE_API_KEY` injection
- no Firebase, Identity Platform, Firestore, Vercel, or production change
- no Terraform apply required

## Validation

- `terraform fmt`: passed
- `terraform fmt -check`: passed
- `terraform init -backend=false`: passed
- `terraform validate`: passed
- Preview scope safeguards: passed
- `git diff --check`: passed

## Expected authoritative plan

- 0 add
- 0 change
- 0 destroy
- 0 import
- 0 actions

The prior check warning must be absent.
