### PR TITLE
Inject Preview backend auth key from Secret Manager

### DIFF
--- a/docs/strategy/preview-infrastructure/phase-b-b7-datastore-auth-foundation.md
+++ b/docs/strategy/preview-infrastructure/phase-b-b7-datastore-auth-foundation.md
@@ -68,11 +68,13 @@ value as sensitive. The governed backend-key stage creates the key in Terraform
 state without exposing it through outputs or attaching it to Cloud Run. Its
 value flows directly from the API Keys resource into a protected Secret Manager
 version through Terraform's write-only `secret_data_wo` argument. Ordinary
-`secret_data` is prohibited. Delivery from Secret Manager to Cloud Run requires
-a separately reviewed runtime activation phase. The runtime service account has
-only `roles/secretmanager.secretAccessor` on this exact secret; it has no
-project-wide Secret Manager role, secret creation permission, or IAM
-administration permission.
+`secret_data` is prohibited. The governed runtime-delivery stage injects
+`FIREBASE_API_KEY` into the Preview Cloud Run service from explicit Secret
+Manager version `1`; it does not expose a literal key or use the mutable
+`latest` alias. The runtime service account has only
+`roles/secretmanager.secretAccessor` on this exact secret; it has no project-wide
+Secret Manager role, secret creation permission, or IAM administration
+permission.
 
 The runtime role `previewBackendAuthReader` contains only
 `firebaseauth.users.get`. The existing login path needs this permission to read
@@ -122,8 +124,13 @@ Google-managed replication, deletion protection, and Terraform
 version `1`, deletion policy `DISABLE`, and `create_before_destroy`. The exact
 secret carries one `roles/secretmanager.secretAccessor` member for
 `preview-backend-runtime@rentchain-preview.iam.gserviceaccount.com`. There is no
-project-wide Secret Manager binding or Cloud Run secret reference. No Firebase
-Management, Firestore Rules, Cloud Run Jobs, or production API is added.
+project-wide Secret Manager binding. Cloud Run references only explicit version
+`1`; no payload appears in Terraform output or Cloud Run's environment
+configuration display. Applying this change creates a new Preview service
+revision while the existing healthy revision remains the rollback target.
+Runtime login QA is separately authorized, and no production traffic is
+involved. No Firebase Management, Firestore Rules, Cloud Run Jobs, or production
+API is added.
 
 ## Apply sequencing and bootstrap gate
 

--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -122,6 +122,30 @@ check "b7_backend_auth_secret_boundary" {
   }
 }
 
+check "b7_preview_backend_auth_secret_injection_boundary" {
+  assert {
+    condition = var.enable_preview_backend_service ? (
+      length([
+        for env in google_cloud_run_v2_service.preview_backend[0].template[0].containers[0].env : env
+        if env.name == "FIREBASE_API_KEY"
+      ]) == 1 &&
+      one([
+        for env in google_cloud_run_v2_service.preview_backend[0].template[0].containers[0].env : env
+        if env.name == "FIREBASE_API_KEY"
+      ]).value_source[0].secret_key_ref[0].secret == google_secret_manager_secret.preview_backend_identity_toolkit[0].secret_id &&
+      one([
+        for env in google_cloud_run_v2_service.preview_backend[0].template[0].containers[0].env : env
+        if env.name == "FIREBASE_API_KEY"
+      ]).value_source[0].secret_key_ref[0].version == "1" &&
+      one([
+        for env in google_cloud_run_v2_service.preview_backend[0].template[0].containers[0].env : env
+        if env.name == "FIRESTORE_ENABLED"
+      ]).value == "false"
+    ) : true
+    error_message = "The Preview backend must receive only explicit version 1 of the governed Identity Toolkit secret while Firestore remains disabled."
+  }
+}
+
 check "b7_hcp_bootstrap_iam_boundary" {
   assert {
     condition = (

--- a/infra/environments/preview-foundation/cloud_run.tf
+++ b/infra/environments/preview-foundation/cloud_run.tf
@@ -59,6 +59,17 @@ resource "google_cloud_run_v2_service" "preview_backend" {
       }
 
       env {
+        name = "FIREBASE_API_KEY"
+
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.preview_backend_identity_toolkit[0].secret_id
+            version = "1"
+          }
+        }
+      }
+
+      env {
         name  = "APP_GIT_SHA"
         value = local.preview_backend_source_sha
       }
@@ -79,5 +90,6 @@ resource "google_cloud_run_v2_service" "preview_backend" {
 
   depends_on = [
     google_project_service.approved_management["run.googleapis.com"],
+    google_secret_manager_secret_iam_member.preview_backend_identity_toolkit_accessor,
   ]
 }

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -127,8 +127,15 @@ if rg -n 'firebaseauth\.users\.(create|delete|update|sendEmail)|datastore\.(data
 fi
 
 rg -U -q 'name  = "FIRESTORE_ENABLED"\n        value = "false"' "$root_dir/cloud_run.tf"
-if rg -n 'FIRESTORE_DATABASE_ID|PREVIEW_AUTH_ENABLED|FIREBASE_PROJECT_ID|FIREBASE_API_KEY|google_apikeys_key' "$root_dir/cloud_run.tf"; then
-  echo "B7 Cloud Run activation must remain deferred until the separately reviewed runtime-image phase" >&2
+test "$(rg -No 'name = "FIREBASE_API_KEY"' "$root_dir/cloud_run.tf" | wc -l | tr -d ' ')" = "1"
+rg -U -q 'env \{\n        name = "FIREBASE_API_KEY"\n\n        value_source \{\n          secret_key_ref \{\n            secret  = google_secret_manager_secret\.preview_backend_identity_toolkit\[0\]\.secret_id\n            version = "1"\n          \}\n        \}\n      \}' "$root_dir/cloud_run.tf"
+grep -Fq 'google_secret_manager_secret_iam_member.preview_backend_identity_toolkit_accessor,' "$root_dir/cloud_run.tf"
+if rg -n 'FIRESTORE_DATABASE_ID|PREVIEW_AUTH_ENABLED|FIREBASE_PROJECT_ID|google_apikeys_key|key_string|version\s*=\s*"latest"' "$root_dir/cloud_run.tf"; then
+  echo "B7 Cloud Run secret injection contains a prohibited activation field, direct key reference, or mutable secret version" >&2
+  exit 1
+fi
+if rg -U -n 'name = "FIREBASE_API_KEY"\n[[:space:]]+value[[:space:]]*=' "$root_dir/cloud_run.tf"; then
+  echo "B7 Cloud Run FIREBASE_API_KEY must not use a literal value" >&2
   exit 1
 fi
 
@@ -261,8 +268,12 @@ if rg -n '(^|[[:space:]])secret_data[[:space:]]*=' "$root_dir" --glob '*.tf'; th
   echo "Ordinary Secret Manager secret_data found; write-only delivery is required" >&2
   exit 1
 fi
-if rg -n 'google_project_iam_(member|binding).*secretmanager|FIREBASE_API_KEY' "$root_dir" --glob '*.tf'; then
-  echo "Project-wide Secret Manager IAM or Cloud Run secret injection found" >&2
+if rg -n 'google_project_iam_(member|binding).*secretmanager' "$root_dir" --glob '*.tf'; then
+  echo "Project-wide Secret Manager IAM found" >&2
+  exit 1
+fi
+if rg -n 'FIREBASE_API_KEY' "$root_dir" --glob '*.tf' | rg -v '/(cloud_run|checks)\.tf:'; then
+  echo "FIREBASE_API_KEY found outside the governed Cloud Run resource or its check" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

Updates only the existing Preview Cloud Run backend service to receive the governed Identity Toolkit API key from Secret Manager.

## Cloud Run change

Adds exactly one environment variable:

```hcl
env {
  name = "FIREBASE_API_KEY"

  value_source {
    secret_key_ref {
      secret  = google_secret_manager_secret.preview_backend_identity_toolkit[0].secret_id
      version = "1"
    }
  }
}
```

The service also explicitly depends on the governed secret-level runtime accessor binding.

## Boundaries

- explicit secret version `1`
- no `latest`
- no literal API-key value
- no direct `key_string` reference
- `FIRESTORE_ENABLED=false` remains unchanged
- no image change
- no runtime service-account change
- no ingress or public-access change
- no traffic, scaling, CPU, memory, concurrency, timeout, probe, or port change
- no API-key or secret-version change
- no IAM change
- no Firebase, Identity Platform, Firestore, Vercel, backend, frontend, or production change
- no Terraform apply authorized by this PR

## Apply behavior

Applying this change will create a new Preview Cloud Run revision. The existing healthy revision remains the rollback target. Runtime login QA remains separately authorized.

## Validation

- `terraform fmt`: passed
- `terraform fmt -check`: passed
- `terraform init -backend=false`: passed
- `terraform validate`: passed
- Preview scope safeguards: passed
- `git diff --check`: passed

## Expected authoritative plan

- 0 add
- 1 change
- 0 destroy
- 0 import
- 0 actions

Exact changed resource:

- `google_cloud_run_v2_service.preview_backend[0]`

This PR remains draft pending authoritative HCP plan review.
