### PR TITLE
Add Vercel Preview OIDC Terraform IAM prerequisites

### DIFF
--- a/docs/strategy/preview-infrastructure/phase-b-b7-datastore-auth-foundation.md
+++ b/docs/strategy/preview-infrastructure/phase-b-b7-datastore-auth-foundation.md
@@ -139,7 +139,7 @@ The B7 speculative plan is not apply authorization.
 Phase 1 creates two dedicated B7 custom roles rather than broadening the
 existing Cloud Run roles:
 
-- `hcpTerraformPreviewB7Reader` contains exactly the nine permissions in
+- `hcpTerraformPreviewB7Reader` contains exactly the thirteen permissions in
   `tests/hcp_b7_plan_permission_delta.txt` and is bound only to
   `hcp-terraform-preview@rentchain-preview.iam.gserviceaccount.com`;
 - `terraformPreviewB7Manager` contains exactly the seventeen permissions in
@@ -162,6 +162,17 @@ isolated Google provider quota project to be charged for Firebase project reads
 when `user_project_override = true`. This does not grant API enablement,
 disablement, service discovery, billing administration, or a predefined Service
 Usage role.
+
+The B7 plan reader additionally has only the four metadata reads required to
+refresh a separately governed Vercel Preview identity foundation:
+`iam.workloadIdentityPools.get`, `iam.workloadIdentityPoolProviders.get`,
+`iam.serviceAccounts.get`, and `iam.serviceAccounts.getIamPolicy`. The existing
+Cloud Run plan viewer adds only `run.services.getIamPolicy`, while the existing
+Cloud Run deployer adds only `run.services.getIamPolicy` and
+`run.services.setIamPolicy`. These permissions prepare a future service-level
+Invoker binding plan; this prerequisite adds no Workload Identity resource,
+service account, federation member, token-generation role, Invoker binding, or
+Cloud Run service change.
 
 The active Firebase association for `rentchain-preview` is adopted through the
 `google-beta` 6.50.0 `google_firebase_project` resource and one declarative

--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -157,6 +157,10 @@ check "b7_hcp_bootstrap_iam_boundary" {
         "datastore.databases.getMetadata",
         "firebase.projects.get",
         "firebaseauth.configs.get",
+        "iam.serviceAccounts.get",
+        "iam.serviceAccounts.getIamPolicy",
+        "iam.workloadIdentityPoolProviders.get",
+        "iam.workloadIdentityPools.get",
         "secretmanager.secrets.get",
         "secretmanager.secrets.getIamPolicy",
         "secretmanager.versions.get",
@@ -164,7 +168,7 @@ check "b7_hcp_bootstrap_iam_boundary" {
       ]) &&
       google_project_iam_member.hcp_terraform_preview_b7_reader.member == local.hcp_terraform_plan_member
     )
-    error_message = "The B7 plan reader must remain the exact nine-permission role bound only to the HCP plan identity."
+    error_message = "The B7 plan reader must remain the exact thirteen-permission role bound only to the HCP plan identity."
   }
 
   assert {
@@ -291,10 +295,12 @@ check "b6_cloud_run_deployer_iam_boundary" {
         "run.services.create",
         "run.services.delete",
         "run.services.get",
+        "run.services.getIamPolicy",
+        "run.services.setIamPolicy",
         "run.services.update",
       ])
     )
-    error_message = "The B6 Cloud Run deployer role must remain Preview-scoped and lifecycle-only."
+    error_message = "The Cloud Run deployer role must remain Preview-scoped with only the governed service lifecycle and IAM-policy permissions."
   }
 
   assert {
@@ -315,12 +321,13 @@ check "b6_cloud_run_plan_viewer_iam_boundary" {
       google_project_iam_custom_role.terraform_preview_cloud_run_viewer.role_id == "hcpTerraformPreviewCloudRunViewer" &&
       local.terraform_preview_cloud_run_viewer_permissions == toset([
         "run.services.get",
+        "run.services.getIamPolicy",
       ]) &&
       google_project_iam_member.terraform_preview_cloud_run_viewer.project == "rentchain-preview" &&
       google_project_iam_member.terraform_preview_cloud_run_viewer.member == local.hcp_terraform_plan_member &&
       local.hcp_terraform_plan_member == "serviceAccount:hcp-terraform-preview@rentchain-preview.iam.gserviceaccount.com"
     )
-    error_message = "The B6 plan viewer must remain a single-permission Preview-only binding for the exact HCP plan identity."
+    error_message = "The Cloud Run plan viewer must remain an exact two-permission Preview-only binding for the HCP plan identity."
   }
 }
 

--- a/infra/environments/preview-foundation/iam.tf
+++ b/infra/environments/preview-foundation/iam.tf
@@ -4,6 +4,7 @@ locals {
 
   terraform_preview_cloud_run_viewer_permissions = toset([
     "run.services.get",
+    "run.services.getIamPolicy",
   ])
 
   terraform_preview_cloud_run_deployer_permissions = toset([
@@ -12,6 +13,8 @@ locals {
     "run.services.create",
     "run.services.delete",
     "run.services.get",
+    "run.services.getIamPolicy",
+    "run.services.setIamPolicy",
     "run.services.update",
   ])
 
@@ -21,6 +24,10 @@ locals {
     "datastore.databases.getMetadata",
     "firebase.projects.get",
     "firebaseauth.configs.get",
+    "iam.serviceAccounts.get",
+    "iam.serviceAccounts.getIamPolicy",
+    "iam.workloadIdentityPoolProviders.get",
+    "iam.workloadIdentityPools.get",
     "secretmanager.secrets.get",
     "secretmanager.secrets.getIamPolicy",
     "secretmanager.versions.get",

--- a/infra/environments/preview-foundation/tests/hcp_b7_plan_permission_delta.txt
+++ b/infra/environments/preview-foundation/tests/hcp_b7_plan_permission_delta.txt
@@ -3,6 +3,10 @@ apikeys.keys.getKeyString
 datastore.databases.getMetadata
 firebase.projects.get
 firebaseauth.configs.get
+iam.serviceAccounts.get
+iam.serviceAccounts.getIamPolicy
+iam.workloadIdentityPoolProviders.get
+iam.workloadIdentityPools.get
 secretmanager.secrets.get
 secretmanager.secrets.getIamPolicy
 secretmanager.versions.get

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -183,6 +183,10 @@ apikeys.keys.getKeyString
 datastore.databases.getMetadata
 firebase.projects.get
 firebaseauth.configs.get
+iam.serviceAccounts.get
+iam.serviceAccounts.getIamPolicy
+iam.workloadIdentityPoolProviders.get
+iam.workloadIdentityPools.get
 secretmanager.secrets.get
 secretmanager.secrets.getIamPolicy
 secretmanager.versions.get
@@ -293,7 +297,12 @@ actual_cloud_run_viewer_permissions="$(
     | rg -No '"[^"]+"' \
     | tr -d '"'
 )"
-test "$actual_cloud_run_viewer_permissions" = "run.services.get"
+expected_cloud_run_viewer_permissions="$(cat <<'EOF'
+run.services.get
+run.services.getIamPolicy
+EOF
+)"
+test "$actual_cloud_run_viewer_permissions" = "$expected_cloud_run_viewer_permissions"
 
 if rg -n 'roles/iam\.serviceAccountUser' "$root_dir" --glob '*.tf' | rg -v '/(iam|checks)\.tf:'; then
   echo "Service Account User must remain limited to the B6 exact runtime binding" >&2
@@ -386,6 +395,10 @@ apikeys.keys.getKeyString
 datastore.databases.getMetadata
 firebase.projects.get
 firebaseauth.configs.get
+iam.serviceAccounts.get
+iam.serviceAccounts.getIamPolicy
+iam.workloadIdentityPoolProviders.get
+iam.workloadIdentityPools.get
 secretmanager.secrets.get
 secretmanager.secrets.getIamPolicy
 secretmanager.versions.get
@@ -393,7 +406,7 @@ serviceusage.services.use
 EOF
 )"
 test "$(sort -u "$b7_plan_delta_file")" = "$expected_b7_plan_delta"
-test "$(wc -l < "$b7_plan_delta_file" | tr -d ' ')" = "9"
+test "$(wc -l < "$b7_plan_delta_file" | tr -d ' ')" = "13"
 
 expected_b7_apply_delta="$(cat <<'EOF'
 apikeys.keys.create
@@ -444,6 +457,8 @@ run.operations.get
 run.services.create
 run.services.delete
 run.services.get
+run.services.getIamPolicy
+run.services.setIamPolicy
 run.services.update
 EOF
 )"


### PR DESCRIPTION
## Summary

Adds the exact Terraform read and Cloud Run service-IAM permissions required for the later isolated Vercel Preview OIDC identity foundation.

## B7 plan reader

Adds only:

- `iam.serviceAccounts.get`
- `iam.serviceAccounts.getIamPolicy`
- `iam.workloadIdentityPoolProviders.get`
- `iam.workloadIdentityPools.get`

Final exact permission count:

- 13

## Cloud Run plan viewer

Adds only:

- `run.services.getIamPolicy`

Final exact permission count:

- 2

## Cloud Run apply deployer

Adds only:

- `run.services.getIamPolicy`
- `run.services.setIamPolicy`

Final exact permission count:

- 8

## Boundaries

- no IAM binding or principal changes
- no Workload Identity pool or provider
- no service account
- no token-generation permissions or roles
- no service-account keys
- no `roles/run.invoker`
- no public Cloud Run access
- no Cloud Run service or revision change
- no Vercel setting or deployment change
- no frontend or backend source change
- no landlord API or production change
- no Terraform apply authorized by this PR

## Validation

- `terraform fmt`: passed
- `terraform fmt -check`: passed
- `terraform validate`: passed locally
- Preview scope safeguards: passed
- `git diff --check`: passed

## Expected authoritative plan

- 0 add
- 3 change
- 0 destroy
- 0 import
- 0 actions

Exact changed resources:

- `google_project_iam_custom_role.hcp_terraform_preview_b7_reader`
- `google_project_iam_custom_role.terraform_preview_cloud_run_viewer`
- `google_project_iam_custom_role.terraform_preview_cloud_run_deployer`

This PR remains draft pending authoritative HCP plan review.
