### PR TITLE
Normalize Vercel Preview Cloud Run IAM check

### DIFF
--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -410,7 +410,9 @@ check "b7_vercel_preview_proxy_identity_boundary" {
     condition = (
       google_cloud_run_v2_service_iam_member.vercel_preview_proxy_invoker.project == "rentchain-preview" &&
       google_cloud_run_v2_service_iam_member.vercel_preview_proxy_invoker.location == "northamerica-northeast1" &&
-      google_cloud_run_v2_service_iam_member.vercel_preview_proxy_invoker.name == "rentchain-preview-backend" &&
+      basename(
+        google_cloud_run_v2_service_iam_member.vercel_preview_proxy_invoker.name
+      ) == "rentchain-preview-backend" &&
       google_cloud_run_v2_service_iam_member.vercel_preview_proxy_invoker.role == "roles/run.invoker" &&
       google_cloud_run_v2_service_iam_member.vercel_preview_proxy_invoker.member == "serviceAccount:vercel-preview-proxy@rentchain-preview.iam.gserviceaccount.com"
     )

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -94,6 +94,7 @@ rg -q 'workload_identity_pool_provider_id = "vercel-preview"' "$vercel_identity_
 rg -q 'vercel_preview_issuer[[:space:]]*=[[:space:]]*"https://oidc\.vercel\.com/rent-chain"' "$vercel_identity_file"
 test "$(rg -No 'allowed_audiences' "$vercel_identity_file" | wc -l | tr -d ' ')" = "0"
 test "$(rg -No 'google_service_account_iam_member\.vercel_preview_proxy_(workload_identity_user|openid_token_creator)\.service_account_id' "$root_dir/checks.tf" | wc -l | tr -d ' ')" = "0"
+rg -U -q 'basename\(\n        google_cloud_run_v2_service_iam_member\.vercel_preview_proxy_invoker\.name\n      \) == "rentchain-preview-backend"' "$root_dir/checks.tf"
 grep -Fq 'length(google_iam_workload_identity_pool_provider.vercel_preview.attribute_mapping) == 4' "$root_dir/checks.tf"
 grep -Fq 'attribute_mapping["google.subject"] == "assertion.sub"' "$root_dir/checks.tf"
 grep -Fq 'attribute_mapping["attribute.owner_id"] == "assertion.owner_id"' "$root_dir/checks.tf"


### PR DESCRIPTION
## Summary
- normalize the Cloud Run IAM member service name with basename() in the post-apply check
- require the normalized assertion in the static preview-foundation scope safeguard
- preserve all exact project, location, role, member, federation, and six-resource boundaries

## Validation
- terraform fmt
- terraform fmt -check
- terraform init -backend=false -upgrade=false
- terraform validate
- bash ./tests/validate_scope.sh
- git diff --check

## Scope
- check-only repair; no Terraform resources, IAM bindings, provider configuration, lock file, runtime code, or cloud resources changed
- no Terraform apply required or performed

## Hold
Do not merge until the authoritative HCP speculative plan reports 0 add, 0 change, 0 destroy, 0 import, and 0 actions, with no failed or unknown-after-apply check assertion.