### PR TITLE
Add secure Vercel Preview backend proxy

### DIFF
--- a/rentchain-frontend/api/preview-backend/[...path].ts
+++ b/rentchain-frontend/api/preview-backend/[...path].ts
@@ -1,0 +1,5 @@
+import { handlePreviewBackendProxy } from "../../server/previewBackendProxy.js";
+
+export default async function handler(req: any, res: any) {
+  return handlePreviewBackendProxy(req, res);
+}

--- a/rentchain-frontend/server/previewAuthBridge.ts
+++ b/rentchain-frontend/server/previewAuthBridge.ts
@@ -162,9 +162,27 @@ export async function exchangeVercelToken(
     );
   }
 
-  const payload = (await response.json()) as { access_token?: unknown };
+  const payload = (await response.json()) as {
+    access_token?: unknown;
+    token_type?: unknown;
+    expires_in?: unknown;
+  };
   if (typeof payload.access_token !== "string" || !payload.access_token) {
     throw new PreviewAuthBridgeError("STS_ACCESS_TOKEN_MISSING");
+  }
+  if (
+    payload.token_type != null &&
+    (typeof payload.token_type !== "string" || payload.token_type.toLowerCase() !== "bearer")
+  ) {
+    throw new PreviewAuthBridgeError("STS_TOKEN_TYPE_INVALID");
+  }
+  if (
+    payload.expires_in != null &&
+    (typeof payload.expires_in !== "number" ||
+      !Number.isFinite(payload.expires_in) ||
+      payload.expires_in <= 0)
+  ) {
+    throw new PreviewAuthBridgeError("STS_TOKEN_EXPIRY_INVALID");
   }
   return payload.access_token;
 }
@@ -199,6 +217,9 @@ export async function generateCloudRunIdToken(
   const payload = (await response.json()) as { token?: unknown };
   if (typeof payload.token !== "string" || !payload.token) {
     throw new PreviewAuthBridgeError("IAM_ID_TOKEN_MISSING");
+  }
+  if (payload.token.split(".").length !== 3) {
+    throw new PreviewAuthBridgeError("IAM_ID_TOKEN_INVALID");
   }
   return payload.token;
 }

--- a/rentchain-frontend/server/previewBackendProxy.ts
+++ b/rentchain-frontend/server/previewBackendProxy.ts
@@ -1,0 +1,339 @@
+import {
+  acquireVercelOidcToken,
+  exchangeVercelToken,
+  generateCloudRunIdToken,
+  PreviewAuthBridgeError,
+  type PreviewAuthConfig,
+} from "./previewAuthBridge.js";
+
+export const PREVIEW_PROXY_CONFIG = {
+  projectNumber: "501298948635",
+  workloadIdentityPoolId: "vercel-preview-proxy",
+  workloadIdentityProviderId: "vercel-preview",
+  serviceAccountEmail:
+    "vercel-preview-proxy@rentchain-preview.iam.gserviceaccount.com",
+  cloudRunServiceUrl:
+    "https://rentchain-preview-backend-glistw4pya-nn.a.run.app",
+} as const;
+
+const PROVIDER_PATH =
+  `projects/${PREVIEW_PROXY_CONFIG.projectNumber}/locations/global/` +
+  `workloadIdentityPools/${PREVIEW_PROXY_CONFIG.workloadIdentityPoolId}/` +
+  `providers/${PREVIEW_PROXY_CONFIG.workloadIdentityProviderId}`;
+
+export const PREVIEW_PROXY_AUTH_CONFIG: PreviewAuthConfig = {
+  vercelOidcTokenAudience: `https://iam.googleapis.com/${PROVIDER_PATH}`,
+  googleStsAudience: `//iam.googleapis.com/${PROVIDER_PATH}`,
+  cloudRunIdTokenAudience: PREVIEW_PROXY_CONFIG.cloudRunServiceUrl,
+  serviceAccountEmail: PREVIEW_PROXY_CONFIG.serviceAccountEmail,
+  cloudRunServiceUrl: PREVIEW_PROXY_CONFIG.cloudRunServiceUrl,
+  expectedSpikeCommit: "",
+};
+
+export const PREVIEW_PROXY_BODY_LIMIT_BYTES = 16 * 1024;
+export const PREVIEW_PROXY_TOKEN_TIMEOUT_MS = 5_000;
+export const PREVIEW_PROXY_UPSTREAM_TIMEOUT_MS = 10_000;
+
+const ROUTE_METHODS = new Map<string, ReadonlySet<string>>([
+  ["/api/auth/login", new Set(["POST"])],
+  ["/api/auth/logout", new Set(["POST"])],
+  ["/api/me", new Set(["GET"])],
+  ["/api/auth/me", new Set(["GET"])],
+]);
+
+const RESPONSE_HEADERS = new Set([
+  "cache-control",
+  "content-type",
+  "x-request-id",
+  "x-route-source",
+]);
+
+type FetchLike = typeof fetch;
+type GetVercelOidcTokenLike = (options: { audience: string }) => Promise<string>;
+
+export type PreviewBackendProxyDependencies = {
+  fetchImpl?: FetchLike;
+  getVercelOidcToken?: GetVercelOidcTokenLike;
+  tokenTimeoutMs?: number;
+  upstreamTimeoutMs?: number;
+};
+
+class PreviewBackendProxyError extends Error {
+  constructor(
+    readonly code: string,
+    readonly status: number,
+  ) {
+    super(code);
+    this.name = "PreviewBackendProxyError";
+  }
+}
+
+function jsonError(res: any, status: number, code: string) {
+  res.setHeader("cache-control", "no-store");
+  return res.status(status).json({ ok: false, error: code });
+}
+
+function rawRequestPath(req: any): { path: string; query: string } {
+  const requestUrl = typeof req?.url === "string" ? req.url : "";
+  const queryIndex = requestUrl.indexOf("?");
+  return {
+    path: queryIndex >= 0 ? requestUrl.slice(0, queryIndex) : requestUrl,
+    query: queryIndex >= 0 ? requestUrl.slice(queryIndex + 1) : "",
+  };
+}
+
+export function resolvePreviewBackendPath(req: any): {
+  backendPath: string;
+  query: string;
+} {
+  const { path, query } = rawRequestPath(req);
+  const prefix = "/api/preview-backend/";
+
+  if (!path.startsWith(prefix) || path.startsWith(`${prefix}/`)) {
+    throw new PreviewBackendProxyError("PREVIEW_PROXY_ROUTE_NOT_ALLOWED", 404);
+  }
+
+  const rawSuffix = path.slice(prefix.length);
+  if (
+    !rawSuffix ||
+    rawSuffix.includes("\\") ||
+    rawSuffix.includes("\0") ||
+    /%2f|%5c/i.test(rawSuffix) ||
+    /%(?![0-9a-f]{2})/i.test(rawSuffix)
+  ) {
+    throw new PreviewBackendProxyError("PREVIEW_PROXY_ROUTE_NOT_ALLOWED", 404);
+  }
+
+  let decodedSuffix = "";
+  try {
+    decodedSuffix = decodeURIComponent(rawSuffix);
+  } catch {
+    throw new PreviewBackendProxyError("PREVIEW_PROXY_ROUTE_NOT_ALLOWED", 404);
+  }
+
+  const segments = decodedSuffix.split("/");
+  if (
+    segments.some((segment) => !segment || segment === "." || segment === "..") ||
+    decodedSuffix.includes("\\") ||
+    decodedSuffix.startsWith("/") ||
+    decodedSuffix.toLowerCase().startsWith("api/preview-backend/")
+  ) {
+    throw new PreviewBackendProxyError("PREVIEW_PROXY_ROUTE_NOT_ALLOWED", 404);
+  }
+
+  const backendPath = `/${decodedSuffix}`;
+  if (!ROUTE_METHODS.has(backendPath)) {
+    throw new PreviewBackendProxyError("PREVIEW_PROXY_ROUTE_NOT_ALLOWED", 404);
+  }
+
+  return { backendPath, query };
+}
+
+function assertMethod(backendPath: string, method: string) {
+  if (!ROUTE_METHODS.get(backendPath)?.has(method)) {
+    throw new PreviewBackendProxyError("PREVIEW_PROXY_METHOD_NOT_ALLOWED", 405);
+  }
+}
+
+function requestBody(req: any, method: string): BodyInit | undefined {
+  if (method === "GET") return undefined;
+
+  const declaredLength = Number(req?.headers?.["content-length"] || 0);
+  if (
+    Number.isFinite(declaredLength) &&
+    declaredLength > PREVIEW_PROXY_BODY_LIMIT_BYTES
+  ) {
+    throw new PreviewBackendProxyError("PREVIEW_PROXY_BODY_TOO_LARGE", 413);
+  }
+
+  const input = req?.body;
+  if (input == null) return undefined;
+
+  let body: string | Uint8Array;
+  if (typeof input === "string") {
+    const contentType = String(req?.headers?.["content-type"] || "").toLowerCase();
+    if (contentType.includes("application/json")) {
+      try {
+        JSON.parse(input);
+      } catch {
+        throw new PreviewBackendProxyError("PREVIEW_PROXY_BODY_INVALID", 400);
+      }
+    }
+    body = input;
+  } else if (ArrayBuffer.isView(input)) {
+    body = new Uint8Array(input.buffer, input.byteOffset, input.byteLength);
+  } else if (input instanceof ArrayBuffer) {
+    body = new Uint8Array(input);
+  } else {
+    try {
+      body = JSON.stringify(input);
+    } catch {
+      throw new PreviewBackendProxyError("PREVIEW_PROXY_BODY_INVALID", 400);
+    }
+  }
+
+  const byteLength =
+    typeof body === "string" ? Buffer.byteLength(body, "utf8") : body.byteLength;
+  if (byteLength > PREVIEW_PROXY_BODY_LIMIT_BYTES) {
+    throw new PreviewBackendProxyError("PREVIEW_PROXY_BODY_TOO_LARGE", 413);
+  }
+  return body;
+}
+
+function upstreamHeaders(req: any, googleIdToken: string): Record<string, string> {
+  const headers: Record<string, string> = {
+    "X-Serverless-Authorization": `Bearer ${googleIdToken}`,
+  };
+
+  for (const name of ["accept", "authorization", "content-type", "x-request-id"]) {
+    const value = req?.headers?.[name];
+    if (typeof value === "string" && value) headers[name] = value;
+  }
+  return headers;
+}
+
+async function withTimeout<T>(
+  timeoutMs: number,
+  code: string,
+  operation: (signal: AbortSignal) => Promise<T>,
+): Promise<T> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await operation(controller.signal);
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw new PreviewBackendProxyError(code, 504);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function timedFetch(fetchImpl: FetchLike, timeoutMs: number, code: string): FetchLike {
+  return ((input: RequestInfo | URL, init?: RequestInit) =>
+    withTimeout(timeoutMs, code, (signal) =>
+      fetchImpl(input, { ...init, signal }),
+    )) as FetchLike;
+}
+
+function mapTokenError(error: unknown): PreviewBackendProxyError {
+  if (error instanceof PreviewBackendProxyError) return error;
+  if (error instanceof PreviewAuthBridgeError) {
+    if (error.code.startsWith("STS_")) {
+      return new PreviewBackendProxyError("GOOGLE_STS_EXCHANGE_FAILED", 502);
+    }
+    if (error.code.startsWith("IAM_")) {
+      return new PreviewBackendProxyError("GOOGLE_ID_TOKEN_FAILED", 502);
+    }
+  }
+  return new PreviewBackendProxyError("PREVIEW_BACKEND_UNAVAILABLE", 502);
+}
+
+export async function handlePreviewBackendProxy(
+  req: any,
+  res: any,
+  dependencies: PreviewBackendProxyDependencies = {},
+) {
+  if (process.env.VERCEL_ENV !== "preview") {
+    return jsonError(res, 403, "PREVIEW_PROXY_ENVIRONMENT_REJECTED");
+  }
+
+  let route: { backendPath: string; query: string };
+  let method: string;
+  let body: BodyInit | undefined;
+  try {
+    route = resolvePreviewBackendPath(req);
+    method = String(req?.method || "GET").toUpperCase();
+    assertMethod(route.backendPath, method);
+    body = requestBody(req, method);
+  } catch (error) {
+    if (error instanceof PreviewBackendProxyError) {
+      if (error.status === 405) res.setHeader("allow", "GET, POST");
+      return jsonError(res, error.status, error.code);
+    }
+    return jsonError(res, 400, "PREVIEW_PROXY_BODY_INVALID");
+  }
+
+  const fetchImpl = dependencies.fetchImpl ?? fetch;
+  const tokenTimeoutMs =
+    dependencies.tokenTimeoutMs ?? PREVIEW_PROXY_TOKEN_TIMEOUT_MS;
+  const stsFetch = timedFetch(
+    fetchImpl,
+    tokenTimeoutMs,
+    "GOOGLE_STS_EXCHANGE_FAILED",
+  );
+  const iamFetch = timedFetch(
+    fetchImpl,
+    tokenTimeoutMs,
+    "GOOGLE_ID_TOKEN_FAILED",
+  );
+
+  let vercelOidcToken: string;
+  let googleIdToken: string;
+  try {
+    vercelOidcToken = await acquireVercelOidcToken(
+      PREVIEW_PROXY_AUTH_CONFIG,
+      dependencies.getVercelOidcToken,
+    );
+    if (!vercelOidcToken) {
+      throw new PreviewBackendProxyError("VERCEL_OIDC_TOKEN_UNAVAILABLE", 502);
+    }
+  } catch {
+    return jsonError(res, 502, "VERCEL_OIDC_TOKEN_UNAVAILABLE");
+  }
+
+  try {
+    const federatedAccessToken = await exchangeVercelToken(
+      vercelOidcToken,
+      PREVIEW_PROXY_AUTH_CONFIG,
+      stsFetch,
+    );
+    googleIdToken = await generateCloudRunIdToken(
+      federatedAccessToken,
+      PREVIEW_PROXY_AUTH_CONFIG,
+      PREVIEW_PROXY_AUTH_CONFIG.cloudRunIdTokenAudience,
+      iamFetch,
+    );
+  } catch (error) {
+    const mapped = mapTokenError(error);
+    return jsonError(res, mapped.status, mapped.code);
+  }
+
+  const targetUrl =
+    `${PREVIEW_PROXY_CONFIG.cloudRunServiceUrl}${route.backendPath}` +
+    (route.query ? `?${route.query}` : "");
+
+  try {
+    const upstream = await withTimeout(
+      dependencies.upstreamTimeoutMs ?? PREVIEW_PROXY_UPSTREAM_TIMEOUT_MS,
+      "PREVIEW_BACKEND_TIMEOUT",
+      async (signal) => {
+        const response = await fetchImpl(targetUrl, {
+          method,
+          headers: upstreamHeaders(req, googleIdToken),
+          body,
+          redirect: "manual",
+          signal,
+        });
+        const responseBody = Buffer.from(await response.arrayBuffer());
+        return { response, responseBody };
+      },
+    );
+
+    for (const [name, value] of upstream.response.headers.entries()) {
+      if (RESPONSE_HEADERS.has(name.toLowerCase())) {
+        res.setHeader(name, value);
+      }
+    }
+    res.setHeader("x-rentchain-api-proxy", "vercel-preview-backend");
+    return res.status(upstream.response.status).send(upstream.responseBody);
+  } catch (error) {
+    const mapped =
+      error instanceof PreviewBackendProxyError
+        ? error
+        : new PreviewBackendProxyError("PREVIEW_BACKEND_UNAVAILABLE", 502);
+    return jsonError(res, mapped.status, mapped.code);
+  }
+}

--- a/rentchain-frontend/src/platform/previewAuthBridge.test.ts
+++ b/rentchain-frontend/src/platform/previewAuthBridge.test.ts
@@ -62,7 +62,7 @@ describe("preview auth bridge", () => {
     const fetchImpl = async (url: string | URL | Request, init?: RequestInit) => {
       requests.push({ url: String(url), init });
       if (requests.length === 1) return jsonResponse({ access_token: "federated-token" });
-      if (requests.length === 2) return jsonResponse({ token: "google-id-token" });
+      if (requests.length === 2) return jsonResponse({ token: "header.google-id-token.signature" });
       return jsonResponse({
         ok: true,
         service: "bounded-oidc-hello",
@@ -105,7 +105,9 @@ describe("preview auth bridge", () => {
         includeEmail: false,
       }),
     );
-    expect(requests[2].init?.headers).toEqual({ Authorization: "Bearer google-id-token" });
+    expect(requests[2].init?.headers).toEqual({
+      Authorization: "Bearer header.google-id-token.signature",
+    });
     expect(JSON.stringify(result)).not.toContain("vercel-token");
     expect(JSON.stringify(result)).not.toContain("federated-token");
     expect(JSON.stringify(result)).not.toContain("google-id-token");
@@ -116,7 +118,9 @@ describe("preview auth bridge", () => {
     const fetchImpl = async (_url: string | URL | Request, init?: RequestInit) => {
       requests.push({ init });
       if (requests.length === 1) return jsonResponse({ access_token: "federated-token" });
-      if (requests.length === 2) return jsonResponse({ token: "wrong-audience-id-token" });
+      if (requests.length === 2) {
+        return jsonResponse({ token: "header.wrong-audience-id-token.signature" });
+      }
       return jsonResponse({}, 403);
     };
 
@@ -183,6 +187,40 @@ describe("preview auth bridge", () => {
     });
   });
 
+  it("rejects malformed STS metadata and non-JWT Google ID tokens", async () => {
+    await expect(
+      runPreviewAuthBridge({
+        config,
+        vercelOidcToken: "vercel-token",
+        fetchImpl: (async () =>
+          jsonResponse({
+            access_token: "federated-token",
+            token_type: "MAC",
+            expires_in: 3600,
+          })) as typeof fetch,
+      }),
+    ).rejects.toMatchObject({ code: "STS_TOKEN_TYPE_INVALID" });
+
+    let requestCount = 0;
+    await expect(
+      runPreviewAuthBridge({
+        config,
+        vercelOidcToken: "vercel-token",
+        fetchImpl: (async () => {
+          requestCount += 1;
+          if (requestCount === 1) {
+            return jsonResponse({
+              access_token: "federated-token",
+              token_type: "Bearer",
+              expires_in: 3600,
+            });
+          }
+          return jsonResponse({ token: "not-a-jwt" });
+        }) as typeof fetch,
+      }),
+    ).rejects.toMatchObject({ code: "IAM_ID_TOKEN_INVALID" });
+  });
+
   it("rejects incomplete configuration without echoing values", () => {
     expect(() => readPreviewAuthConfig({ GCP_PROJECT_NUMBER: "1089948756798" })).toThrow(
       new PreviewAuthBridgeError("CONFIG_MISSING_WORKLOADIDENTITYPOOLID", 500),
@@ -194,7 +232,7 @@ describe("preview auth bridge", () => {
     const fetchImpl = async () => {
       requestCount += 1;
       if (requestCount === 1) return jsonResponse({ access_token: "federated-token" });
-      if (requestCount === 2) return jsonResponse({ token: "google-id-token" });
+      if (requestCount === 2) return jsonResponse({ token: "header.google-id-token.signature" });
       return jsonResponse({
         ok: true,
         service: "bounded-oidc-hello",

--- a/rentchain-frontend/src/platform/previewBackendProxy.test.ts
+++ b/rentchain-frontend/src/platform/previewBackendProxy.test.ts
@@ -1,0 +1,364 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  handlePreviewBackendProxy,
+  PREVIEW_PROXY_AUTH_CONFIG,
+  PREVIEW_PROXY_BODY_LIMIT_BYTES,
+  PREVIEW_PROXY_CONFIG,
+  resolvePreviewBackendPath,
+} from "../../server/previewBackendProxy";
+
+function token(payload = "payload") {
+  return `header.${payload}.signature`;
+}
+
+function jsonResponse(payload: unknown, status = 200, headers?: HeadersInit) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "content-type": "application/json", ...headers },
+  });
+}
+
+function responseRecorder() {
+  const headers = new Map<string, string | string[]>();
+  return {
+    statusCode: 200,
+    body: undefined as unknown,
+    headers,
+    setHeader: vi.fn((name: string, value: string | string[]) => {
+      headers.set(name.toLowerCase(), value);
+    }),
+    status: vi.fn(function status(this: any, code: number) {
+      this.statusCode = code;
+      return this;
+    }),
+    json: vi.fn(function json(this: any, body: unknown) {
+      this.body = body;
+      return this;
+    }),
+    send: vi.fn(function send(this: any, body: unknown) {
+      this.body = body;
+      return this;
+    }),
+  };
+}
+
+function request(
+  url: string,
+  method: string,
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    url,
+    method,
+    headers: {},
+    query: { path: url.split("?")[0].split("/").slice(3) },
+    ...overrides,
+  };
+}
+
+function successfulDependencies(upstreamStatus = 200) {
+  const requests: Array<{ url: string; init?: RequestInit }> = [];
+  const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+    const url = String(input);
+    requests.push({ url, init });
+    if (url === "https://sts.googleapis.com/v1/token") {
+      return jsonResponse({
+        access_token: "federated-access-token",
+        token_type: "Bearer",
+        expires_in: 3600,
+      });
+    }
+    if (url.startsWith("https://iamcredentials.googleapis.com/")) {
+      return jsonResponse({ token: token("google-id-token") });
+    }
+    return jsonResponse(
+      { ok: upstreamStatus < 400, error: upstreamStatus === 401 ? "UNAUTHORIZED" : undefined },
+      upstreamStatus,
+      { "x-request-id": "request-1" },
+    );
+  });
+  return {
+    requests,
+    dependencies: {
+      fetchImpl: fetchImpl as typeof fetch,
+      getVercelOidcToken: vi.fn(async () => token("vercel-oidc")),
+    },
+  };
+}
+
+describe("Preview backend proxy", () => {
+  const originalVercelEnv = process.env.VERCEL_ENV;
+
+  beforeEach(() => {
+    process.env.VERCEL_ENV = "preview";
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    if (originalVercelEnv == null) delete process.env.VERCEL_ENV;
+    else process.env.VERCEL_ENV = originalVercelEnv;
+  });
+
+  it("accepts only Preview and rejects Production or Development", async () => {
+    for (const environment of ["production", "development"]) {
+      process.env.VERCEL_ENV = environment;
+      const res = responseRecorder();
+      await handlePreviewBackendProxy(
+        request("/api/preview-backend/api/auth/login", "POST"),
+        res,
+        successfulDependencies().dependencies,
+      );
+      expect(res.statusCode).toBe(403);
+      expect(res.body).toEqual({
+        ok: false,
+        error: "PREVIEW_PROXY_ENVIRONMENT_REJECTED",
+      });
+    }
+
+    process.env.VERCEL_ENV = "preview";
+    const { dependencies } = successfulDependencies();
+    const res = responseRecorder();
+    await handlePreviewBackendProxy(
+      request("/api/preview-backend/api/auth/login", "POST"),
+      res,
+      dependencies,
+    );
+    expect(res.statusCode).toBe(200);
+  });
+
+  it.each([
+    ["/api/preview-backend/api/auth/login", "POST", "/api/auth/login"],
+    ["/api/preview-backend/api/auth/logout", "POST", "/api/auth/logout"],
+    ["/api/preview-backend/api/me", "GET", "/api/me"],
+    ["/api/preview-backend/api/auth/me", "GET", "/api/auth/me"],
+  ])("allows exact auth route %s", (url, method, expected) => {
+    expect(resolvePreviewBackendPath(request(url, method))).toEqual({
+      backendPath: expected,
+      query: "",
+    });
+  });
+
+  it.each([
+    "/api/preview-backend/api/admin/users",
+    "/api/preview-backend/api/auth/signup",
+    "/api/preview-backend/api/auth/login/extra",
+    "/api/preview-backend/api/preview-backend/api/auth/login",
+    "/api/preview-backend//api/auth/login",
+    "/api/preview-backend/https://example.invalid",
+    "/api/preview-backend/%2F%2Fevil.invalid",
+    "/api/preview-backend/api/auth/%",
+  ])("rejects unknown or malformed path %s", (url) => {
+    expect(() => resolvePreviewBackendPath(request(url, "GET"))).toThrow(
+      "PREVIEW_PROXY_ROUTE_NOT_ALLOWED",
+    );
+  });
+
+  it.each([
+    "/api/preview-backend/../api/auth/login",
+    "/api/preview-backend/%2e%2e/api/auth/login",
+    "/api/preview-backend/api/auth/%2e%2e/login",
+    "/api/preview-backend/api%2fauth%2flogin",
+    "/api/preview-backend/api%5cauth%5clogin",
+  ])("rejects traversal path %s", (url) => {
+    expect(() => resolvePreviewBackendPath(request(url, "POST"))).toThrow(
+      "PREVIEW_PROXY_ROUTE_NOT_ALLOWED",
+    );
+  });
+
+  it("rejects unsupported methods", async () => {
+    const res = responseRecorder();
+    await handlePreviewBackendProxy(
+      request("/api/preview-backend/api/auth/login", "GET"),
+      res,
+      successfulDependencies().dependencies,
+    );
+    expect(res.statusCode).toBe(405);
+    expect(res.body).toEqual({
+      ok: false,
+      error: "PREVIEW_PROXY_METHOD_NOT_ALLOWED",
+    });
+  });
+
+  it("uses exact identity constants and preserves application authorization separately", async () => {
+    const { requests, dependencies } = successfulDependencies();
+    const res = responseRecorder();
+    await handlePreviewBackendProxy(
+      request("/api/preview-backend/api/me?source=smoke", "GET", {
+        headers: {
+          authorization: "Bearer application-session-token",
+          "x-vercel-oidc-token": "must-not-forward",
+          cookie: "session=must-not-forward",
+          host: "preview.example.vercel.app",
+        },
+      }),
+      res,
+      dependencies,
+    );
+
+    expect(PREVIEW_PROXY_AUTH_CONFIG.vercelOidcTokenAudience).toBe(
+      "https://iam.googleapis.com/projects/501298948635/locations/global/workloadIdentityPools/vercel-preview-proxy/providers/vercel-preview",
+    );
+    expect(PREVIEW_PROXY_AUTH_CONFIG.googleStsAudience).toBe(
+      "//iam.googleapis.com/projects/501298948635/locations/global/workloadIdentityPools/vercel-preview-proxy/providers/vercel-preview",
+    );
+    expect(PREVIEW_PROXY_CONFIG.serviceAccountEmail).toBe(
+      "vercel-preview-proxy@rentchain-preview.iam.gserviceaccount.com",
+    );
+    expect(PREVIEW_PROXY_AUTH_CONFIG.cloudRunIdTokenAudience).toBe(
+      "https://rentchain-preview-backend-glistw4pya-nn.a.run.app",
+    );
+    expect(requests[1].url).toBe(
+      "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/vercel-preview-proxy%40rentchain-preview.iam.gserviceaccount.com:generateIdToken",
+    );
+    expect(requests[1].init?.body).toBe(
+      JSON.stringify({
+        audience: PREVIEW_PROXY_CONFIG.cloudRunServiceUrl,
+        includeEmail: false,
+      }),
+    );
+    expect(requests[2].url).toBe(
+      `${PREVIEW_PROXY_CONFIG.cloudRunServiceUrl}/api/me?source=smoke`,
+    );
+    expect(requests[2].init?.headers).toMatchObject({
+      authorization: "Bearer application-session-token",
+      "X-Serverless-Authorization": `Bearer ${token("google-id-token")}`,
+    });
+    expect(JSON.stringify(requests[2].init?.headers)).not.toContain("must-not-forward");
+  });
+
+  it("returns sanitized token-boundary errors", async () => {
+    const res = responseRecorder();
+    await handlePreviewBackendProxy(
+      request("/api/preview-backend/api/auth/login", "POST"),
+      res,
+      {
+        getVercelOidcToken: vi.fn(async () => token("secret-vercel-token")),
+        fetchImpl: vi.fn(async () =>
+          jsonResponse(
+            {
+              error: "invalid_target",
+              error_description: "secret-vercel-token secret-google-token",
+            },
+            400,
+          ),
+        ) as typeof fetch,
+      },
+    );
+    expect(res.statusCode).toBe(502);
+    expect(res.body).toEqual({ ok: false, error: "GOOGLE_STS_EXCHANGE_FAILED" });
+    expect(JSON.stringify(res.body)).not.toContain("secret");
+  });
+
+  it("preserves upstream invalid-credential 401 responses", async () => {
+    const { dependencies } = successfulDependencies(401);
+    const res = responseRecorder();
+    await handlePreviewBackendProxy(
+      request("/api/preview-backend/api/auth/login", "POST", {
+        headers: { "content-type": "application/json" },
+        body: { email: "preview@example.invalid", password: "invalid" },
+      }),
+      res,
+      dependencies,
+    );
+    expect(res.statusCode).toBe(401);
+    expect(Buffer.isBuffer(res.body)).toBe(true);
+    expect(JSON.parse((res.body as Buffer).toString("utf8"))).toMatchObject({
+      error: "UNAUTHORIZED",
+    });
+  });
+
+  it("returns a controlled timeout without retrying the upstream request", async () => {
+    const { requests, dependencies } = successfulDependencies();
+    const upstreamFetch = dependencies.fetchImpl;
+    dependencies.fetchImpl = vi.fn(async (input, init) => {
+      if (String(input).startsWith(PREVIEW_PROXY_CONFIG.cloudRunServiceUrl)) {
+        return new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () =>
+            reject(new DOMException("Aborted", "AbortError")),
+          );
+        });
+      }
+      return upstreamFetch(input, init);
+    }) as typeof fetch;
+
+    const res = responseRecorder();
+    await handlePreviewBackendProxy(
+      request("/api/preview-backend/api/me", "GET"),
+      res,
+      { ...dependencies, upstreamTimeoutMs: 5 },
+    );
+    expect(res.statusCode).toBe(504);
+    expect(res.body).toEqual({ ok: false, error: "PREVIEW_BACKEND_TIMEOUT" });
+    expect(
+      requests.filter(({ url }) =>
+        url.startsWith(PREVIEW_PROXY_CONFIG.cloudRunServiceUrl),
+      ),
+    ).toHaveLength(0);
+  });
+
+  it("enforces the auth request body limit before token acquisition", async () => {
+    const getVercelOidcToken = vi.fn(async () => token("vercel"));
+    const res = responseRecorder();
+    await handlePreviewBackendProxy(
+      request("/api/preview-backend/api/auth/login", "POST", {
+        body: "x".repeat(PREVIEW_PROXY_BODY_LIMIT_BYTES + 1),
+      }),
+      res,
+      { ...successfulDependencies().dependencies, getVercelOidcToken },
+    );
+    expect(res.statusCode).toBe(413);
+    expect(getVercelOidcToken).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed JSON before token acquisition", async () => {
+    const getVercelOidcToken = vi.fn(async () => token("vercel"));
+    const res = responseRecorder();
+    await handlePreviewBackendProxy(
+      request("/api/preview-backend/api/auth/login", "POST", {
+        headers: { "content-type": "application/json" },
+        body: "{\"email\":",
+      }),
+      res,
+      { ...successfulDependencies().dependencies, getVercelOidcToken },
+    );
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ ok: false, error: "PREVIEW_PROXY_BODY_INVALID" });
+    expect(getVercelOidcToken).not.toHaveBeenCalled();
+  });
+
+  it("keeps the production rewrite unchanged and relies on the dedicated filesystem Function", () => {
+    const frontendRoot = path.resolve(process.cwd());
+    const vercelConfig = JSON.parse(
+      fs.readFileSync(path.join(frontendRoot, "vercel.json"), "utf8"),
+    );
+    expect(
+      vercelConfig.rewrites.find((rewrite: { source: string }) =>
+        rewrite.source === "/api/:path*"),
+    ).toEqual({
+      source: "/api/:path*",
+      destination:
+        "https://rentchain-landlord-api-cyaabkl54a-uc.a.run.app/api/:path*",
+    });
+    expect(
+      fs.existsSync(path.join(frontendRoot, "api/preview-backend/[...path].ts")),
+    ).toBe(true);
+  });
+
+  it("does not introduce the Preview Cloud Run URL into browser source", () => {
+    const sourceRoot = path.resolve(process.cwd(), "src");
+    const files = fs
+      .readdirSync(sourceRoot, { recursive: true })
+      .filter(
+        (entry) =>
+          /\.(ts|tsx|js|jsx)$/.test(String(entry)) &&
+          !/(\.test\.|\.spec\.|__tests__)/.test(String(entry)),
+      );
+    const browserSource = files
+      .map((entry) => fs.readFileSync(path.join(sourceRoot, String(entry)), "utf8"))
+      .join("\n");
+    expect(browserSource).not.toContain(PREVIEW_PROXY_CONFIG.cloudRunServiceUrl);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a Preview-only, server-side Vercel Function proxy for bounded authentication requests to the private Preview Cloud Run backend.

## Route

`/api/preview-backend/*`

## Allowed operations

- `POST /api/auth/login`
- `POST /api/auth/logout`
- `GET /api/me`
- `GET /api/auth/me`

All other routes and unsupported methods fail closed.

## Identity chain

Vercel Preview OIDC  
→ Google STS  
→ dedicated `vercel-preview-proxy` service account  
→ Google ID token  
→ private `rentchain-preview-backend`

The Google ID token is sent using `X-Serverless-Authorization`. The application `Authorization` header remains separate.

## Safeguards

- Preview-only environment gate
- exact path and method allowlist
- traversal and malformed-path rejection
- 16 KiB body limit
- 5-second identity timeouts
- 10-second upstream timeout
- no retries
- restricted request and response headers
- sanitized errors
- no token logging
- no Google credentials or service-account keys
- no public Cloud Run access

## Boundaries

- Production `/api/*` rewrite unchanged
- `vercel.json` unchanged
- frontend API-base routing unchanged
- no `VITE_API_BASE_URL` change
- no Terraform or cloud mutation
- no deployment or Vercel setting change
- PR #1453 and PR #1435 remain untouched
- Stage 2 has not started

## Validation

- focused proxy/auth tests passed
- full frontend suite: 338 files, 1,547 tests passed
- `npx tsc --noEmit`: passed
- production build: passed
- route-precedence test: passed
- security scans: passed
- `git diff --check`: passed
