### PR TITLE
Route Vercel Preview auth through the private backend proxy

### DIFF
--- a/rentchain-frontend/src/api/apiFetch.test.ts
+++ b/rentchain-frontend/src/api/apiFetch.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { apiFetch } from "./apiFetch";
+
+const mocks = vi.hoisted(() => ({
+  getAuthToken: vi.fn(() => null),
+  getTenantToken: vi.fn(() => null),
+  getFirebaseIdToken: vi.fn(async () => null),
+}));
+
+vi.mock("../lib/authToken", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../lib/authToken")>()),
+  getAuthToken: mocks.getAuthToken,
+  getTenantToken: mocks.getTenantToken,
+}));
+
+vi.mock("../lib/firebaseAuthToken", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../lib/firebaseAuthToken")>()),
+  getFirebaseIdToken: mocks.getFirebaseIdToken,
+}));
+
+const PRODUCTION_API =
+  "https://rentchain-landlord-api-cyaabkl54a-uc.a.run.app";
+
+describe("legacy apiFetch URL parity", () => {
+  beforeEach(() => {
+    vi.stubEnv("VITE_DEPLOY_ENV", "production");
+    vi.stubEnv("VITE_API_BASE_URL", PRODUCTION_API);
+    mocks.getAuthToken.mockClear();
+    mocks.getTenantToken.mockClear();
+    mocks.getFirebaseIdToken.mockClear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    ["/api/example", `${PRODUCTION_API}/api/example`],
+    ["api/example", `${PRODUCTION_API}/api/example`],
+    ["/example", `${PRODUCTION_API}/api/example`],
+    ["example", `${PRODUCTION_API}/api/example`],
+    ["/api/api/example", `${PRODUCTION_API}/api/example`],
+    ["api/api/example", `${PRODUCTION_API}/api/example`],
+    [`${PRODUCTION_API}/api/example`, `${PRODUCTION_API}/api/example`],
+  ])("preserves Production resolution for %s", async (input, expected) => {
+    const fetchMock = vi.fn(async () =>
+      new Response("{}", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    );
+    global.fetch = fetchMock as typeof fetch;
+    await apiFetch(input);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expected,
+      expect.objectContaining({ credentials: "include" })
+    );
+  });
+
+  it.each([
+    "/api/api/auth/login",
+    "api/api/auth/login",
+    "/api/properties",
+  ])("rejects malformed or unsupported Preview input %s before credentials", async (input) => {
+    vi.stubEnv("VITE_DEPLOY_ENV", "preview");
+    vi.stubEnv("VITE_API_BASE_URL", "/api/preview-backend");
+    const fetchMock = vi.fn();
+    global.fetch = fetchMock as typeof fetch;
+
+    await expect(apiFetch(input, { method: "POST" })).rejects.toMatchObject({
+      code: "PREVIEW_API_ROUTE_NOT_AVAILABLE",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(mocks.getFirebaseIdToken).not.toHaveBeenCalled();
+    expect(mocks.getAuthToken).not.toHaveBeenCalled();
+  });
+
+  it("does not duplicate the Preview proxy prefix", async () => {
+    vi.stubEnv("VITE_DEPLOY_ENV", "preview");
+    vi.stubEnv("VITE_API_BASE_URL", "/api/preview-backend");
+    const fetchMock = vi.fn(async () =>
+      new Response("{}", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    );
+    global.fetch = fetchMock as typeof fetch;
+
+    await apiFetch("/api/auth/login", { method: "POST" });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/preview-backend/api/auth/login",
+      expect.any(Object)
+    );
+    expect(String(fetchMock.mock.calls[0][0])).not.toContain("/api/api/");
+  });
+});

--- a/rentchain-frontend/src/api/apiFetch.ts
+++ b/rentchain-frontend/src/api/apiFetch.ts
@@ -1,8 +1,13 @@
-import { API_BASE_URL } from "./config";
 import { clearAuthToken, clearTenantToken, getAuthToken, getTenantToken } from "../lib/authToken";
 import { getFirebaseIdToken, warnIfFirebaseDomainMismatch } from "../lib/firebaseAuthToken";
 import { maybeDispatchUpgradePrompt } from "../lib/upgradePrompt";
 import { isPublicRoutePath } from "../lib/publicRoute";
+import { resolveApiUrl } from "../lib/apiClient";
+import {
+  PreviewApiRouteUnavailableError,
+  PREVIEW_API_BASE_URL,
+  getApiBaseUrl,
+} from "./baseUrl";
 
 type Jsonish = Record<string, any>;
 export type ApiFetchInit = Omit<RequestInit, "body"> & {
@@ -32,35 +37,18 @@ export async function apiFetch<T = any>(
   path: string,
   init: ApiFetchInit = {}
 ): Promise<T> {
+  const method = String(init.method || "GET").trim().toUpperCase();
+  const normalizedInput = path
+    .replace(/^\/api\/api\//, "/api/")
+    .replace(/^api\/api\//, "api/");
+  if (
+    getApiBaseUrl() === PREVIEW_API_BASE_URL &&
+    normalizedInput !== path
+  ) {
+    throw new PreviewApiRouteUnavailableError(path, method);
+  }
+  const url = resolveApiUrl(normalizedInput, method);
   warnIfFirebaseDomainMismatch();
-  if (!API_BASE_URL) {
-    throw new Error("API_BASE_URL is not configured");
-  }
-  const base = API_BASE_URL.replace(/\/$/, "").replace(/\/api$/i, "");
-  if (!(apiFetch as any)._loggedBase) {
-    console.log("[apiFetch] API base:", base);
-    (apiFetch as any)._loggedBase = true;
-  }
-
-  const normalizedPath = (() => {
-    if (path.startsWith("http")) return path;
-    let p = path;
-    if (p.startsWith("/api/api/")) {
-      p = p.replace("/api/api/", "/api/");
-    } else if (p.startsWith("api/api/")) {
-      p = p.replace("api/api/", "api/");
-    }
-    if (p.startsWith("/api/")) {
-      return `${base}${p}`;
-    }
-    if (p.startsWith("api/")) {
-      return `${base}/${p}`;
-    }
-    if (p.startsWith("/")) {
-      return `${base}/api${p}`;
-    }
-    return `${base}/api/${p}`;
-  })();
 
   let pathForMatch = path;
   try {
@@ -76,8 +64,6 @@ export async function apiFetch<T = any>(
   const rawToken = explicitToken || (isTenantPath ? getTenantToken() : getAuthToken());
   const token = typeof rawToken === "string" ? rawToken.trim() : rawToken;
   const effectiveToken = token || firebaseToken;
-
-  const url = normalizedPath;
 
   const { allowStatuses, allow404, suppressToasts, token: _ignoredToken, ...fetchInit } = init;
 

--- a/rentchain-frontend/src/api/baseUrl.test.ts
+++ b/rentchain-frontend/src/api/baseUrl.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  PREVIEW_API_BASE_URL,
+  PRODUCTION_API_BASE_URL,
+  PreviewApiRouteUnavailableError,
+  assertPreviewBrowserRequestAvailable,
+  isPreviewAuthPath,
+  isPreviewAuthRequest,
+  resolveConfiguredApiBase,
+} from "./baseUrl";
+
+const production = {
+  apiBaseUrl: PRODUCTION_API_BASE_URL,
+  deployEnv: "production",
+  isDevelopment: false,
+};
+
+describe("resolveConfiguredApiBase", () => {
+  it("accepts the exact Preview classification and proxy base", () => {
+    expect(
+      resolveConfiguredApiBase({
+        apiBaseUrl: PREVIEW_API_BASE_URL,
+        deployEnv: "preview",
+        isDevelopment: false,
+      })
+    ).toBe(PREVIEW_API_BASE_URL);
+  });
+
+  it("preserves the Production HTTPS base", () => {
+    expect(resolveConfiguredApiBase(production)).toBe(PRODUCTION_API_BASE_URL);
+  });
+
+  it.each([
+    [PREVIEW_API_BASE_URL, "production"],
+    [PREVIEW_API_BASE_URL, ""],
+    [PRODUCTION_API_BASE_URL, "preview"],
+    [PRODUCTION_API_BASE_URL, "staging"],
+  ])("rejects contradictory base %s and environment %s", (apiBaseUrl, deployEnv) => {
+    expect(() =>
+      resolveConfiguredApiBase({ apiBaseUrl, deployEnv, isDevelopment: false })
+    ).toThrow();
+  });
+
+  it.each([
+    "/",
+    "/api",
+    "/api/preview-backend/",
+    "/api/preview-backend/extra",
+    "api/preview-backend",
+    "//example.com",
+    "\\api\\preview-backend",
+    "/api/preview%2dbackend",
+    "/api/preview-backend?x=1",
+    "/api/preview-backend#fragment",
+  ])("rejects unauthorized relative base %s", (apiBaseUrl) => {
+    expect(() =>
+      resolveConfiguredApiBase({ apiBaseUrl, deployEnv: "preview", isDevelopment: false })
+    ).toThrow();
+  });
+
+  it("preserves documented local HTTP behavior without using the Preview proxy", () => {
+    expect(
+      resolveConfiguredApiBase({
+        apiBaseUrl: "http://localhost:8080",
+        deployEnv: "development",
+        isDevelopment: true,
+      })
+    ).toBe("http://localhost:8080");
+  });
+});
+
+describe("Preview auth path scope", () => {
+  it.each([
+    ["/api/auth/login", "POST"],
+    ["/api/auth/logout", "POST"],
+    ["/api/me", "GET"],
+    ["/api/auth/me", "GET"],
+  ])("allows %s with %s", (path, method) => {
+    expect(isPreviewAuthRequest(path, method)).toBe(true);
+  });
+
+  it.each([
+    ["/api/auth/login", "GET"],
+    ["/api/auth/logout", "GET"],
+    ["/api/me", "POST"],
+    ["/api/auth/me", "POST"],
+  ])("rejects %s with %s", (path, method) => {
+    expect(isPreviewAuthPath(path)).toBe(true);
+    expect(isPreviewAuthRequest(path, method)).toBe(false);
+  });
+
+  it.each([
+    "/api/auth/signup",
+    "/api/auth/login/demo",
+    "/api/tenant/me",
+    "/api/properties",
+  ])("does not repoint unrelated path %s", (path) => {
+    expect(isPreviewAuthPath(path)).toBe(false);
+  });
+});
+
+describe("Preview browser dispatch guard", () => {
+  it("allows only exact same-origin authorized proxy operations", () => {
+    vi.stubEnv("VITE_DEPLOY_ENV", "preview");
+    vi.stubEnv("VITE_API_BASE_URL", PREVIEW_API_BASE_URL);
+    try {
+      expect(() =>
+        assertPreviewBrowserRequestAvailable(
+          "/api/preview-backend/api/auth/login",
+          "POST"
+        )
+      ).not.toThrow();
+      expect(() =>
+        assertPreviewBrowserRequestAvailable("/api/properties", "GET")
+      ).toThrow(PreviewApiRouteUnavailableError);
+      expect(() =>
+        assertPreviewBrowserRequestAvailable(
+          `${PRODUCTION_API_BASE_URL}/api/properties`,
+          "GET"
+        )
+      ).toThrow(PreviewApiRouteUnavailableError);
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+});

--- a/rentchain-frontend/src/api/baseUrl.ts
+++ b/rentchain-frontend/src/api/baseUrl.ts
@@ -1,45 +1,187 @@
-let warnedBase = false;
+export const PREVIEW_DEPLOY_ENV = "preview";
+export const PRODUCTION_DEPLOY_ENV = "production";
+export const PREVIEW_API_BASE_URL = "/api/preview-backend";
+export const PRODUCTION_API_BASE_URL =
+  "https://rentchain-landlord-api-cyaabkl54a-uc.a.run.app";
+export const PREVIEW_API_ROUTE_NOT_AVAILABLE = "PREVIEW_API_ROUTE_NOT_AVAILABLE";
+
+const PREVIEW_AUTH_OPERATIONS = new Map([
+  ["/api/auth/login", "POST"],
+  ["/api/auth/logout", "POST"],
+  ["/api/me", "GET"],
+  ["/api/auth/me", "GET"],
+]);
+
 let warnedMissing = false;
 
-export function getApiBaseUrl(): string {
-  const rawEnv = (import.meta as any)?.env?.VITE_API_BASE_URL || "";
-  let raw = typeof rawEnv === "string" ? rawEnv.trim() : "";
+type ApiEnvironment = {
+  apiBaseUrl: unknown;
+  deployEnv: unknown;
+  isDevelopment: boolean;
+};
 
-  if (/^value:/i.test(raw)) {
-    raw = raw.replace(/^value:/i, "").trim();
+export class PreviewApiRouteUnavailableError extends Error {
+  readonly code = PREVIEW_API_ROUTE_NOT_AVAILABLE;
+  readonly path: string;
+  readonly method: string;
+
+  constructor(path: string, method: string) {
+    super("This operation is not available in the current Preview environment.");
+    this.name = "PreviewApiRouteUnavailableError";
+    this.path = normalizeBackendPath(path);
+    this.method = String(method || "GET").trim().toUpperCase();
   }
+}
 
-  const normalized = raw.replace(/\/$/, "").replace(/\/api$/i, "");
+function readEnvironment(): ApiEnvironment {
+  return {
+    apiBaseUrl: (import.meta as any)?.env?.VITE_API_BASE_URL,
+    deployEnv: (import.meta as any)?.env?.VITE_DEPLOY_ENV,
+    isDevelopment: Boolean((import.meta as any)?.env?.DEV),
+  };
+}
 
-  if (!normalized) {
-    if (import.meta.env.PROD) {
-      if (!warnedMissing) {
-        warnedMissing = true;
-        console.error("[api] VITE_API_BASE_URL is missing. API calls will fail.");
-      }
-      return "";
-    }
+function normalizeBackendPath(input: string): string {
+  const path = String(input || "").split(/[?#]/, 1)[0];
+  const withSlash = path.startsWith("/") ? path : `/${path}`;
+  return withSlash.startsWith("/api/") ? withSlash : `/api${withSlash}`;
+}
+
+export function isPreviewAuthPath(input: string): boolean {
+  return PREVIEW_AUTH_OPERATIONS.has(normalizeBackendPath(input));
+}
+
+export function isPreviewAuthRequest(input: string, method = "GET"): boolean {
+  return (
+    PREVIEW_AUTH_OPERATIONS.get(normalizeBackendPath(input)) ===
+    String(method || "GET").trim().toUpperCase()
+  );
+}
+
+export function resolveConfiguredApiBase({
+  apiBaseUrl,
+  deployEnv,
+  isDevelopment,
+}: ApiEnvironment): string {
+  const rawBase = typeof apiBaseUrl === "string" ? apiBaseUrl.trim() : "";
+  const rawDeployEnv = typeof deployEnv === "string" ? deployEnv.trim() : "";
+
+  if (!rawBase) {
     throw new Error("VITE_API_BASE_URL is not configured");
   }
 
-  if (!/^https?:\/\//i.test(normalized)) {
-    if (import.meta.env.PROD && !warnedBase) {
-      warnedBase = true;
-      console.error("[api] VITE_API_BASE_URL must be absolute. Value:", normalized);
+  if (rawDeployEnv === PREVIEW_DEPLOY_ENV) {
+    if (rawBase !== PREVIEW_API_BASE_URL) {
+      throw new Error(
+        "Preview API configuration is invalid: use the authorized same-origin proxy"
+      );
     }
-    if (!import.meta.env.PROD) {
-      throw new Error("VITE_API_BASE_URL must be absolute (include http/https)");
-    }
-    return "";
+    return PREVIEW_API_BASE_URL;
   }
 
-  return normalized;
+  if (rawDeployEnv && rawDeployEnv !== PRODUCTION_DEPLOY_ENV && rawDeployEnv !== "development") {
+    throw new Error("VITE_DEPLOY_ENV is not recognized");
+  }
+
+  if (rawBase === PREVIEW_API_BASE_URL) {
+    throw new Error("The Preview API proxy requires VITE_DEPLOY_ENV=preview");
+  }
+
+  if (rawBase.startsWith("/") || rawBase.startsWith("\\") || rawBase.startsWith("//")) {
+    throw new Error("VITE_API_BASE_URL contains an unauthorized relative value");
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(rawBase);
+  } catch {
+    throw new Error("VITE_API_BASE_URL must be an absolute URL");
+  }
+
+  if (parsed.search || parsed.hash || parsed.username || parsed.password) {
+    throw new Error("VITE_API_BASE_URL contains unsupported URL components");
+  }
+
+  if (rawDeployEnv === PRODUCTION_DEPLOY_ENV && parsed.protocol !== "https:") {
+    throw new Error("Production VITE_API_BASE_URL must use HTTPS");
+  }
+
+  if (!isDevelopment && parsed.protocol !== "https:") {
+    throw new Error("VITE_API_BASE_URL must use HTTPS outside local development");
+  }
+
+  if (isDevelopment && !["http:", "https:"].includes(parsed.protocol)) {
+    throw new Error("Development VITE_API_BASE_URL must use HTTP or HTTPS");
+  }
+
+  return rawBase.replace(/\/$/, "").replace(/\/api$/i, "");
 }
 
-export function debugApiBase(): { raw?: string; normalized: string } {
-  const rawEnv = (import.meta as any)?.env?.VITE_API_BASE_URL || "";
+export function getApiBaseUrl(): string {
+  try {
+    return resolveConfiguredApiBase(readEnvironment());
+  } catch (error) {
+    if ((import.meta as any)?.env?.PROD) {
+      if (!warnedMissing) {
+        warnedMissing = true;
+        console.error("[api] API environment configuration is invalid.");
+      }
+    }
+    throw error;
+  }
+}
+
+export function getApiBaseUrlForRequest(input: string, method = "GET"): string {
+  const configuredBase = getApiBaseUrl();
+  if (configuredBase !== PREVIEW_API_BASE_URL) return configuredBase;
+  if (isPreviewAuthRequest(input, method)) return PREVIEW_API_BASE_URL;
+  throw new PreviewApiRouteUnavailableError(input, method);
+}
+
+export function getApiBaseUrlForPath(input: string): string {
+  return getApiBaseUrlForRequest(input, "GET");
+}
+
+export function assertPreviewBrowserRequestAvailable(inputUrl: string, method = "GET"): void {
+  const environment = readEnvironment();
+  if (
+    typeof environment.deployEnv !== "string" ||
+    environment.deployEnv.trim() !== PREVIEW_DEPLOY_ENV
+  ) {
+    return;
+  }
+
+  const rawUrl = String(inputUrl || "").trim();
+  const origin =
+    typeof window !== "undefined" && window.location?.origin
+      ? window.location.origin
+      : "https://preview.invalid";
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl, origin);
+  } catch {
+    throw new PreviewApiRouteUnavailableError(rawUrl, method);
+  }
+
+  const isProductionApi = rawUrl.startsWith(PRODUCTION_API_BASE_URL);
+  const isSameOriginApi = parsed.origin === origin && parsed.pathname.startsWith("/api/");
+  if (!isProductionApi && !isSameOriginApi) return;
+
+  const prefix = `${PREVIEW_API_BASE_URL}/`;
+  if (parsed.origin === origin && parsed.pathname.startsWith(prefix)) {
+    const backendPath = parsed.pathname.slice(PREVIEW_API_BASE_URL.length);
+    if (isPreviewAuthRequest(backendPath, method)) return;
+    throw new PreviewApiRouteUnavailableError(backendPath, method);
+  }
+
+  throw new PreviewApiRouteUnavailableError(parsed.pathname, method);
+}
+
+export function debugApiBase(): { raw?: string; deployEnv?: string; normalized: string } {
+  const environment = readEnvironment();
   return {
-    raw: typeof rawEnv === "string" ? rawEnv : undefined,
+    raw: typeof environment.apiBaseUrl === "string" ? environment.apiBaseUrl : undefined,
+    deployEnv: typeof environment.deployEnv === "string" ? environment.deployEnv : undefined,
     normalized: getApiBaseUrl(),
   };
 }

--- a/rentchain-frontend/src/api/http.ts
+++ b/rentchain-frontend/src/api/http.ts
@@ -18,6 +18,7 @@ export async function apiFetch<T>(
 ): Promise<T> {
   warnIfFirebaseDomainMismatch();
   const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  const url = resolveApiUrl(normalizedPath, opts.method || "GET");
   const isTenantPath = isTenantApiPath(normalizedPath);
   const firebaseToken = !isTenantPath ? await getFirebaseIdToken() : null;
   const explicitToken = (opts as any)?.token;
@@ -46,7 +47,7 @@ export async function apiFetch<T>(
     }
   }
 
-  const res = await fetch(resolveApiUrl(normalizedPath), {
+  const res = await fetch(url, {
     ...opts,
     headers,
     credentials: "include",
@@ -85,7 +86,8 @@ export async function apiGetJson<T>(
 ): Promise<{ ok: true; data: T } | { ok: false; status: number; error: string }> {
   const allow = opts.allowStatuses ?? [404, 501];
   const normalizedPath = path.startsWith("/") ? path : `/${path}`;
-  const res = await fetch(resolveApiUrl(normalizedPath), {
+  const url = resolveApiUrl(normalizedPath, "GET");
+  const res = await fetch(url, {
     method: "GET",
     signal: opts.signal,
     headers: {

--- a/rentchain-frontend/src/api/tenantAuthApi.ts
+++ b/rentchain-frontend/src/api/tenantAuthApi.ts
@@ -1,7 +1,7 @@
 import { resolveApiUrl } from "../lib/apiClient";
 
 export async function tenantLogin(email: string, password: string): Promise<{ token: string }> {
-  const res = await fetch(resolveApiUrl("/api/auth/login"), {
+  const res = await fetch(resolveApiUrl("/api/auth/login", "POST"), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ email, password }),

--- a/rentchain-frontend/src/context/__tests__/AuthContext.previewDashboardIsolation.test.tsx
+++ b/rentchain-frontend/src/context/__tests__/AuthContext.previewDashboardIsolation.test.tsx
@@ -1,0 +1,117 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ToastProvider } from "../../components/ui/ToastProvider";
+import { AuthProvider } from "../AuthContext";
+
+vi.mock("../../lib/firebaseAuthToken", () => ({
+  getFirebaseIdToken: vi.fn(async () => null),
+  awaitFirebaseAuthReady: vi.fn(async () => ({ ready: true, user: null })),
+  warnIfFirebaseDomainMismatch: vi.fn(),
+}));
+
+const PRODUCTION_API =
+  "https://rentchain-landlord-api-cyaabkl54a-uc.a.run.app";
+const PREVIEW_PROXY = "/api/preview-backend";
+const TEST_TOKEN = "header.payload.signature";
+const testUser = {
+  id: "preview-landlord",
+  email: "preview@example.test",
+  role: "landlord",
+};
+
+describe("Preview login-to-dashboard isolation", () => {
+  beforeEach(() => {
+    vi.stubEnv("VITE_DEPLOY_ENV", "preview");
+    vi.stubEnv("VITE_API_BASE_URL", PREVIEW_PROXY);
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("mounts the dashboard while rejecting every unsupported loader before fetch", async () => {
+    const [{ default: DashboardPage }, { LoginPage }] = await Promise.all([
+      import("../../pages/DashboardPage"),
+      import("../../pages/LoginPage"),
+    ]);
+    const captured: Array<{ url: string; init: RequestInit }> = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init: RequestInit = {}) => {
+      const url = String(input);
+      captured.push({ url, init });
+
+      if (url === `${PREVIEW_PROXY}/api/auth/login`) {
+        return new Response(JSON.stringify({ token: TEST_TOKEN, user: testUser }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (url === `${PREVIEW_PROXY}/api/me`) {
+        return new Response(JSON.stringify({ user: testUser }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      throw new Error(`Dashboard request reached fetch: ${url}`);
+    });
+    global.fetch = fetchMock as typeof fetch;
+
+    render(
+      <ToastProvider>
+        <AuthProvider>
+          <MemoryRouter initialEntries={["/login"]}>
+            <Routes>
+              <Route path="/login" element={<LoginPage />} />
+              <Route path="/dashboard" element={<DashboardPage />} />
+            </Routes>
+          </MemoryRouter>
+        </AuthProvider>
+      </ToastProvider>
+    );
+
+    fireEvent.change(screen.getByLabelText("Email"), {
+      target: { value: "preview@example.test" },
+    });
+    fireEvent.change(screen.getByLabelText("Password"), {
+      target: { value: "test-password" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Sign in" }));
+
+    expect(await screen.findByTestId("dashboard-operational-grid")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        screen.getAllByText(
+          "This operation is not available in the current Preview environment."
+        ).length
+      ).toBeGreaterThan(0)
+    );
+
+    expect(
+      captured.map(({ url, init }) => [String(init.method || "GET").toUpperCase(), url])
+    ).toEqual([
+      ["POST", `${PREVIEW_PROXY}/api/auth/login`],
+      ["GET", `${PREVIEW_PROXY}/api/me`],
+    ]);
+
+    for (const { url } of captured) {
+      expect(url.startsWith(PRODUCTION_API)).toBe(false);
+      expect(url).not.toMatch(
+        /\/api\/(?:landlord\/(?:portfolio-status-financial|decision-queue|maintenance|inbox)|applications|tenants|work-orders)/
+      );
+    }
+  });
+});

--- a/rentchain-frontend/src/context/__tests__/AuthContext.previewRouting.test.tsx
+++ b/rentchain-frontend/src/context/__tests__/AuthContext.previewRouting.test.tsx
@@ -1,0 +1,137 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthProvider, useAuth } from "../AuthContext";
+
+vi.mock("../../lib/firebaseAuthToken", () => ({
+  getFirebaseIdToken: vi.fn(async () => null),
+  awaitFirebaseAuthReady: vi.fn(async () => ({ ready: true, user: null })),
+  warnIfFirebaseDomainMismatch: vi.fn(),
+}));
+
+const PRODUCTION_API =
+  "https://rentchain-landlord-api-cyaabkl54a-uc.a.run.app";
+const PREVIEW_PROXY = "/api/preview-backend";
+const TEST_TOKEN = "header.payload.signature";
+const testUser = {
+  id: "preview-landlord",
+  email: "preview@example.test",
+  role: "landlord",
+};
+
+function AuthLifecycleHarness() {
+  const auth = useAuth();
+  return (
+    <div>
+      <button onClick={() => void auth.login("preview@example.test", "test-password")}>
+        Login
+      </button>
+      <button onClick={() => void auth.logout()}>Logout</button>
+      <div data-testid="ready">{String(auth.ready)}</div>
+      <div data-testid="email">{auth.user?.email || ""}</div>
+      <div data-testid="status">{auth.authStatus}</div>
+    </div>
+  );
+}
+
+describe("AuthContext Preview routing isolation", () => {
+  beforeEach(() => {
+    vi.stubEnv("VITE_DEPLOY_ENV", "preview");
+    vi.stubEnv("VITE_API_BASE_URL", PREVIEW_PROXY);
+    window.history.replaceState({}, "", "/login");
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("keeps the real login, session fallback, and logout lifecycle off Production", async () => {
+    const captured: Array<{ url: string; init: RequestInit }> = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init: RequestInit = {}) => {
+      const url = String(input);
+      captured.push({ url, init });
+
+      if (url === `${PREVIEW_PROXY}/api/auth/login`) {
+        return new Response(JSON.stringify({ token: TEST_TOKEN, user: testUser }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (url === `${PREVIEW_PROXY}/api/me`) {
+        return new Response(JSON.stringify({ error: "fallback required" }), {
+          status: 401,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (url === `${PREVIEW_PROXY}/api/auth/me`) {
+        return new Response(JSON.stringify({ user: testUser }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (url === `${PREVIEW_PROXY}/api/auth/logout`) {
+        return new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    global.fetch = fetchMock as typeof fetch;
+
+    render(
+      <AuthProvider>
+        <AuthLifecycleHarness />
+      </AuthProvider>
+    );
+
+    await waitFor(() => expect(screen.getByTestId("ready")).toHaveTextContent("true"));
+    expect(captured).toEqual([]);
+
+    fireEvent.click(screen.getByRole("button", { name: "Login" }));
+    await waitFor(() =>
+      expect(screen.getByTestId("email")).toHaveTextContent("preview@example.test")
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Logout" }));
+    await waitFor(() => expect(screen.getByTestId("status")).toHaveTextContent("guest"));
+    await waitFor(() => expect(captured).toHaveLength(4));
+
+    expect(
+      captured.map(({ url, init }) => [String(init.method || "GET").toUpperCase(), url])
+    ).toEqual([
+      ["POST", `${PREVIEW_PROXY}/api/auth/login`],
+      ["GET", `${PREVIEW_PROXY}/api/me`],
+      ["GET", `${PREVIEW_PROXY}/api/auth/me`],
+      ["POST", `${PREVIEW_PROXY}/api/auth/logout`],
+    ]);
+
+    const productionCalls = captured.filter(({ url }) => url.startsWith(PRODUCTION_API));
+    for (const { url, init } of productionCalls) {
+      const headers = new Headers(init.headers);
+      expect(headers.has("authorization"), `Authorization leaked to ${url}`).toBe(false);
+      expect(headers.get("x-rc-auth"), `Auth source leaked to ${url}`).toBeNull();
+      expect(init.credentials, `Cookie credentials leaked to ${url}`).not.toBe("include");
+      expect(init.body, `Request body leaked to ${url}`).toBeUndefined();
+      expect(url).not.toMatch(/\/api\/(?:auth\/(?:login|logout|me)|me)(?:[/?]|$)/);
+    }
+    expect(productionCalls).toHaveLength(0);
+
+    const loginCall = captured[0];
+    expect(loginCall.init.body).toBe(
+      JSON.stringify({ email: "preview@example.test", password: "test-password" })
+    );
+    expect(new Headers(captured[1].init.headers).get("authorization")).toBe(
+      `Bearer ${TEST_TOKEN}`
+    );
+    expect(new Headers(captured[2].init.headers).get("authorization")).toBe(
+      `Bearer ${TEST_TOKEN}`
+    );
+    expect(new Headers(captured[3].init.headers).get("authorization")).toBe(
+      `Bearer ${TEST_TOKEN}`
+    );
+  });
+});

--- a/rentchain-frontend/src/context/__tests__/AuthContext.test.ts
+++ b/rentchain-frontend/src/context/__tests__/AuthContext.test.ts
@@ -6,6 +6,9 @@ import { TOKEN_KEY } from "../../lib/authToken";
 
 vi.mock("../../api/baseUrl", () => ({
   getApiBaseUrl: () => "https://rentchain.test",
+  getApiBaseUrlForPath: () => "https://rentchain.test",
+  getApiBaseUrlForRequest: () => "https://rentchain.test",
+  PREVIEW_API_BASE_URL: "/api/preview-backend",
 }));
 
 vi.mock("../../lib/firebaseAuthToken", () => ({

--- a/rentchain-frontend/src/lib/apiClient.test.ts
+++ b/rentchain-frontend/src/lib/apiClient.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  PREVIEW_API_BASE_URL,
+  PREVIEW_API_ROUTE_NOT_AVAILABLE,
+  PRODUCTION_API_BASE_URL,
+  PreviewApiRouteUnavailableError,
+} from "../api/baseUrl";
+import * as authToken from "./authToken";
+import * as firebaseAuthToken from "./firebaseAuthToken";
+import {
+  apiFetch,
+  isAccidentalSameOriginApiUrl,
+  isAuthorizedPreviewProxyUrl,
+  resolveApiUrl,
+} from "./apiClient";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+function usePreviewEnvironment() {
+  vi.stubEnv("VITE_DEPLOY_ENV", "preview");
+  vi.stubEnv("VITE_API_BASE_URL", PREVIEW_API_BASE_URL);
+}
+
+describe("resolveApiUrl", () => {
+  it.each([
+    ["/api/auth/login", "POST", "/api/preview-backend/api/auth/login"],
+    ["/api/auth/logout", "POST", "/api/preview-backend/api/auth/logout"],
+    ["/api/me", "GET", "/api/preview-backend/api/me"],
+    ["/api/auth/me", "GET", "/api/preview-backend/api/auth/me"],
+  ])("routes Preview auth %s %s through the same-origin proxy", (path, method, expected) => {
+    usePreviewEnvironment();
+    expect(resolveApiUrl(path, method)).toBe(expected);
+  });
+
+  it.each([
+    ["/api/auth/login", "GET"],
+    ["/api/auth/logout", "GET"],
+    ["/api/me", "POST"],
+    ["/api/auth/me", "POST"],
+  ])("fails closed for unauthorized Preview auth operation %s %s", (path, method) => {
+    usePreviewEnvironment();
+    expect(() => resolveApiUrl(path, method)).toThrow(PreviewApiRouteUnavailableError);
+  });
+
+  it("preserves query strings without duplicating the proxy prefix", () => {
+    usePreviewEnvironment();
+    expect(resolveApiUrl("/api/me?refresh=1")).toBe(
+      "/api/preview-backend/api/me?refresh=1"
+    );
+  });
+
+  it("rejects an already-prefixed path instead of duplicating the proxy prefix", () => {
+    usePreviewEnvironment();
+    expect(() => resolveApiUrl("/api/preview-backend/api/me")).toThrow(
+      "Preview proxy paths must be resolved"
+    );
+  });
+
+  it("fails closed for unrelated Preview calls", () => {
+    usePreviewEnvironment();
+    expect(() => resolveApiUrl("/api/properties")).toThrow(
+      "not available in the current Preview environment"
+    );
+  });
+
+  it.each([
+    "/api/properties",
+    "/api/tenants",
+    "/api/applications",
+    "/api/work-orders",
+    "/api/landlord/portfolio-status-financial",
+    "/api/landlord/decision-queue",
+    "/api/landlord/inbox",
+  ])("rejects unsupported Preview request %s before credentials or fetch", async (path) => {
+    usePreviewEnvironment();
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const firebaseSpy = vi.spyOn(firebaseAuthToken, "getFirebaseIdToken");
+    const bearerSpy = vi.spyOn(authToken, "getAuthToken");
+
+    await expect(apiFetch(path, { method: "GET" })).rejects.toMatchObject({
+      code: PREVIEW_API_ROUTE_NOT_AVAILABLE,
+      path,
+      method: "GET",
+      message: "This operation is not available in the current Preview environment.",
+    });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(firebaseSpy).not.toHaveBeenCalled();
+    expect(bearerSpy).not.toHaveBeenCalled();
+  });
+
+  it("preserves normal Production URL construction", () => {
+    vi.stubEnv("VITE_DEPLOY_ENV", "production");
+    vi.stubEnv("VITE_API_BASE_URL", PRODUCTION_API_BASE_URL);
+    expect(resolveApiUrl("/api/me")).toBe(`${PRODUCTION_API_BASE_URL}/api/me`);
+  });
+
+  it("rejects accidental same-origin API routing in Production", () => {
+    vi.stubEnv("VITE_DEPLOY_ENV", "production");
+    vi.stubEnv("VITE_API_BASE_URL", "/api");
+    expect(() => resolveApiUrl("/api/me")).toThrow();
+  });
+
+  it("distinguishes the authorized proxy from accidental same-origin API routing", () => {
+    expect(
+      isAuthorizedPreviewProxyUrl("/api/preview-backend/api/auth/login")
+    ).toBe(true);
+    expect(
+      isAccidentalSameOriginApiUrl("/api/preview-backend/api/auth/login")
+    ).toBe(false);
+    expect(isAccidentalSameOriginApiUrl("/api/auth/login")).toBe(true);
+  });
+});

--- a/rentchain-frontend/src/lib/apiClient.ts
+++ b/rentchain-frontend/src/lib/apiClient.ts
@@ -1,15 +1,37 @@
-import { getApiBaseUrl } from "../api/baseUrl";
+import {
+  getApiBaseUrlForRequest,
+  PREVIEW_API_BASE_URL,
+} from "../api/baseUrl";
 import { clearAuthToken, getAuthToken, setAuthToken } from "./authToken";
 import { getFirebaseIdToken, warnIfFirebaseDomainMismatch } from "./firebaseAuthToken";
 import { maybeDispatchUpgradePrompt } from "./upgradePrompt";
 
 let warnedMisconfig = false;
 
+export function isAuthorizedPreviewProxyUrl(url: string): boolean {
+  return (
+    url === PREVIEW_API_BASE_URL ||
+    url.startsWith(`${PREVIEW_API_BASE_URL}/`) ||
+    url.startsWith(`${PREVIEW_API_BASE_URL}?`)
+  );
+}
+
+export function isAccidentalSameOriginApiUrl(url: string): boolean {
+  return url.startsWith("/api/") && !isAuthorizedPreviewProxyUrl(url);
+}
+
 export { getAuthToken, setAuthToken, clearAuthToken };
 
-export function resolveApiUrl(input: string) {
+export function resolveApiUrl(input: string, method = "GET") {
   const sRaw = String(input || "").trim();
-  const base = (getApiBaseUrl() || "").replace(/\/$/, "");
+  if (
+    sRaw === PREVIEW_API_BASE_URL ||
+    sRaw.startsWith(`${PREVIEW_API_BASE_URL}/`) ||
+    sRaw.startsWith(`${PREVIEW_API_BASE_URL}?`)
+  ) {
+    throw new Error("Preview proxy paths must be resolved from backend API paths");
+  }
+  const base = (getApiBaseUrlForRequest(sRaw, method) || "").replace(/\/$/, "");
 
   if (!sRaw) return base;
   if (/^https?:\/\//i.test(sRaw)) return sRaw;
@@ -18,14 +40,15 @@ export function resolveApiUrl(input: string) {
   const path = pathPart.startsWith("/") ? pathPart : `/${pathPart}`;
   const stripApi = path.startsWith("/api/") ? path.slice(4) : path;
   const normalized = stripApi.startsWith("/") ? stripApi : `/${stripApi}`;
-  const url = `${base}/api${normalized}${queryPart ? `?${queryPart}` : ""}`;
+  const apiPath = `/api${normalized}${queryPart ? `?${queryPart}` : ""}`;
+  const url = `${base}${apiPath}`;
 
   if (
     import.meta.env.DEV &&
     !warnedMisconfig &&
     typeof window !== "undefined" &&
     window.location.host.includes("rentchain.ai") &&
-    url.startsWith("https://www.rentchain.ai/api/")
+    isAccidentalSameOriginApiUrl(url)
   ) {
     warnedMisconfig = true;
     console.warn(
@@ -48,7 +71,7 @@ export async function apiFetch(path: string, init: RequestInit = {}) {
     p = `/api${stripApi.startsWith("/") ? "" : "/"}${stripApi}`;
   }
 
-  const url = resolveApiUrl(p);
+  const url = resolveApiUrl(p, init.method || "GET");
 
   const normalizedPath = (() => {
     try {

--- a/rentchain-frontend/src/main.tsx
+++ b/rentchain-frontend/src/main.tsx
@@ -16,6 +16,7 @@ import { API_BASE_URL } from "./api/config";
 import { AuthDebugOverlay } from "./components/debug/AuthDebugOverlay";
 import { getAuthToken } from "./lib/authToken";
 import MaintenancePage from "./pages/MaintenancePage";
+import { installPreviewFetchGuard } from "./runtime/previewFetchGuard";
 
 const App = React.lazy(() => import("./App"));
 
@@ -30,47 +31,20 @@ if (typeof window !== "undefined" && window.location.hostname === "rentchain.ai"
   window.location.replace(target.toString());
 }
 
-const originalFetch = window.fetch.bind(window);
 // Legacy global (DO NOT REMOVE until all fetch() calls are migrated)
 (window as any).API_BASE_URL = API_BASE_URL;
 (window as any).__tenantFlag = import.meta.env.VITE_TENANT_PORTAL_ENABLED;
 
-window.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
-  const initHeaders = new Headers(
-    init?.headers ||
-      (input instanceof Request ? input.headers : undefined) ||
-      undefined
-  );
-  const clientHeader = initHeaders.get("x-api-client");
-  const marked = clientHeader === "web";
-
-  const token = getAuthToken();
-  const url =
-    typeof input === "string" || input instanceof URL ? input.toString() : input.url;
-
-  if (import.meta.env.DEV && !marked && url.includes("/api/")) {
+installPreviewFetchGuard(window, {
+  getAuthToken,
+  apiBaseUrl: API_BASE_URL,
+  browserOrigin: window.location.origin,
+  deployEnv: String(import.meta.env.VITE_DEPLOY_ENV || ""),
+  isDevelopment: import.meta.env.DEV,
+  reportDirectApiFetch: (url) => {
     console.error("🚫 Direct fetch() forbidden for /api. Use apiFetch/apiJson.", url);
-  }
-
-  const shouldAttachAuth =
-    !!token &&
-    (url.startsWith("http") ? url.startsWith(API_BASE_URL) : true);
-
-  if (!shouldAttachAuth) {
-    return originalFetch(input, init);
-  }
-
-  const headers = initHeaders;
-
-  if (token && !headers.has("Authorization")) {
-    headers.set("Authorization", `Bearer ${token}`);
-  }
-
-  return originalFetch(input, {
-    ...init,
-    headers,
-  });
-};
+  },
+});
 
 const MAINTENANCE_MODE = String(import.meta.env.VITE_MAINTENANCE_MODE || "false").trim().toLowerCase() === "true";
 const MAINTENANCE_ADMIN_BYPASS =

--- a/rentchain-frontend/src/runtime/previewFetchGuard.test.ts
+++ b/rentchain-frontend/src/runtime/previewFetchGuard.test.ts
@@ -1,0 +1,234 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createGovernedFetch, installPreviewFetchGuard } from "./previewFetchGuard";
+
+const ORIGIN = window.location.origin;
+const PROXY = `${ORIGIN}/api/preview-backend`;
+const PRODUCTION_API = "https://rentchain-landlord-api-cyaabkl54a-uc.a.run.app";
+
+describe("Preview governed fetch", () => {
+  beforeEach(() => {
+    vi.stubEnv("VITE_DEPLOY_ENV", "preview");
+    vi.stubEnv("VITE_API_BASE_URL", "/api/preview-backend");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  function setup(apiBaseUrl = "/api/preview-backend") {
+    const originalFetch = vi.fn(async () => new Response(null, { status: 204 }));
+    const getAuthToken = vi.fn(() => "stored.preview.token");
+    const governedFetch = createGovernedFetch(originalFetch as typeof fetch, {
+      getAuthToken,
+      apiBaseUrl,
+      browserOrigin: ORIGIN,
+      deployEnv: String(import.meta.env.VITE_DEPLOY_ENV || ""),
+      isDevelopment: false,
+    });
+    return { originalFetch, getAuthToken, governedFetch };
+  }
+
+  it("uses Request methods and gives init.method browser override precedence", async () => {
+    const { originalFetch, governedFetch } = setup();
+    const post = new Request(`${PROXY}/api/auth/login`, { method: "POST" });
+    const get = new Request(`${PROXY}/api/auth/login`, { method: "GET" });
+
+    await governedFetch(post);
+    await governedFetch(get, { method: "POST" });
+
+    expect(
+      new Headers(originalFetch.mock.calls[0][1]?.headers).get("authorization")
+    ).toBe("Bearer stored.preview.token");
+    expect(originalFetch.mock.calls[0][0]).toBe(post);
+    expect(originalFetch.mock.calls[1][0]).toBe(get);
+    expect(originalFetch.mock.calls[1][1]?.method).toBe("POST");
+  });
+
+  it("rejects Request paths and init method overrides before credentials", async () => {
+    const { originalFetch, getAuthToken, governedFetch } = setup();
+    expect(() =>
+      governedFetch(new Request(`${ORIGIN}/api/auth/login`, { method: "POST" }))
+    ).toThrow(expect.objectContaining({ code: "PREVIEW_API_ROUTE_NOT_AVAILABLE" }));
+    expect(() =>
+      governedFetch(
+        new Request(`${PROXY}/api/auth/login`, { method: "POST" }),
+        { method: "GET" }
+      )
+    ).toThrow(expect.objectContaining({ code: "PREVIEW_API_ROUTE_NOT_AVAILABLE" }));
+    expect(getAuthToken).not.toHaveBeenCalled();
+    expect(originalFetch).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "/assets/index.js",
+    "/manifest.webmanifest",
+    "/sw.js",
+    "/favicon.ico",
+    "https://fonts.googleapis.com/css2",
+    "https://www.gstatic.com/example",
+    "https://identitytoolkit.googleapis.com/v1/accounts:lookup",
+    "https://api.stripe.com/v1/payment_methods",
+    "https://vercel.live/_next-live/feedback",
+  ])("passes non-API traffic through unchanged: %s", async (input) => {
+    const { originalFetch, getAuthToken, governedFetch } = setup();
+    await governedFetch(input);
+    expect(originalFetch).toHaveBeenCalledOnce();
+    expect(originalFetch).toHaveBeenCalledWith(input, undefined);
+    expect(getAuthToken).not.toHaveBeenCalled();
+  });
+
+  it("blocks unsupported relative and Production APIs without consuming the body", async () => {
+    const { originalFetch, getAuthToken, governedFetch } = setup();
+    const request = new Request(`${ORIGIN}/api/properties`, {
+      method: "POST",
+      body: "must-not-be-consumed",
+    });
+    expect(() => governedFetch(request)).toThrow(
+      expect.objectContaining({ code: "PREVIEW_API_ROUTE_NOT_AVAILABLE" })
+    );
+    expect(() =>
+      governedFetch(`${PRODUCTION_API}/api/properties`)
+    ).toThrow(expect.objectContaining({ code: "PREVIEW_API_ROUTE_NOT_AVAILABLE" }));
+    expect(request.bodyUsed).toBe(false);
+    expect(getAuthToken).not.toHaveBeenCalled();
+    expect(originalFetch).not.toHaveBeenCalled();
+  });
+
+  it("passes authorized login and me and rejects their wrong methods", async () => {
+    const { originalFetch, governedFetch } = setup();
+    await governedFetch("/api/preview-backend/api/auth/login", { method: "POST" });
+    await governedFetch("/api/preview-backend/api/me", { method: "GET" });
+    expect(() =>
+      governedFetch("/api/preview-backend/api/auth/login", { method: "GET" })
+    ).toThrow(expect.objectContaining({ code: "PREVIEW_API_ROUTE_NOT_AVAILABLE" }));
+    expect(() =>
+      governedFetch("/api/preview-backend/api/me", { method: "POST" })
+    ).toThrow(expect.objectContaining({ code: "PREVIEW_API_ROUTE_NOT_AVAILABLE" }));
+    expect(originalFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("attaches the token only to relative or exact same-origin Preview proxy URLs", async () => {
+    const { originalFetch, getAuthToken, governedFetch } = setup();
+
+    await governedFetch("/api/preview-backend/api/auth/login", { method: "POST" });
+    await governedFetch(`${PROXY}/api/auth/login`, { method: "POST" });
+
+    expect(getAuthToken).toHaveBeenCalledTimes(2);
+    for (const call of originalFetch.mock.calls) {
+      expect(new Headers(call[1]?.headers).get("authorization")).toBe(
+        "Bearer stored.preview.token"
+      );
+    }
+  });
+
+  it.each([
+    "https://evil.example/api/preview-backend/api/me",
+    "https://evil.example/api/auth/login",
+    "https://preview.example.vercel.app.evil.example/api/preview-backend/api/me",
+    "https://evil.example/path?next=/api/preview-backend/api/me",
+  ])("never classifies deceptive third-party URL as Preview API: %s", async (input) => {
+    const { originalFetch, getAuthToken, governedFetch } = setup();
+    await governedFetch(input);
+
+    expect(originalFetch).toHaveBeenCalledOnce();
+    expect(originalFetch).toHaveBeenCalledWith(input, undefined);
+    expect(getAuthToken).not.toHaveBeenCalled();
+    expect(originalFetch.mock.calls[0][1]).toBeUndefined();
+  });
+
+  it("rejects same-origin unsupported proxy paths before token access", () => {
+    const { originalFetch, getAuthToken, governedFetch } = setup();
+    expect(() =>
+      governedFetch("/api/preview-backend/api/properties", { method: "GET" })
+    ).toThrow(expect.objectContaining({ code: "PREVIEW_API_ROUTE_NOT_AVAILABLE" }));
+    expect(getAuthToken).not.toHaveBeenCalled();
+    expect(originalFetch).not.toHaveBeenCalled();
+  });
+
+  it.each(["production", "development"])("does not apply Preview blocking in %s", async (env) => {
+    vi.stubEnv("VITE_DEPLOY_ENV", env);
+    vi.stubEnv("VITE_API_BASE_URL", PRODUCTION_API);
+    const { originalFetch, governedFetch } = setup(PRODUCTION_API);
+    await governedFetch("/api/properties");
+    expect(originalFetch).toHaveBeenCalledOnce();
+  });
+
+  describe("legacy Production token parity", () => {
+    beforeEach(() => {
+      vi.stubEnv("VITE_DEPLOY_ENV", "production");
+      vi.stubEnv("VITE_API_BASE_URL", PRODUCTION_API);
+    });
+
+    it.each(["/api/me", "/assets/legacy-relative.js"])(
+      "attaches the stored token to relative request %s",
+      async (input) => {
+        const { originalFetch, governedFetch } = setup(PRODUCTION_API);
+        await governedFetch(input);
+        const forwarded = originalFetch.mock.calls[0][1];
+        expect(new Headers(forwarded?.headers).get("authorization")).toBe(
+          "Bearer stored.preview.token"
+        );
+      }
+    );
+
+    it("attaches to configured absolute API URLs but not unrelated third parties", async () => {
+      const { originalFetch, governedFetch } = setup(PRODUCTION_API);
+      await governedFetch(`${PRODUCTION_API}/api/me`);
+      expect(
+        new Headers(originalFetch.mock.calls[0][1]?.headers).get("authorization")
+      ).toBe("Bearer stored.preview.token");
+
+      originalFetch.mockClear();
+      await governedFetch("https://fonts.googleapis.com/css2");
+      expect(originalFetch).toHaveBeenCalledWith(
+        "https://fonts.googleapis.com/css2",
+        undefined
+      );
+    });
+
+    it("preserves existing Authorization and init.headers precedence for Request objects", async () => {
+      const { originalFetch, governedFetch } = setup(PRODUCTION_API);
+      const request = new Request(`${PRODUCTION_API}/api/me`, {
+        headers: { Authorization: "Bearer request-token", "x-request": "request" },
+      });
+      await governedFetch(request, {
+        headers: { Authorization: "Bearer init-token", "x-init": "init" },
+      });
+      const headers = new Headers(originalFetch.mock.calls[0][1]?.headers);
+      expect(headers.get("authorization")).toBe("Bearer init-token");
+      expect(headers.get("x-init")).toBe("init");
+      expect(headers.get("x-request")).toBeNull();
+    });
+
+    it("passes through unchanged when no stored token exists", async () => {
+      const originalFetch = vi.fn(async () => new Response(null, { status: 204 }));
+      const governedFetch = createGovernedFetch(originalFetch as typeof fetch, {
+        getAuthToken: vi.fn(() => null),
+        apiBaseUrl: PRODUCTION_API,
+        browserOrigin: ORIGIN,
+        deployEnv: "production",
+        isDevelopment: false,
+      });
+      await governedFetch("/api/me");
+      expect(originalFetch).toHaveBeenCalledWith("/api/me", undefined);
+    });
+  });
+
+  it("installs once and retains the first native fetch reference", async () => {
+    const nativeFetch = vi.fn(async () => new Response(null, { status: 204 }));
+    const windowLike = { fetch: nativeFetch as typeof fetch };
+    const dependencies = {
+      getAuthToken: vi.fn(() => null),
+      apiBaseUrl: "/api/preview-backend",
+      browserOrigin: ORIGIN,
+      deployEnv: "preview",
+      isDevelopment: false,
+    };
+    const first = installPreviewFetchGuard(windowLike, dependencies);
+    const second = installPreviewFetchGuard(windowLike, dependencies);
+    expect(second).toBe(first);
+    await second("/assets/index.js");
+    expect(nativeFetch).toHaveBeenCalledOnce();
+  });
+});

--- a/rentchain-frontend/src/runtime/previewFetchGuard.ts
+++ b/rentchain-frontend/src/runtime/previewFetchGuard.ts
@@ -1,0 +1,90 @@
+import { assertPreviewBrowserRequestAvailable } from "../api/baseUrl";
+
+const INSTALL_MARKER = Symbol.for("rentchain.previewFetchGuard.installed");
+
+type FetchWindow = {
+  fetch: typeof fetch;
+  [INSTALL_MARKER]?: boolean;
+};
+
+type GovernedFetchDependencies = {
+  getAuthToken: () => string | null;
+  apiBaseUrl: string;
+  browserOrigin: string;
+  deployEnv: string;
+  isDevelopment: boolean;
+  reportDirectApiFetch?: (url: string) => void;
+};
+
+function isSameOriginPreviewProxyUrl(url: string, browserOrigin: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url, browserOrigin);
+  } catch {
+    return false;
+  }
+  return (
+    parsed.origin === browserOrigin &&
+    parsed.pathname.startsWith("/api/preview-backend/")
+  );
+}
+
+function requestUrl(input: RequestInfo | URL): string {
+  return typeof input === "string" || input instanceof URL ? input.toString() : input.url;
+}
+
+function effectiveMethod(input: RequestInfo | URL, init?: RequestInit): string {
+  return String(init?.method || (input instanceof Request ? input.method : "GET")).toUpperCase();
+}
+
+export function createGovernedFetch(
+  originalFetch: typeof fetch,
+  dependencies: GovernedFetchDependencies
+): typeof fetch {
+  return ((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = requestUrl(input);
+    assertPreviewBrowserRequestAvailable(url, effectiveMethod(input, init));
+
+    const initHeaders = new Headers(
+      init?.headers || (input instanceof Request ? input.headers : undefined) || undefined
+    );
+    const marked = initHeaders.get("x-api-client") === "web";
+    if (dependencies.isDevelopment && !marked && url.includes("/api/")) {
+      dependencies.reportDirectApiFetch?.(url);
+    }
+
+    const isPreview = dependencies.deployEnv.trim().toLowerCase() === "preview";
+    const isPreviewApi = isSameOriginPreviewProxyUrl(
+      url,
+      dependencies.browserOrigin
+    );
+    if (isPreview && !isPreviewApi) {
+      return originalFetch(input, init);
+    }
+
+    const token = dependencies.getAuthToken();
+    const shouldAttachAuth =
+      Boolean(token) &&
+      (isPreview ||
+        (url.startsWith("http")
+          ? Boolean(dependencies.apiBaseUrl) && url.startsWith(dependencies.apiBaseUrl)
+          : true));
+    if (!shouldAttachAuth || initHeaders.has("Authorization")) {
+      return originalFetch(input, init);
+    }
+
+    initHeaders.set("Authorization", `Bearer ${token}`);
+    return originalFetch(input, { ...init, headers: initHeaders });
+  }) as typeof fetch;
+}
+
+export function installPreviewFetchGuard(
+  windowLike: FetchWindow,
+  dependencies: GovernedFetchDependencies
+): typeof fetch {
+  if (windowLike[INSTALL_MARKER]) return windowLike.fetch;
+  const originalFetch = windowLike.fetch.bind(windowLike);
+  windowLike.fetch = createGovernedFetch(originalFetch, dependencies);
+  windowLike[INSTALL_MARKER] = true;
+  return windowLike.fetch;
+}

--- a/rentchain-frontend/src/vite-env.d.ts
+++ b/rentchain-frontend/src/vite-env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_BASE_URL?: string;
+  readonly VITE_DEPLOY_ENV?: "development" | "preview" | "production";
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary

Adds Preview-only frontend routing for the four authorized authentication and
session operations through the secure same-origin Vercel proxy introduced in
PR #1487.

## Preview routing

Authorized operations:

- `POST /api/auth/login`
- `POST /api/auth/logout`
- `GET /api/me`
- `GET /api/auth/me`

These resolve through:

`/api/preview-backend/*`

All other Preview API routes or methods fail locally with:

`PREVIEW_API_ROUTE_NOT_AVAILABLE`

before credential acquisition, header construction, or network dispatch.

## Isolation

- no Preview fallback to the Production landlord API
- unsupported dashboard loaders reject locally
- no Production request occurs after login redirects to `/dashboard`
- no Firebase token or stored bearer token is read for rejected requests
- third-party URLs never receive RentChain credentials
- exact same-origin and pathname matching is required
- deceptive hostnames, query-only proxy text, and third-party proxy-like paths
  do not qualify
- non-API traffic passes through unchanged

## Production compatibility

- existing Production API endpoint remains unchanged
- original Production/development global token behavior is preserved
- existing Authorization headers are preserved
- Request and `init.headers` precedence is preserved
- legacy double-`api` normalization remains supported
- local HTTP development behavior remains supported

## Validation

- fetch-guard tests: 27/27 passed
- focused Stage 2 tests: 126/126 passed
- full frontend suite: 344 files, 1,638 tests passed
- `npx tsc --noEmit`: passed
- production build: passed
- `git diff --check`: passed
- browser identity and credential scans: passed

## Boundaries

- Stage 1 proxy and identity code unchanged
- Stage 1 route allowlist unchanged
- `vercel.json` unchanged
- no Terraform or Cloud Run changes
- no Vercel environment settings applied
- no deployment performed
- Production unchanged
- PR #1453 and PR #1435 untouched
- Stage 3 not started

## Stage 3 configuration plan

Not applied in this PR:

- `VITE_DEPLOY_ENV=preview`
- `VITE_API_BASE_URL=/api/preview-backend`
- Vercel scope: Preview only
- Preview redeployment required after configuration
