### PR TITLE
Ensure the Preview backend Function precedes the Production API rewrite

### DIFF
--- a/rentchain-frontend/src/platform/vercelRoutePrecedence.test.ts
+++ b/rentchain-frontend/src/platform/vercelRoutePrecedence.test.ts
@@ -1,0 +1,91 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+type VercelRoute = {
+  src?: string;
+  dest?: string;
+  handle?: string;
+};
+
+type VercelRewrite = {
+  source: string;
+  destination: string;
+};
+
+type VercelConfig = {
+  routes: VercelRoute[];
+  rewrites: VercelRewrite[];
+};
+
+const frontendRoot = process.cwd();
+const config = JSON.parse(
+  readFileSync(join(frontendRoot, "vercel.json"), "utf8"),
+) as VercelConfig;
+
+const productionApi =
+  "https://rentchain-landlord-api-cyaabkl54a-uc.a.run.app";
+
+describe("Vercel Preview backend route precedence", () => {
+  it("routes the complete Preview suffix to the existing Function before filesystem misses", () => {
+    expect(config.routes).toEqual([
+      {
+        src: "^/api/preview-backend/(.*)$",
+        dest: "/api/preview-backend/[...path]?path=$1",
+      },
+      { handle: "filesystem" },
+    ]);
+    expect(
+      existsSync(join(frontendRoot, "api/preview-backend/[...path].ts")),
+    ).toBe(true);
+  });
+
+  it.each([
+    "/api/preview-backend/api/me",
+    "/api/preview-backend/api/auth/login",
+  ])("reserves %s for the dedicated filesystem Function", (requestPath) => {
+    const functionRoute = config.routes[0];
+    const match = new RegExp(functionRoute.src as string).exec(requestPath);
+
+    expect(match?.[1]).toBe(requestPath.slice("/api/preview-backend/".length));
+    expect(functionRoute.dest?.replace("$1", match?.[1] ?? "")).toBe(
+      `/api/preview-backend/[...path]?path=${match?.[1]}`,
+    );
+    expect(config.routes[1]).toEqual({ handle: "filesystem" });
+  });
+
+  it.each(["/api/properties", "/api/tenants"])(
+    "retains the Production rewrite for %s after a filesystem miss",
+    (requestPath) => {
+      const rewrite = config.rewrites.find(
+        ({ source }) => source === "/api/:path*",
+      );
+      expect(requestPath.startsWith("/api/")).toBe(true);
+      expect(rewrite).toEqual({
+        source: "/api/:path*",
+        destination: `${productionApi}/api/:path*`,
+      });
+    },
+  );
+
+  it("preserves health and SPA fallbacks", () => {
+    expect(config.rewrites).toContainEqual({
+      source: "/health",
+      destination: `${productionApi}/health`,
+    });
+    expect(config.rewrites.at(-1)).toEqual({
+      source: "/:path*",
+      destination: "/index.html",
+    });
+  });
+
+  it("does not expose Preview Cloud Run or public-access configuration", () => {
+    const serialized = JSON.stringify(config);
+    expect(serialized).not.toContain(
+      "rentchain-preview-backend-glistw4pya-nn.a.run.app",
+    );
+    expect(serialized).not.toContain("allUsers");
+    expect(serialized).not.toContain("allAuthenticatedUsers");
+  });
+});

--- a/rentchain-frontend/vercel.json
+++ b/rentchain-frontend/vercel.json
@@ -81,6 +81,15 @@
       "permanent": true
     }
   ],
+  "routes": [
+    {
+      "src": "^/api/preview-backend/(.*)$",
+      "dest": "/api/preview-backend/[...path]?path=$1"
+    },
+    {
+      "handle": "filesystem"
+    }
+  ],
   "rewrites": [
     {
       "source": "/health",


### PR DESCRIPTION
## Summary

Adds an explicit ordered Vercel route for nested requests under:

`/api/preview-backend/*`

so they target the existing dedicated Vercel Function before the broad
Production `/api/:path*` external rewrite.

## Runtime blocker

The Stage 3 smoke deployment showed that Preview proxy requests were handled by
the Production landlord API rewrite instead of the Vercel Function.

Evidence:

- `x-route-source: riskAgentRoutes.ts`
- missing `x-rentchain-api-proxy: vercel-preview-backend`
- no Vercel Function runtime logs

## Route contract

```json
{
  "src": "^/api/preview-backend/(.*)$",
  "dest": "/api/preview-backend/[...path]?path=$1"
},
{
  "handle": "filesystem"
}

The existing Production API rewrite, /health, and SPA fallback remain
unchanged.

Validation
focused route and proxy tests: 34/34 passed
full frontend suite: 345 files, 1,645 tests passed
npx tsc --noEmit: passed
production frontend build: passed
git diff --check: passed
identity and credential scans: passed

Local vercel build was inconclusive because the local CLI failed while
spawning sh during installation:

Error: spawn sh ENOENT

The command did not report a route-schema or configuration rejection.

Boundaries
Stage 1 proxy and identity code unchanged
Stage 2 frontend routing unchanged
Production endpoint and rewrites unchanged
no Terraform, Cloud Run, IAM, or environment-variable changes
no deployment performed from the implementation branch
held product PRs untouched
Mandatory pre-merge live gate

This PR must not merge until its live Vercel Preview proves:

GET /api/preview-backend/api/me reaches the dedicated Function;
the response contains:
x-rentchain-api-proxy: vercel-preview-backend;
Vercel Function runtime logs exist for the request;
invalid login reaches the private Preview backend;
no route recursion occurs;
ordinary /api/* behavior remains unchanged;
Production remains unchanged.
