### PR TITLE
Initialize Firebase Admin Auth while Preview Firestore is disabled

### DIFF
--- a/rentchain-api/src/firebase/__tests__/adminInitialization.test.ts
+++ b/rentchain-api/src/firebase/__tests__/adminInitialization.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const initializeAppMock = vi.hoisted(() => vi.fn());
+const applicationDefaultMock = vi.hoisted(() => vi.fn(() => ({ kind: "application-default" })));
+const authMock = vi.hoisted(() => vi.fn(() => ({ getUser: vi.fn() })));
+const settingsMock = vi.hoisted(() => vi.fn());
+const firestoreMock = vi.hoisted(() =>
+  Object.assign(vi.fn(() => ({ settings: settingsMock })), {
+    FieldValue: { serverTimestamp: vi.fn() },
+  })
+);
+const apps = vi.hoisted(() => [] as Array<Record<string, unknown>>);
+
+vi.mock("firebase-admin", () => ({
+  default: {
+    apps,
+    initializeApp: initializeAppMock,
+    credential: { applicationDefault: applicationDefaultMock },
+    auth: authMock,
+    firestore: firestoreMock,
+  },
+}));
+
+const originalEnv = { ...process.env };
+
+function setPreviewDisabledEnvironment() {
+  process.env.APP_ENV = "preview";
+  process.env.NODE_ENV = "production";
+  process.env.GOOGLE_CLOUD_PROJECT = "rentchain-preview";
+  process.env.FIREBASE_PROJECT_ID = "rentchain-preview";
+  process.env.FIREBASE_API_KEY = "preview-test-key";
+  process.env.PREVIEW_AUTH_ENABLED = "true";
+  process.env.FIRESTORE_ENABLED = "false";
+  delete process.env.FIRESTORE_DATABASE_ID;
+  delete process.env.FIRESTORE_EMULATOR_HOST;
+  delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
+}
+
+async function importAdminModule() {
+  return import("../admin");
+}
+
+describe("Firebase Admin initialization boundaries", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    apps.splice(0);
+    initializeAppMock.mockImplementation((options) => {
+      const app = { options };
+      apps.push(app);
+      return app;
+    });
+    setPreviewDisabledEnvironment();
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("initializes Admin Auth exactly once while Preview Firestore remains disabled", async () => {
+    const firebase = await importAdminModule();
+
+    expect(initializeAppMock).toHaveBeenCalledTimes(1);
+    expect(initializeAppMock).toHaveBeenCalledWith({
+      credential: { kind: "application-default" },
+      projectId: "rentchain-preview",
+    });
+    expect(authMock()).toEqual(expect.objectContaining({ getUser: expect.any(Function) }));
+    expect(firestoreMock).not.toHaveBeenCalled();
+    expect(settingsMock).not.toHaveBeenCalled();
+    expect(() => firebase.db.collection).toThrow(
+      "[firebase] Firestore is disabled in Preview until separately provisioned."
+    );
+    expect(() => firebase.firestore.doc).toThrow(
+      "[firebase] Firestore is disabled in Preview until separately provisioned."
+    );
+  });
+
+  it("fails closed before initialization when Preview has no resolvable project ID", async () => {
+    delete process.env.GOOGLE_CLOUD_PROJECT;
+    delete process.env.GCLOUD_PROJECT;
+    delete process.env.FIREBASE_PROJECT_ID;
+
+    await expect(importAdminModule()).rejects.toThrow(
+      "[runtime-env] APP_ENV=preview requires GOOGLE_CLOUD_PROJECT=rentchain-preview."
+    );
+    expect(initializeAppMock).not.toHaveBeenCalled();
+    expect(authMock).not.toHaveBeenCalled();
+    expect(firestoreMock).not.toHaveBeenCalled();
+  });
+
+  it("does not initialize a duplicate default app for multiple module consumers", async () => {
+    await importAdminModule();
+    vi.resetModules();
+    await importAdminModule();
+
+    expect(initializeAppMock).toHaveBeenCalledTimes(1);
+    expect(apps).toHaveLength(1);
+    expect(firestoreMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves non-disabled Preview Firestore initialization", async () => {
+    process.env.FIRESTORE_ENABLED = "true";
+    process.env.FIRESTORE_DATABASE_ID = "(default)";
+
+    const firebase = await importAdminModule();
+
+    expect(initializeAppMock).toHaveBeenCalledTimes(1);
+    expect(firestoreMock).toHaveBeenCalledTimes(1);
+    expect(settingsMock).toHaveBeenCalledWith({ ignoreUndefinedProperties: true });
+    expect(firebase.db).toEqual({ settings: settingsMock });
+  });
+
+  it("preserves Production Firebase and Firestore initialization", async () => {
+    process.env.APP_ENV = "production";
+    process.env.GOOGLE_CLOUD_PROJECT = "project-0d9658de-af29-4dc0-a99";
+    process.env.FIREBASE_PROJECT_ID = "project-0d9658de-af29-4dc0-a99";
+    process.env.FIRESTORE_ENABLED = "true";
+    delete process.env.PREVIEW_AUTH_ENABLED;
+
+    await importAdminModule();
+
+    expect(initializeAppMock).toHaveBeenCalledTimes(1);
+    expect(initializeAppMock).toHaveBeenCalledWith({
+      credential: { kind: "application-default" },
+      projectId: "project-0d9658de-af29-4dc0-a99",
+    });
+    expect(firestoreMock).toHaveBeenCalledTimes(1);
+    expect(settingsMock).toHaveBeenCalledWith({ ignoreUndefinedProperties: true });
+  });
+});

--- a/rentchain-api/src/firebase/admin.ts
+++ b/rentchain-api/src/firebase/admin.ts
@@ -10,6 +10,13 @@ export const PROJECT_ID = getConfiguredProjectId() || (runtime === "production" 
 const guard = assertSafeFirestoreEnvironment();
 const previewFoundation = getPreviewFoundationConfig();
 
+if (!admin.apps.length) {
+  admin.initializeApp({
+    credential: admin.credential.applicationDefault(),
+    projectId: PROJECT_ID,
+  });
+}
+
 let firestore: admin.firestore.Firestore;
 let db: admin.firestore.Firestore;
 const FieldValue = admin.firestore.FieldValue;
@@ -24,33 +31,24 @@ if (runtime === "preview" && guard.mode === "preview-disabled") {
   firestore = unavailable;
   db = unavailable;
 } else {
+  const firestoreInstance = admin.firestore();
+  firestoreInstance.settings({ ignoreUndefinedProperties: true });
 
-if (!admin.apps.length) {
-  admin.initializeApp({
-    credential: admin.credential.applicationDefault(),
+  if (runtime === "preview" && (
+    previewFoundation.projectId !== PREVIEW_PROJECT ||
+    previewFoundation.databaseId !== "(default)"
+  )) {
+    throw new Error("[firebase] Preview Firestore initialization boundary is invalid.");
+  }
+
+  recordInitializationState({
+    guard,
     projectId: PROJECT_ID,
+    caller: "rentchain-api/src/firebase/admin.ts",
   });
-}
 
-const firestoreInstance = admin.firestore();
-firestoreInstance.settings({ ignoreUndefinedProperties: true });
-
-if (runtime === "preview" && (
-  previewFoundation.projectId !== PREVIEW_PROJECT ||
-  previewFoundation.databaseId !== "(default)"
-)) {
-  throw new Error("[firebase] Preview Firestore initialization boundary is invalid.");
-}
-
-recordInitializationState({
-  guard,
-  projectId: PROJECT_ID,
-  caller: "rentchain-api/src/firebase/admin.ts",
-});
-
-firestore = firestoreInstance;
-db = firestoreInstance;
-
+  firestore = firestoreInstance;
+  db = firestoreInstance;
 }
 
 export { firestore, db, FieldValue };

--- a/rentchain-api/src/routes/__tests__/authPropertyManagerCompanyLogin.test.ts
+++ b/rentchain-api/src/routes/__tests__/authPropertyManagerCompanyLogin.test.ts
@@ -320,6 +320,75 @@ describe("auth login property manager company profiles", () => {
       email: "owner@example.com",
       role: "landlord",
     });
+    expect(getUserMock).toHaveBeenCalledWith("landlord-user-1");
+  });
+
+  it("keeps missing and unverified Firebase users on their controlled login paths", async () => {
+    const authRouter = (await import("../authRoutes")).default;
+
+    signInWithPasswordMock.mockResolvedValueOnce(null);
+    const missing = await invokeRouter(authRouter, {
+      method: "POST",
+      url: "/login",
+      body: { email: "missing@example.com", password: "secretpass" },
+    });
+    expect(missing.status).toBe(401);
+    expect(missing.body.code).toBe("INVALID_CREDENTIALS");
+    expect(getUserMock).not.toHaveBeenCalled();
+
+    signInWithPasswordMock.mockResolvedValueOnce({
+      uid: "unverified-user-1",
+      email: "unverified@example.com",
+    });
+    getUserMock.mockResolvedValueOnce({
+      uid: "unverified-user-1",
+      email: "unverified@example.com",
+      emailVerified: false,
+    });
+    const unverified = await invokeRouter(authRouter, {
+      method: "POST",
+      url: "/login",
+      body: { email: "unverified@example.com", password: "secretpass" },
+    });
+    expect(unverified.status).toBe(403);
+    expect(unverified.body.code).toBe("EMAIL_NOT_VERIFIED");
+  });
+
+  it("sanitizes unexpected login failure logs without changing the response", async () => {
+    signInWithPasswordMock.mockResolvedValue({
+      uid: "firebase-user-1",
+      email: "private.user@example.com",
+    });
+    getUserMock.mockRejectedValueOnce(
+      Object.assign(new Error("sensitive provider response"), { code: "app/no-app\ninternal" })
+    );
+    const errorLog = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const authRouter = (await import("../authRoutes")).default;
+
+    const response = await invokeRouter(authRouter, {
+      method: "POST",
+      url: "/login",
+      body: { email: "private.user@example.com", password: "secretpass" },
+    });
+
+    expect(response.status).toBe(500);
+    expect(response.body).toMatchObject({
+      code: "INTERNAL",
+      step: "firebase_signin",
+      errCode: "app/no-app_internal",
+    });
+    expect(response.body).not.toHaveProperty("detail");
+    expect(errorLog).toHaveBeenCalledWith("[auth/login] failed", {
+      requestId: response.body.requestId,
+      step: "firebase_signin",
+      status: 500,
+      code: "app/no-app_internal",
+    });
+    const serializedLog = JSON.stringify(errorLog.mock.calls);
+    expect(serializedLog).not.toContain("private.user@example.com");
+    expect(serializedLog).not.toContain("secretpass");
+    expect(serializedLog).not.toContain("sensitive provider response");
+    expect(JSON.stringify(response.body)).not.toContain("sensitive provider response");
   });
 
   it("keeps existing delegate and contractor login branches safe", async () => {

--- a/rentchain-api/src/routes/authRoutes.ts
+++ b/rentchain-api/src/routes/authRoutes.ts
@@ -90,6 +90,10 @@ function maskEmail(value: string): string {
   return `${local.slice(0, 2)}***@${domain}`;
 }
 
+function sanitizeAuthErrorCode(value: unknown): string {
+  return String(value || "INTERNAL").replace(/[^A-Za-z0-9_/-]/g, "_").slice(0, 80);
+}
+
 function tokenFingerprint(value: string): string {
   const token = String(value || "").trim();
   if (!token) return "none";
@@ -1709,9 +1713,9 @@ router.post("/login", rateLimitAuth, async (req, res) => {
       AUTH_LOGIN_ENABLED: process.env.AUTH_LOGIN_ENABLED,
       PASSWORD_LOGIN_ENABLED: process.env.PASSWORD_LOGIN_ENABLED,
     });
-    console.log("[auth/login] hit", { email, passwordLoginEnabled });
+    console.log("[auth/login] hit", { email: maskEmail(email), passwordLoginEnabled });
     console.log("[auth/login] request", {
-      email,
+      email: maskEmail(email),
       passwordLoginEnabled,
       envPasswordEnabled: process.env.PASSWORD_LOGIN_ENABLED,
     });
@@ -1935,10 +1939,8 @@ router.post("/login", rateLimitAuth, async (req, res) => {
     console.error("[auth/login] failed", {
       requestId,
       step,
-      message: err?.message,
-      code: err?.code,
-      stack: err?.stack,
-      email: (req as any)?.body?.email,
+      status: 500,
+      code: sanitizeAuthErrorCode(err?.code),
     });
     return res.status(500).json({
       ok: false,
@@ -1946,8 +1948,7 @@ router.post("/login", rateLimitAuth, async (req, res) => {
       error: "Login failed",
       requestId,
       step,
-      detail: String(err?.message || ""),
-      errCode: String(err?.code || ""),
+      errCode: sanitizeAuthErrorCode(err?.code),
     });
   }
 });

--- a/rentchain-api/src/services/__tests__/authServiceLogging.test.ts
+++ b/rentchain-api/src/services/__tests__/authServiceLogging.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const getUserMock = vi.hoisted(() => vi.fn());
+const documentGetMock = vi.hoisted(() => vi.fn());
+const documentSetMock = vi.hoisted(() => vi.fn());
+
+vi.mock("firebase-admin", () => ({
+  default: {
+    auth: () => ({ getUser: getUserMock }),
+  },
+}));
+
+vi.mock("../../firebase", () => ({
+  db: {
+    collection: () => ({
+      doc: () => ({
+        get: documentGetMock,
+        set: documentSetMock,
+      }),
+    }),
+  },
+}));
+
+const originalEnv = { ...process.env };
+
+describe("Identity Toolkit authentication failure logging", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    process.env.FIREBASE_API_KEY = "test-api-key";
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.restoreAllMocks();
+  });
+
+  it("logs only the provider status, stable code, and a non-reversible email hash", async () => {
+    const providerPayload = {
+      error: {
+        code: 400,
+        message: "INVALID_PASSWORD : private provider context",
+        errors: [{ message: "sensitive provider detail", domain: "global" }],
+      },
+    };
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: vi.fn().mockResolvedValue(providerPayload),
+      text: vi.fn(),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const { signInWithPassword } = await import("../authService");
+
+    await expect(signInWithPassword("private.user@example.com", "secret-password")).resolves.toBeNull();
+
+    expect(warn).toHaveBeenCalledWith("[auth] firebase signInWithPassword failed", {
+      status: 400,
+      code: "INVALID_PASSWORD",
+      emailHash: expect.stringMatching(/^[a-f0-9]{12}$/),
+    });
+    const serializedLog = JSON.stringify(warn.mock.calls);
+    expect(serializedLog).not.toContain("private.user@example.com");
+    expect(serializedLog).not.toContain("secret-password");
+    expect(serializedLog).not.toContain("sensitive provider detail");
+    expect(serializedLog).not.toContain("private provider context");
+    expect(serializedLog).not.toContain(JSON.stringify(providerPayload));
+  });
+
+  it("logs no raw email or UID while validating landlord credentials", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: vi.fn().mockResolvedValue({
+          localId: "sensitive-firebase-uid",
+          email: "private.user@example.com",
+        }),
+      })
+    );
+    getUserMock.mockResolvedValue({
+      uid: "sensitive-firebase-uid",
+      email: "private.user@example.com",
+      emailVerified: true,
+    });
+    documentGetMock.mockResolvedValue({
+      exists: true,
+      data: () => ({
+        id: "sensitive-firebase-uid",
+        email: "private.user@example.com",
+        role: "landlord",
+      }),
+    });
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const { validateLandlordCredentials } = await import("../authService");
+
+    await expect(
+      validateLandlordCredentials("private.user@example.com", "secret-password")
+    ).resolves.toMatchObject({ role: "landlord" });
+
+    expect(log).toHaveBeenCalledWith("[auth/validate] start", {
+      emailHash: expect.stringMatching(/^[a-f0-9]{12}$/),
+    });
+    expect(log).toHaveBeenCalledWith("[auth/validate] firebase ok", {
+      uidPresent: true,
+    });
+    const serializedOutput = JSON.stringify([
+      ...log.mock.calls,
+      ...warn.mock.calls,
+      ...error.mock.calls,
+    ]);
+    expect(serializedOutput).not.toContain("private.user@example.com");
+    expect(serializedOutput).not.toContain("sensitive-firebase-uid");
+    expect(serializedOutput).not.toContain("secret-password");
+  });
+});

--- a/rentchain-api/src/services/authService.ts
+++ b/rentchain-api/src/services/authService.ts
@@ -1,4 +1,5 @@
 // src/services/authService.ts
+import crypto from "crypto";
 import jwt from "jsonwebtoken";
 import admin from "firebase-admin";
 import { JWT_EXPIRES_IN, JWT_SECRET } from "../config/authConfig";
@@ -24,7 +25,7 @@ export async function validateLandlordCredentials(
   email: string,
   password: string
 ): Promise<LandlordUser | null> {
-  console.log("[auth/validate] start", { email });
+  console.log("[auth/validate] start", { emailHash: emailHash(email) });
 
   const fb = await signInWithPassword(email, password);
 
@@ -34,8 +35,7 @@ export async function validateLandlordCredentials(
   }
 
   console.log("[auth/validate] firebase ok", {
-    uid: fb.uid,
-    email: fb.email,
+    uidPresent: Boolean(fb.uid),
   });
 
   try {
@@ -50,7 +50,7 @@ export async function validateLandlordCredentials(
 
     if (!snap.exists) {
       console.log("[auth/validate] landlord doc missing — creating", {
-        uid: fb.uid,
+        uidPresent: Boolean(fb.uid),
       });
 
       const createdAt = new Date().toISOString();
@@ -77,7 +77,9 @@ export async function validateLandlordCredentials(
       plan: data?.plan || "screening",
     };
   } catch (err: any) {
-    console.error("[auth/validate] firestore error", err?.message || err);
+    console.error("[auth/validate] failed", {
+      code: stableAuthErrorCode(err),
+    });
     return null;
   }
 }
@@ -106,6 +108,29 @@ export function generateJwtForLandlord(
 
 const FIREBASE_API_KEY = process.env.FIREBASE_API_KEY;
 
+function emailHash(email: string): string {
+  return crypto.createHash("sha256").update(String(email || "").trim().toLowerCase()).digest("hex").slice(0, 12);
+}
+
+function stableIdentityToolkitErrorCode(payload: unknown): string {
+  const value =
+    payload && typeof payload === "object"
+      ? String((payload as any)?.error?.message || (payload as any)?.error?.status || "")
+      : "";
+  const stableCode = value.trim().split(/[\s:]+/, 1)[0] || "";
+  const normalized = stableCode.toUpperCase().replace(/[^A-Z0-9_-]/g, "_").slice(0, 80);
+  return normalized || "IDENTITY_TOOLKIT_REQUEST_FAILED";
+}
+
+function stableAuthErrorCode(error: unknown): string {
+  const value =
+    error && typeof error === "object"
+      ? String((error as any)?.code || "")
+      : "";
+  const normalized = value.trim().replace(/[^A-Za-z0-9_/-]/g, "_").slice(0, 80);
+  return normalized || "AUTH_VALIDATION_FAILED";
+}
+
 export async function signInWithPassword(
   email: string,
   password: string
@@ -128,8 +153,8 @@ export async function signInWithPassword(
       (await res.json().catch(async () => ({ raw: await res.text().catch(() => "") }))) || {};
     console.warn("[auth] firebase signInWithPassword failed", {
       status: res.status,
-      email,
-      error: errJson,
+      code: stableIdentityToolkitErrorCode(errJson),
+      emailHash: emailHash(email),
     });
     return null;
   }


### PR DESCRIPTION
## Summary

Initializes the default Firebase Admin application in Preview even when
Firestore remains intentionally disabled.

This fixes the Stage 3 login failure:

`app/no-app`

while preserving the existing Preview Firestore isolation boundary.

## Runtime behavior

Preview with `FIRESTORE_ENABLED=false` now has:

- Firebase Admin app initialized
- Firebase Admin Auth available
- Firestore client not initialized
- `db` and `firestore` exports remaining fail-closed proxies

Production and Preview-enabled Firestore behavior remain unchanged.

## Authentication behavior

Preserved:

- invalid credentials → `401 INVALID_CREDENTIALS`
- unverified email → `403 EMAIL_NOT_VERIFIED`
- unexpected failures → controlled `500`

## Logging hardening

Authentication logs no longer include:

- raw email addresses
- Firebase UIDs
- provider response payloads
- passwords
- tokens
- headers
- stack traces

Unexpected login failures retain only stable request metadata and sanitized
error codes. Internal exception details are no longer returned to clients.

## Validation

- Stage 3B focused tests: 15/15 passed
- affected Firebase/auth matrix: 52/54 passed
- two failures are existing expired delegated-invite fixtures
- full base: 2,966/2,998 passed; 32 failed
- full branch: 2,975/3,007 passed; 32 failed
- normalized base and branch failure sets: identical
- build-specific TypeScript: passed
- backend build: passed
- `git diff --check`: passed
- credential and logging scans: passed

## Boundaries

- no frontend or Vercel changes
- no Terraform changes
- no Cloud Run or IAM changes
- no image build or deployment
- Production unchanged
- Stage 1 and Stage 2 unchanged
- PR #1453 and PR #1435 untouched

## Post-merge deployment plan

After merge and separate authorization:

1. build a new immutable Preview backend image;
2. verify and record its digest;
3. update only the Preview Terraform-pinned digest;
4. apply only the Preview deployment;
5. confirm the new Cloud Run revision;
6. rerun valid Preview login/session/logout smoke tests;
7. verify Firestore remains disabled;
8. do not deploy Production.
