### PR TITLE
Pin Stage 3B Preview backend image digest

### DIFF
--- a/infra/environments/preview-foundation/cloud_run.tf
+++ b/infra/environments/preview-foundation/cloud_run.tf
@@ -1,6 +1,6 @@
 locals {
   preview_backend_service_name = "rentchain-preview-backend"
-  preview_backend_image_digest = "northamerica-northeast1-docker.pkg.dev/rentchain-preview/rentchain-preview/backend@sha256:3a7de2792511786d9f984de5f99ee19b5466ad8336d9ec4e307702c9dedd8cfd"
+  preview_backend_image_digest = "northamerica-northeast1-docker.pkg.dev/rentchain-preview/rentchain-preview/backend@sha256:270adb21de2b271eb468b28b1a591a3f27544aae162f1f028ad74c7bfd30960f"
   preview_backend_source_sha   = "d28c61991131e9a76874d5eb92adceac048f9417"
 }
 


### PR DESCRIPTION
## Summary

Pins the Preview Cloud Run backend to the immutable Stage 3B image built from merge commit:

`44e04e9e618841701bdac084f1aff329a9668591`

## Image

Repository:

`northamerica-northeast1-docker.pkg.dev/rentchain-preview/rentchain-preview/backend`

Traceability tag:

`sha-44e04e9e618841701bdac084f1aff329a9668591`

Immutable digest:

`sha256:270adb21de2b271eb468b28b1a591a3f27544aae162f1f028ad74c7bfd30960f`

Build workflow:

`preview-deployment-identity-validation.yml`

Build run:

`30601879384`

Build result:

success

Architecture:

`linux/amd64`

## Terraform change

Changes only:

`infra/environments/preview-foundation/cloud_run.tf`

Digest transition:

- old:
  `sha256:3a7de2792511786d9f984de5f99ee19b5466ad8336d9ec4e307702c9dedd8cfd`
- new:
  `sha256:270adb21de2b271eb468b28b1a591a3f27544aae162f1f028ad74c7bfd30960f`

## Plan

HCP speculative run:

`run-6U5MeS7skPeDbmT8`

Result:

- 0 add
- 1 change
- 0 destroy
- 0 import

Only the Preview Cloud Run container image changes.

## Current runtime

The live Preview service remains unchanged pending separate apply authorization:

- revision:
  `rentchain-preview-backend-00002-bqm`
- current digest:
  `sha256:3a7de2792511786d9f984de5f99ee19b5466ad8336d9ec4e307702c9dedd8cfd`
- `FIRESTORE_ENABLED=false`

## Boundaries

- no Terraform apply
- no Cloud Run deployment
- no Production changes
- no Vercel changes
- no IAM changes
- no Identity Platform changes
- no Firestore enablement
- no backend or frontend source changes
- PR #1453 untouched
- PR #1435 untouched

## Post-merge step

After merge and separate authorization:

1. apply the Preview-only Terraform run;
2. confirm the new Cloud Run revision and immutable digest;
3. verify `FIRESTORE_ENABLED=false`;
4. run valid Preview login, session, and logout smoke tests;
5. confirm Firebase Admin Auth works;
6. confirm Firestore remains inaccessible;
7. do not deploy Production.