### PR TITLE
Grant Preview runtime Firebase Auth read access

### DIFF
--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -79,7 +79,7 @@ check "b7_preview_authentication_boundary" {
   }
 
   assert {
-    condition = var.b7_foundation_phase < 3 ? true : (
+    condition = var.b7_foundation_phase < 2 ? true : (
       local.preview_runtime_auth_permissions == toset(["firebaseauth.users.get"]) &&
       google_project_iam_custom_role.preview_runtime_auth_reader[0].role_id == "previewBackendAuthReader" &&
       google_project_iam_member.preview_runtime_auth_reader[0].member == google_service_account.preview_backend_runtime.member

--- a/infra/environments/preview-foundation/datastore_auth.tf
+++ b/infra/environments/preview-foundation/datastore_auth.tf
@@ -150,7 +150,7 @@ resource "google_project_iam_member" "preview_runtime_firestore" {
 }
 
 resource "google_project_iam_custom_role" "preview_runtime_auth_reader" {
-  count = var.b7_foundation_phase >= 3 ? 1 : 0
+  count = var.b7_foundation_phase >= 2 ? 1 : 0
 
   project     = var.project_id
   role_id     = "previewBackendAuthReader"
@@ -165,7 +165,7 @@ resource "google_project_iam_custom_role" "preview_runtime_auth_reader" {
 }
 
 resource "google_project_iam_member" "preview_runtime_auth_reader" {
-  count = var.b7_foundation_phase >= 3 ? 1 : 0
+  count = var.b7_foundation_phase >= 2 ? 1 : 0
 
   project = var.project_id
   role    = google_project_iam_custom_role.preview_runtime_auth_reader[0].name

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -159,6 +159,8 @@ rg -U -q 'multi_tenant \{\n    allow_tenants           = false\n    default_tena
 test "$(rg -No 'multi_tenant \{' "$root_dir/datastore_auth.tf" | wc -l | tr -d ' ')" = "1"
 rg -q 'role_id     = "previewBackendAuthReader"' "$root_dir/datastore_auth.tf"
 test "$(sed -n '/preview_runtime_auth_permissions = toset(/,/])/p' "$root_dir/datastore_auth.tf" | rg -No '"[^"]+"' | tr -d '"')" = "firebaseauth.users.get"
+test "$(sed -n '/resource "google_project_iam_custom_role" "preview_runtime_auth_reader"/,/^}/p' "$root_dir/datastore_auth.tf" | rg -No 'count = var\.b7_foundation_phase >= 2 \? 1 : 0' | wc -l | tr -d ' ')" = "1"
+test "$(sed -n '/resource "google_project_iam_member" "preview_runtime_auth_reader"/,/^}/p' "$root_dir/datastore_auth.tf" | rg -No 'count = var\.b7_foundation_phase >= 2 \? 1 : 0' | wc -l | tr -d ' ')" = "1"
 rg -q 'service = "identitytoolkit.googleapis.com"' "$root_dir/datastore_auth.tf"
 rg -q 'name         = "preview-backend-auth"' "$root_dir/datastore_auth.tf"
 rg -q 'display_name = "Preview Backend Identity Toolkit"' "$root_dir/datastore_auth.tf"
@@ -182,7 +184,7 @@ if rg -U -n 'name = "FIREBASE_API_KEY"\n[[:space:]]+value[[:space:]]*=' "$root_d
   exit 1
 fi
 
-test "$(rg -No 'count = var\.b7_foundation_phase >= 2 \? 1 : 0' "$root_dir/datastore_auth.tf" | wc -l | tr -d ' ')" = "1"
+test "$(rg -No 'count = var\.b7_foundation_phase >= 2 \? 1 : 0' "$root_dir/datastore_auth.tf" | wc -l | tr -d ' ')" = "3"
 test "$(rg -No 'count = var\.b7_foundation_phase >= 2 && var\.b7_phase2_recovery_stage >= 2 && var\.b7_identity_platform_initialization \? 1 : 0' "$root_dir/datastore_auth.tf" | wc -l | tr -d ' ')" = "1"
 test "$(rg -No 'count = var\.b7_foundation_phase >= 2 && var\.b7_phase2_recovery_stage >= 2 && var\.b7_restricted_api_key_activation \? 1 : 0' "$root_dir/datastore_auth.tf" | wc -l | tr -d ' ')" = "1"
 test "$(rg -No 'count = var\.b7_foundation_phase >= 2 && var\.b7_phase2_recovery_stage >= 2 && var\.b7_restricted_api_key_activation \? 1 : 0' "$root_dir/secret_manager.tf" | wc -l | tr -d ' ')" = "3"

--- a/rentchain-api/src/routes/__tests__/authPropertyManagerCompanyLogin.test.ts
+++ b/rentchain-api/src/routes/__tests__/authPropertyManagerCompanyLogin.test.ts
@@ -334,6 +334,7 @@ describe("auth login property manager company profiles", () => {
     });
     expect(missing.status).toBe(401);
     expect(missing.body.code).toBe("INVALID_CREDENTIALS");
+    expect(missing.body).not.toHaveProperty("detail");
     expect(getUserMock).not.toHaveBeenCalled();
 
     signInWithPasswordMock.mockResolvedValueOnce({
@@ -352,6 +353,67 @@ describe("auth login property manager company profiles", () => {
     });
     expect(unverified.status).toBe(403);
     expect(unverified.body.code).toBe("EMAIL_NOT_VERIFIED");
+    expect(unverified.body).not.toHaveProperty("detail");
+  });
+
+  it.each([
+    {
+      code: "auth/insufficient-permission",
+      message: "application-default credential has insufficient permission: sensitive context",
+    },
+    {
+      code: "app/invalid-credential",
+      message: "credential initialization failed with sensitive context",
+    },
+    {
+      code: "PERMISSION_DENIED",
+      message: "PERMISSION_DENIED: sensitive provider payload",
+    },
+  ])("returns a sanitized 500 for Firebase Admin infrastructure failure $code", async ({ code, message }) => {
+    signInWithPasswordMock.mockResolvedValue({
+      uid: "sensitive-firebase-uid",
+      email: "private.user@example.com",
+    });
+    getUserMock.mockRejectedValueOnce(Object.assign(new Error(message), { code }));
+    const errorLog = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const authRouter = (await import("../authRoutes")).default;
+
+    const response = await invokeRouter(authRouter, {
+      method: "POST",
+      url: "/login",
+      body: { email: "private.user@example.com", password: "secretpass" },
+    });
+
+    expect(response.status).toBe(500);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: "INTERNAL",
+      error: "Login failed",
+      step: "firebase_signin",
+      errCode: code,
+      requestId: expect.any(String),
+    });
+    expect(response.body).not.toHaveProperty("detail");
+
+    const serializedResponse = JSON.stringify(response.body);
+    const serializedLog = JSON.stringify(errorLog.mock.calls);
+    for (const sensitiveValue of [
+      message,
+      "sensitive context",
+      "sensitive provider payload",
+      "private.user@example.com",
+      "sensitive-firebase-uid",
+      "secretpass",
+    ]) {
+      expect(serializedResponse).not.toContain(sensitiveValue);
+      expect(serializedLog).not.toContain(sensitiveValue);
+    }
+    expect(errorLog).toHaveBeenCalledWith("[auth/login] failed", {
+      requestId: response.body.requestId,
+      step: "firebase_signin",
+      status: 500,
+      code,
+    });
   });
 
   it("sanitizes unexpected login failure logs without changing the response", async () => {

--- a/rentchain-api/src/routes/authRoutes.ts
+++ b/rentchain-api/src/routes/authRoutes.ts
@@ -74,12 +74,13 @@ function jsonError(res: any, status: number, error: string, code?: string, detai
 }
 
 function loginError(res: any, status: number, code: string, detail?: string) {
-  return res.status(status).json({
+  const payload: Record<string, unknown> = {
     ok: false,
     code,
     error: status === 401 ? "UNAUTHORIZED" : "LOGIN_FAILED",
-    detail,
-  });
+  };
+  if (detail !== undefined) payload.detail = detail;
+  return res.status(status).json(payload);
 }
 
 function maskEmail(value: string): string {
@@ -1915,22 +1916,21 @@ router.post("/login", rateLimitAuth, async (req, res) => {
     });
   } catch (err: any) {
     try {
-      const msg = String(err?.message || "");
       const code = String(err?.code || "");
       if (code === "FIREBASE_API_KEY_NOT_CONFIGURED") {
         return loginError(res, 500, "FIREBASE_API_KEY_MISSING");
       }
       if (code === "EMAIL_NOT_VERIFIED") {
-        return loginError(res, 403, "EMAIL_NOT_VERIFIED", "Email verification required");
+        return loginError(res, 403, "EMAIL_NOT_VERIFIED");
       }
-      const looksLikeAuthFailure =
-        code.includes("auth/") ||
-        code === "UNAUTHORIZED" ||
-        code === "INVALID_CREDENTIALS" ||
-        /invalid|expired|revoked|credential|password|token|unauthorized/i.test(msg);
+      const looksLikeAuthFailure = [
+        "UNAUTHORIZED",
+        "INVALID_CREDENTIALS",
+        "auth/user-not-found",
+      ].includes(code);
 
       if (looksLikeAuthFailure) {
-        return loginError(res, 401, "UNAUTHORIZED", msg || code || undefined);
+        return loginError(res, 401, "UNAUTHORIZED");
       }
     } catch {
       // fall through to generic error


### PR DESCRIPTION
## Summary

Fixes the remaining Stage 3 Preview authentication blocker.

The Preview runtime Firebase Admin application initializes successfully, but
the runtime service account cannot complete:

`admin.auth().getUser()`

because the existing minimal Auth reader role and binding were incorrectly
gated to foundation phase 3 while Preview currently runs phase 2.

This PR:

- activates the existing Preview Firebase Auth reader role at phase 2;
- binds it to the Preview runtime service account;
- grants only `firebaseauth.users.get`;
- keeps all Firestore IAM and resources gated to phase 3;
- fixes backend error classification so Firebase Admin infrastructure failures
  are returned as sanitized HTTP 500 responses rather than misleading 401s.

## IAM

Custom role:

`previewBackendAuthReader`

Permission:

`firebaseauth.users.get`

Member:

`serviceAccount:preview-backend-runtime@rentchain-preview.iam.gserviceaccount.com`

No predefined broad Firebase, Identity Platform, Editor, Owner, or Admin role
is introduced.

No Firebase Auth write permission is added.

## Firestore boundary

- `FIRESTORE_ENABLED=false` remains unchanged
- Firestore IAM remains phase-3 gated
- no Firestore permission is added
- no Firestore database or runtime access is enabled

## Backend behavior

Preserved:

- invalid credentials -> `401 INVALID_CREDENTIALS`
- unverified email -> `403 EMAIL_NOT_VERIFIED`

Corrected:

- Firebase Admin IAM/infrastructure failures -> sanitized `500 INTERNAL`
- stable `requestId`, `step`, and sanitized `errCode` retained
- internal provider messages omitted from responses and logs
- `detail` omitted

## Terraform plan

HCP run:

`run-tSLwqvrrjPKcpfME`

Plan:

`plan-ejNATddva1d2QwQf`

Result:

- 2 add
- 0 change
- 0 destroy
- 0 import

Planned resources:

- `google_project_iam_custom_role.preview_runtime_auth_reader[0]`
- `google_project_iam_member.preview_runtime_auth_reader[0]`

No apply occurred.

## Validation

- Stage 3E focused matrix: 3 files, 18 passed
- Stage 3B initialization: 1 file, 5 passed
- affected authentication matrix: 2 files, 13 passed
- base comparison: no branch-only failures
- build-specific TypeScript: passed
- backend production build: passed
- Terraform fmt: passed
- Terraform validate: passed
- Terraform scope validation: passed
- staged diff check: passed
- security scan: passed

## Current runtime

The live Preview environment remains unchanged:

- revision: `rentchain-preview-backend-00003-42c`
- digest: `sha256:270adb21de2b271eb468b28b1a591a3f27544aae162f1f028ad74c7bfd30960f`
- traffic: 100%
- `FIRESTORE_ENABLED=false`

The new role and binding are not live until a separately authorized Terraform
apply.

## Vercel verification limitation

The Preview deployment was confirmed ready.

The authenticated Vercel CLI request was intercepted by Deployment Protection
before reaching the RentChain proxy. The automatic protection bypass did not
work in this session.

No Vercel setting was modified, no bypass secret was created, and this is
classified as an external verification-tool limitation rather than a Stage 3E
regression.

## Boundaries

- no Terraform apply
- no IAM mutation
- no image build
- no Cloud Run deployment
- no Vercel change
- no Identity Platform change
- no Firebase-user change
- no Firestore enablement
- Production unchanged
- PR #1453 untouched
- PR #1435 untouched

## Post-merge sequence

After merge and separate authorization:

1. apply only the two Preview IAM resources;
2. confirm the custom role and binding exist;
3. rerun valid Preview login;
4. verify authenticated `/api/me`;
5. verify logout and post-logout 401;
6. confirm no `app/no-app`;
7. confirm no internal error detail;
8. confirm `FIRESTORE_ENABLED=false`;
9. do not deploy Production.
