### PR TITLE
Prepare Preview Firestore account-context foundation

### DIFF
--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -42,11 +42,8 @@ check "b7_preview_datastore_boundary" {
   assert {
     condition = local.preview_runtime_firestore_permissions == toset([
       "datastore.databases.get",
-      "datastore.entities.create",
-      "datastore.entities.delete",
       "datastore.entities.get",
       "datastore.entities.list",
-      "datastore.entities.update",
     ])
     error_message = "B7 Preview runtime Firestore permissions changed outside the exact data-plane set."
   }

--- a/infra/environments/preview-foundation/datastore_auth.tf
+++ b/infra/environments/preview-foundation/datastore_auth.tf
@@ -6,11 +6,8 @@ locals {
 
   preview_runtime_firestore_permissions = toset([
     "datastore.databases.get",
-    "datastore.entities.create",
-    "datastore.entities.delete",
     "datastore.entities.get",
     "datastore.entities.list",
-    "datastore.entities.update",
   ])
 
   preview_runtime_auth_permissions = toset([

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -49,7 +49,7 @@ rg -q 'var\.project_id != "project-0d9658de-af29-4dc0-a99"' "$root_dir/variables
 rg -q 'variable "enable_preview_backend_service"' "$root_dir/variables.tf"
 rg -q 'default     = true' "$root_dir/variables.tf"
 rg -q 'variable "b7_foundation_phase"' "$root_dir/variables.tf"
-rg -U -q 'variable "b7_foundation_phase" \{\n  description = "[^"]+"\n  type        = number\n  default     = 2' "$root_dir/variables.tf"
+rg -U -q 'variable "b7_foundation_phase" \{\n  description = "[^"]+"\n  type        = number\n  default     = 3' "$root_dir/variables.tf"
 grep -Fq 'condition     = contains([1, 2, 3], var.b7_foundation_phase)' "$root_dir/variables.tf"
 rg -U -q 'variable "b7_phase2_recovery_stage" \{\n  description = "[^"]+"\n  type        = number\n  default     = 2' "$root_dir/variables.tf"
 grep -Fq 'condition     = contains([1, 2], var.b7_phase2_recovery_stage)' "$root_dir/variables.tf"
@@ -134,11 +134,8 @@ grep -Fq "resource.name == 'projects/\${var.project_id}/databases/\${local.previ
 
 expected_runtime_firestore_permissions="$(cat <<'EOF'
 datastore.databases.get
-datastore.entities.create
-datastore.entities.delete
 datastore.entities.get
 datastore.entities.list
-datastore.entities.update
 EOF
 )"
 actual_runtime_firestore_permissions="$(
@@ -166,7 +163,7 @@ rg -q 'name         = "preview-backend-auth"' "$root_dir/datastore_auth.tf"
 rg -q 'display_name = "Preview Backend Identity Toolkit"' "$root_dir/datastore_auth.tf"
 rg -U -q '(?s)resource "google_apikeys_key" "preview_backend_auth" \{.*lifecycle \{\n    prevent_destroy = true\n  \}' "$root_dir/datastore_auth.tf"
 
-if rg -n 'firebaseauth\.users\.(create|delete|update|sendEmail)|datastore\.(databases\.(delete|update)|indexes\.|operations\.)|roles/(datastore|firebase|identityplatform)' "$root_dir/datastore_auth.tf"; then
+if rg -n 'firebaseauth\.users\.(create|delete|update|sendEmail)|datastore\.(databases\.(delete|update)|entities\.(create|delete|update)|indexes\.|operations\.)|roles/(datastore|firebase|identityplatform)' "$root_dir/datastore_auth.tf"; then
   echo "B7 runtime IAM broadening or destructive datastore permission found" >&2
   exit 1
 fi
@@ -194,7 +191,7 @@ if rg -n 'b7_identity_platform_initialization|b7_restricted_api_key_activation' 
   echo "The B7 authentication activation gates must not control Cloud Run or IAM" >&2
   exit 1
 fi
-test "$(rg -No 'count = var\.b7_foundation_phase >= 3 \? 1 : 0' "$root_dir/datastore_auth.tf" | wc -l | tr -d ' ')" = "4"
+test "$(rg -No 'count = var\.b7_foundation_phase >= 3 \? 1 : 0' "$root_dir/datastore_auth.tf" | wc -l | tr -d ' ')" = "2"
 
 test "$(rg -No '^resource "google_artifact_registry_repository"' "$root_dir" --glob '*.tf' | wc -l | tr -d ' ')" = "1"
 rg -q 'project       = var\.project_id' "$root_dir/deployment_foundation.tf"

--- a/infra/environments/preview-foundation/variables.tf
+++ b/infra/environments/preview-foundation/variables.tf
@@ -74,7 +74,7 @@ variable "enable_preview_backend_service" {
 variable "b7_foundation_phase" {
   description = "Governed B7 phase gate: 1=APIs only, 2=datastore/auth resources, 3=runtime IAM. Cloud Run activation is separately reviewed."
   type        = number
-  default     = 2
+  default     = 3
 
   validation {
     condition     = contains([1, 2, 3], var.b7_foundation_phase)

--- a/rentchain-api/package.json
+++ b/rentchain-api/package.json
@@ -27,6 +27,7 @@
     "test:e2e:debug": "npm run preflight && FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 ALLOW_LOCAL_PROD_FIRESTORE=false playwright test --config=../playwright.config.ts --project=api-chromium --headed --debug",
     "fixture:pm-company-preview": "npm run preflight && ts-node-dev --transpile-only --exit-child src/scripts/propertyManagerCompanyPreviewFixture.ts",
     "setup:pm-company-auth-profile": "npm run preflight && ts-node-dev --transpile-only --exit-child src/scripts/propertyManagerCompanyAuthProfileSetup.ts",
+    "seed:preview-account-context": "npm run preflight && ts-node-dev --transpile-only --exit-child src/scripts/previewAccountContextSeed.ts",
     "test:docker": "docker run --rm -v \"$PWD/..:/workspace/rentchain\" -w /workspace/rentchain/rentchain-api rentchain-dev npm run test:e2e",
     "storage-state:export": "npm run preflight && ts-node tests/storage-state/export-storage-state.ts ./.smoke-storage-state",
     "smoke": "node scripts/smoke-safe-build.js",

--- a/rentchain-api/src/scripts/__tests__/previewAccountContextSeed.test.ts
+++ b/rentchain-api/src/scripts/__tests__/previewAccountContextSeed.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  PREVIEW_ACCOUNT_EMAIL,
+  PREVIEW_PROJECT_ID,
+  PREVIEW_RUNTIME_FIRESTORE_PERMISSIONS,
+  PREVIEW_SEED_OPERATOR_PERMISSIONS,
+  seedPreviewAccountContext,
+} from "../previewAccountContextSeed";
+
+function harness(input?: {
+  projectId?: string;
+  user?: { uid: string; email?: string; emailVerified: boolean } | null;
+  documents?: Record<string, Record<string, unknown>>;
+  commitFails?: boolean;
+}) {
+  const documents = new Map(Object.entries(input?.documents || {}));
+  const writes: Array<{ collection: string; fields: Record<string, unknown> }> = [];
+  const logs: Record<string, unknown>[] = [];
+  return {
+    writes,
+    logs,
+    dependencies: {
+      projectId: input?.projectId ?? PREVIEW_PROJECT_ID,
+      getUserByEmail: vi.fn(async () => {
+        if (input && "user" in input && input.user === null) throw new Error("preview_user_not_found");
+        return input?.user ?? { uid: "private-preview-uid", email: PREVIEW_ACCOUNT_EMAIL, emailVerified: true };
+      }),
+      getDocument: vi.fn(async (collection: string) => documents.get(collection) || null),
+      commitDocuments: vi.fn(async (pending: Array<{ collection: string; fields: Record<string, unknown> }>) => {
+        if (input?.commitFails) throw new Error("atomic_commit_failed");
+        for (const { collection, fields } of pending) {
+          writes.push({ collection, fields });
+          documents.set(collection, { ...(documents.get(collection) || {}), ...fields });
+        }
+      }),
+      now: vi.fn(() => "2026-07-31T00:00:00.000Z"),
+      log: vi.fn((summary: Record<string, unknown>) => logs.push(summary)),
+    },
+  };
+}
+
+describe("Preview account-context seed", () => {
+  it("is dry-run by default at the core boundary and performs no writes", async () => {
+    const h = harness();
+    const result = await seedPreviewAccountContext(h.dependencies, { apply: false });
+    expect(result).toMatchObject({ documents: 3, writes: 0 });
+    expect(h.dependencies.commitDocuments).not.toHaveBeenCalled();
+  });
+
+  it("accepts only the exact Preview project and rejects a missing project", async () => {
+    const accepted = harness({ projectId: PREVIEW_PROJECT_ID });
+    await expect(seedPreviewAccountContext(accepted.dependencies, { apply: false })).resolves.toMatchObject({
+      documents: 3,
+    });
+    const missing = harness({ projectId: "" });
+    await expect(seedPreviewAccountContext(missing.dependencies, { apply: false })).rejects.toThrow(
+      "preview_project_guard_failed"
+    );
+    expect(missing.dependencies.getUserByEmail).not.toHaveBeenCalled();
+  });
+
+  it("fails closed outside the exact Preview project", async () => {
+    const h = harness({ projectId: "not-preview-project" });
+    await expect(seedPreviewAccountContext(h.dependencies, { apply: false })).rejects.toThrow(
+      "preview_project_guard_failed"
+    );
+    expect(h.dependencies.getUserByEmail).not.toHaveBeenCalled();
+  });
+
+  it("fails closed for a missing or unverified Preview user", async () => {
+    const missing = harness({ user: null });
+    await expect(seedPreviewAccountContext(missing.dependencies, { apply: false })).rejects.toThrow(
+      "preview_user_not_found"
+    );
+    const unverified = harness({
+      user: { uid: "private-preview-uid", email: PREVIEW_ACCOUNT_EMAIL, emailVerified: false },
+    });
+    await expect(seedPreviewAccountContext(unverified.dependencies, { apply: false })).rejects.toThrow(
+      "preview_user_email_unverified"
+    );
+  });
+
+  it("creates only users, accounts, and landlords documents", async () => {
+    const h = harness();
+    const result = await seedPreviewAccountContext(h.dependencies, { apply: true });
+    expect(result).toMatchObject({ documents: 3, writes: 3 });
+    expect(h.writes.map((write) => write.collection)).toEqual(["users", "accounts", "landlords"]);
+    expect(h.writes[0].fields).toMatchObject({ role: "landlord", approved: true, disabled: false });
+    expect(h.writes[1].fields).toMatchObject({ plan: "screening", planStatus: "active" });
+    expect(h.writes[2].fields).toMatchObject({ role: "landlord", plan: "screening" });
+  });
+
+  it("does not fabricate optional product, entitlement, or usage fields", async () => {
+    const h = harness();
+    await seedPreviewAccountContext(h.dependencies, { apply: true });
+    const serialized = JSON.stringify(h.writes);
+    expect(serialized).not.toMatch(
+      /capabilit|entitlement|permission|feature|usage|limit|quota|subscription|billing/i
+    );
+  });
+
+  it("is idempotent after the first apply", async () => {
+    const h = harness();
+    expect((await seedPreviewAccountContext(h.dependencies, { apply: true })).writes).toBe(3);
+    expect((await seedPreviewAccountContext(h.dependencies, { apply: true })).writes).toBe(0);
+  });
+
+  it("commits all three documents atomically", async () => {
+    const h = harness();
+    await seedPreviewAccountContext(h.dependencies, { apply: true });
+    expect(h.dependencies.commitDocuments).toHaveBeenCalledTimes(1);
+    expect(h.dependencies.commitDocuments).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ collection: "users" }),
+        expect.objectContaining({ collection: "accounts" }),
+        expect.objectContaining({ collection: "landlords" }),
+      ])
+    );
+  });
+
+  it("leaves no partial state when the atomic commit fails", async () => {
+    const h = harness({ commitFails: true });
+    await expect(seedPreviewAccountContext(h.dependencies, { apply: true })).rejects.toThrow(
+      "atomic_commit_failed"
+    );
+    expect(h.writes).toHaveLength(0);
+  });
+
+  it("fails closed on existing ownership, role, or status mismatch", async () => {
+    for (const documents of [
+      { users: { email: "other@example.com" } },
+      { users: { role: "admin" } },
+      { accounts: { ownerUserId: "unexpected-owner" } },
+      { accounts: { disabled: true } },
+      { landlords: { approved: false } },
+    ]) {
+      const h = harness({ documents });
+      await expect(seedPreviewAccountContext(h.dependencies, { apply: true })).rejects.toThrow(
+        /unexpected_existing_/
+      );
+      expect(h.writes).toHaveLength(0);
+    }
+  });
+
+  it("writes only the approved account-context field names", async () => {
+    const h = harness();
+    await seedPreviewAccountContext(h.dependencies, { apply: true });
+    expect(h.writes.map(({ collection, fields }) => [collection, Object.keys(fields).sort()])).toEqual([
+      ["users", ["actorRole", "approved", "createdAt", "disabled", "email", "id", "landlordId", "role", "updatedAt"]],
+      ["accounts", ["actorRole", "approved", "createdAt", "disabled", "id", "landlordId", "ownerUserId", "plan", "planStatus", "role", "updatedAt"]],
+      ["landlords", ["approved", "createdAt", "email", "id", "landlordId", "plan", "role", "updatedAt"]],
+    ]);
+  });
+
+  it("exposes no delete or collection-scan dependency", () => {
+    const h = harness();
+    expect(Object.keys(h.dependencies).sort()).toEqual([
+      "commitDocuments",
+      "getDocument",
+      "getUserByEmail",
+      "log",
+      "now",
+      "projectId",
+    ]);
+  });
+
+  it("keeps runtime read-only and seed permissions separate without delete access", () => {
+    expect(PREVIEW_RUNTIME_FIRESTORE_PERMISSIONS).toEqual([
+      "datastore.databases.get",
+      "datastore.entities.get",
+      "datastore.entities.list",
+    ]);
+    expect(PREVIEW_SEED_OPERATOR_PERMISSIONS).toEqual([
+      "datastore.databases.get",
+      "datastore.entities.create",
+      "datastore.entities.get",
+      "datastore.entities.update",
+      "firebaseauth.users.get",
+    ]);
+    expect([...PREVIEW_RUNTIME_FIRESTORE_PERMISSIONS, ...PREVIEW_SEED_OPERATOR_PERMISSIONS].join(" ")).not.toMatch(
+      /delete/
+    );
+  });
+
+  it("logs only collection field names and never the raw UID", async () => {
+    const h = harness();
+    await seedPreviewAccountContext(h.dependencies, { apply: false });
+    const serialized = JSON.stringify(h.logs);
+    expect(serialized).not.toContain("private-preview-uid");
+    expect(serialized).not.toMatch(/password|token|cookie|api.?key|authorization/i);
+    expect(serialized).toContain("users");
+    expect(serialized).toContain("accounts");
+    expect(serialized).toContain("landlords");
+  });
+});

--- a/rentchain-api/src/scripts/previewAccountContextSeed.ts
+++ b/rentchain-api/src/scripts/previewAccountContextSeed.ts
@@ -1,0 +1,210 @@
+import admin from "firebase-admin";
+
+export const PREVIEW_PROJECT_ID = "rentchain-preview";
+export const PREVIEW_ACCOUNT_EMAIL = "admin+previewtest@rentchain.ai";
+
+export const PREVIEW_RUNTIME_FIRESTORE_PERMISSIONS = [
+  "datastore.databases.get",
+  "datastore.entities.get",
+  "datastore.entities.list",
+] as const;
+
+export const PREVIEW_SEED_OPERATOR_PERMISSIONS = [
+  "datastore.databases.get",
+  "datastore.entities.create",
+  "datastore.entities.get",
+  "datastore.entities.update",
+  "firebaseauth.users.get",
+] as const;
+
+type SeedDocument = {
+  collection: "users" | "accounts" | "landlords";
+  fields: Record<string, unknown>;
+  guardedFields: readonly string[];
+};
+
+type AuthUser = { uid: string; email?: string; emailVerified: boolean };
+
+type SeedDependencies = {
+  projectId: string;
+  getUserByEmail(email: string): Promise<AuthUser>;
+  getDocument(collection: string, id: string): Promise<Record<string, unknown> | null>;
+  commitDocuments(
+    documents: Array<{ collection: SeedDocument["collection"]; id: string; fields: Record<string, unknown> }>
+  ): Promise<void>;
+  now(): string;
+  log(summary: Record<string, unknown>): void;
+};
+
+export type SeedOptions = { apply: boolean };
+
+function assertPreviewProject(projectId: string): void {
+  if (projectId !== PREVIEW_PROJECT_ID) throw new Error("preview_project_guard_failed");
+}
+
+function buildDocuments(uid: string): SeedDocument[] {
+  return [
+    {
+      collection: "users",
+      fields: {
+        id: uid,
+        email: PREVIEW_ACCOUNT_EMAIL,
+        role: "landlord",
+        actorRole: "landlord",
+        landlordId: uid,
+        approved: true,
+        disabled: false,
+      },
+      guardedFields: ["id", "email", "role", "actorRole", "landlordId", "approved", "disabled"],
+    },
+    {
+      collection: "accounts",
+      fields: {
+        id: uid,
+        ownerUserId: uid,
+        role: "landlord",
+        actorRole: "landlord",
+        landlordId: uid,
+        plan: "screening",
+        planStatus: "active",
+        approved: true,
+        disabled: false,
+      },
+      guardedFields: [
+        "id",
+        "ownerUserId",
+        "role",
+        "actorRole",
+        "landlordId",
+        "plan",
+        "planStatus",
+        "approved",
+        "disabled",
+      ],
+    },
+    {
+      collection: "landlords",
+      fields: {
+        id: uid,
+        landlordId: uid,
+        email: PREVIEW_ACCOUNT_EMAIL,
+        role: "landlord",
+        plan: "screening",
+        approved: true,
+      },
+      guardedFields: ["id", "landlordId", "email", "role", "plan", "approved"],
+    },
+  ];
+}
+
+function fieldsToMerge(
+  document: SeedDocument,
+  existing: Record<string, unknown> | null,
+  now: string
+): Record<string, unknown> {
+  if (existing) {
+    for (const field of document.guardedFields) {
+      if (field in existing && existing[field] !== document.fields[field]) {
+        throw new Error(`unexpected_existing_${document.collection}_${field}_mismatch`);
+      }
+    }
+  }
+
+  const patch: Record<string, unknown> = {};
+  for (const [field, value] of Object.entries(document.fields)) {
+    if (!existing || !(field in existing)) patch[field] = value;
+  }
+  if (!existing || !("createdAt" in existing)) patch.createdAt = now;
+  if (Object.keys(patch).length) patch.updatedAt = now;
+  return patch;
+}
+
+export async function seedPreviewAccountContext(
+  dependencies: SeedDependencies,
+  options: SeedOptions
+): Promise<{ documents: number; writes: number; fields: Record<string, string[]> }> {
+  assertPreviewProject(dependencies.projectId);
+  const user = await dependencies.getUserByEmail(PREVIEW_ACCOUNT_EMAIL);
+  if (!user?.uid) throw new Error("preview_user_not_found");
+  if (!user.emailVerified) throw new Error("preview_user_email_unverified");
+  if (String(user.email || "").trim().toLowerCase() !== PREVIEW_ACCOUNT_EMAIL) {
+    throw new Error("preview_user_email_mismatch");
+  }
+
+  const fields: Record<string, string[]> = {};
+  const plannedWrites: Array<{ document: SeedDocument; patch: Record<string, unknown> }> = [];
+  for (const document of buildDocuments(user.uid)) {
+    const existing = await dependencies.getDocument(document.collection, user.uid);
+    const patch = fieldsToMerge(document, existing, dependencies.now());
+    fields[document.collection] = Object.keys(patch).sort();
+    if (Object.keys(patch).length) plannedWrites.push({ document, patch });
+  }
+
+  let writes = 0;
+  if (options.apply && plannedWrites.length) {
+    await dependencies.commitDocuments(
+      plannedWrites.map(({ document, patch }) => ({
+        collection: document.collection,
+        id: user.uid,
+        fields: patch,
+      }))
+    );
+    writes = plannedWrites.length;
+  }
+
+  const summary = { mode: options.apply ? "apply" : "dry-run", documents: 3, writes, fields };
+  dependencies.log(summary);
+  return { documents: 3, writes, fields };
+}
+
+function parseApply(argv: string[]): boolean {
+  const unknown = argv.filter((arg) => arg !== "--apply");
+  if (unknown.length) throw new Error("unsupported_seed_argument");
+  return argv.includes("--apply");
+}
+
+async function main(): Promise<void> {
+  const projectId = String(process.env.GOOGLE_CLOUD_PROJECT || process.env.GCLOUD_PROJECT || "").trim();
+  assertPreviewProject(projectId);
+  if (!admin.apps.length) {
+    admin.initializeApp({ credential: admin.credential.applicationDefault(), projectId });
+  }
+  const firestore = admin.firestore();
+  await seedPreviewAccountContext(
+    {
+      projectId,
+      getUserByEmail: async (email) => {
+        try {
+          const user = await admin.auth().getUserByEmail(email);
+          return { uid: user.uid, email: user.email, emailVerified: user.emailVerified };
+        } catch (error: any) {
+          if (String(error?.code || "") === "auth/user-not-found") throw new Error("preview_user_not_found");
+          throw error;
+        }
+      },
+      getDocument: async (collection, id) => {
+        const snap = await firestore.collection(collection).doc(id).get();
+        return snap.exists ? ((snap.data() as Record<string, unknown>) || {}) : null;
+      },
+      commitDocuments: async (documents) => {
+        const batch = firestore.batch();
+        for (const document of documents) {
+          batch.set(firestore.collection(document.collection).doc(document.id), document.fields, { merge: true });
+        }
+        await batch.commit();
+      },
+      now: () => new Date().toISOString(),
+      log: (summary) => console.info("[preview-account-context-seed]", summary),
+    },
+    { apply: parseApply(process.argv.slice(2)) }
+  );
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error("[preview-account-context-seed] failed", {
+      code: String(error?.message || "seed_failed").replace(/[^A-Za-z0-9_:-]/g, "_").slice(0, 96),
+    });
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary

Prepares the minimum isolated Preview Firestore account-context foundation required to complete valid authentication and session smoke testing.

The existing Preview authentication flow now succeeds through Identity Toolkit password verification, Firebase Admin user lookup, and the email-verification gate. It currently stops at `load_account_context` because Cloud Run intentionally runs with `FIRESTORE_ENABLED=false` and does not yet have Firestore runtime IAM.

This PR prepares:

- a read-only Preview runtime Firestore role;
- a database-scoped binding to the Preview runtime service account;
- a dry-run-first, explicit-apply seed tool for the three minimum account-context documents.

No live Firestore IAM, seed execution, document write, Cloud Run change, or deployment is performed by this PR.

## Runtime Firestore IAM

Custom role: `previewBackendFirestoreRuntime`

Permissions:

- `datastore.databases.get`
- `datastore.entities.get`
- `datastore.entities.list`

Member: `serviceAccount:preview-backend-runtime@rentchain-preview.iam.gserviceaccount.com`

IAM condition: `resource.name == 'projects/rentchain-preview/databases/(default)'`

The runtime receives no create, update, delete, commit, index, backup, export, or administrative permission. No broad predefined Firestore role is used.

## Existing database

Reuses the existing isolated Preview `(default)` `FIRESTORE_NATIVE` database in `northamerica-northeast1`, with pessimistic concurrency, delete protection enabled, and PITR disabled.

No database, index, rule, backup, PITR, or delete-protection change is planned.

## Seed tooling

Command: `npm run seed:preview-account-context`

Safety:

- dry-run by default; explicit `--apply` required;
- exact `rentchain-preview` project guard and fixed approved Preview account lookup;
- verified-email requirement;
- Firebase UID is runtime-derived and never committed or logged;
- all three documents are preflighted before one atomic Firestore batch commit;
- idempotent, with no delete or collection-wide scan;
- fails closed on identity, ownership, role, approval, or disabled-state conflicts;
- logs only mode, counts, collection names, and field names.

Planned paths are `users/{firebaseUid}`, `accounts/{firebaseUid}`, and `landlords/{firebaseUid}`. No password, token, UID, billing, subscription, quota, usage, permission, capability, entitlement, impersonation, support, or admin field is seeded. The seed was not executed.

## Data-state verification

Read-only checks confirmed all three planned document paths are absent. The UID and document contents were not printed.

## Seed operator boundary

The runtime service account remains read-only. Future seed execution requires separately authorized, short-lived operator permissions:

- `datastore.databases.get`
- `datastore.entities.create`
- `datastore.entities.get`
- `datastore.entities.update`
- `firebaseauth.users.get`

No seed identity or write authorization is created by this PR.

## Terraform plan

- HCP run: `run-ak5QSsF1Rxu2YEBv`
- Plan: `plan-S74vHyFCmEk2g111`
- Configuration: `cv-V4eU16aT3zFExN9v`
- Result: 2 add, 0 change, 0 destroy, 0 import

Planned resources:

- `google_project_iam_custom_role.preview_runtime_firestore[0]`
- `google_project_iam_member.preview_runtime_firestore[0]`

No apply occurred.

## Validation

- seed tests: 14/14 passed
- broader exact-base comparison: identical failure sets
- Firebase initialization: 5/5 passed
- build-specific TypeScript: passed
- backend production build: passed
- Terraform fmt and validate: passed
- Preview scope validation: passed
- security and staged-diff checks: passed

## Current live environment

Unchanged: Cloud Run revision `rentchain-preview-backend-00003-42c`, image digest `sha256:270adb21de2b271eb468b28b1a591a3f27544aae162f1f028ad74c7bfd30960f`, 100% traffic, `FIRESTORE_ENABLED=false`, runtime Firestore IAM absent, and Stage 3G seed data absent.

## Boundaries

- no Terraform apply or live IAM mutation
- no seed execution or Firestore document write
- no Cloud Run deployment or image build
- no Vercel, Identity Platform, Firebase-user, or Production change
- PR #1453 and PR #1435 untouched

## Post-merge sequence

After merge and separate Founder authorization:

1. apply only the read-only Preview runtime Firestore IAM resources;
2. provision a separately authorized short-lived seed operator path;
3. run seed dry-run and review the exact three-document plan;
4. separately authorize one atomic seed apply;
5. prepare and deploy the explicit `FIRESTORE_ENABLED=true` Cloud Run revision;
6. run valid login, authenticated session, logout, and post-logout smoke tests;
7. confirm Production remains untouched.
