### PR TITLE
Gate Production deployment behind explicit release approval

### DIFF
--- a/.github/workflows/production-candidate-deploy.yml
+++ b/.github/workflows/production-candidate-deploy.yml
@@ -1,0 +1,173 @@
+name: Production backend candidate deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_sha:
+        description: Full 40-character source SHA reachable from main
+        required: true
+        type: string
+      image_uri:
+        description: Immutable Production image URI ending in @sha256:<digest>
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  actions: read
+  id-token: write
+
+jobs:
+  deploy-zero-traffic-candidate:
+    if: github.repository == 'rentchaincanada/rentchain' && github.event_name == 'workflow_dispatch'
+    environment: production-candidate
+    runs-on: ubuntu-latest
+    env:
+      SOURCE_SHA: ${{ inputs.source_sha }}
+      IMAGE_URI: ${{ inputs.image_uri }}
+      PROJECT_ID: project-0d9658de-af29-4dc0-a99
+      REGION: us-central1
+      SERVICE: rentchain-landlord-api
+    steps:
+      - name: Check out protected main
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: refs/heads/main
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Validate release inputs and source ancestry
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/production-deployment/validate-release-inputs.sh \
+            candidate "${SOURCE_SHA}" "${IMAGE_URI}" "${PROJECT_ID}" "${REGION}" "${SERVICE}"
+          git cat-file -e "${SOURCE_SHA}^{commit}"
+          git merge-base --is-ancestor "${SOURCE_SHA}" origin/main
+          git checkout --detach "${SOURCE_SHA}"
+          test "$(git rev-parse HEAD)" = "${SOURCE_SHA}"
+          test -z "$(git status --porcelain)"
+
+      - name: Authenticate with the protected Production deployment identity
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ vars.PRODUCTION_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.PRODUCTION_DEPLOY_SERVICE_ACCOUNT }}
+          create_credentials_file: true
+          export_environment_variables: true
+
+      - name: Set up Google Cloud CLI
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
+
+      - name: Verify immutable artifact provenance
+        shell: bash
+        run: |
+          set -euo pipefail
+          digest="${IMAGE_URI##*@}"
+          repository="${IMAGE_URI%@*}"
+          gcloud artifacts docker images describe "${IMAGE_URI}" \
+            --project="${PROJECT_ID}" \
+            --format='value(image_summary.digest)' | grep -Fx "${digest}"
+          tag_version="$(gcloud artifacts docker tags list "${repository}" \
+            --project="${PROJECT_ID}" \
+            --filter="tag:sha-${SOURCE_SHA}" \
+            --format='value(version)' | tail -n 1)"
+          [[ "${tag_version}" == *"/versions/${digest}" ]]
+
+      - name: Validate governed Production service contract
+        shell: bash
+        run: |
+          set -euo pipefail
+          service_json="${RUNNER_TEMP}/production-service.json"
+          contract_json="${RUNNER_TEMP}/production-contract.json"
+          gcloud run services describe "${SERVICE}" \
+            --project="${PROJECT_ID}" \
+            --region="${REGION}" \
+            --format=json > "${service_json}"
+          jq -f scripts/production-deployment/validate-service-contract.jq \
+            "${service_json}" > "${contract_json}"
+          jq '{missingNames,missingSecretRefs,projectConfigured,baseUrlConfigured,elitePriceConfigured,emailConfigured,startupReadyProbe,livenessHealthProbe,ok}' \
+            "${contract_json}"
+          jq -e '.ok == true' "${contract_json}" >/dev/null
+
+      - name: Deploy immutable candidate with zero traffic
+        id: deploy
+        shell: bash
+        run: |
+          set -euo pipefail
+          before_service="${RUNNER_TEMP}/service-before.json"
+          after_service="${RUNNER_TEMP}/service-after.json"
+          gcloud run services describe "${SERVICE}" --project="${PROJECT_ID}" --region="${REGION}" --format=json > "${before_service}"
+          before_ready="$(jq -r '.status.latestReadyRevisionName' "${before_service}")"
+          before_traffic="$(jq -cS --arg ready "${before_ready}" '[.status.traffic[]? | if .latestRevision then .revisionName = $ready else . end | del(.latestRevision,.url)] | sort_by(.revisionName,.tag)' "${before_service}")"
+          jq -S -f scripts/production-deployment/governed-template.jq "${before_service}" > "${RUNNER_TEMP}/governed-template-before.json"
+          before_ingress="$(jq -r '.metadata.annotations["run.googleapis.com/ingress"] // ""' "${before_service}")"
+          suffix="candidate-${SOURCE_SHA:0:12}"
+          gcloud run deploy "${SERVICE}" \
+            --image="${IMAGE_URI}" \
+            --project="${PROJECT_ID}" \
+            --region="${REGION}" \
+            --revision-suffix="${suffix}" \
+            --no-traffic \
+            --quiet
+          revision="${SERVICE}-${suffix}"
+          gcloud run services describe "${SERVICE}" --project="${PROJECT_ID}" --region="${REGION}" --format=json > "${after_service}"
+          after_ready="$(jq -r '.status.latestReadyRevisionName' "${after_service}")"
+          after_traffic="$(jq -cS --arg ready "${after_ready}" '[.status.traffic[]? | if .latestRevision then .revisionName = $ready else . end | del(.latestRevision,.url)] | sort_by(.revisionName,.tag)' "${after_service}")"
+          test "${after_traffic}" = "${before_traffic}"
+          test "$(jq -r '.metadata.annotations["run.googleapis.com/ingress"] // ""' "${after_service}")" = "${before_ingress}"
+          printf 'revision=%s\n' "${revision}" >> "${GITHUB_OUTPUT}"
+
+      - name: Verify internal health probes and zero-traffic readiness
+        shell: bash
+        env:
+          CANDIDATE_REVISION: ${{ steps.deploy.outputs.revision }}
+        run: |
+          set -euo pipefail
+          revision_json="${RUNNER_TEMP}/candidate-revision.json"
+          for attempt in $(seq 1 60); do
+            gcloud run revisions describe "${CANDIDATE_REVISION}" \
+              --project="${PROJECT_ID}" --region="${REGION}" --format=json > "${revision_json}"
+            if jq -e '.status.conditions[] | select(.type == "Ready" and .status == "True")' "${revision_json}" >/dev/null; then
+              break
+            fi
+            test "${attempt}" != 60
+            sleep 5
+          done
+          test "$(jq -r '.spec.containers[0].image' "${revision_json}")" = "${IMAGE_URI}"
+          test "$(jq -r '.spec.containers[0].startupProbe.httpGet.path' "${revision_json}")" = "/health/ready"
+          test "$(jq -r '.spec.containers[0].livenessProbe.httpGet.path' "${revision_json}")" = "/health"
+          jq -S -f scripts/production-deployment/governed-template.jq "${revision_json}" > "${RUNNER_TEMP}/governed-template-candidate.json"
+          cmp "${RUNNER_TEMP}/governed-template-before.json" "${RUNNER_TEMP}/governed-template-candidate.json"
+          traffic_refs="$(gcloud run services describe "${SERVICE}" --project="${PROJECT_ID}" --region="${REGION}" --format=json | jq --arg revision "${CANDIDATE_REVISION}" '[.status.traffic[]? | select(.revisionName == $revision and ((.percent // 0) > 0))] | length')"
+          test "${traffic_refs}" = "0"
+          printf 'candidate_revision=%s\n' "${CANDIDATE_REVISION}"
+          printf 'candidate_digest=%s\n' "${IMAGE_URI##*@}"
+          printf 'candidate_ready=true\n'
+          printf 'candidate_traffic_percent=0\n'
+          printf 'health_verification=cloud-run-internal-http-probes\n'
+          printf 'promotion=not_performed\n'
+
+      - name: Record governed candidate evidence
+        shell: bash
+        env:
+          CANDIDATE_REVISION: ${{ steps.deploy.outputs.revision }}
+        run: |
+          set -euo pipefail
+          jq -n \
+            --arg source_sha "${SOURCE_SHA}" \
+            --arg image_uri "${IMAGE_URI}" \
+            --arg revision "${CANDIDATE_REVISION}" \
+            --arg project "${PROJECT_ID}" \
+            --arg region "${REGION}" \
+            --arg service "${SERVICE}" \
+            '{sourceSha:$source_sha,imageUri:$image_uri,candidateRevision:$revision,project:$project,region:$region,service:$service,ready:true,trafficPercent:0,healthVerification:"cloud-run-internal-http-probes",promotionPerformed:false}' \
+            > candidate-evidence.json
+
+      - name: Upload candidate evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: production-candidate-evidence
+          path: candidate-evidence.json
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/production-candidate-promote.yml
+++ b/.github/workflows/production-candidate-promote.yml
@@ -1,0 +1,131 @@
+name: Production backend candidate promotion
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_sha:
+        description: Full 40-character source SHA for the verified candidate
+        required: true
+        type: string
+      image_uri:
+        description: Verified immutable Production image URI at digest
+        required: true
+        type: string
+      candidate_revision:
+        description: Exact zero-traffic candidate revision
+        required: true
+        type: string
+      candidate_evidence_run_id:
+        description: Successful Production candidate workflow run ID
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  actions: read
+  id-token: write
+
+jobs:
+  promote-verified-candidate:
+    if: github.repository == 'rentchaincanada/rentchain' && github.event_name == 'workflow_dispatch'
+    environment: production-promotion
+    runs-on: ubuntu-latest
+    env:
+      SOURCE_SHA: ${{ inputs.source_sha }}
+      IMAGE_URI: ${{ inputs.image_uri }}
+      CANDIDATE_REVISION: ${{ inputs.candidate_revision }}
+      EVIDENCE_RUN_ID: ${{ inputs.candidate_evidence_run_id }}
+      PROJECT_ID: project-0d9658de-af29-4dc0-a99
+      REGION: us-central1
+      SERVICE: rentchain-landlord-api
+    steps:
+      - name: Check out protected main
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: refs/heads/main
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Validate promotion inputs and source ancestry
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/production-deployment/validate-release-inputs.sh \
+            promotion "${SOURCE_SHA}" "${IMAGE_URI}" "${PROJECT_ID}" "${REGION}" "${SERVICE}"
+          [[ "${CANDIDATE_REVISION}" =~ ^rentchain-landlord-api-candidate-[0-9a-f]{12}$ ]]
+          [[ "${EVIDENCE_RUN_ID}" =~ ^[0-9]+$ ]]
+          git cat-file -e "${SOURCE_SHA}^{commit}"
+          git merge-base --is-ancestor "${SOURCE_SHA}" origin/main
+
+      - name: Require successful candidate workflow run
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          evidence="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${EVIDENCE_RUN_ID}")"
+          test "$(jq -r '.name' <<<"${evidence}")" = "Production backend candidate deploy"
+          test "$(jq -r '.event' <<<"${evidence}")" = "workflow_dispatch"
+          test "$(jq -r '.conclusion' <<<"${evidence}")" = "success"
+          test "$(jq -r '.head_branch' <<<"${evidence}")" = "main"
+
+      - name: Download candidate evidence
+        uses: actions/download-artifact@v4
+        with:
+          name: production-candidate-evidence
+          path: candidate-evidence
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.candidate_evidence_run_id }}
+
+      - name: Validate candidate evidence binding
+        shell: bash
+        run: |
+          set -euo pipefail
+          evidence="candidate-evidence/candidate-evidence.json"
+          test "$(jq -r '.sourceSha' "${evidence}")" = "${SOURCE_SHA}"
+          test "$(jq -r '.imageUri' "${evidence}")" = "${IMAGE_URI}"
+          test "$(jq -r '.candidateRevision' "${evidence}")" = "${CANDIDATE_REVISION}"
+          test "$(jq -r '.project' "${evidence}")" = "${PROJECT_ID}"
+          test "$(jq -r '.region' "${evidence}")" = "${REGION}"
+          test "$(jq -r '.service' "${evidence}")" = "${SERVICE}"
+          jq -e '.ready == true and .trafficPercent == 0 and .healthVerification == "cloud-run-internal-http-probes" and .promotionPerformed == false' "${evidence}" >/dev/null
+
+      - name: Authenticate with the protected Production promotion identity
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ vars.PRODUCTION_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.PRODUCTION_PROMOTION_SERVICE_ACCOUNT }}
+          create_credentials_file: true
+          export_environment_variables: true
+
+      - name: Set up Google Cloud CLI
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
+
+      - name: Reverify candidate and current traffic baseline
+        id: baseline
+        shell: bash
+        run: |
+          set -euo pipefail
+          revision_json="${RUNNER_TEMP}/candidate-revision.json"
+          service_json="${RUNNER_TEMP}/production-service.json"
+          gcloud run revisions describe "${CANDIDATE_REVISION}" \
+            --project="${PROJECT_ID}" --region="${REGION}" --format=json > "${revision_json}"
+          gcloud run services describe "${SERVICE}" \
+            --project="${PROJECT_ID}" --region="${REGION}" --format=json > "${service_json}"
+          test "$(jq -r '.spec.containers[0].image' "${revision_json}")" = "${IMAGE_URI}"
+          jq -e '.status.conditions[] | select(.type == "Ready" and .status == "True")' "${revision_json}" >/dev/null
+          test "$(jq --arg revision "${CANDIDATE_REVISION}" '[.status.traffic[]? | select(.revisionName == $revision and ((.percent // 0) > 0))] | length' "${service_json}")" = "0"
+          jq -e --arg revision "${CANDIDATE_REVISION}" '.status.latestReadyRevisionName != $revision' "${service_json}" >/dev/null
+          printf 'previous_ready_revision=%s\n' "$(jq -r '.status.latestReadyRevisionName' "${service_json}")" >> "${GITHUB_OUTPUT}"
+
+      - name: Promote the separately approved candidate
+        shell: bash
+        run: |
+          set -euo pipefail
+          gcloud run services update-traffic "${SERVICE}" \
+            --project="${PROJECT_ID}" \
+            --region="${REGION}" \
+            --to-revisions="${CANDIDATE_REVISION}=100" \
+            --quiet
+          printf 'promoted_revision=%s\n' "${CANDIDATE_REVISION}"
+          printf 'rollback_revision=%s\n' "${{ steps.baseline.outputs.previous_ready_revision }}"

--- a/docs/operations/production-build-deploy-reconciliation-plan.md
+++ b/docs/operations/production-build-deploy-reconciliation-plan.md
@@ -1,0 +1,57 @@
+# Production build/deploy separation and reconciliation plan
+
+## Governed release sequence
+
+An ordinary `main` change under `rentchain-api/**` may build and push a traceable candidate image. It must stop before Cloud Run deployment. Production candidate deployment and traffic promotion are separate protected manual workflows.
+
+1. Cloud Build validates, builds, and pushes `sha-<40-character-source-sha>`.
+2. An operator supplies the exact source SHA and immutable image URI to the protected `production-candidate` workflow.
+3. The workflow verifies source ancestry, artifact provenance, and the current service contract before deploying with `--no-traffic`.
+4. Cloud Run's internal `/health/ready` startup probe and `/health` liveness probe must make the candidate Ready while it remains at zero traffic.
+5. A separate `production-promotion` approval verifies the successful candidate workflow evidence and promotes the exact revision.
+
+No changed path authorizes Production deployment by itself.
+
+## Required external configuration
+
+Trigger `07c21dce-42db-4d5f-89d4-616534f27e4f` is externally managed. Keep its `^main$` branch and `rentchain-api/**` build scope, but retain `rentchain-api/cloudbuild.yaml` as build-only. Do not narrow away files that can affect the image.
+
+Before either manual workflow can be used, separately authorize and configure:
+
+- protected GitHub environments `production-candidate` and `production-promotion` with required reviewers;
+- `PRODUCTION_WORKLOAD_IDENTITY_PROVIDER`;
+- least-privilege `PRODUCTION_DEPLOY_SERVICE_ACCOUNT` and `PRODUCTION_PROMOTION_SERVICE_ACCOUNT` environment variables;
+- distinct deployment and traffic-promotion IAM boundaries.
+- a build-only Cloud Build service account for trigger `07c21dce-42db-4d5f-89d4-616534f27e4f`, replacing its currently over-privileged deployer identity after separate authorization.
+
+Repository preparation does not change the trigger, GitHub settings, workload identity, or IAM.
+
+## Service-template reconciliation
+
+The current service template points to failed digest `sha256:0e6edd50ed6477ee3abd74e87f3ec8c77505f3df2290a2a5e3395e5ff6d237eb`, while 100% traffic remains on healthy revision `rentchain-landlord-api-01967-djh` at digest `sha256:e57b58376f46dda31f4c7459283b2e4525a7ec8f37c42539cb14eb08ddc6eaee`.
+
+Production is represented by HCP resource `google_cloud_run_service.landlord_api`. The preferred reconciliation is a separately authorized Terraform review and apply that restores the governed known-good image/template and adds the required configuration before any new candidate deployment:
+
+- `GOOGLE_CLOUD_PROJECT=project-0d9658de-af29-4dc0-a99`;
+- existing service account unchanged;
+- existing environment names and secret-reference names/versions preserved;
+- `/health/ready` internal HTTP startup probe;
+- `/health` internal HTTP liveness probe;
+- existing CPU, memory, timeout, concurrency, scaling, ingress, port, and required annotations preserved.
+
+Reconciliation is expected to create a new revision. It must not shift traffic without separate promotion authorization. A fresh speculative HCP plan is required after the repository correction is reviewed; the pre-incident zero-change plan cannot assess current drift.
+
+If Terraform cannot preserve zero traffic for the reconciliation revision, use the protected candidate workflow with the known-good digest after the required template fields are reconciled. Do not use a bare `gcloud run deploy` as a substitute.
+
+## Rollback and evidence preservation
+
+Traffic rollback, template reconciliation, and artifact cleanup are distinct actions. If a future promotion must be rolled back, use a separately authorized traffic-only command:
+
+```bash
+gcloud run services update-traffic rentchain-landlord-api \
+  --project=project-0d9658de-af29-4dc0-a99 \
+  --region=us-central1 \
+  --to-revisions=rentchain-landlord-api-01967-djh=100
+```
+
+Do not delete failed revision `rentchain-landlord-api-01972-blq` or the incident image until the correction and reconciliation are complete and the evidence-retention decision is reviewed.

--- a/rentchain-api/cloudbuild.yaml
+++ b/rentchain-api/cloudbuild.yaml
@@ -1,77 +1,61 @@
 substitutions:
   _REGION: us-central1
-  _SERVICE: rentchain-landlord-api
   _REPO: rentchain-api
   _IMAGE: rentchain-landlord-api
-  _IMAGE_TAG: "${SHORT_SHA}"
 
 options:
   logging: CLOUD_LOGGING_ONLY
 
 steps:
-  - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
-    entrypoint: "bash"
-    args:
-      - "-lc"
-      - |
-        set -euxo pipefail
-        echo "==== ENV (first 120) ===="
-        env | sort | sed -n '1,120p'
-        echo "==== PWD/FILES ===="
-        pwd
-        ls -la
-        echo "==== ROOT ===="
-        ls -la /workspace
-        echo "==== API DIR ===="
-        ls -la /workspace/rentchain-api
-
-  - name: "node:20"
+  - name: "node:20.20.2"
+    id: "validate-backend"
     dir: "rentchain-api"
     entrypoint: "bash"
     args:
       - "-lc"
       - |
-        set -euxo pipefail
+        set -euo pipefail
         npm ci
         npm run build
 
-  - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
-    entrypoint: "bash"
-    args:
-      - "-c"
-      - |
-        if [ -z "${_IMAGE_TAG}" ]; then
-          echo "ERROR: _IMAGE_TAG is empty. Provide --substitutions=_IMAGE_TAG=xxxx"
-          exit 1
-        fi
-        echo "Using _IMAGE_TAG=${_IMAGE_TAG}"
-
   - name: "gcr.io/cloud-builders/docker"
-    args:
-      [
-        "build",
-        "-f",
-        "rentchain-api/Dockerfile",
-        "-t",
-        "${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO}/${_IMAGE}:${_IMAGE_TAG}",
-        "rentchain-api"
-      ]
-
-  - name: "gcr.io/cloud-builders/docker"
-    args:
-      [
-        "push",
-        "${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO}/${_IMAGE}:${_IMAGE_TAG}"
-      ]
-
-  - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
+    id: "build-candidate"
     entrypoint: "bash"
     args:
       - "-lc"
       - |
-        set -euxo pipefail
-        gcloud run deploy "${_SERVICE}" \
-          --image "${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO}/${_IMAGE}:${_IMAGE_TAG}" \
-          --region "${_REGION}" \
-          --platform managed \
-          --allow-unauthenticated
+        set -euo pipefail
+        [[ "${COMMIT_SHA}" =~ ^[0-9a-f]{40}$ ]]
+        image="${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO}/${_IMAGE}:sha-${COMMIT_SHA}"
+        docker build \
+          --file rentchain-api/Dockerfile \
+          --tag "${image}" \
+          rentchain-api
+
+        test "$(docker image inspect "${image}" --format '{{.Config.User}}')" = "node"
+        test "$(docker image inspect "${image}" --format '{{.Os}}/{{.Architecture}}')" = "linux/amd64"
+        test "$(docker image inspect "${image}" --format '{{json .Config.Cmd}}')" = '["node","dist/index.build.js"]'
+        docker image inspect "${image}" --format '{{json .Config.ExposedPorts}}' | grep -Fq '8080/tcp'
+
+  - name: "gcr.io/cloud-builders/docker"
+    id: "push-candidate"
+    entrypoint: "bash"
+    args:
+      - "-lc"
+      - |
+        set -euo pipefail
+        image="${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO}/${_IMAGE}:sha-${COMMIT_SHA}"
+        push_log="$(mktemp)"
+        docker push "${image}" 2>&1 | tee "${push_log}"
+        digest="$(sed -nE 's/^.*digest: (sha256:[0-9a-f]{64}).*$/\1/p' "${push_log}" | tail -n 1)"
+        [[ "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]]
+        printf 'Production candidate built only; deployment requires a separate protected workflow.\n'
+        printf 'source_sha=%s\n' "${COMMIT_SHA}"
+        printf 'image=%s\n' "${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO}/${_IMAGE}"
+        printf 'tag=sha-%s\n' "${COMMIT_SHA}"
+        printf 'digest=%s\n' "${digest}"
+        printf 'build_id=%s\n' "${BUILD_ID}"
+        printf 'architecture=linux/amd64\n'
+
+images:
+  - "${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO}/${_IMAGE}:sha-${COMMIT_SHA}"

--- a/scripts/production-deployment/classify-changed-paths.sh
+++ b/scripts/production-deployment/classify-changed-paths.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+build_required=false
+no_build_only=true
+
+classify() {
+  local path="$1"
+  case "${path}" in
+    rentchain-api/src/*|rentchain-api/scripts/*|rentchain-api/Dockerfile|rentchain-api/.dockerignore|rentchain-api/package.json|rentchain-api/package-lock.json|rentchain-api/tsconfig*.json|rentchain-api/cloudbuild*.yaml|rentchain-api/cloudbuild*.yml)
+      printf 'build-required\t%s\n' "${path}"
+      build_required=true
+      no_build_only=false
+      ;;
+    infra/environments/preview-foundation/*|docs/*|rentchain-frontend/*|rentchain-status/*)
+      printf 'no-build\t%s\n' "${path}"
+      ;;
+    *)
+      printf 'review-required\t%s\n' "${path}"
+      no_build_only=false
+      ;;
+  esac
+}
+
+if (( "$#" > 0 )); then
+  for path in "$@"; do classify "${path}"; done
+else
+  while IFS= read -r path; do
+    test -n "${path}" && classify "${path}"
+  done
+fi
+
+printf 'build_required=%s\n' "${build_required}"
+printf 'no_build_only=%s\n' "${no_build_only}"
+printf 'deployment_authorized=false\n'

--- a/scripts/production-deployment/governed-template.jq
+++ b/scripts/production-deployment/governed-template.jq
@@ -1,0 +1,80 @@
+def governed_annotation_keys:
+  [
+    "autoscaling.knative.dev/maxScale",
+    "autoscaling.knative.dev/minScale",
+    "run.googleapis.com/execution-environment",
+    "run.googleapis.com/startup-cpu-boost"
+  ];
+
+def annotation_map($value; $location):
+  if $value == null then {}
+  elif ($value | type) == "object" then $value
+  else error("governed annotations at \($location) must be an object")
+  end;
+
+def reject_malformed_governed_values($annotations; $location):
+  [governed_annotation_keys[] as $key
+    | select($annotations[$key] != null and ($annotations[$key] | type) != "string")
+    | $key] as $malformed
+  | if ($malformed | length) == 0 then $annotations
+    else error("governed annotation at \($location) must be a string: \($malformed | join(","))")
+    end;
+
+def reject_conflicts($primary; $alternate):
+  [governed_annotation_keys[] as $key
+    | select($primary[$key] != null and $alternate[$key] != null and $primary[$key] != $alternate[$key])
+    | $key] as $conflicts
+  | if ($conflicts | length) == 0 then empty
+    else error("conflicting governed annotation locations: \($conflicts | join(","))")
+    end;
+
+def resolved_shape:
+  ((.spec.template.spec.containers? | type) == "array") as $is_service
+  | ((.spec.containers? | type) == "array") as $is_revision
+  | if ($is_service and $is_revision) then
+    error("ambiguous Cloud Run resource shape")
+  elif $is_service then
+    annotation_map(.spec.template.metadata.annotations?; ".spec.template.metadata.annotations") as $primary
+    | annotation_map(.metadata.annotations?; ".metadata.annotations") as $alternate
+    | reject_conflicts($primary; $alternate),
+      {
+        resourceShape: "service",
+        spec: .spec.template.spec,
+        annotations: reject_malformed_governed_values($primary; ".spec.template.metadata.annotations")
+      }
+  elif $is_revision then
+    annotation_map(.metadata.annotations?; ".metadata.annotations") as $primary
+    | annotation_map(.spec.template.metadata.annotations?; ".spec.template.metadata.annotations") as $alternate
+    | reject_conflicts($primary; $alternate),
+      {
+        resourceShape: "revision",
+        spec: .spec,
+        annotations: reject_malformed_governed_values($primary; ".metadata.annotations")
+      }
+  else
+    error("unrecognized Cloud Run resource shape")
+  end;
+
+resolved_shape as $resolved
+| ($resolved.spec) as $spec
+| ($resolved.annotations) as $annotations
+| ($spec.containers[0]) as $container
+| {
+    serviceAccount: $spec.serviceAccountName,
+    containerConcurrency: $spec.containerConcurrency,
+    timeoutSeconds: $spec.timeoutSeconds,
+    ports: $container.ports,
+    resources: $container.resources,
+    envNames: ([$container.env[]?.name] | sort),
+    secretRefs: ([$container.env[]? | select(.valueFrom.secretKeyRef) | {
+      name,
+      secret: .valueFrom.secretKeyRef.name,
+      version: .valueFrom.secretKeyRef.key
+    }] | sort_by(.name)),
+    startupProbe: $container.startupProbe,
+    livenessProbe: $container.livenessProbe,
+    maxScale: $annotations["autoscaling.knative.dev/maxScale"],
+    minScale: $annotations["autoscaling.knative.dev/minScale"],
+    executionEnvironment: $annotations["run.googleapis.com/execution-environment"],
+    startupCpuBoost: $annotations["run.googleapis.com/startup-cpu-boost"]
+  }

--- a/scripts/production-deployment/tests/validate-governance.sh
+++ b/scripts/production-deployment/tests/validate-governance.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+build="${root}/rentchain-api/cloudbuild.yaml"
+candidate="${root}/.github/workflows/production-candidate-deploy.yml"
+promotion="${root}/.github/workflows/production-candidate-promote.yml"
+guard="${root}/scripts/production-deployment/validate-release-inputs.sh"
+classifier="${root}/scripts/production-deployment/classify-changed-paths.sh"
+contract="${root}/scripts/production-deployment/validate-service-contract.jq"
+template="${root}/scripts/production-deployment/governed-template.jq"
+
+for file in "${build}" "${candidate}" "${promotion}" "${guard}" "${classifier}" "${contract}" "${template}"; do
+  test -f "${file}"
+done
+
+test "$(rg -n 'gcloud run deploy|update-traffic|--allow-unauthenticated|--no-traffic' "${build}" | wc -l | tr -d ' ')" = "0"
+grep -Fq 'sha-${COMMIT_SHA}' "${build}"
+grep -Fq 'docker push' "${build}"
+grep -Fq 'workflow_dispatch:' "${candidate}"
+grep -Fq 'environment: production-candidate' "${candidate}"
+grep -Fq -- '--no-traffic' "${candidate}"
+test "$(rg -n 'update-traffic' "${candidate}" | wc -l | tr -d ' ')" = "0"
+grep -Fq 'workflow_dispatch:' "${promotion}"
+grep -Fq 'environment: production-promotion' "${promotion}"
+grep -Fq 'Require successful candidate workflow run' "${promotion}"
+grep -Fq 'Validate candidate evidence binding' "${promotion}"
+grep -Fq 'production-candidate-evidence' "${candidate}"
+grep -Fq 'production-candidate-evidence' "${promotion}"
+grep -Fq 'update-traffic' "${promotion}"
+test "$(rg -n 'gcloud run deploy' "${promotion}" | wc -l | tr -d ' ')" = "0"
+
+sha="0123456789abcdef0123456789abcdef01234567"
+digest="$(printf 'a%.0s' $(seq 1 64))"
+image="us-central1-docker.pkg.dev/project-0d9658de-af29-4dc0-a99/rentchain-api/rentchain-landlord-api@sha256:${digest}"
+bash "${guard}" candidate "${sha}" "${image}" project-0d9658de-af29-4dc0-a99 us-central1 rentchain-landlord-api >/dev/null
+if bash "${guard}" candidate short "${image}" project-0d9658de-af29-4dc0-a99 us-central1 rentchain-landlord-api >/dev/null 2>&1; then exit 1; fi
+if bash "${guard}" candidate "${sha}" "${image%@*}:mutable" project-0d9658de-af29-4dc0-a99 us-central1 rentchain-landlord-api >/dev/null 2>&1; then exit 1; fi
+if bash "${guard}" candidate "${sha}" "${image}" rentchain-preview us-central1 rentchain-landlord-api >/dev/null 2>&1; then exit 1; fi
+if bash "${guard}" candidate "${sha}" "${image}" project-0d9658de-af29-4dc0-a99 us-central1 rentchain-preview-backend >/dev/null 2>&1; then exit 1; fi
+
+backend_result="$(bash "${classifier}" rentchain-api/package.json)"
+grep -Fq $'build-required\trentchain-api/package.json' <<<"${backend_result}"
+grep -Fq 'deployment_authorized=false' <<<"${backend_result}"
+preview_result="$(bash "${classifier}" infra/environments/preview-foundation/datastore_auth.tf)"
+grep -Fq $'no-build\tinfra/environments/preview-foundation/datastore_auth.tf' <<<"${preview_result}"
+grep -Fq 'build_required=false' <<<"${preview_result}"
+frontend_result="$(bash "${classifier}" rentchain-frontend/src/main.tsx)"
+grep -Fq $'no-build\trentchain-frontend/src/main.tsx' <<<"${frontend_result}"
+
+incident_service="$(mktemp)"
+valid_service="$(mktemp)"
+missing_secret_service="$(mktemp)"
+valid_revision="$(mktemp)"
+drifted_revision="$(mktemp)"
+misplaced_service="$(mktemp)"
+misplaced_revision="$(mktemp)"
+conflicting_service="$(mktemp)"
+malformed_service="$(mktemp)"
+unrecognized_resource="$(mktemp)"
+trap 'rm -f "${incident_service}" "${valid_service}" "${missing_secret_service}" "${valid_revision}" "${drifted_revision}" "${misplaced_service}" "${misplaced_revision}" "${conflicting_service}" "${malformed_service}" "${unrecognized_resource}"' EXIT
+printf '%s\n' '{"spec":{"template":{"spec":{"containers":[{"env":[{"name":"JWT_SECRET","valueFrom":{"secretKeyRef":{"name":"JWT_SECRET","key":"latest"}}},{"name":"FIREBASE_API_KEY","valueFrom":{"secretKeyRef":{"name":"FIREBASE_API_KEY","key":"latest"}}}]}]}}}}' > "${incident_service}"
+contract_result="$(jq -f "${contract}" "${incident_service}")"
+grep -Fq '"GOOGLE_CLOUD_PROJECT"' <<<"${contract_result}"
+test "$(jq -r '.ok' <<<"${contract_result}")" = "false"
+
+jq -n '{spec:{template:{metadata:{annotations:{"autoscaling.knative.dev/maxScale":"20","run.googleapis.com/startup-cpu-boost":"true"}},spec:{serviceAccountName:"production-runtime-service-account",containerConcurrency:80,timeoutSeconds:300,containers:[{ports:[{containerPort:8080,name:"http1"}],resources:{limits:{cpu:"1000m",memory:"512Mi"}},startupProbe:{httpGet:{path:"/health/ready",port:8080}},livenessProbe:{httpGet:{path:"/health",port:8080}},env:(( ["JWT_SECRET","STRIPE_SECRET_KEY","STRIPE_WEBHOOK_SECRET","INTERNAL_JOB_TOKEN","FIREBASE_API_KEY","MAILGUN_API_KEY"] | map({name:.,valueFrom:{secretKeyRef:{name:.,key:"latest"}}}) ) + [{name:"GOOGLE_CLOUD_PROJECT",value:"project-0d9658de-af29-4dc0-a99"},{name:"FRONTEND_URL",value:"configured"},{name:"STRIPE_PRICE_STARTER_MONTHLY_LIVE",value:"configured"},{name:"STRIPE_PRICE_PRO_MONTHLY_LIVE",value:"configured"},{name:"STRIPE_PRICE_ELITE_MONTHLY_LIVE",value:"configured"},{name:"EMAIL_PROVIDER",value:"mailgun"},{name:"MAILGUN_DOMAIN",value:"configured"},{name:"EMAIL_FROM",value:"configured"}])}]}}}}' > "${valid_service}"
+test "$(jq -r -f "${contract}" "${valid_service}" | jq -r '.ok')" = "true"
+jq '(.spec.template.spec.containers[0].env[] | select(.name == "JWT_SECRET")) |= {name:"JWT_SECRET",value:"not-a-secret-reference"}' "${valid_service}" > "${missing_secret_service}"
+test "$(jq -r -f "${contract}" "${missing_secret_service}" | jq -r '.ok')" = "false"
+grep -Fq 'JWT_SECRET' <(jq -c -f "${contract}" "${missing_secret_service}")
+
+jq '{metadata:{annotations:.spec.template.metadata.annotations},spec:.spec.template.spec}' "${valid_service}" > "${valid_revision}"
+service_template="$(jq -S -f "${template}" "${valid_service}")"
+revision_template="$(jq -S -f "${template}" "${valid_revision}")"
+test "$(jq -r '.maxScale' <<<"${service_template}")" = "20"
+test "$(jq -r '.maxScale' <<<"${revision_template}")" = "20"
+test "$(jq -r '.startupCpuBoost' <<<"${service_template}")" = "true"
+test "$(jq -r '.startupCpuBoost' <<<"${revision_template}")" = "true"
+test "${service_template}" = "${revision_template}"
+
+jq '.metadata.annotations["autoscaling.knative.dev/maxScale"] = "21"' "${valid_revision}" > "${drifted_revision}"
+test "${service_template}" != "$(jq -S -f "${template}" "${drifted_revision}")"
+
+jq 'del(.spec.template.metadata.annotations) | .metadata.annotations["autoscaling.knative.dev/maxScale"] = "999"' "${valid_service}" > "${misplaced_service}"
+test "$(jq -r -f "${template}" "${misplaced_service}" | jq -r '.maxScale')" = "null"
+
+jq 'del(.metadata.annotations) | .spec.template.metadata.annotations["autoscaling.knative.dev/maxScale"] = "999"' "${valid_revision}" > "${misplaced_revision}"
+test "$(jq -r -f "${template}" "${misplaced_revision}" | jq -r '.maxScale')" = "null"
+
+jq '.metadata.annotations["autoscaling.knative.dev/maxScale"] = "21"' "${valid_service}" > "${conflicting_service}"
+if jq -f "${template}" "${conflicting_service}" >/dev/null 2>&1; then exit 1; fi
+
+jq '.spec.template.metadata.annotations["autoscaling.knative.dev/maxScale"] = 20' "${valid_service}" > "${malformed_service}"
+if jq -f "${template}" "${malformed_service}" >/dev/null 2>&1; then exit 1; fi
+
+printf '%s\n' '{"spec":{"containers":null}}' > "${unrecognized_resource}"
+if jq -f "${template}" "${unrecognized_resource}" >/dev/null 2>&1; then exit 1; fi
+
+grep -Fq 'candidate_traffic_percent=0' "${candidate}"
+grep -Fq 'health_verification=cloud-run-internal-http-probes' "${candidate}"
+grep -Fq 'promotion=not_performed' "${candidate}"
+
+printf '%s\n' 'Production deployment governance validation passed (32 boundaries).'

--- a/scripts/production-deployment/validate-release-inputs.sh
+++ b/scripts/production-deployment/validate-release-inputs.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly EXPECTED_PROJECT="project-0d9658de-af29-4dc0-a99"
+readonly EXPECTED_REGION="us-central1"
+readonly EXPECTED_SERVICE="rentchain-landlord-api"
+readonly EXPECTED_IMAGE_PREFIX="us-central1-docker.pkg.dev/${EXPECTED_PROJECT}/rentchain-api/rentchain-landlord-api@sha256:"
+
+mode="${1:-}"
+source_sha="${2:-}"
+image_uri="${3:-}"
+project="${4:-}"
+region="${5:-}"
+service="${6:-}"
+
+case "${mode}" in
+  candidate|promotion) ;;
+  *) echo "unsupported release validation mode" >&2; exit 2 ;;
+esac
+
+[[ "${source_sha}" =~ ^[0-9a-f]{40}$ ]] || { echo "source SHA must be 40 lowercase hexadecimal characters" >&2; exit 2; }
+test "${project}" = "${EXPECTED_PROJECT}" || { echo "production project guard failed" >&2; exit 2; }
+test "${region}" = "${EXPECTED_REGION}" || { echo "production region guard failed" >&2; exit 2; }
+test "${service}" = "${EXPECTED_SERVICE}" || { echo "production service guard failed" >&2; exit 2; }
+[[ "${image_uri}" =~ ^${EXPECTED_IMAGE_PREFIX}[0-9a-f]{64}$ ]] || {
+  echo "immutable Production image digest is required" >&2
+  exit 2
+}
+
+case "${image_uri}" in
+  *rentchain-preview*|*preview-backend*)
+    echo "Preview image is prohibited by the Production release guard" >&2
+    exit 2
+    ;;
+esac
+
+printf 'release_input_mode=%s\n' "${mode}"
+printf 'source_sha_valid=true\n'
+printf 'production_boundary_valid=true\n'
+printf 'immutable_digest_valid=true\n'

--- a/scripts/production-deployment/validate-service-contract.jq
+++ b/scripts/production-deployment/validate-service-contract.jq
@@ -1,0 +1,38 @@
+def env_by_name:
+  [.spec.template.spec.containers[0].env[]?] | map({key:.name, value:.}) | from_entries;
+
+env_by_name as $env
+| [
+    "GOOGLE_CLOUD_PROJECT",
+    "JWT_SECRET",
+    "STRIPE_SECRET_KEY",
+    "STRIPE_WEBHOOK_SECRET",
+    "INTERNAL_JOB_TOKEN",
+    "FIREBASE_API_KEY",
+    "STRIPE_PRICE_STARTER_MONTHLY_LIVE",
+    "STRIPE_PRICE_PRO_MONTHLY_LIVE"
+  ] as $required
+| ["JWT_SECRET", "STRIPE_SECRET_KEY", "STRIPE_WEBHOOK_SECRET", "INTERNAL_JOB_TOKEN", "FIREBASE_API_KEY"] as $requiredSecrets
+| {
+    missingNames: [$required[] | select($env[.] == null)],
+    missingSecretRefs: [$requiredSecrets[] | select(($env[.].valueFrom.secretKeyRef // null) == null)],
+    projectConfigured: (($env.GOOGLE_CLOUD_PROJECT.value // "") == "project-0d9658de-af29-4dc0-a99"),
+    baseUrlConfigured: (($env.APP_BASE_URL // $env.FRONTEND_URL // $env.PUBLIC_APP_URL // null) != null),
+    elitePriceConfigured: (($env.STRIPE_PRICE_ELITE_MONTHLY_LIVE // $env.STRIPE_PRICE_BUSINESS_MONTHLY_LIVE // null) != null),
+    emailProvider: ($env.EMAIL_PROVIDER.value // "sendgrid"),
+    mailgunConfigured: (($env.MAILGUN_API_KEY.valueFrom.secretKeyRef // null) != null and $env.MAILGUN_DOMAIN != null and $env.EMAIL_FROM != null),
+    sendgridConfigured: (($env.SENDGRID_API_KEY.valueFrom.secretKeyRef // null) != null and $env.SENDGRID_FROM_EMAIL != null),
+    startupReadyProbe: ((.spec.template.spec.containers[0].startupProbe.httpGet.path // "") == "/health/ready"),
+    livenessHealthProbe: ((.spec.template.spec.containers[0].livenessProbe.httpGet.path // "") == "/health")
+  }
+| .emailConfigured = (if .emailProvider == "mailgun" then .mailgunConfigured else .sendgridConfigured end)
+| .ok = (
+    (.missingNames | length) == 0 and
+    (.missingSecretRefs | length) == 0 and
+    .projectConfigured and
+    .baseUrlConfigured and
+    .elitePriceConfigured and
+    .emailConfigured and
+    .startupReadyProbe and
+    .livenessHealthProbe
+  )


### PR DESCRIPTION
## Incident

A Preview-focused merge changed `rentchain-api/package.json`, correctly matching the existing Production backend trigger. The trigger built and pushed a Production image and then automatically attempted deployment. The candidate required `GOOGLE_CLOUD_PROJECT`, which the Production service template lacked, creating failed revision `rentchain-landlord-api-01972-blq` while 100% traffic remained on healthy revision `rentchain-landlord-api-01967-djh`.

## Correction

This PR separates Production image build/push from deployment. Qualifying `main` pushes validate, build, push a full-SHA traceability tag, record the immutable digest and build metadata, then stop. They do not deploy Cloud Run or change traffic.

## Candidate deployment

A separate manual `production-candidate` protected-environment workflow requires an exact 40-character SHA reachable from `main`, an immutable Production Artifact Registry digest with matching SHA provenance, and exact Production project, region, and service guards. It validates the current service contract before deploying with `--no-traffic`, then requires readiness, digest parity, governed-template parity, startup and liveness health, and zero traffic before producing candidate evidence.

## Promotion

A separate manual `production-promotion` protected workflow requires evidence from the exact successful candidate workflow run and binds the candidate revision, source SHA, and image digest. No automatic promotion path exists.

## Compatibility validation

The current Production template fails closed before deployment because `GOOGLE_CLOUD_PROJECT`, the `/health/ready` startup probe, and the `/health` liveness probe are absent. Required secret references, live Stripe price configuration, application base URL, and email-provider configuration are also validated without printing values.

## Cloud Run shape normalization

Governed-template comparison distinguishes service annotations at `.spec.template.metadata.annotations` from revision annotations at `.metadata.annotations`. Ambiguous, unknown, conflicting, and malformed shapes fail closed. Real Production service and revision JSON normalize consistently for maximum scale, minimum scale, execution environment, and startup CPU boost.

## Reconciliation plan

The operations document proposes a separately authorized Terraform-governed reconciliation restoring the known-good governed template, adding the missing project setting and reviewed health probes, creating a zero-traffic candidate, and retaining separate promotion approval. Failed revision and incident image evidence remain preserved. This PR performs no reconciliation, deployment, promotion, rollback, or cleanup.

## Validation

- Production governance suite: 32 boundaries passed
- Realistic service/revision normalization and genuine-drift detection: passed
- Changed-path classification: passed
- Shell syntax, YAML parsing, and jq validation: passed
- Backend TypeScript and build under Node 20.11.1: passed
- Security scan and staged diff check: passed

Optional tools not installed: `actionlint`, `shellcheck`, and `yamllint`.

## Current live state

Production remains healthy with 100% traffic on `rentchain-landlord-api-01967-djh`; failed revision `rentchain-landlord-api-01972-blq` remains at zero traffic and public `/health` returns HTTP 200. Preview remains paused on `rentchain-preview-backend-00003-42c` with `FIRESTORE_ENABLED=false`, the Preview IAM plan unapplied, and seed unexecuted.

## External follow-up and boundaries

The external Cloud Build trigger remains unchanged. After merge and separate authorization, replace its deploy-capable service account with a build-only identity while retaining `^main$` and `rentchain-api/**` matching. No workflow was dispatched, no build submitted, no trigger/IAM/Terraform/Vercel mutation occurred, no deployment or traffic change occurred, and PRs #1453 and #1435 remain untouched.