### PR TITLE
Prepare build-only identity for Production Cloud Build

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "5.45.2"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:iy2Q9VcnMu4z/bH3v/NmI/nEpgYY7bXgJmT/hVTAUS4=",
+    "zh:0d09c8f20b556305192cdbe0efa6d333ceebba963a8ba91f9f1714b5a20c4b7a",
+    "zh:117143fc91be407874568df416b938a6896f94cb873f26bba279cedab646a804",
+    "zh:16ccf77d18dd2c5ef9c0625f9cf546ebdf3213c0a452f432204c69feed55081e",
+    "zh:3e555cf22a570a4bd247964671f421ed7517970cd9765ceb46f335edc2c6f392",
+    "zh:688bd5b05a75124da7ae6e885b2b92bd29f4261808b2b78bd5f51f525c1052ca",
+    "zh:6db3ef37a05010d82900bfffb3261c59a0c247e0692049cb3eb8c2ef16c9d7bf",
+    "zh:70316fde75f6a15d72749f66d994ccbdde5f5ed4311b6d06b99850f698c9bbf9",
+    "zh:84b8e583771a4f2bd514e519d98ed7fd28dce5efe0634e973170e1cfb5556fb4",
+    "zh:9d4b8ef0a9b6677935c604d94495042e68ff5489932cfd1ec41052e094a279d3",
+    "zh:a2089dd9bd825c107b148dd12d6b286f71aa37dfd4ca9c35157f2dcba7bc19d8",
+    "zh:f03d795c0fd9721e59839255ee7ba7414173017dc530b4ce566daf3802a0d6dd",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/docs/operations/production-cloudbuild-build-only-identity-plan.md
+++ b/docs/operations/production-cloudbuild-build-only-identity-plan.md
@@ -1,0 +1,107 @@
+# Production Cloud Build build-only identity plan
+
+## Current boundary
+
+External trigger `07c21dce-42db-4d5f-89d4-616534f27e4f` uses `rentchain-cloudbuild-deployer@project-0d9658de-af29-4dc0-a99.iam.gserviceaccount.com`. Its project roles include Cloud Run Admin, Cloud Build Editor, project-wide Artifact Registry Writer, project-wide Service Account User, Storage Admin, Logs Writer, and Service Usage Consumer. Those grants substantially exceed the corrected automatic pipeline, which validates the backend, builds one image, pushes it to the existing `rentchain-api` repository, writes Cloud Logging entries, and stops.
+
+The trigger is externally managed. Production HCP workspace `rentchain` (`ws-1dXGdYNdZhQh3RpV`) manages an older `rentchain-api` repository in `northamerica-northeast1`, while the corrected build uses a distinct existing `rentchain-api` repository in `us-central1`. The target repository and trigger are not in HCP state. This change manages only a new IAM member on the exact `us-central1` repository plus the new identity, custom role, and logging member; it does not import or take ownership of either repository, the external trigger, or the existing deployer.
+
+## Dedicated identity
+
+The proposed account is:
+
+```text
+rentchain-cloudbuild-builder@project-0d9658de-af29-4dc0-a99.iam.gserviceaccount.com
+```
+
+It receives `roles/logging.logWriter` at the Production project because the build uses `CLOUD_LOGGING_ONLY`. It receives a custom Artifact Registry role only on:
+
+```text
+projects/project-0d9658de-af29-4dc0-a99/locations/us-central1/repositories/rentchain-api
+```
+
+The custom role contains exactly:
+
+| Permission | Required operation |
+| --- | --- |
+| `artifactregistry.repositories.get` | Resolve the approved repository |
+| `artifactregistry.repositories.downloadArtifacts` | Check existing content-addressed layers during push |
+| `artifactregistry.repositories.uploadArtifacts` | Upload image layers and manifest |
+| `artifactregistry.tags.create` | Create the immutable `sha-<commit>` tag |
+| `artifactregistry.tags.get` | Resolve the exact uploaded tag |
+| `artifactregistry.dockerimages.get` | Inspect the exact image and digest |
+
+No source or logs bucket is configured. The successful build fetched the exact GitHub revision directly, used the default worker pool, emitted logs only to Cloud Logging, and recorded no secrets, KMS key, private pool, attestation, or user bucket. Base images are public Docker Hub and Google Cloud Builder images pulled by the build platform. No Storage role is proposed.
+
+No Cloud Build Editor or Builder role is proposed for the execution identity: the Cloud Build control plane runs the configured steps, while the identity needs only permissions exercised inside those steps. The existing Cloud Build service agent retains its platform-managed service-agent role. The current deployer has no service-account IAM-policy binding, and its successful build used no key or explicit token-minting binding; therefore no Workload Identity User, Token Creator, or project-wide Service Account User grant is proposed.
+
+## Forbidden authority
+
+The build-only identity receives no Cloud Run, traffic, IAM administration, trigger administration, Artifact Registry administration or deletion, Storage, Secret Manager, Firebase, Firestore, Identity Platform, service-account impersonation, key-creation, Terraform, or Vercel authority. It remains distinct from the separately governed candidate-deployment and promotion identities.
+
+## Governed migration
+
+1. Review the Terraform plan for only the new service account, custom role, repository-scoped member, and Logs Writer member.
+2. Separately authorize and apply those additive resources.
+3. Separately authorize a test build that explicitly uses the new identity against an approved main SHA.
+4. Verify backend validation, immutable image push, digest metadata, and Cloud Logging output.
+5. Verify no Cloud Run revision, traffic, IAM, Secret Manager, Terraform, Firebase, Firestore, Identity Platform, or Vercel mutation.
+6. Separately authorize updating only the external trigger service-account field to the new account. Keep `^main$`, `rentchain-api/**`, and `rentchain-api/cloudbuild.yaml` unchanged.
+7. Verify one main-triggered build and the unchanged Production service revision/traffic baseline.
+8. If the test or trigger build fails, restore the trigger service-account field to `rentchain-cloudbuild-deployer@project-0d9658de-af29-4dc0-a99.iam.gserviceaccount.com`. Do not delete the new identity automatically.
+9. Retain the old deployer until all other dependencies are reviewed. Remove its obsolete automatic-build rights only through a separate subtractive IAM change; do not assume it is unused by legacy operations.
+
+The trigger operator must already have `iam.serviceAccounts.actAs` on the new account when performing the separately authorized switch. This plan does not add a persistent impersonation binding and does not modify the trigger.
+
+## Separately authorized commands
+
+After the additive Terraform apply is reviewed and separately authorized, check out the exact approved main SHA and run one build explicitly as the new identity:
+
+```bash
+git checkout --detach <APPROVED_FULL_MAIN_SHA>
+
+gcloud builds submit . \
+  --config=rentchain-api/cloudbuild.yaml \
+  --project=project-0d9658de-af29-4dc0-a99 \
+  --region=us-central1 \
+  --service-account=projects/project-0d9658de-af29-4dc0-a99/serviceAccounts/rentchain-cloudbuild-builder@project-0d9658de-af29-4dc0-a99.iam.gserviceaccount.com \
+  --substitutions=COMMIT_SHA=<APPROVED_FULL_MAIN_SHA>
+```
+
+After verifying the build, immutable digest, logs, and unchanged Cloud Run revision/traffic state, separately authorize the external trigger switch:
+
+```bash
+gcloud builds triggers update github \
+  07c21dce-42db-4d5f-89d4-616534f27e4f \
+  --project=project-0d9658de-af29-4dc0-a99 \
+  --region=us-central1 \
+  --service-account=projects/project-0d9658de-af29-4dc0-a99/serviceAccounts/rentchain-cloudbuild-builder@project-0d9658de-af29-4dc0-a99.iam.gserviceaccount.com
+```
+
+Verify the trigger identity without changing it again:
+
+```bash
+gcloud builds triggers describe \
+  07c21dce-42db-4d5f-89d4-616534f27e4f \
+  --project=project-0d9658de-af29-4dc0-a99 \
+  --region=us-central1 \
+  --format='value(serviceAccount)'
+```
+
+If the governed test fails, separately authorize rollback of only the trigger identity:
+
+```bash
+gcloud builds triggers update github \
+  07c21dce-42db-4d5f-89d4-616534f27e4f \
+  --project=project-0d9658de-af29-4dc0-a99 \
+  --region=us-central1 \
+  --service-account=projects/project-0d9658de-af29-4dc0-a99/serviceAccounts/rentchain-cloudbuild-deployer@project-0d9658de-af29-4dc0-a99.iam.gserviceaccount.com
+```
+
+Do not delete the new account or remove old deployer rights as part of rollback.
+
+## Evidence and audit
+
+The separately authorized test must record the build ID, source SHA, trigger or explicit build context, immutable image digest, step statuses, principal email, and timestamps. Cloud Audit Logs must show only expected Cloud Build, Artifact Registry upload/read, and Logging operations by the new identity. Preserve the old and new IAM snapshots, trigger snapshots, build logs, Production revision/traffic snapshots, and rollback decision as review evidence.
+
+This preparation performs no IAM change, trigger update, build submission, deployment, traffic change, Terraform apply, or cleanup.

--- a/production_cloudbuild_identity.tf
+++ b/production_cloudbuild_identity.tf
@@ -1,0 +1,60 @@
+locals {
+  production_cloudbuild_builder_member = google_service_account.production_cloudbuild_builder.member
+  production_cloudbuild_repository     = "rentchain-api"
+  production_cloudbuild_region         = "us-central1"
+
+  production_cloudbuild_artifact_publisher_permissions = toset([
+    "artifactregistry.dockerimages.get",
+    "artifactregistry.repositories.downloadArtifacts",
+    "artifactregistry.repositories.get",
+    "artifactregistry.repositories.uploadArtifacts",
+    "artifactregistry.tags.create",
+    "artifactregistry.tags.get",
+  ])
+}
+
+resource "google_service_account" "production_cloudbuild_builder" {
+  project      = var.project_id
+  account_id   = "rentchain-cloudbuild-builder"
+  display_name = "RentChain Production Cloud Build builder"
+  description  = "Build-only identity for the Production backend image trigger; no deploy or runtime authority."
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_project_iam_custom_role" "production_cloudbuild_artifact_publisher" {
+  project     = var.project_id
+  role_id     = "productionCloudBuildArtifactPublisher"
+  title       = "Production Cloud Build Artifact Publisher"
+  description = "Repository-scoped immutable image upload and exact-artifact inspection for Production builds."
+  permissions = local.production_cloudbuild_artifact_publisher_permissions
+  stage       = "GA"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_artifact_registry_repository_iam_member" "production_cloudbuild_artifact_publisher" {
+  project    = var.project_id
+  location   = local.production_cloudbuild_region
+  repository = local.production_cloudbuild_repository
+  role       = google_project_iam_custom_role.production_cloudbuild_artifact_publisher.name
+  member     = local.production_cloudbuild_builder_member
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_project_iam_member" "production_cloudbuild_log_writer" {
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = local.production_cloudbuild_builder_member
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/scripts/production-deployment/tests/validate-build-identity.sh
+++ b/scripts/production-deployment/tests/validate-build-identity.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+identity="${root}/production_cloudbuild_identity.tf"
+build="${root}/rentchain-api/cloudbuild.yaml"
+
+test -f "${identity}"
+test -f "${build}"
+
+grep -Fq 'account_id   = "rentchain-cloudbuild-builder"' "${identity}"
+grep -Fq 'resource "google_service_account" "production_cloudbuild_builder"' "${identity}"
+grep -Fq 'resource "google_project_iam_custom_role" "production_cloudbuild_artifact_publisher"' "${identity}"
+grep -Fq 'resource "google_artifact_registry_repository_iam_member" "production_cloudbuild_artifact_publisher"' "${identity}"
+rg -q 'production_cloudbuild_repository\s*= "rentchain-api"' "${identity}"
+rg -q 'production_cloudbuild_region\s*= "us-central1"' "${identity}"
+grep -Fq 'repository = local.production_cloudbuild_repository' "${identity}"
+grep -Fq 'location   = local.production_cloudbuild_region' "${identity}"
+grep -Fq 'resource "google_project_iam_member" "production_cloudbuild_log_writer"' "${identity}"
+grep -Fq 'role    = "roles/logging.logWriter"' "${identity}"
+
+actual_permissions="$({
+  sed -n '/production_cloudbuild_artifact_publisher_permissions = toset(/,/])/p' "${identity}" \
+    | rg -No '"artifactregistry\.[^"]+"' \
+    | tr -d '"' \
+    | sort -u
+})"
+expected_permissions="$(cat <<'EOF'
+artifactregistry.dockerimages.get
+artifactregistry.repositories.downloadArtifacts
+artifactregistry.repositories.get
+artifactregistry.repositories.uploadArtifacts
+artifactregistry.tags.create
+artifactregistry.tags.get
+EOF
+)"
+test "${actual_permissions}" = "${expected_permissions}"
+test "$(printf '%s\n' "${actual_permissions}" | wc -l | tr -d ' ')" = "6"
+
+forbidden='roles/(owner|editor|run\.admin|run\.developer|resourcemanager\.projectIamAdmin|iam\.securityAdmin|iam\.serviceAccountAdmin|iam\.serviceAccountUser|iam\.serviceAccountTokenCreator|artifactregistry\.admin|artifactregistry\.writer|storage\.admin|secretmanager\.(admin|secretAccessor)|cloudbuild\.(builds\.(builder|editor)|connectionAdmin))|run\.(services\.(update|setIamPolicy)|routes\.invoke)|resourcemanager\.projects\.setIamPolicy|iam\.roles\.(create|update)|cloudbuild\.triggers\.(update|delete)|secretmanager\.versions\.access|google_service_account_key'
+if rg -n "${forbidden}" "${identity}"; then
+  echo "Forbidden Production build-identity capability found" >&2
+  exit 1
+fi
+
+if rg -n 'gcloud run|update-traffic|terraform apply|set-iam-policy|add-iam-policy-binding|remove-iam-policy-binding|secrets versions access' "${build}"; then
+  echo "Automatic build path contains a governed mutation command" >&2
+  exit 1
+fi
+
+test "$(rg -n 'resource "google_service_account"' "${identity}" | wc -l | tr -d ' ')" = "1"
+test "$(rg -n 'resource "google_artifact_registry_repository_iam_member"' "${identity}" | wc -l | tr -d ' ')" = "1"
+test "$(rg -n 'resource "google_project_iam_member"' "${identity}" | wc -l | tr -d ' ')" = "1"
+test "$(rg -n 'resource "google_cloudbuild_trigger"' "${identity}" | wc -l | tr -d ' ')" = "0"
+
+printf '%s\n' 'Production Cloud Build identity validation passed (20 boundaries).'


### PR DESCRIPTION
## Current risk

The automatic Production Cloud Build trigger still runs as the deploy-capable service account `rentchain-cloudbuild-deployer@project-0d9658de-af29-4dc0-a99.iam.gserviceaccount.com`. Its current roles include Cloud Run Admin, Cloud Build Editor, Storage Admin, Artifact Registry Writer, Service Account User, and Logs Writer.

PR #1494 removed deployment commands from the automatic build configuration, but the trigger identity still retains unnecessary deployment authority.

## Prepared correction

This PR prepares the dedicated build-only service account `rentchain-cloudbuild-builder@project-0d9658de-af29-4dc0-a99.iam.gserviceaccount.com`. It adds:

- one service account;
- one six-permission custom Artifact Registry publishing role;
- one repository-scoped IAM binding on the exact `us-central1/rentchain-api` repository;
- one project-level Logging Writer binding.

## Explicit exclusions

The proposed identity has no Cloud Run administration, traffic authority, trigger administration, IAM mutation, Storage role, Secret Manager access, Firebase or Firestore access, service-account impersonation, key creation, Terraform authority, or Vercel authority.

## Validation

- deterministic identity tests: 20 boundaries passed;
- Terraform format, initialization, and validation passed;
- speculative local plan: 4 add, 0 change, 0 destroy;
- existing eight state resources unchanged;
- credential scan passed;
- no live IAM or trigger change occurred.

## Migration remains separately gated

After merge and separate authorization:

1. apply only the four additive resources;
2. run one approved test build using the new identity;
3. verify image publication, logs, digest, and unchanged Cloud Run state;
4. switch only the trigger service-account field;
5. verify the next governed build;
6. retain rollback to the old identity;
7. reduce old deployer permissions only through a later subtractive IAM mission.

The custom role’s operational sufficiency is not claimed until the separately authorized test build passes.

## Other external follow-up

The Production candidate and promotion GitHub environments currently return 404 and must be configured separately before the release workflows can be used.

## Boundaries

- no Terraform apply;
- no IAM mutation;
- no trigger mutation;
- no build submission;
- no Cloud Run deployment;
- no traffic change;
- no Preview mutation;
- PR #1453 untouched;
- PR #1435 untouched.