### PR TITLE
Import build-only Cloud Build IAM resources

### DIFF
--- a/production_cloudbuild_identity_imports.tf
+++ b/production_cloudbuild_identity_imports.tf
@@ -1,0 +1,14 @@
+import {
+  to = google_project_iam_custom_role.production_cloudbuild_artifact_publisher
+  id = "projects/project-0d9658de-af29-4dc0-a99/roles/productionCloudBuildArtifactPublisher"
+}
+
+import {
+  to = google_artifact_registry_repository_iam_member.production_cloudbuild_artifact_publisher
+  id = "projects/project-0d9658de-af29-4dc0-a99/locations/us-central1/repositories/rentchain-api projects/project-0d9658de-af29-4dc0-a99/roles/productionCloudBuildArtifactPublisher serviceAccount:rentchain-cloudbuild-builder@project-0d9658de-af29-4dc0-a99.iam.gserviceaccount.com"
+}
+
+import {
+  to = google_project_iam_member.production_cloudbuild_log_writer
+  id = "project-0d9658de-af29-4dc0-a99 roles/logging.logWriter serviceAccount:rentchain-cloudbuild-builder@project-0d9658de-af29-4dc0-a99.iam.gserviceaccount.com"
+}


### PR DESCRIPTION
## Context

The original additive Terraform apply partially succeeded by creating the build-only service account, then failed because the HCP Terraform execution identity lacks custom-role creation and IAM policy mutation permissions.

## Exact administrative completion

The approved administrator created exactly:

* `productionCloudBuildArtifactPublisher`;
* the repository-scoped custom-role binding on `us-central1/rentchain-api`;
* the project-level `roles/logging.logWriter` binding.

The live custom-role description was corrected to match the merged Terraform source of truth exactly.

## Import strategy

This PR adds three Terraform import blocks for:

* the custom role;
* the repository IAM member;
* the project Logs Writer member.

Expected plan:

* 3 imports;
* 0 add;
* 0 change;
* 0 destroy.

## Boundaries

* no Terraform import apply;
* no trigger change;
* no test build;
* no Cloud Run deployment;
* no traffic change;
* no old-identity reduction;
* no Preview mutation.
