### PR TITLE
Prepare narrow Cloud Build source-object access

### DIFF
--- a/docs/operations/production-cloudbuild-source-object-access.md
+++ b/docs/operations/production-cloudbuild-source-object-access.md
@@ -1,0 +1,46 @@
+# Production Cloud Build Source-Object Access
+
+## Evidence
+
+The corrected manual submission for source commit
+`28668818191bf9c6ea7c9802295b1c243ec440f1` was made by
+`admin@rentchain.ai` for the build-only identity
+`rentchain-cloudbuild-builder@project-0d9658de-af29-4dc0-a99.iam.gserviceaccount.com`.
+Cloud Build rejected the submission before creating a build because that
+identity lacked `storage.objects.get` on the uploaded archive under
+`gs://project-0d9658de-af29-4dc0-a99_cloudbuild/source/`.
+
+The submitting user uploads the archive through `gcloud builds submit`. The
+custom build identity then reads the known archive to start the build. The
+builder does not create, update, delete, or list source objects.
+
+## Least-privilege decision
+
+The staging bucket is a Google-created US multi-region bucket with uniform
+bucket-level access. Object-level IAM is therefore unavailable. Predefined
+`roles/storage.objectViewer` is broader than the observed need because it
+includes listing and additional folder/metadata reads.
+
+The selected correction declares a project custom role named
+`productionCloudBuildSourceObjectReader` containing only
+`storage.objects.get`, bound only on the exact staging bucket to the build-only
+service account. It grants no project-level Storage role and no object list,
+create, update, delete, bucket administration, Cloud Run, secret, trigger, or
+impersonation authority.
+
+## Ownership and governed lifecycle
+
+The Cloud Build staging bucket is external to the repository-root Terraform
+state; Terraform manages only the exact bucket IAM member, not the bucket.
+The existing HCP execution identity cannot create custom roles or mutate bucket
+IAM. Use the established Path B sequence:
+
+1. review and merge the two-resource Terraform declaration without apply;
+2. separately authorize exact administrative creation of the custom role and
+   exact bucket binding;
+3. add and review import blocks through VCS;
+4. apply only the approved imports and prove zero drift;
+5. separately authorize one corrected build test.
+
+No live permission, build, trigger, or runtime change is made by this design
+mission.

--- a/production_cloudbuild_source_object_reader.tf
+++ b/production_cloudbuild_source_object_reader.tf
@@ -1,0 +1,30 @@
+locals {
+  production_cloudbuild_source_bucket = "project-0d9658de-af29-4dc0-a99_cloudbuild"
+
+  production_cloudbuild_source_object_reader_permissions = toset([
+    "storage.objects.get",
+  ])
+}
+
+resource "google_project_iam_custom_role" "production_cloudbuild_source_object_reader" {
+  project     = var.project_id
+  role_id     = "productionCloudBuildSourceObjectReader"
+  title       = "Production Cloud Build Source Object Reader"
+  description = "Reads Cloud Build source archives from the approved Production staging bucket."
+  permissions = local.production_cloudbuild_source_object_reader_permissions
+  stage       = "GA"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_storage_bucket_iam_member" "production_cloudbuild_source_object_reader" {
+  bucket = local.production_cloudbuild_source_bucket
+  role   = google_project_iam_custom_role.production_cloudbuild_source_object_reader.name
+  member = local.production_cloudbuild_builder_member
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/scripts/production-deployment/tests/validate-source-object-reader.sh
+++ b/scripts/production-deployment/tests/validate-source-object-reader.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+source_reader="${root}/production_cloudbuild_source_object_reader.tf"
+identity="${root}/production_cloudbuild_identity.tf"
+build="${root}/rentchain-api/cloudbuild.yaml"
+
+test -f "${source_reader}"
+grep -Fq 'role_id     = "productionCloudBuildSourceObjectReader"' "${source_reader}"
+grep -Fq '"storage.objects.get"' "${source_reader}"
+test "$(rg -No '"storage\.[^"]+"' "${source_reader}" | sort -u)" = '"storage.objects.get"'
+test "$(rg -n 'storage\.objects\.list' "${source_reader}" | wc -l | tr -d ' ')" = "0"
+test "$(rg -n 'storage\.objects\.create' "${source_reader}" | wc -l | tr -d ' ')" = "0"
+test "$(rg -n 'storage\.objects\.update' "${source_reader}" | wc -l | tr -d ' ')" = "0"
+test "$(rg -n 'storage\.objects\.delete' "${source_reader}" | wc -l | tr -d ' ')" = "0"
+test "$(rg -n 'storage\.buckets\.' "${source_reader}" | wc -l | tr -d ' ')" = "0"
+grep -Fq 'resource "google_storage_bucket_iam_member" "production_cloudbuild_source_object_reader"' "${source_reader}"
+grep -Fq 'production_cloudbuild_source_bucket = "project-0d9658de-af29-4dc0-a99_cloudbuild"' "${source_reader}"
+grep -Fq 'member = local.production_cloudbuild_builder_member' "${source_reader}"
+test "$(rg -n 'google_project_iam_member' "${source_reader}" | wc -l | tr -d ' ')" = "0"
+test "$(rg -n 'roles/storage\.(admin|objectAdmin|objectViewer)' "${source_reader}" | wc -l | tr -d ' ')" = "0"
+test "$(rg -n 'google_cloudbuild_trigger' "${source_reader}" | wc -l | tr -d ' ')" = "0"
+test "$(rg -n 'run\.|secretmanager\.' "${source_reader}" | wc -l | tr -d ' ')" = "0"
+test "$(rg -n 'serviceAccount(User|TokenCreator)|workloadIdentityUser' "${source_reader}" | wc -l | tr -d ' ')" = "0"
+test "$(rg -n 'prevent_destroy = true' "${source_reader}" | wc -l | tr -d ' ')" = "2"
+test "$(rg -No '"artifactregistry\.[^"]+"' "${identity}" | sort -u | wc -l | tr -d ' ')" = "6"
+grep -Fq 'role    = "roles/logging.logWriter"' "${identity}"
+test "$(rg -n 'gcloud run|terraform apply|secrets versions access' "${build}" | wc -l | tr -d ' ')" = "0"
+
+printf '%s\n' 'Production Cloud Build source-object reader validation passed (20 boundaries).'


### PR DESCRIPTION
## Evidence

The corrected manual Cloud Build submission was rejected before build creation because the custom builder identity lacked `storage.objects.get`.

The source archive was uploaded to `gs://project-0d9658de-af29-4dc0-a99_cloudbuild/source/...`. No evidence showed a need for object listing, creation, update, deletion, or bucket administration.

## Prepared correction

This PR declares:

* one custom role: `productionCloudBuildSourceObjectReader`;
* exact permission: `storage.objects.get`;
* one bucket-scoped IAM member on `project-0d9658de-af29-4dc0-a99_cloudbuild`;
* member: `rentchain-cloudbuild-builder@project-0d9658de-af29-4dc0-a99.iam.gserviceaccount.com`.

## Explicit exclusions

The correction grants no object listing, object write or delete authority, bucket administration, project-level Storage role, Cloud Run authority, trigger administration, secret access, impersonation, or service-account keys.

## Terraform result

Speculative plan:

* 2 add
* 0 change
* 0 destroy
* 0 import

No apply occurred.

## Expected migration

Because HCP cannot create custom roles or mutate bucket IAM, completion remains separately gated through the established Path B sequence:

1. merge declaration;
2. separately authorize exact administrative creation;
3. prepare reviewed import blocks;
4. apply imports;
5. verify zero drift;
6. separately authorize one corrected build test.

## Boundaries

* no live IAM change;
* no build submission;
* no trigger change;
* no Cloud Run deployment;
* no traffic mutation;
* no Preview mutation;
* PR #1453 untouched;
* PR #1435 untouched.
