### PR TITLE
Import Cloud Build source-object reader IAM

### DIFF
--- a/production_cloudbuild_source_object_reader_imports.tf
+++ b/production_cloudbuild_source_object_reader_imports.tf
@@ -1,0 +1,9 @@
+import {
+  to = google_project_iam_custom_role.production_cloudbuild_source_object_reader
+  id = "projects/project-0d9658de-af29-4dc0-a99/roles/productionCloudBuildSourceObjectReader"
+}
+
+import {
+  to = google_storage_bucket_iam_member.production_cloudbuild_source_object_reader
+  id = "b/project-0d9658de-af29-4dc0-a99_cloudbuild projects/project-0d9658de-af29-4dc0-a99/roles/productionCloudBuildSourceObjectReader serviceAccount:rentchain-cloudbuild-builder@project-0d9658de-af29-4dc0-a99.iam.gserviceaccount.com"
+}


### PR DESCRIPTION
## Context

The builder identity required `storage.objects.get` to read the exact source archive uploaded by `gcloud builds submit`.

The approved administrator manually created:

- custom role `productionCloudBuildSourceObjectReader`;
- exact-bucket IAM binding on `project-0d9658de-af29-4dc0-a99_cloudbuild`.

## Exact live scope

The role contains only:

`storage.objects.get`

The binding is limited to the exact Cloud Build staging bucket and the exact build-only service account.

No object listing, write, update, deletion, bucket administration, project-level Storage role, Cloud Run authority, secret access, trigger authority, key, or impersonation was added.

## Import strategy

This PR adds exactly two Terraform import blocks:

- custom role;
- exact-bucket IAM member.

Speculative HCP plan `plan-HUTzjkgknAVZqbqj` in run `run-QpwxtXeyYJ3haFGq`:

- 2 imports;
- 0 add;
- 0 change;
- 0 destroy;
- all 14 resource actions no-op.

## Boundaries

- no Terraform import apply;
- no live IAM mutation;
- no build submission;
- no trigger change;
- no Cloud Run deployment;
- no traffic change;
- no Preview mutation;
- PR #1453 untouched;
- PR #1435 untouched.
