### PR TITLE
Prepare legacy Production Cloud Build deployer reduction

### DIFF
--- a/docs/operations/production-cloudbuild-build-only-identity-plan.md
+++ b/docs/operations/production-cloudbuild-build-only-identity-plan.md
@@ -2,7 +2,7 @@
 
 ## Current boundary
 
-External trigger `07c21dce-42db-4d5f-89d4-616534f27e4f` uses `rentchain-cloudbuild-deployer@project-0d9658de-af29-4dc0-a99.iam.gserviceaccount.com`. Its project roles include Cloud Run Admin, Cloud Build Editor, project-wide Artifact Registry Writer, project-wide Service Account User, Storage Admin, Logs Writer, and Service Usage Consumer. Those grants substantially exceed the corrected automatic pipeline, which validates the backend, builds one image, pushes it to the existing `rentchain-api` repository, writes Cloud Logging entries, and stops.
+External trigger `07c21dce-42db-4d5f-89d4-616534f27e4f` uses `rentchain-cloudbuild-builder@project-0d9658de-af29-4dc0-a99.iam.gserviceaccount.com`. The retired automatic-path identity, `rentchain-cloudbuild-deployer@project-0d9658de-af29-4dc0-a99.iam.gserviceaccount.com`, retains historical project grants pending the separately governed reduction in `production-cloudbuild-legacy-deployer-reduction.md`. Those grants substantially exceed the corrected automatic pipeline, which validates the backend, builds one image, pushes it to the existing `rentchain-api` repository, writes Cloud Logging entries, and stops.
 
 The trigger is externally managed. Production HCP workspace `rentchain` (`ws-1dXGdYNdZhQh3RpV`) manages an older `rentchain-api` repository in `northamerica-northeast1`, while the corrected build uses a distinct existing `rentchain-api` repository in `us-central1`. The target repository and trigger are not in HCP state. This change manages only a new IAM member on the exact `us-central1` repository plus the new identity, custom role, and logging member; it does not import or take ownership of either repository, the external trigger, or the existing deployer.
 
@@ -48,8 +48,8 @@ The build-only identity receives no Cloud Run, traffic, IAM administration, trig
 5. Verify no Cloud Run revision, traffic, IAM, Secret Manager, Terraform, Firebase, Firestore, Identity Platform, or Vercel mutation.
 6. Separately authorize updating only the external trigger service-account field to the new account. Keep `^main$`, `rentchain-api/**`, and `rentchain-api/cloudbuild.yaml` unchanged.
 7. Verify one main-triggered build and the unchanged Production service revision/traffic baseline.
-8. If the test or trigger build fails, restore the trigger service-account field to `rentchain-cloudbuild-deployer@project-0d9658de-af29-4dc0-a99.iam.gserviceaccount.com`. Do not delete the new identity automatically.
-9. Retain the old deployer until all other dependencies are reviewed. Remove its obsolete automatic-build rights only through a separate subtractive IAM change; do not assume it is unused by legacy operations.
+8. If a future builder-identity regression occurs, disable or pause the automatic trigger and stop for Founder review. Do not restore the broadly privileged legacy identity as an automatic-path rollback.
+9. Retain the old deployer account, without assuming its historical grants are still required, until the separately governed subtractive IAM review is complete.
 
 The trigger operator must already have `iam.serviceAccounts.actAs` on the new account when performing the separately authorized switch. This plan does not add a persistent impersonation binding and does not modify the trigger.
 
@@ -88,17 +88,7 @@ gcloud builds triggers describe \
   --format='value(serviceAccount)'
 ```
 
-If the governed test fails, separately authorize rollback of only the trigger identity:
-
-```bash
-gcloud builds triggers update github \
-  07c21dce-42db-4d5f-89d4-616534f27e4f \
-  --project=project-0d9658de-af29-4dc0-a99 \
-  --region=us-central1 \
-  --service-account=projects/project-0d9658de-af29-4dc0-a99/serviceAccounts/rentchain-cloudbuild-deployer@project-0d9658de-af29-4dc0-a99.iam.gserviceaccount.com
-```
-
-Do not delete the new account or remove old deployer rights as part of rollback.
+If the governed path fails, pause the automatic trigger and investigate the builder identity. Reintroducing the legacy deployer is not an approved rollback because it would restore deploy-capable authority to the automatic build path.
 
 ## Evidence and audit
 

--- a/docs/operations/production-cloudbuild-legacy-deployer-reduction.md
+++ b/docs/operations/production-cloudbuild-legacy-deployer-reduction.md
@@ -1,0 +1,83 @@
+# Production Cloud Build legacy deployer reduction
+
+## Audited boundary
+
+The legacy account is external to the Production Terraform state:
+
+```text
+rentchain-cloudbuild-deployer@project-0d9658de-af29-4dc0-a99.iam.gserviceaccount.com
+```
+
+The enabled automatic trigger `07c21dce-42db-4d5f-89d4-616534f27e4f` uses the separately managed build-only account. Its controlled build `9eca674c-6164-44f1-b519-7bdbff3fd1f6` succeeded from source `0757e284c32341df4bb9b464a32c4e13815bca83` without a Cloud Run deployment or traffic change. The legacy account has no user-managed key, service-account IAM binding, Workload Identity Federation binding, repository-level IAM binding, bucket-level IAM binding, or Cloud Run service-level IAM binding.
+
+The bounded regional history returned 100 legacy-account builds: 93 successful and 7 failed, all from the primary trigger and none manual. The last was successful build `9fe1a9c8-9ae7-4e45-8a32-249c5626874d` at `2026-08-01T02:03:42.560994Z`, before the builder switch. The 90-day audit query returned 918 historical records: 306 Cloud Run service replacements, 306 Cloud Run IAM-policy calls, and 306 service-account act-as checks. Its latest record was `2026-07-31T22:36:05.058414Z`. No observed legacy use followed the successful builder-path validation.
+
+A disabled external trigger, `6fb97ddb-6f1b-4c62-9532-6852b9e9975c` (`rentchain-deploy`), still names the legacy account. It must remain disabled. Removing the legacy account's roles makes any accidental re-enablement fail closed; deletion or mutation of that trigger is a separate operational-ownership decision.
+
+The candidate and promotion workflows refer only to the unconfigured names `PRODUCTION_DEPLOY_SERVICE_ACCOUNT`, `PRODUCTION_PROMOTION_SERVICE_ACCOUNT`, and `PRODUCTION_WORKLOAD_IDENTITY_PROVIDER`. The required `production-candidate` and `production-promotion` environments do not exist. Neither workflow names the legacy account, and this reduction does not assume or create their future identities.
+
+## Dependency classification
+
+All current bindings are unconditional project-level grants and are external to Terraform.
+
+| Role | Classification | Evidence | Prepared action |
+| --- | --- | --- | --- |
+| `roles/artifactregistry.writer` | A - proven obsolete | Enabled trigger uses the repository-scoped builder; no resource-level legacy binding | Remove project binding |
+| `roles/cloudbuild.builds.editor` | A - proven obsolete | No enabled trigger or workflow uses the legacy account | Remove project binding |
+| `roles/iam.serviceAccountUser` | A - proven obsolete | No governed current deploy path; no account-level impersonation binding | Remove project binding |
+| `roles/logging.logWriter` | A - proven obsolete | Enabled trigger logs as the builder | Remove project binding |
+| `roles/run.admin` | A - proven obsolete | Last observed operations were historical deploys before the builder switch; candidate/promotion identities are not configured | Remove project binding |
+| `roles/serviceusage.serviceUsageConsumer` | A - proven obsolete | No enabled trigger, workflow, or Terraform resource requires legacy execution | Remove project binding |
+| `roles/storage.admin` | A - proven obsolete | No bucket-level dependency; builder has a one-permission source-object reader | Remove project binding |
+
+No role is retained. The service account remains enabled and undeleted for audit continuity. Disabling or deleting it is a later, separately authorized retirement action.
+
+## Separately authorized external removal
+
+Before removal, reverify that the enabled trigger still uses the builder and that the legacy trigger is disabled:
+
+```bash
+gcloud builds triggers describe 07c21dce-42db-4d5f-89d4-616534f27e4f \
+  --project=project-0d9658de-af29-4dc0-a99 \
+  --region=us-central1 \
+  --format='value(serviceAccount,filename,disabled)'
+
+gcloud builds triggers describe 6fb97ddb-6f1b-4c62-9532-6852b9e9975c \
+  --project=project-0d9658de-af29-4dc0-a99 \
+  --region=us-central1 \
+  --format='value(serviceAccount,filename,disabled)'
+```
+
+Only after separate approval, remove exactly these seven project bindings:
+
+```bash
+gcloud projects remove-iam-policy-binding project-0d9658de-af29-4dc0-a99 \
+  --member='serviceAccount:rentchain-cloudbuild-deployer@project-0d9658de-af29-4dc0-a99.iam.gserviceaccount.com' \
+  --role='roles/artifactregistry.writer'
+gcloud projects remove-iam-policy-binding project-0d9658de-af29-4dc0-a99 \
+  --member='serviceAccount:rentchain-cloudbuild-deployer@project-0d9658de-af29-4dc0-a99.iam.gserviceaccount.com' \
+  --role='roles/cloudbuild.builds.editor'
+gcloud projects remove-iam-policy-binding project-0d9658de-af29-4dc0-a99 \
+  --member='serviceAccount:rentchain-cloudbuild-deployer@project-0d9658de-af29-4dc0-a99.iam.gserviceaccount.com' \
+  --role='roles/iam.serviceAccountUser'
+gcloud projects remove-iam-policy-binding project-0d9658de-af29-4dc0-a99 \
+  --member='serviceAccount:rentchain-cloudbuild-deployer@project-0d9658de-af29-4dc0-a99.iam.gserviceaccount.com' \
+  --role='roles/logging.logWriter'
+gcloud projects remove-iam-policy-binding project-0d9658de-af29-4dc0-a99 \
+  --member='serviceAccount:rentchain-cloudbuild-deployer@project-0d9658de-af29-4dc0-a99.iam.gserviceaccount.com' \
+  --role='roles/run.admin'
+gcloud projects remove-iam-policy-binding project-0d9658de-af29-4dc0-a99 \
+  --member='serviceAccount:rentchain-cloudbuild-deployer@project-0d9658de-af29-4dc0-a99.iam.gserviceaccount.com' \
+  --role='roles/serviceusage.serviceUsageConsumer'
+gcloud projects remove-iam-policy-binding project-0d9658de-af29-4dc0-a99 \
+  --member='serviceAccount:rentchain-cloudbuild-deployer@project-0d9658de-af29-4dc0-a99.iam.gserviceaccount.com' \
+  --role='roles/storage.admin'
+```
+
+Do not disable or delete the account, change either trigger, run a build, deploy Cloud Run, or change traffic as part of that removal.
+
+## Post-removal verification
+
+Read back project and service-account IAM, confirm zero legacy bindings and zero user-managed keys, then confirm the enabled trigger still uses the builder. Verify the Production revision, traffic, and health baseline remain unchanged. Any newly discovered legacy principal use or trigger movement stops the removal for Founder review.
+
+This preparation does not remove IAM, mutate a trigger, submit a build, apply Terraform, deploy Cloud Run, change traffic, or configure GitHub environments.

--- a/scripts/production-deployment/tests/validate-legacy-deployer-reduction.sh
+++ b/scripts/production-deployment/tests/validate-legacy-deployer-reduction.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+plan="${root}/docs/operations/production-cloudbuild-legacy-deployer-reduction.md"
+builder="${root}/production_cloudbuild_identity.tf"
+build="${root}/rentchain-api/cloudbuild.yaml"
+workflows="${root}/.github/workflows"
+legacy='rentchain-cloudbuild-deployer@project-0d9658de-af29-4dc0-a99.iam.gserviceaccount.com'
+
+test -f "${plan}"
+test -f "${builder}"
+test -f "${build}"
+
+# The repository must not manage, impersonate, or execute as the legacy account.
+if rg -n "${legacy}" "${root}" --glob '*.tf' --glob '*.tfvars' --glob '*.yml' --glob '*.yaml' --glob '*.sh' --glob '!scripts/production-deployment/tests/validate-legacy-deployer-reduction.sh'; then
+  echo 'Legacy deployer found in executable or Terraform configuration' >&2
+  exit 1
+fi
+
+grep -Fq 'account_id   = "rentchain-cloudbuild-builder"' "${builder}"
+grep -Fq 'no deploy or runtime authority' "${builder}"
+if rg -n 'gcloud run|update-traffic|terraform apply|set-iam-policy|add-iam-policy-binding|remove-iam-policy-binding|secrets versions access' "${build}"; then
+  echo 'Automatic build path contains governed mutation authority' >&2
+  exit 1
+fi
+
+# Candidate and promotion workflows must remain identity-name indirections and
+# must not silently fall back to the legacy account.
+grep -Fq '${{ vars.PRODUCTION_DEPLOY_SERVICE_ACCOUNT }}' "${workflows}/production-candidate-deploy.yml"
+grep -Fq '${{ vars.PRODUCTION_PROMOTION_SERVICE_ACCOUNT }}' "${workflows}/production-candidate-promote.yml"
+test "$(rg -n "${legacy}" "${workflows}" | wc -l | tr -d ' ')" = '0'
+
+# The external removal is explicit, complete, and preserves the account.
+for role in \
+  roles/artifactregistry.writer \
+  roles/cloudbuild.builds.editor \
+  roles/iam.serviceAccountUser \
+  roles/logging.logWriter \
+  roles/run.admin \
+  roles/serviceusage.serviceUsageConsumer \
+  roles/storage.admin; do
+  test "$(grep -F -- "--role='${role}'" "${plan}" | wc -l | tr -d ' ')" = '1'
+done
+test "$(grep -F -- "--member='serviceAccount:${legacy}'" "${plan}" | wc -l | tr -d ' ')" = '7'
+grep -Fq 'The service account remains enabled and undeleted' "${plan}"
+grep -Fq 'must remain disabled' "${plan}"
+
+for forbidden in \
+  roles/owner \
+  roles/editor \
+  roles/resourcemanager.projectIamAdmin \
+  roles/iam.securityAdmin \
+  roles/secretmanager.admin \
+  roles/secretmanager.secretAccessor; do
+  if grep -Fq -- "--role='${forbidden}'" "${plan}"; then
+    echo "Unexpected legacy role in removal plan: ${forbidden}" >&2
+    exit 1
+  fi
+done
+
+printf '%s\n' 'Legacy deployer reduction validation passed (20 boundaries).'


### PR DESCRIPTION
## Context

The automatic Production backend trigger now runs successfully under the verified build-only service account.

The former deployer identity is no longer used by the active trigger.

## Legacy identity audit

The legacy account remains enabled and has zero user-managed keys and no impersonation or WIF bindings.

Its seven unconditional project-level roles are:

* `roles/artifactregistry.writer`
* `roles/cloudbuild.builds.editor`
* `roles/iam.serviceAccountUser`
* `roles/logging.logWriter`
* `roles/run.admin`
* `roles/serviceusage.serviceUsageConsumer`
* `roles/storage.admin`

All seven are classified as obsolete based on trigger, build-history, workflow, repository, WIF, audit-log, and resource-IAM evidence.

## Disabled trigger

Disabled trigger `6fb97ddb-6f1b-4c62-9532-6852b9e9975c` still references the legacy account and remains disabled.

This PR does not change that trigger.

## Prepared reduction

This PR documents the exact future external removal sequence and adds a deterministic guard.

It does not remove any live role. It does not disable or delete the service account.

## Validation

* legacy reduction guard: 20 passed;
* build identity guard: 20 passed;
* Production governance: 32 passed;
* Terraform validation: passed;
* HCP speculative plan: 0 import / 0 add / 0 change / 0 destroy;
* credential scan: passed;
* diff check: passed.

## Separate authorization still required

After merge:

1. reverify all seven roles and both triggers;
2. remove the seven exact project-level bindings using an approved administrator;
3. verify the account remains enabled with zero roles;
4. verify the active trigger and automatic builder path remain healthy;
5. retain the disabled trigger unchanged;
6. obtain Terraform zero drift;
7. consider service-account disablement or deletion only through a later retirement mission.

## Boundaries

* no IAM removal;
* no trigger mutation;
* no build submission;
* no Terraform apply;
* no Cloud Run deployment;
* no traffic change;
* no Preview mutation;
* no GitHub environment mutation;
* no Vercel mutation;
* PR #1453 untouched;
* PR #1435 untouched.
