### PR TITLE
Fix Production promotion evidence artifact

### DIFF
--- a/.github/workflows/production-candidate-promote.yml
+++ b/.github/workflows/production-candidate-promote.yml
@@ -88,15 +88,9 @@ jobs:
         run: |
           set -euo pipefail
           printf '%s' "${HUMAN_CANDIDATE_EVIDENCE}" > human-candidate-evidence.json
-          jq -e . human-candidate-evidence.json >/dev/null
           request=candidate-request/candidate-request.json
           test "$(jq -r '.sourceSha' "${request}")" = "${SOURCE_SHA}"
           test "$(jq -r '.imageUri' "${request}")" = "${IMAGE_URI}"
-          test "$(jq -r '.sourceSha' human-candidate-evidence.json)" = "${SOURCE_SHA}"
-          test "$(jq -r '.imageUri' human-candidate-evidence.json)" = "${IMAGE_URI}"
-          test "$(jq -r '.candidateRevision' human-candidate-evidence.json)" = "${CANDIDATE_REVISION}"
-          test "$(jq -r '.candidateRequestId' human-candidate-evidence.json)" = "$(jq -r '.candidateRequestId' "${request}")"
-          jq -e '.ready == true and .trafficPercent == 0 and (.previousReadyRevision | type == "string" and length > 0)' human-candidate-evidence.json >/dev/null
 
       - name: Prepare inert promotion request evidence
         shell: bash
@@ -109,7 +103,16 @@ jobs:
             "${RUN_URL}" \
             "${RUN_ACTOR}" \
             promotion-request.json
-          jq -e '.status == "prepared" and .trafficMutationPerformed == false' promotion-request.json >/dev/null
+          jq -e '
+            .status == "prepared" and
+            .candidateReady == true and
+            .candidateTrafficPercent == 0 and
+            .templateParityPassed == true and
+            .currentServingTrafficPercent == 100 and
+            .productionHealthStatus == 200 and
+            .trafficMutationPerformed == false
+          ' promotion-request.json >/dev/null
+          test "$(jq -r '.candidateRevision' promotion-request.json)" = "${CANDIDATE_REVISION}"
 
       - name: Record promotion preparation summary
         shell: bash

--- a/scripts/production-deployment/prepare-human-promotion.sh
+++ b/scripts/production-deployment/prepare-human-promotion.sh
@@ -14,7 +14,6 @@ actor="$5"
 output_json="$6"
 
 jq -e . "${candidate_request}" >/dev/null
-jq -e . "${human_evidence}" >/dev/null
 [[ "${request_id}" =~ ^promotion-[A-Za-z0-9._-]+$ ]]
 [[ "${run_url}" =~ ^https://github\.com/rentchaincanada/rentchain/actions/runs/[0-9]+$ ]]
 test -n "${actor}"
@@ -25,16 +24,49 @@ candidate_request_id="$(jq -r '.candidateRequestId' "${candidate_request}")"
 project="$(jq -r '.project' "${candidate_request}")"
 region="$(jq -r '.region' "${candidate_request}")"
 service="$(jq -r '.service' "${candidate_request}")"
-candidate_revision="$(jq -r '.candidateRevision' "${human_evidence}")"
-previous_ready_revision="$(jq -r '.previousReadyRevision' "${human_evidence}")"
+
+verified_human_evidence="$(
+  jq -ce '
+    . as $e |
+    if (
+      (.sourceSha | type == "string" and length == 40) and
+      (.imageUri | type == "string" and contains("@sha256:")) and
+      (.approvedDigest | type == "string" and test("^sha256:[0-9a-f]{64}$")) and
+      ($e.imageUri | endswith("@" + $e.approvedDigest)) and
+      (.candidateRequestId | type == "string" and length > 0) and
+      (.candidateRevision | type == "string" and length > 0) and
+      (.previousReadyRevision | type == "string" and length > 0) and
+      (.servingRevisionAfterDeployment == .previousReadyRevision) and
+      (.ready | type == "boolean" and . == true) and
+      (.trafficPercent | type == "number" and . == 0) and
+      (.templateParity | type == "boolean" and . == true) and
+      (.servingTrafficPercent | type == "number" and . == 100) and
+      (.productionHealthHttpStatus | type == "number" and . == 200)
+    ) then {
+      sourceSha,
+      imageUri,
+      digest: .approvedDigest,
+      candidateRequestId,
+      candidateRevision,
+      previousReadyRevision,
+      candidateReady: .ready,
+      candidateTrafficPercent: .trafficPercent,
+      templateParityPassed: .templateParity,
+      currentServingRevision: .servingRevisionAfterDeployment,
+      currentServingTrafficPercent: .servingTrafficPercent,
+      productionHealthStatus: .productionHealthHttpStatus
+    } else error("human candidate evidence does not satisfy the promotion contract") end
+  ' "${human_evidence}"
+)"
+
+candidate_revision="$(jq -r '.candidateRevision' <<<"${verified_human_evidence}")"
+previous_ready_revision="$(jq -r '.previousReadyRevision' <<<"${verified_human_evidence}")"
 
 test "$(jq -r '.status' "${candidate_request}")" = "prepared"
 test "$(jq -r '.cloudMutationPerformed' "${candidate_request}")" = "false"
-test "$(jq -r '.sourceSha' "${human_evidence}")" = "${source_sha}"
-test "$(jq -r '.imageUri' "${human_evidence}")" = "${image_uri}"
-test "$(jq -r '.candidateRequestId' "${human_evidence}")" = "${candidate_request_id}"
-test "$(jq -r '.ready' "${human_evidence}")" = "true"
-test "$(jq -r '.trafficPercent' "${human_evidence}")" = "0"
+test "$(jq -r '.sourceSha' <<<"${verified_human_evidence}")" = "${source_sha}"
+test "$(jq -r '.imageUri' <<<"${verified_human_evidence}")" = "${image_uri}"
+test "$(jq -r '.candidateRequestId' <<<"${verified_human_evidence}")" = "${candidate_request_id}"
 [[ "${candidate_revision}" =~ ^rentchain-landlord-api-candidate-[0-9a-f]{12}$ ]]
 [[ "${previous_ready_revision}" =~ ^rentchain-landlord-api-[0-9]{5}-[a-z0-9]{3}$ ]]
 
@@ -56,6 +88,7 @@ jq -n \
   --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
   --arg run_url "${run_url}" \
   --arg actor "${actor}" \
-  '{schemaVersion:1,status:"prepared",promotionRequestId:$request_id,candidateRequestId:$candidate_request_id,sourceSha:$source_sha,imageUri:$image_uri,candidateRevision:$candidate_revision,previousReadyRevision:$previous_ready_revision,project:$project,region:$region,service:$service,proposedHumanAdminTrafficCommand:$command,rollbackCommandTemplate:$rollback,prePromotionChecklist:["separate Founder promotion authorization","interactive administrator authentication","candidate evidence linkage verified","candidate revision ready at approved digest","candidate remains at zero traffic","current Production traffic and health recorded"],requiredPostPromotionEvidence:["administratorIdentity","promotionAuthorization","trafficCommand","trafficResult","healthResult","rollbackStatus","approverIdentity","incidentNotes"],preparedAt:$timestamp,workflowRunUrl:$run_url,workflowActor:$actor,trafficMutationPerformed:false}' > "${output_json}"
+  --argjson human "${verified_human_evidence}" \
+  '{schemaVersion:1,status:"prepared",promotionRequestId:$request_id,candidateRequestId:$candidate_request_id,sourceSha:$source_sha,imageUri:$image_uri,digest:$human.digest,candidateRevision:$candidate_revision,previousReadyRevision:$previous_ready_revision,candidateReady:$human.candidateReady,candidateTrafficPercent:$human.candidateTrafficPercent,templateParityPassed:$human.templateParityPassed,currentServingRevision:$human.currentServingRevision,currentServingTrafficPercent:$human.currentServingTrafficPercent,productionHealthStatus:$human.productionHealthStatus,project:$project,region:$region,service:$service,proposedHumanAdminTrafficCommand:$command,rollbackCommandTemplate:$rollback,prePromotionChecklist:["separate Founder promotion authorization","interactive administrator authentication","candidate evidence linkage verified","candidate revision ready at approved digest","candidate remains at zero traffic","current Production traffic and health recorded"],requiredPostPromotionEvidence:["administratorIdentity","promotionAuthorization","trafficCommand","trafficResult","healthResult","rollbackStatus","approverIdentity","incidentNotes"],preparedAt:$timestamp,workflowRunUrl:$run_url,workflowActor:$actor,noMutationStatement:"NO TRAFFIC MUTATION PERFORMED",trafficMutationPerformed:false}' > "${output_json}"
 
 printf 'promotion request written to %s; NO TRAFFIC MUTATION PERFORMED\n' "${output_json}"

--- a/scripts/production-deployment/tests/validate-human-admin-pilot.sh
+++ b/scripts/production-deployment/tests/validate-human-admin-pilot.sh
@@ -72,10 +72,49 @@ digest="$(printf 'a%.0s' $(seq 1 64))"
 image="us-central1-docker.pkg.dev/project-0d9658de-af29-4dc0-a99/rentchain-api/rentchain-landlord-api@sha256:${digest}"
 bash "${candidate_script}" "${sha}" "${image}" "sha-${sha}" project-0d9658de-af29-4dc0-a99 us-central1 rentchain-landlord-api candidate-123-1 https://github.com/rentchaincanada/rentchain/actions/runs/123 operator "${tmp}/candidate.json" >/dev/null
 jq -e '.cloudMutationPerformed == false and .status == "prepared"' "${tmp}/candidate.json" >/dev/null
-jq -n --arg sha "${sha}" --arg image "${image}" '{candidateRequestId:"candidate-123-1",sourceSha:$sha,imageUri:$image,candidateRevision:"rentchain-landlord-api-candidate-0123456789ab",previousReadyRevision:"rentchain-landlord-api-01967-djh",ready:true,trafficPercent:0}' > "${tmp}/human.json"
+jq -n --arg sha "${sha}" --arg image "${image}" --arg digest "sha256:${digest}" '{candidateRequestId:"candidate-123-1",sourceSha:$sha,imageUri:$image,approvedDigest:$digest,candidateRevision:"rentchain-landlord-api-candidate-0123456789ab",previousReadyRevision:"rentchain-landlord-api-01967-djh",servingRevisionAfterDeployment:"rentchain-landlord-api-01967-djh",ready:true,trafficPercent:0,templateParity:true,servingTrafficPercent:100,productionHealthHttpStatus:200}' > "${tmp}/human.json"
 bash "${promotion_script}" "${tmp}/candidate.json" "${tmp}/human.json" promotion-456-1 https://github.com/rentchaincanada/rentchain/actions/runs/456 operator "${tmp}/promotion.json" >/dev/null
 jq -e '.trafficMutationPerformed == false and .status == "prepared"' "${tmp}/promotion.json" >/dev/null
 check "preparation scripts produce non-mutating evidence" test -s "${tmp}/promotion.json"
 
-test "${pass}" -ge 30
+expect_promotion_failure() {
+  local evidence="$1"
+  ! bash "${promotion_script}" "${tmp}/candidate.json" "${evidence}" promotion-invalid-1 https://github.com/rentchaincanada/rentchain/actions/runs/999 operator "${tmp}/invalid-promotion.json" >/dev/null 2>&1
+}
+
+check "promotion artifact records Boolean candidate readiness" bash -c "jq -e '.candidateReady == true and (.candidateReady | type) == \"boolean\"' '${tmp}/promotion.json' >/dev/null"
+check "promotion artifact records integer zero candidate traffic" bash -c "jq -e '.candidateTrafficPercent == 0 and (.candidateTrafficPercent | type) == \"number\"' '${tmp}/promotion.json' >/dev/null"
+check "promotion artifact records Boolean template parity" bash -c "jq -e '.templateParityPassed == true and (.templateParityPassed | type) == \"boolean\"' '${tmp}/promotion.json' >/dev/null"
+check "promotion artifact records integer serving traffic" bash -c "jq -e '.currentServingTrafficPercent == 100 and (.currentServingTrafficPercent | type) == \"number\"' '${tmp}/promotion.json' >/dev/null"
+check "promotion artifact records integer Production health" bash -c "jq -e '.productionHealthStatus == 200 and (.productionHealthStatus | type) == \"number\"' '${tmp}/promotion.json' >/dev/null"
+check "promotion artifact records serving revision and immutable digest" bash -c "jq -e '.currentServingRevision == \"rentchain-landlord-api-01967-djh\" and (.digest | test(\"^sha256:[0-9a-f]{64}$\"))' '${tmp}/promotion.json' >/dev/null"
+
+jq '.ready = false' "${tmp}/human.json" > "${tmp}/invalid-ready.json"
+check "invalid candidate readiness fails closed" expect_promotion_failure "${tmp}/invalid-ready.json"
+jq '.trafficPercent = 1' "${tmp}/human.json" > "${tmp}/invalid-candidate-traffic.json"
+check "nonzero candidate traffic fails closed" expect_promotion_failure "${tmp}/invalid-candidate-traffic.json"
+jq '.templateParity = false' "${tmp}/human.json" > "${tmp}/invalid-template-parity.json"
+check "failed template parity fails closed" expect_promotion_failure "${tmp}/invalid-template-parity.json"
+jq '.productionHealthHttpStatus = 503' "${tmp}/human.json" > "${tmp}/invalid-health.json"
+check "non-200 Production health fails closed" expect_promotion_failure "${tmp}/invalid-health.json"
+jq 'del(.servingTrafficPercent)' "${tmp}/human.json" > "${tmp}/missing-serving-traffic.json"
+check "missing serving traffic fails closed" expect_promotion_failure "${tmp}/missing-serving-traffic.json"
+
+check "promotion artifact remains linked to exact candidate request" bash -c "jq -e '.candidateRequestId == \"candidate-123-1\" and .candidateRevision == \"rentchain-landlord-api-candidate-0123456789ab\"' '${tmp}/promotion.json' >/dev/null"
+check "promotion command remains revision pinned" contains "${tmp}/promotion.json" '--to-revisions=rentchain-landlord-api-candidate-0123456789ab=100'
+check "rollback command remains serving-revision pinned" contains "${tmp}/promotion.json" '--to-revisions=rentchain-landlord-api-01967-djh=100'
+check "corrected artifact records no traffic mutation" bash -c "jq -e '.trafficMutationPerformed == false and .noMutationStatement == \"NO TRAFFIC MUTATION PERFORMED\"' '${tmp}/promotion.json' >/dev/null"
+check "corrected workflow still executes no traffic update" not_contains "${promotion}" "gcloud run services update-traffic"
+check "corrected workflow executes no Cloud Run deploy" not_contains "${promotion}" "gcloud run deploy"
+check "corrected workflow has no Google authentication" not_contains "${promotion}" "google-github-actions/auth"
+check "corrected workflow has no OIDC write permission" not_contains "${promotion}" "id-token: write"
+check "corrected workflow has no environment binding" not_contains "${promotion}" "environment:"
+check "corrected workflow has no WIF or service-account variable" bash -c "! grep -Eq 'PRODUCTION_(WORKLOAD_IDENTITY_PROVIDER|DEPLOY|PROMOTION)_SERVICE_ACCOUNT' '${promotion}'"
+check "corrected scripts contain no eval" bash -c "! grep -Eq '(^|[[:space:]])eval([[:space:]]|$)' '${promotion_script}'"
+check "corrected scripts expose no apply or execute mode" bash -c "! grep -Eq -- '--(apply|execute)' '${promotion_script}'"
+check "generated promotion fixture contains no credential material" bash -c "! grep -Eq 'BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY|Bearer [A-Za-z0-9._-]{20,}|gho_[A-Za-z0-9]+|github_pat_[A-Za-z0-9_]+|private_key|access_token|refresh_token|password|secretValue' '${tmp}/promotion.json'"
+jq 'del(.candidateReady,.candidateTrafficPercent,.templateParityPassed,.currentServingTrafficPercent,.productionHealthStatus)' "${tmp}/promotion.json" > "${tmp}/prior-schema.json"
+check "prior failed promotion artifact fails corrected contract" bash -c "! jq -e '.candidateReady == true and .candidateTrafficPercent == 0 and .templateParityPassed == true and .currentServingTrafficPercent == 100 and .productionHealthStatus == 200' '${tmp}/prior-schema.json' >/dev/null"
+
+test "${pass}" -eq 66
 printf 'Human-admin Production pilot validation passed (%d boundaries).\n' "${pass}"


### PR DESCRIPTION
## Defect

Run `30777572943` completed without mutation, but uploaded artifact `8842555785` omitted:

- candidate readiness;
- candidate traffic percentage;
- template-parity result;
- serving traffic percentage;
- Production health status.

## Correction

- validated fields are serialized into `promotion-request.json`;
- missing or invalid evidence fails closed;
- generated commands remain inert;
- no cloud authentication or mutation capability is added.

## Regression coverage

The human-admin pilot guard now passes 66/66 boundaries. New failure coverage rejects false candidate readiness, nonzero candidate traffic, failed template parity, non-200 Production health, missing serving traffic, and the prior incomplete artifact schema.

## Boundaries

- no workflow rerun;
- no traffic update;
- no deployment;
- no rollback;
- no IAM/WIF/environment change;
- no Terraform apply;
- no Preview or Vercel configuration change;
- PR #1453 untouched;
- PR #1435 untouched.
