### PR TITLE
Exit nonzero on fatal backend startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Install backend dependencies
         run: npm ci
 
+      - name: Validate fatal startup exit semantics
+        run: npm run test:single -- src/process/__tests__/fatalStartup.test.ts
+
       - name: Build backend
         run: npm run build
 

--- a/docs/operations/production-human-admin-release-pilot.md
+++ b/docs/operations/production-human-admin-release-pilot.md
@@ -42,6 +42,10 @@ The earlier reference containing `/rentchain-api/rentchain-api@sha256:...` was i
 
 ## Candidate startup incident and correction
 
+### Rejected replacement digest: fatal startup exited successfully
+
+Cloud Build `5bb65876-f98e-4522-ac30-fd5d1976a3b6` published digest `sha256:ac1fdfb6bfe64473098db631a3daf54c4e9e950ac649fc10408f1f81259b3f7c`. Exact-image testing proved that missing or incorrect Production project configuration logged the expected fatal error but exited with status `0`, so the runtime contract failed and no private smoke service was deployed. This digest is ineligible for smoke, candidate deployment, or promotion and must not be retagged or overwritten. A corrected replacement image must be built only from a later merged SHA under separate authorization.
+
 Candidate `rentchain-landlord-api-candidate-0757e284c323` failed during the separately authorized promotion attempt on `2026-08-03`. Its process exited before listening on port 8080 with `Production requires GOOGLE_CLOUD_PROJECT to be explicitly configured.` The healthy revision `rentchain-landlord-api-01967-djh` remained at 100% traffic, the failed candidate returned to zero traffic, and the completed Production release counter remains zero. No promotion retry is authorized.
 
 The runtime guard is intentionally fail closed. Production must explicitly receive the non-secret configuration `GOOGLE_CLOUD_PROJECT=project-0d9658de-af29-4dc0-a99`. Root Terraform is not the authoritative owner for this correction: it still models an obsolete Montréal service and image with no live environment configuration. Applying that model could reintroduce unrelated service drift. Until full Terraform reconciliation is separately approved, the reviewed human-admin candidate command uses the additive `--update-env-vars` operation for this one value. It must never use `--set-env-vars`, `--clear-env-vars`, or `--env-vars-file`, because those operations replace or clear existing environment configuration.

--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -204,13 +204,6 @@ import riskAgentRoutes from "./routes/riskAgentRoutes";
 import decisionRoutes from "./routes/decisionRoutes";
 import attestationRoutes from "./routes/attestationRoutes";
 
-process.on("unhandledRejection", (reason) => {
-  console.error("[FATAL] unhandledRejection", reason);
-});
-process.on("uncaughtException", (err) => {
-  console.error("[FATAL] uncaughtException", err);
-});
-
 export const app = express();
 
 const pricingHealth = getPricingHealth();

--- a/rentchain-api/src/index.build.ts
+++ b/rentchain-api/src/index.build.ts
@@ -1,6 +1,7 @@
 console.log("[BOOT] index.build starting");
-process.on("uncaughtException", (e) => console.error("[FATAL] uncaughtException", e));
-process.on("unhandledRejection", (e) => console.error("[FATAL] unhandledRejection", e));
+import { installFatalStartupHandlers } from "./process/fatalStartup";
+
+installFatalStartupHandlers();
 
 import { app } from "./app.build";
 import { assertRequiredEnv } from "./config/requiredEnv";

--- a/rentchain-api/src/process/__tests__/fatalStartup.test.ts
+++ b/rentchain-api/src/process/__tests__/fatalStartup.test.ts
@@ -1,0 +1,64 @@
+import { EventEmitter } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+import { createFatalStartupHandler, installFatalStartupHandlers } from "../fatalStartup";
+
+class FakeProcess extends EventEmitter {
+  exitCode: string | number | undefined;
+}
+
+describe("fatal startup handling", () => {
+  it("sets a nonzero exit status and preserves the original error", () => {
+    const processLike = new FakeProcess();
+    const log = vi.fn();
+    const error = new Error("startup failed");
+
+    createFatalStartupHandler(processLike, log)("bootstrap", error);
+
+    expect(processLike.exitCode).toBe(1);
+    expect(log).toHaveBeenCalledWith("[FATAL] bootstrap", error);
+    expect(error.stack).toContain("startup failed");
+  });
+
+  it("overrides a prior success status and executes only once", () => {
+    const processLike = new FakeProcess();
+    processLike.exitCode = 0;
+    const log = vi.fn();
+    const fatal = createFatalStartupHandler(processLike, log);
+
+    fatal("uncaughtException", new Error("first"));
+    fatal("unhandledRejection", new Error("second"));
+
+    expect(processLike.exitCode).toBe(1);
+    expect(log).toHaveBeenCalledTimes(1);
+  });
+
+  it("sets failure before logging even when the logger throws", () => {
+    const processLike = new FakeProcess();
+    const fatal = createFatalStartupHandler(processLike, () => {
+      throw new Error("logger failure");
+    });
+
+    expect(() => fatal("bootstrap", new Error("startup failed"))).toThrow("logger failure");
+    expect(processLike.exitCode).toBe(1);
+  });
+
+  it("routes uncaught exceptions and rejections through one fatal path", () => {
+    const processLike = new FakeProcess();
+    const log = vi.fn();
+    installFatalStartupHandlers(processLike, log);
+
+    const original = new Error("configuration failure");
+    processLike.emit("uncaughtException", original);
+    processLike.emit("unhandledRejection", new Error("later failure"));
+
+    expect(processLike.exitCode).toBe(1);
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(log).toHaveBeenCalledWith("[FATAL] uncaughtException", original);
+  });
+
+  it("does not alter normal process status before a fatal event", () => {
+    const processLike = new FakeProcess();
+    installFatalStartupHandlers(processLike, vi.fn());
+    expect(processLike.exitCode).toBeUndefined();
+  });
+});

--- a/rentchain-api/src/process/fatalStartup.ts
+++ b/rentchain-api/src/process/fatalStartup.ts
@@ -1,0 +1,33 @@
+type FatalKind = "uncaughtException" | "unhandledRejection" | "bootstrap";
+
+type FatalProcess = Pick<NodeJS.Process, "on"> & {
+  exitCode?: string | number;
+};
+
+type FatalLogger = (message: string, error: unknown) => void;
+
+export function createFatalStartupHandler(
+  processLike: FatalProcess = process,
+  log: FatalLogger = console.error,
+) {
+  let handled = false;
+
+  return (kind: FatalKind, error: unknown): void => {
+    if (handled) return;
+    handled = true;
+
+    // Set the failure status before logging so logger failures cannot turn a
+    // fatal startup error into a successful process exit.
+    processLike.exitCode = 1;
+    log(`[FATAL] ${kind}`, error);
+  };
+}
+
+export function installFatalStartupHandlers(
+  processLike: FatalProcess = process,
+  log: FatalLogger = console.error,
+): void {
+  const fatal = createFatalStartupHandler(processLike, log);
+  processLike.on("uncaughtException", (error) => fatal("uncaughtException", error));
+  processLike.on("unhandledRejection", (error) => fatal("unhandledRejection", error));
+}

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
@@ -877,7 +877,7 @@ describe("LandlordLeaseWorkflowPage", () => {
     expect(sendReview).toHaveTextContent("Jane Tenant");
     expect(sendReview).toHaveTextContent("Tenant recipient reviewed");
     expect(sendReview).toHaveTextContent("Needs review");
-    const sendButton = screen.getByRole("button", { name: "Send renewal email" });
+    const sendButton = await screen.findByRole("button", { name: "Send renewal email" });
     expect(sendButton).toBeDisabled();
     fireEvent.click(sendButton);
     expect(mocks.saveRenewalNoticeDraftSnapshot).not.toHaveBeenCalled();

--- a/scripts/production-deployment/tests/validate-backend-image-runtime.sh
+++ b/scripts/production-deployment/tests/validate-backend-image-runtime.sh
@@ -27,6 +27,7 @@ else
 fi
 
 common_env=(
+  --platform linux/amd64
   --env APP_ENV=production
   --env NODE_ENV=production
   --env PORT=8080
@@ -45,10 +46,18 @@ common_env=(
   --env EMAIL_FROM=runtime@runtime.test.invalid
 )
 
-docker run --name "${missing_name}" "${common_env[@]}" "${image}" >"${tmp}/missing-project.log" 2>&1 || true
+set +e
+docker run --name "${missing_name}" "${common_env[@]}" "${image}" >"${tmp}/missing-project.log" 2>&1
+missing_status=$?
+set -e
+test "${missing_status}" -ne 0
 grep -Fq 'Production requires GOOGLE_CLOUD_PROJECT to be explicitly configured.' "${tmp}/missing-project.log"
 
-docker run --name "${wrong_name}" "${common_env[@]}" --env GOOGLE_CLOUD_PROJECT=rentchain-preview "${image}" >"${tmp}/wrong-project.log" 2>&1 || true
+set +e
+docker run --name "${wrong_name}" "${common_env[@]}" --env GOOGLE_CLOUD_PROJECT=rentchain-preview "${image}" >"${tmp}/wrong-project.log" 2>&1
+wrong_status=$?
+set -e
+test "${wrong_status}" -ne 0
 grep -Fq 'Production must target the approved production project.' "${tmp}/wrong-project.log"
 
 docker run --detach --name "${name}" --publish 127.0.0.1::8080 "${common_env[@]}" --env GOOGLE_CLOUD_PROJECT="${project}" "${image}" >/dev/null

--- a/scripts/production-deployment/tests/validate-human-admin-pilot.sh
+++ b/scripts/production-deployment/tests/validate-human-admin-pilot.sh
@@ -8,6 +8,8 @@ candidate_script="${root}/scripts/production-deployment/prepare-human-candidate.
 promotion_script="${root}/scripts/production-deployment/prepare-human-promotion.sh"
 runbook="${root}/docs/operations/production-human-admin-release-pilot.md"
 decisions="${root}/docs/operations/production-release-control-founder-decisions.md"
+runtime_contract="${root}/scripts/production-deployment/tests/validate-backend-image-runtime.sh"
+fatal_handler="${root}/rentchain-api/src/process/fatalStartup.ts"
 
 pass=0
 check() {
@@ -137,5 +139,13 @@ check "generated promotion fixture contains no credential material" bash -c "! g
 jq 'del(.candidateReady,.candidateTrafficPercent,.templateParityPassed,.candidateInstanceStarted,.candidateSmokeMethod,.candidateSmokeHttpStatus,.candidateSmokePath,.candidateSmokeDigestVerified,.candidateStartupLogObserved,.candidateStartupError,.currentServingTrafficPercent,.productionHealthStatus)' "${tmp}/promotion.json" > "${tmp}/prior-schema.json"
 check "prior failed promotion artifact fails corrected contract" bash -c "! jq -e '.candidateReady == true and .candidateTrafficPercent == 0 and .templateParityPassed == true and .currentServingTrafficPercent == 100 and .productionHealthStatus == 200' '${tmp}/prior-schema.json' >/dev/null"
 
-test "${pass}" -eq 80
+check "fatal startup sets a nonzero exit status" contains "${fatal_handler}" "processLike.exitCode = 1"
+check "missing project rejects a zero exit" contains "${runtime_contract}" 'test "${missing_status}" -ne 0'
+check "incorrect project rejects a zero exit" contains "${runtime_contract}" 'test "${wrong_status}" -ne 0'
+check "successful startup still requires HTTP 200" contains "${runtime_contract}" 'test "${status}" = 200'
+check "runtime contract uses amd64 explicitly" contains "${runtime_contract}" "--platform linux/amd64"
+check "rejected digest remains ineligible" contains "${runbook}" "ineligible for smoke, candidate deployment, or promotion"
+check "runtime correction introduces no deploy command" not_contains "${runtime_contract}" "gcloud run deploy"
+
+test "${pass}" -eq 87
 printf 'Human-admin Production pilot validation passed (%d boundaries).\n' "${pass}"


### PR DESCRIPTION
## Defect

The replacement image logged fatal startup configuration errors but exited with code `0`.

## Impact

- The runtime-contract gate failed.
- Private smoke deployment was blocked.
- Digest `sha256:ac1fdfb6bfe64473098db631a3daf54c4e9e950ac649fc10408f1f81259b3f7c` is rejected for smoke, candidate, or promotion.

## Correction

- Fatal startup exits nonzero through one idempotent handler.
- Successful startup remains unchanged.
- Missing and incorrect project configuration fail closed.
- Correct project configuration starts, listens on port 8080, and passes `/health`.

## Validation

- Focused fatal-startup and runtime-environment tests: 9 passed.
- Corrected local `linux/amd64` image: missing project exit 1; incorrect project exit 1; configured startup and HTTP 200 passed.
- Backend build passed.
- Full backend comparison: branch 2,997 passed / 32 unrelated failures; pinned base 2,992 passed / the same 32 failures.
- Runtime-contract test passed.
- Governance guards: 87/20/20/20/20/32 passed.
- Shell syntax and workflow YAML passed.
- Terraform init with backend disabled and validation passed.
- Changed-diff credential and mutation scans passed.

## Boundaries

- No build or image publication.
- No smoke service.
- No Production deployment or traffic change.
- No Terraform apply.
- No Preview mutation.
- PR #1453 and PR #1435 untouched.
