### PR TITLE
Stabilize Terraform and LeaseLedger validation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@
 
 resource "google_storage_bucket" "reports" {
   name          = "${var.project_id}-reports-bucket"
-  location      = "NORTHAMERICA-NORTHEAST1"  // Montréal region (Canada)
+  location      = "NORTHAMERICA-NORTHEAST1" // Montréal region (Canada)
   storage_class = "STANDARD"
 
   uniform_bucket_level_access = true
@@ -24,7 +24,7 @@ resource "google_storage_bucket" "audit_logs" {
       type = "Delete"
     }
     condition {
-      age = 365  # keep audit logs for 1 year
+      age = 365 # keep audit logs for 1 year
     }
   }
 }

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
@@ -754,7 +754,7 @@ describe("LeaseLedgerPage", () => {
     expect(
       screen.getByText("Obligation status is financial truth from payments and reconciliation. Decision workflow actions do not change these values.")
     ).toBeInTheDocument();
-    expect(screen.getByRole("columnheader", { name: "Financial status" })).toBeInTheDocument();
+    expect(await screen.findByRole("columnheader", { name: "Financial status" })).toBeInTheDocument();
     expect(screen.getByRole("columnheader", { name: "Financial signal" })).toBeInTheDocument();
     expect(screen.getByLabelText("Payment obligation cards")).toBeInTheDocument();
     expect(screen.queryByRole("columnheader", { name: "Status" })).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary

- normalize the two root Terraform comment-spacing differences reported by `terraform fmt -check -recursive`
- wait for the first data-dependent LeaseLedger table header before making synchronous assertions

## Root cause

The root Terraform file predated current formatter alignment, so the repository-wide formatting check failed despite no semantic configuration difference. The LeaseLedger test waited for the always-present section heading and then queried asynchronously loaded table content synchronously, allowing the full suite to catch a loading-state race.

## Impact

This changes no Terraform semantics and no product behavior. It makes repository validation deterministic without weakening the LeaseLedger assertions.

## Validation

- `terraform fmt -check -recursive`
- `terraform init -backend=false`
- `terraform validate`
- `terraform -chdir=infra/environments/preview-foundation validate`
- focused LeaseLedger file repeated 10 times: 210/210 assertions passed
- CI-equivalent frontend suite: 1,645/1,645 tests passed
- frontend production build passed
- backend fatal-startup suite: 5/5 passed
- backend TypeScript build passed
- immutable-image runtime contract passed locally
- Production deployment governance guard: 32/32 boundaries passed
- `git diff --check`

No Production, Preview, Vercel, HCP Terraform, IAM, traffic, image, or deployment mutation occurred.
