### PR TITLE
Add Preview Firestore indexes for Unified Inbox QA

### DIFF
--- a/rentchain-api/firestore.indexes.json
+++ b/rentchain-api/firestore.indexes.json
@@ -388,6 +388,24 @@
         { "fieldPath": "createdAt", "order": "DESCENDING" },
         { "fieldPath": "__name__", "order": "DESCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "conversations",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "landlordId", "order": "ASCENDING" },
+        { "fieldPath": "lastMessageAt", "order": "DESCENDING" },
+        { "fieldPath": "__name__", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "messages",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "conversationId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" },
+        { "fieldPath": "__name__", "order": "DESCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []


### PR DESCRIPTION
## Purpose

Unblock the two composite-index failures encountered during governed PR #1435 Preview QA.

## Exact Preview-only indexes

- `conversations`: `landlordId ASC`, `lastMessageAt DESC`, `__name__ DESC`
- `messages`: `conversationId ASC`, `createdAt DESC`, `__name__ DESC`

Both use collection query scope and target `projects/rentchain-preview/databases/(default)` when deployed through the governed Preview-only release step.

## Containment

- Production is untouched.
- No index deletion or Firestore data mutation.
- No Firestore rules, Cloud Run, IAM, secret, Vercel, application, or Terraform resource change.
- Deployment remains separately gated until review and all substantive checks complete.

## Validation

- JSON parse and exact-definition checks passed.
- Existing 27 index entries and field overrides preserved; exactly two unique definitions added.
- Terraform init/validate/fmt checks passed; no plan or apply.
- Preview PR-head governance: 36/36.
- Production deployment governance: 32/32.
- `git diff --check`, credential scan, and mutation scan passed.
