### PR TITLE
Restore scoped Unified Inbox operational projections

### DIFF
--- a/rentchain-api/src/middleware/__tests__/previewQaAuth.test.ts
+++ b/rentchain-api/src/middleware/__tests__/previewQaAuth.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  PREVIEW_QA_IDENTITY_ALIAS,
+  PREVIEW_QA_LANDLORD_ID,
+  decidePreviewQaAuth,
+  isPreviewQaAuthenticatedRequest,
+  previewQaAuth,
+} from "../previewQaAuth";
+
+const enabledEnv = {
+  PREVIEW_QA_AUTH_ENABLED: "true",
+  PREVIEW_QA_AUTH_SCOPE: "pr1509-unified-inbox",
+  APP_ENV: "preview",
+  GOOGLE_CLOUD_PROJECT: "rentchain-preview",
+  K_SERVICE: "rentchain-pr1509-inbox-qa-b82c9914",
+  FIRESTORE_ENABLED: "true",
+  FIRESTORE_DATABASE_ID: "(default)",
+} as NodeJS.ProcessEnv;
+
+function decide(overrides: Partial<Parameters<typeof decidePreviewQaAuth>[0]> = {}) {
+  return decidePreviewQaAuth({
+    env: enabledEnv,
+    method: "GET",
+    route: "landlord-inbox",
+    selector: PREVIEW_QA_IDENTITY_ALIAS,
+    authorizationPresent: false,
+    ...overrides,
+  });
+}
+
+function invoke(options: {
+  env?: NodeJS.ProcessEnv;
+  method?: string;
+  selector?: string;
+  authorization?: string;
+  headers?: Record<string, string>;
+} = {}) {
+  process.env = { ...options.env };
+  const headers: Record<string, string> = { ...(options.headers || {}) };
+  if (options.selector !== undefined) headers["x-rentchain-preview-qa-identity"] = options.selector;
+  if (options.authorization !== undefined) headers.authorization = options.authorization;
+  const req: any = {
+    method: options.method || "GET",
+    header(name: string) {
+      return headers[name.toLowerCase()];
+    },
+  };
+  let status = 200;
+  let body: unknown;
+  let nextCalled = false;
+  const res: any = {
+    status(code: number) {
+      status = code;
+      return this;
+    },
+    json(value: unknown) {
+      body = value;
+      return this;
+    },
+  };
+  previewQaAuth("landlord-inbox")(req, res, () => {
+    nextCalled = true;
+  });
+  return { req, status, body, nextCalled };
+}
+
+describe("previewQaAuth", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("allows only the fixed synthetic landlord under every isolated Preview QA guard", () => {
+    const result = invoke({ env: enabledEnv, selector: PREVIEW_QA_IDENTITY_ALIAS });
+
+    expect(result.nextCalled).toBe(true);
+    expect(isPreviewQaAuthenticatedRequest(result.req)).toBe(true);
+    expect(result.req.user).toMatchObject({
+      id: PREVIEW_QA_LANDLORD_ID,
+      landlordId: PREVIEW_QA_LANDLORD_ID,
+      role: "landlord",
+      plan: "starter",
+      capabilities: ["messaging"],
+    });
+  });
+
+  it.each([
+    ["missing flag", { ...enabledEnv, PREVIEW_QA_AUTH_ENABLED: undefined }],
+    ["false flag", { ...enabledEnv, PREVIEW_QA_AUTH_ENABLED: "false" }],
+    ["malformed flag", { ...enabledEnv, PREVIEW_QA_AUTH_ENABLED: "yes" }],
+    ["missing scope", { ...enabledEnv, PREVIEW_QA_AUTH_SCOPE: undefined }],
+    ["wrong scope", { ...enabledEnv, PREVIEW_QA_AUTH_SCOPE: "other" }],
+    ["missing project", { ...enabledEnv, GOOGLE_CLOUD_PROJECT: undefined }],
+    ["wrong project", { ...enabledEnv, GOOGLE_CLOUD_PROJECT: "other-preview" }],
+    ["Production project", { ...enabledEnv, GOOGLE_CLOUD_PROJECT: "project-0d9658de-af29-4dc0-a99" }],
+    ["unsupported environment", { ...enabledEnv, APP_ENV: "production" }],
+    ["wrong service", { ...enabledEnv, K_SERVICE: "rentchain-preview-backend" }],
+    ["Firestore disabled", { ...enabledEnv, FIRESTORE_ENABLED: "false" }],
+    ["wrong database", { ...enabledEnv, FIRESTORE_DATABASE_ID: "other" }],
+  ])("rejects the selector with %s", (_label, env) => {
+    expect(decide({ env })).toEqual({ kind: "reject" });
+  });
+
+  it.each([
+    ["true", PREVIEW_QA_IDENTITY_ALIAS],
+    ["false", PREVIEW_QA_IDENTITY_ALIAS],
+    ["malformed", PREVIEW_QA_IDENTITY_ALIAS],
+    ["true", "unknown"],
+    ["false", "unknown"],
+  ])("hard-locks Production with flag %s and selector %s", (flag, selector) => {
+    expect(decide({
+      env: {
+        ...enabledEnv,
+        PREVIEW_QA_AUTH_ENABLED: flag,
+        GOOGLE_CLOUD_PROJECT: "project-0d9658de-af29-4dc0-a99",
+      },
+      selector,
+    })).toEqual({ kind: "reject" });
+  });
+
+  it.each(["", "unknown", "qa-pr1509-landlord", "pr1509-landlord ", "PR1509-LANDLORD"])(
+    "rejects non-allowlisted or malformed selector %j",
+    (selector) => {
+      expect(decide({ selector })).toEqual(selector ? { kind: "reject" } : { kind: "continue-normal-auth" });
+    }
+  );
+
+  it("never accepts write methods", () => {
+    for (const method of ["POST", "PUT", "PATCH", "DELETE"]) {
+      expect(decide({ method })).toEqual({ kind: "reject" });
+    }
+  });
+
+  it("does not allow caller-supplied role or landlord headers to affect identity", () => {
+    const result = invoke({
+      env: enabledEnv,
+      selector: PREVIEW_QA_IDENTITY_ALIAS,
+      headers: { "x-landlord-id": "arbitrary", "x-role": "admin" },
+    });
+    expect(result.req.user.landlordId).toBe(PREVIEW_QA_LANDLORD_ID);
+    expect(result.req.user.role).toBe("landlord");
+  });
+
+  it("preserves bearer-token precedence and never falls through to QA after JWT failure", () => {
+    const result = invoke({
+      env: enabledEnv,
+      selector: PREVIEW_QA_IDENTITY_ALIAS,
+      authorization: "Bearer invalid-token",
+    });
+    expect(result.nextCalled).toBe(true);
+    expect(isPreviewQaAuthenticatedRequest(result.req)).toBe(false);
+    expect(result.req.user).toBeUndefined();
+  });
+
+  it("ignores the mechanism entirely when no QA selector is supplied", () => {
+    const result = invoke({ env: enabledEnv });
+    expect(result.nextCalled).toBe(true);
+    expect(isPreviewQaAuthenticatedRequest(result.req)).toBe(false);
+  });
+});

--- a/rentchain-api/src/middleware/__tests__/previewQaAuth.test.ts
+++ b/rentchain-api/src/middleware/__tests__/previewQaAuth.test.ts
@@ -12,7 +12,8 @@ const enabledEnv = {
   PREVIEW_QA_AUTH_SCOPE: "pr1509-unified-inbox",
   APP_ENV: "preview",
   GOOGLE_CLOUD_PROJECT: "rentchain-preview",
-  K_SERVICE: "rentchain-pr1509-inbox-qa-b82c9914",
+  K_SERVICE: "rentchain-pr1509-inbox-qa-4605bba7",
+  PREVIEW_QA_EXPECTED_SERVICE: "rentchain-pr1509-inbox-qa-4605bba7",
   FIRESTORE_ENABLED: "true",
   FIRESTORE_DATABASE_ID: "(default)",
 } as NodeJS.ProcessEnv;
@@ -99,7 +100,12 @@ describe("previewQaAuth", () => {
     ["wrong project", { ...enabledEnv, GOOGLE_CLOUD_PROJECT: "other-preview" }],
     ["Production project", { ...enabledEnv, GOOGLE_CLOUD_PROJECT: "project-0d9658de-af29-4dc0-a99" }],
     ["unsupported environment", { ...enabledEnv, APP_ENV: "production" }],
-    ["wrong service", { ...enabledEnv, K_SERVICE: "rentchain-preview-backend" }],
+    ["missing expected service", { ...enabledEnv, PREVIEW_QA_EXPECTED_SERVICE: undefined }],
+    ["malformed expected service", { ...enabledEnv, PREVIEW_QA_EXPECTED_SERVICE: "rentchain-pr1509-inbox-qa-head4605" }],
+    ["uppercase suffix", { ...enabledEnv, PREVIEW_QA_EXPECTED_SERVICE: "rentchain-pr1509-inbox-qa-4605BBA7" }],
+    ["arbitrary service", { ...enabledEnv, K_SERVICE: "rentchain-pr1509-other-qa-4605bba7" }],
+    ["stale service", { ...enabledEnv, K_SERVICE: "rentchain-pr1509-inbox-qa-b82c9914" }],
+    ["permanent Preview service", { ...enabledEnv, K_SERVICE: "rentchain-preview-backend" }],
     ["Firestore disabled", { ...enabledEnv, FIRESTORE_ENABLED: "false" }],
     ["wrong database", { ...enabledEnv, FIRESTORE_DATABASE_ID: "other" }],
   ])("rejects the selector with %s", (_label, env) => {

--- a/rentchain-api/src/middleware/__tests__/previewQaAuthRouteScope.test.ts
+++ b/rentchain-api/src/middleware/__tests__/previewQaAuthRouteScope.test.ts
@@ -1,0 +1,169 @@
+import { readFileSync } from "node:fs";
+import jwt from "jsonwebtoken";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { requireAuth } from "../requireAuth";
+import { requireLandlord } from "../requireLandlord";
+import { PREVIEW_QA_IDENTITY_ALIAS, previewQaAuth } from "../previewQaAuth";
+
+vi.mock("../../services/sessionUserService", () => ({
+  buildCanonicalSessionUserFromClaims: async (claims: any) => ({
+    id: claims.sub,
+    email: claims.email,
+    role: claims.role,
+    landlordId: claims.landlordId,
+    plan: "starter",
+    capabilities: ["messaging"],
+    entitlements: {
+      userId: claims.sub,
+      role: claims.role,
+      plan: "starter",
+      capabilities: ["messaging"],
+      landlordId: claims.landlordId,
+    },
+  }),
+}));
+
+const originalEnv = process.env;
+
+function enabledQaEnv() {
+  process.env = {
+    ...originalEnv,
+    PREVIEW_QA_AUTH_ENABLED: "true",
+    PREVIEW_QA_AUTH_SCOPE: "pr1509-unified-inbox",
+    APP_ENV: "preview",
+    GOOGLE_CLOUD_PROJECT: "rentchain-preview",
+    K_SERVICE: "rentchain-pr1509-inbox-qa-b82c9914",
+    FIRESTORE_ENABLED: "true",
+    FIRESTORE_DATABASE_ID: "(default)",
+  };
+  delete process.env.JWT_SECRET;
+}
+
+async function invoke(options: {
+  method?: string;
+  selector?: string;
+  authorization?: string;
+  useQaMiddleware?: boolean;
+  route?: "landlord-inbox" | "landlord-message-list" | "landlord-message-detail";
+}) {
+  const headers: Record<string, string> = {};
+  if (options.selector) headers["x-rentchain-preview-qa-identity"] = options.selector;
+  if (options.authorization) headers.authorization = options.authorization;
+  const req: any = {
+    method: options.method || "GET",
+    headers,
+    header(name: string) {
+      return headers[name.toLowerCase()];
+    },
+  };
+
+  return await new Promise<{ status: number; body: any; req: any }>((resolve, reject) => {
+    let status = 200;
+    const res: any = {
+      status(code: number) {
+        status = code;
+        return this;
+      },
+      json(body: unknown) {
+        resolve({ status, body, req });
+        return this;
+      },
+    };
+    const finish = () => res.json({ ok: true, user: req.user });
+    const authorize = () => Promise.resolve(requireLandlord(req, res, finish)).catch(reject);
+    if (options.useQaMiddleware) {
+      previewQaAuth(options.route || "landlord-inbox")(req, res, authorize);
+    } else {
+      Promise.resolve(requireAuth(req, res, authorize)).catch(reject);
+    }
+  });
+}
+
+describe("Preview QA auth route scope", () => {
+  beforeEach(enabledQaEnv);
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it.each([
+    "landlord-inbox",
+    "landlord-message-list",
+    "landlord-message-detail",
+  ] as const)("establishes only the fixed synthetic landlord on %s", async (route) => {
+    const result = await invoke({
+      selector: PREVIEW_QA_IDENTITY_ALIAS,
+      useQaMiddleware: true,
+      route,
+    });
+    expect(result.status).toBe(200);
+    expect(result.body.user).toMatchObject({
+      id: "qa-pr1509-landlord",
+      landlordId: "qa-pr1509-landlord",
+      role: "landlord",
+    });
+  });
+
+  it.each(["POST", "PUT", "PATCH", "DELETE"])("rejects %s even if QA middleware is misapplied", async (method) => {
+    const result = await invoke({
+      method,
+      selector: PREVIEW_QA_IDENTITY_ALIAS,
+      useQaMiddleware: true,
+    });
+    expect(result.status).toBe(401);
+    expect(result.body).toMatchObject({ ok: false, error: "unauthenticated" });
+  });
+
+  it("does not enable a representative write route that lacks the QA middleware", async () => {
+    const result = await invoke({ method: "POST", selector: PREVIEW_QA_IDENTITY_ALIAS });
+    expect(result.status).toBe(401);
+    expect(result.body).toMatchObject({ ok: false, error: "unauthenticated" });
+  });
+
+  it("does not reinterpret an invalid bearer token as the synthetic identity", async () => {
+    const result = await invoke({
+      selector: PREVIEW_QA_IDENTITY_ALIAS,
+      authorization: "Bearer invalid-token",
+      useQaMiddleware: true,
+    });
+    expect(result.status).toBe(401);
+    expect(result.body).toMatchObject({ ok: false, error: "unauthenticated" });
+  });
+
+  it("keeps missing JWT_SECRET fail-closed when QA auth is disabled", async () => {
+    process.env.PREVIEW_QA_AUTH_ENABLED = "false";
+    const result = await invoke({ selector: PREVIEW_QA_IDENTITY_ALIAS, useQaMiddleware: true });
+    expect(result.status).toBe(401);
+  });
+
+  it("preserves the normal valid bearer path when no QA selector is present", async () => {
+    process.env.JWT_SECRET = "preview-qa-auth-test-only";
+    const token = jwt.sign({
+      sub: "normal-landlord",
+      email: "normal-landlord@example.invalid",
+      role: "landlord",
+      landlordId: "normal-landlord",
+      ver: 1,
+    }, process.env.JWT_SECRET);
+    const result = await invoke({ authorization: `Bearer ${token}` });
+    expect(result.status).toBe(200);
+    expect(result.body.user).toMatchObject({
+      id: "normal-landlord",
+      landlordId: "normal-landlord",
+      role: "landlord",
+    });
+  });
+
+  it("wires QA auth only to the three approved GET handlers", () => {
+    const inboxSource = readFileSync(new URL("../../routes/landlordInboxRoutes.ts", import.meta.url), "utf8");
+    const messagesSource = readFileSync(new URL("../../routes/messagesRoutes.ts", import.meta.url), "utf8");
+    expect(inboxSource).toContain('router.get("/inbox", previewQaAuth("landlord-inbox")');
+    expect(inboxSource).not.toMatch(/router\.post\([^\n]+previewQaAuth/);
+    expect(messagesSource).toContain(
+      'router.get("/landlord/messages/conversations", previewQaAuth("landlord-message-list")'
+    );
+    expect(messagesSource).toContain(
+      'router.get("/landlord/messages/conversations/:id", previewQaAuth("landlord-message-detail")'
+    );
+    expect(messagesSource).not.toMatch(/router\.post\([^\n]+previewQaAuth/);
+  });
+});

--- a/rentchain-api/src/middleware/__tests__/previewQaAuthRouteScope.test.ts
+++ b/rentchain-api/src/middleware/__tests__/previewQaAuthRouteScope.test.ts
@@ -154,9 +154,10 @@ describe("Preview QA auth route scope", () => {
     });
   });
 
-  it("wires QA auth only to the three approved GET handlers", () => {
+  it("wires QA auth only to the three approved GET operations, including preempting public routes", () => {
     const inboxSource = readFileSync(new URL("../../routes/landlordInboxRoutes.ts", import.meta.url), "utf8");
     const messagesSource = readFileSync(new URL("../../routes/messagesRoutes.ts", import.meta.url), "utf8");
+    const publicSource = readFileSync(new URL("../../routes/publicRoutes.ts", import.meta.url), "utf8");
     expect(inboxSource).toContain('router.get("/inbox", previewQaAuth("landlord-inbox")');
     expect(inboxSource).not.toMatch(/router\.post\([^\n]+previewQaAuth/);
     expect(messagesSource).toContain(
@@ -166,5 +167,12 @@ describe("Preview QA auth route scope", () => {
       'router.get("/landlord/messages/conversations/:id", previewQaAuth("landlord-message-detail")'
     );
     expect(messagesSource).not.toMatch(/router\.post\([^\n]+previewQaAuth/);
+    expect(publicSource).toMatch(
+      /router\.get\(\s*"\/landlord\/messages\/conversations",\s*previewQaAuth\("landlord-message-list"\)/
+    );
+    expect(publicSource).toMatch(
+      /router\.get\(\s*"\/landlord\/messages\/conversations\/:id",\s*previewQaAuth\("landlord-message-detail"\)/
+    );
+    expect(publicSource).not.toMatch(/router\.post\([\s\S]{0,160}?previewQaAuth/);
   });
 });

--- a/rentchain-api/src/middleware/__tests__/previewQaAuthRouteScope.test.ts
+++ b/rentchain-api/src/middleware/__tests__/previewQaAuthRouteScope.test.ts
@@ -32,7 +32,8 @@ function enabledQaEnv() {
     PREVIEW_QA_AUTH_SCOPE: "pr1509-unified-inbox",
     APP_ENV: "preview",
     GOOGLE_CLOUD_PROJECT: "rentchain-preview",
-    K_SERVICE: "rentchain-pr1509-inbox-qa-b82c9914",
+    K_SERVICE: "rentchain-pr1509-inbox-qa-4605bba7",
+    PREVIEW_QA_EXPECTED_SERVICE: "rentchain-pr1509-inbox-qa-4605bba7",
     FIRESTORE_ENABLED: "true",
     FIRESTORE_DATABASE_ID: "(default)",
   };

--- a/rentchain-api/src/middleware/previewQaAuth.ts
+++ b/rentchain-api/src/middleware/previewQaAuth.ts
@@ -1,0 +1,107 @@
+import type { RequestHandler } from "express";
+import type { UserEntitlements } from "../services/entitlementsService";
+
+export const PREVIEW_QA_IDENTITY_HEADER = "x-rentchain-preview-qa-identity";
+export const PREVIEW_QA_IDENTITY_ALIAS = "pr1509-landlord";
+export const PREVIEW_QA_LANDLORD_ID = "qa-pr1509-landlord";
+
+const PREVIEW_PROJECT_ID = "rentchain-preview";
+const PREVIEW_QA_SERVICE = "rentchain-pr1509-inbox-qa-b82c9914";
+const PREVIEW_QA_SCOPE = "pr1509-unified-inbox";
+const previewQaAuthenticated = Symbol("previewQaAuthenticated");
+
+export type PreviewQaRoute = "landlord-inbox" | "landlord-message-list" | "landlord-message-detail";
+
+type PreviewQaDecision =
+  | { kind: "continue-normal-auth" }
+  | { kind: "reject" }
+  | { kind: "allow" };
+
+type PreviewQaDecisionInput = {
+  env: NodeJS.ProcessEnv;
+  method: string;
+  route: PreviewQaRoute;
+  selector: string;
+  authorizationPresent: boolean;
+};
+
+function isSupportedRoute(route: string): route is PreviewQaRoute {
+  return route === "landlord-inbox" || route === "landlord-message-list" || route === "landlord-message-detail";
+}
+
+export function decidePreviewQaAuth(input: PreviewQaDecisionInput): PreviewQaDecision {
+  if (!input.selector) return { kind: "continue-normal-auth" };
+  if (input.authorizationPresent) return { kind: "continue-normal-auth" };
+
+  const projectId = String(input.env.GOOGLE_CLOUD_PROJECT || input.env.GCLOUD_PROJECT || "").trim();
+  const appEnvironment = String(input.env.APP_ENV || "").trim().toLowerCase();
+  const enabled = String(input.env.PREVIEW_QA_AUTH_ENABLED || "").trim().toLowerCase();
+  const scope = String(input.env.PREVIEW_QA_AUTH_SCOPE || "").trim();
+  const service = String(input.env.K_SERVICE || "").trim();
+  const firestoreEnabled = String(input.env.FIRESTORE_ENABLED || "").trim().toLowerCase();
+  const firestoreDatabaseId = String(input.env.FIRESTORE_DATABASE_ID || "").trim();
+
+  const isolatedPreviewQa =
+    enabled === "true" &&
+    scope === PREVIEW_QA_SCOPE &&
+    appEnvironment === "preview" &&
+    projectId === PREVIEW_PROJECT_ID &&
+    service === PREVIEW_QA_SERVICE &&
+    firestoreEnabled === "true" &&
+    firestoreDatabaseId === "(default)";
+
+  if (!isolatedPreviewQa) return { kind: "reject" };
+  if (input.method.toUpperCase() !== "GET" || !isSupportedRoute(input.route)) return { kind: "reject" };
+  if (input.selector !== PREVIEW_QA_IDENTITY_ALIAS) return { kind: "reject" };
+  return { kind: "allow" };
+}
+
+function syntheticLandlordEntitlements(): UserEntitlements {
+  return {
+    userId: PREVIEW_QA_LANDLORD_ID,
+    role: "landlord",
+    plan: "starter",
+    capabilities: ["messaging"],
+    landlordId: PREVIEW_QA_LANDLORD_ID,
+  };
+}
+
+export function previewQaAuth(route: PreviewQaRoute): RequestHandler {
+  return (req, res, next) => {
+    const readHeader = (name: string) => {
+      if (typeof req.header === "function") return req.header(name);
+      return (req.headers as Record<string, string | string[] | undefined> | undefined)?.[name.toLowerCase()];
+    };
+    const selector = String(readHeader(PREVIEW_QA_IDENTITY_HEADER) || "").trim();
+    const decision = decidePreviewQaAuth({
+      env: process.env,
+      method: req.method,
+      route,
+      selector,
+      authorizationPresent: Boolean(String(readHeader("authorization") || "").trim()),
+    });
+
+    if (decision.kind === "continue-normal-auth") return next();
+    if (decision.kind === "reject") {
+      return res.status(401).json({ ok: false, error: "unauthenticated" });
+    }
+
+    const entitlements = syntheticLandlordEntitlements();
+    (req as any).user = {
+      id: PREVIEW_QA_LANDLORD_ID,
+      email: "qa-pr1509-landlord@example.invalid",
+      role: "landlord",
+      landlordId: PREVIEW_QA_LANDLORD_ID,
+      plan: "starter",
+      capabilities: [...entitlements.capabilities],
+      entitlements,
+    };
+    (req as any).entitlements = entitlements;
+    (req as any)[previewQaAuthenticated] = true;
+    return next();
+  };
+}
+
+export function isPreviewQaAuthenticatedRequest(req: unknown): boolean {
+  return Boolean(req && typeof req === "object" && (req as any)[previewQaAuthenticated] === true);
+}

--- a/rentchain-api/src/middleware/previewQaAuth.ts
+++ b/rentchain-api/src/middleware/previewQaAuth.ts
@@ -6,7 +6,9 @@ export const PREVIEW_QA_IDENTITY_ALIAS = "pr1509-landlord";
 export const PREVIEW_QA_LANDLORD_ID = "qa-pr1509-landlord";
 
 const PREVIEW_PROJECT_ID = "rentchain-preview";
-const PREVIEW_QA_SERVICE = "rentchain-pr1509-inbox-qa-b82c9914";
+const PRODUCTION_PROJECT_ID = "project-0d9658de-af29-4dc0-a99";
+const PERMANENT_PREVIEW_SERVICE = "rentchain-preview-backend";
+const PREVIEW_QA_SERVICE_PATTERN = /^rentchain-pr1509-inbox-qa-[a-f0-9]{8}$/;
 const PREVIEW_QA_SCOPE = "pr1509-unified-inbox";
 const previewQaAuthenticated = Symbol("previewQaAuthenticated");
 
@@ -38,6 +40,7 @@ export function decidePreviewQaAuth(input: PreviewQaDecisionInput): PreviewQaDec
   const enabled = String(input.env.PREVIEW_QA_AUTH_ENABLED || "").trim().toLowerCase();
   const scope = String(input.env.PREVIEW_QA_AUTH_SCOPE || "").trim();
   const service = String(input.env.K_SERVICE || "").trim();
+  const expectedService = String(input.env.PREVIEW_QA_EXPECTED_SERVICE || "").trim();
   const firestoreEnabled = String(input.env.FIRESTORE_ENABLED || "").trim().toLowerCase();
   const firestoreDatabaseId = String(input.env.FIRESTORE_DATABASE_ID || "").trim();
 
@@ -45,8 +48,12 @@ export function decidePreviewQaAuth(input: PreviewQaDecisionInput): PreviewQaDec
     enabled === "true" &&
     scope === PREVIEW_QA_SCOPE &&
     appEnvironment === "preview" &&
+    projectId !== PRODUCTION_PROJECT_ID &&
     projectId === PREVIEW_PROJECT_ID &&
-    service === PREVIEW_QA_SERVICE &&
+    service !== PERMANENT_PREVIEW_SERVICE &&
+    expectedService !== PERMANENT_PREVIEW_SERVICE &&
+    PREVIEW_QA_SERVICE_PATTERN.test(expectedService) &&
+    service === expectedService &&
     firestoreEnabled === "true" &&
     firestoreDatabaseId === "(default)";
 

--- a/rentchain-api/src/middleware/requireAuth.ts
+++ b/rentchain-api/src/middleware/requireAuth.ts
@@ -1,6 +1,7 @@
 import type { Request, Response, NextFunction } from "express";
 import { verifyAuthToken, type JwtClaimsV1 } from "../auth/jwt";
 import { buildCanonicalSessionUserFromClaims } from "../services/sessionUserService";
+import { isPreviewQaAuthenticatedRequest } from "./previewQaAuth";
 
 function getBearerToken(req: any): string | null {
   const raw = req.headers?.authorization || req.headers?.Authorization;
@@ -11,6 +12,10 @@ function getBearerToken(req: any): string | null {
 
 export async function requireAuth(req: any, res: any, next: any) {
   try {
+    if (isPreviewQaAuthenticatedRequest(req)) {
+      return next();
+    }
+
     const token = getBearerToken(req);
     if (!token) {
       return res.status(401).json({ ok: false, error: "unauthenticated" });

--- a/rentchain-api/src/routes/__tests__/publicRoutes.messages.test.ts
+++ b/rentchain-api/src/routes/__tests__/publicRoutes.messages.test.ts
@@ -1,10 +1,11 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { sendEmailMock } = vi.hoisted(() => ({
   sendEmailMock: vi.fn(),
 }));
 
 const collections = new Map<string, Map<string, any>>();
+const originalEnv = process.env;
 
 function ensureCollection(name: string) {
   if (!collections.has(name)) collections.set(name, new Map<string, any>());
@@ -188,6 +189,7 @@ async function invokeRouter(router: any, options: {
 
 describe("publicRoutes message endpoints", () => {
   beforeEach(() => {
+    process.env = { ...originalEnv };
     collections.clear();
     sendEmailMock.mockReset();
     sendEmailMock.mockResolvedValue(undefined);
@@ -222,6 +224,21 @@ describe("publicRoutes message endpoints", () => {
     });
   });
 
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  function enablePreviewQaAuth() {
+    process.env.PREVIEW_QA_AUTH_ENABLED = "true";
+    process.env.PREVIEW_QA_AUTH_SCOPE = "pr1509-unified-inbox";
+    process.env.APP_ENV = "preview";
+    process.env.GOOGLE_CLOUD_PROJECT = "rentchain-preview";
+    process.env.K_SERVICE = "rentchain-pr1509-inbox-qa-7255f05e";
+    process.env.PREVIEW_QA_EXPECTED_SERVICE = "rentchain-pr1509-inbox-qa-7255f05e";
+    process.env.FIRESTORE_ENABLED = "true";
+    process.env.FIRESTORE_DATABASE_ID = "(default)";
+  }
+
   it("serves landlord messages through publicRoutes with active lease labels", async () => {
     const router = (await import("../publicRoutes")).default;
     const res = await invokeRouter(router, {
@@ -244,6 +261,144 @@ describe("publicRoutes message endpoints", () => {
         }),
       ])
     );
+  });
+
+  it("allows the isolated Preview QA identity through the preempting conversation-list route", async () => {
+    enablePreviewQaAuth();
+    ensureCollection("conversations").set("qa-conversation", {
+      landlordId: "qa-pr1509-landlord",
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      lastMessageAt: 3000,
+    });
+    const router = (await import("../publicRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/landlord/messages/conversations",
+      headers: { "x-rentchain-preview-qa-identity": "pr1509-landlord" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers["x-route-source"]).toBe("publicRoutes.ts");
+    expect(res.body?.conversations).toEqual([
+      expect.objectContaining({ id: "qa-conversation", landlordId: "qa-pr1509-landlord" }),
+    ]);
+  });
+
+  it("allows the isolated Preview QA identity through the preempting conversation-detail route", async () => {
+    enablePreviewQaAuth();
+    ensureCollection("conversations").set("qa-conversation", {
+      landlordId: "qa-pr1509-landlord",
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      lastMessageAt: 3000,
+    });
+    ensureCollection("messages").set("qa-message", {
+      conversationId: "qa-conversation",
+      senderRole: "tenant",
+      body: "Scoped QA message",
+      createdAt: 3000,
+    });
+    const router = (await import("../publicRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/landlord/messages/conversations/qa-conversation",
+      headers: { "x-rentchain-preview-qa-identity": "pr1509-landlord" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers["x-route-source"]).toBe("publicRoutes.ts");
+    expect(res.body).toMatchObject({
+      ok: true,
+      conversation: { id: "qa-conversation", landlordId: "qa-pr1509-landlord" },
+      messages: [expect.objectContaining({ id: "qa-message", body: "Scoped QA message" })],
+    });
+  });
+
+  it.each([
+    ["Production project", () => (process.env.GOOGLE_CLOUD_PROJECT = "project-0d9658de-af29-4dc0-a99")],
+    ["permanent Preview service", () => (process.env.K_SERVICE = "rentchain-preview-backend")],
+    ["missing QA flag", () => delete process.env.PREVIEW_QA_AUTH_ENABLED],
+    ["wrong expected service", () => (process.env.PREVIEW_QA_EXPECTED_SERVICE = "rentchain-pr1509-inbox-qa-deadbeef")],
+  ])("rejects the synthetic selector in %s", async (_label, mutateEnvironment) => {
+    enablePreviewQaAuth();
+    mutateEnvironment();
+    const router = (await import("../publicRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/landlord/messages/conversations",
+      headers: { "x-rentchain-preview-qa-identity": "pr1509-landlord" },
+    });
+
+    expect(res.status).toBe(401);
+    expect(res.body).toMatchObject({ ok: false });
+  });
+
+  it("rejects an unknown synthetic identity", async () => {
+    enablePreviewQaAuth();
+    const router = (await import("../publicRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/landlord/messages/conversations",
+      headers: { "x-rentchain-preview-qa-identity": "unknown-landlord" },
+    });
+
+    expect(res.status).toBe(401);
+  });
+
+  it("does not let an invalid bearer token fall through to synthetic QA authentication", async () => {
+    enablePreviewQaAuth();
+    const router = (await import("../publicRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/landlord/messages/conversations",
+      headers: {
+        authorization: "Bearer invalid-token",
+        "x-rentchain-preview-qa-identity": "pr1509-landlord",
+      },
+    });
+
+    expect(res.status).toBe(401);
+  });
+
+  it("fails closed for foreign and missing conversation detail under synthetic QA auth", async () => {
+    enablePreviewQaAuth();
+    ensureCollection("conversations").set("foreign-conversation", {
+      landlordId: "foreign-landlord",
+      tenantId: "tenant-1",
+    });
+    const router = (await import("../publicRoutes")).default;
+    const headers = { "x-rentchain-preview-qa-identity": "pr1509-landlord" };
+
+    const foreign = await invokeRouter(router, {
+      method: "GET",
+      url: "/landlord/messages/conversations/foreign-conversation",
+      headers,
+    });
+    const missing = await invokeRouter(router, {
+      method: "GET",
+      url: "/landlord/messages/conversations/missing-conversation",
+      headers,
+    });
+
+    expect(foreign.status).toBe(403);
+    expect(missing.status).toBe(404);
+  });
+
+  it("keeps synthetic Preview QA authentication disabled on message writes", async () => {
+    enablePreviewQaAuth();
+    const router = (await import("../publicRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/landlord/messages/conversations/conv-unit-only",
+      headers: { "x-rentchain-preview-qa-identity": "pr1509-landlord" },
+      body: { body: "must not be written" },
+    });
+
+    expect(res.status).toBe(401);
+    expect(sendEmailMock).not.toHaveBeenCalled();
   });
 
   it("sends tenant email notifications for landlord replies on unit-linked conversations", async () => {

--- a/rentchain-api/src/routes/landlord.test.ts
+++ b/rentchain-api/src/routes/landlord.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { readFileSync } from "node:fs";
 
 const { fakeDb, queryCalls, resetFakeDb, seedDoc } = vi.hoisted(() => {
@@ -116,6 +116,7 @@ vi.mock("../services/landlord/landlordAnalyticsSnapshot", () => ({
 
 vi.mock("../middleware/requireAuth", () => ({
   requireAuth: (req: any, res: any, next: any) => {
+    if (req.user) return next();
     if (!mockUser) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
     req.user = mockUser;
     return next();
@@ -133,7 +134,13 @@ vi.mock("../middleware/requireLandlord", () => ({
   },
 }));
 
-async function invokeRouter(router: any, options: { url: string; user?: any; method?: string; body?: any }) {
+async function invokeRouter(router: any, options: {
+  url: string;
+  user?: any;
+  method?: string;
+  body?: any;
+  headers?: Record<string, string>;
+}) {
   return await new Promise<{ status: number; body: any }>((resolve, reject) => {
     const [path, queryString] = options.url.split("?");
     const query = new URLSearchParams(queryString || "");
@@ -145,7 +152,7 @@ async function invokeRouter(router: any, options: { url: string; user?: any; met
       path,
       query: Object.fromEntries(query.entries()),
       params: {},
-      headers: {},
+      headers: options.headers || {},
       body: options.body || {},
     };
     const res: any = {
@@ -277,6 +284,10 @@ describe("landlord unified inbox route", () => {
     });
   });
 
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it("requires authentication", async () => {
     const router = (await import("./landlordInboxRoutes")).default;
     const res = await invokeRouter(router, { url: "/inbox" });
@@ -314,6 +325,118 @@ describe("landlord unified inbox route", () => {
       "landlord.message",
       "landlord.lease",
     ]);
+    expectSafeResponse(res.body);
+  });
+
+  it("uses the fixed Preview QA identity for the 25-item mixed-source regression fixture", async () => {
+    vi.stubEnv("PREVIEW_QA_AUTH_ENABLED", "true");
+    vi.stubEnv("PREVIEW_QA_AUTH_SCOPE", "pr1509-unified-inbox");
+    vi.stubEnv("APP_ENV", "preview");
+    vi.stubEnv("GOOGLE_CLOUD_PROJECT", "rentchain-preview");
+    vi.stubEnv("K_SERVICE", "rentchain-pr1509-inbox-qa-b82c9914");
+    vi.stubEnv("FIRESTORE_ENABLED", "true");
+    vi.stubEnv("FIRESTORE_DATABASE_ID", "(default)");
+
+    resetFakeDb();
+    seedDoc("properties", "qa-property", { landlordId: "qa-pr1509-landlord", name: "QA Property One" });
+    seedDoc("units", "qa-unit", { landlordId: "qa-pr1509-landlord", propertyId: "qa-property" });
+    for (let index = 1; index <= 19; index += 1) {
+      seedDoc("leases", `qa-lease-${index}`, {
+        landlordId: "qa-pr1509-landlord",
+        propertyId: "qa-property",
+        unitId: "qa-unit",
+        title: `QA Lease ${index}`,
+        updatedAt: `2026-08-06T${String(index).padStart(2, "0")}:00:00.000Z`,
+      });
+    }
+    seedDoc("maintenanceRequests", "qa-maintenance", {
+      landlordId: "qa-pr1509-landlord",
+      propertyId: "qa-property",
+      unitId: "qa-unit",
+      title: "QA Maintenance",
+      status: "submitted",
+      updatedAt: "2026-08-06T20:00:00.000Z",
+    });
+    seedDoc("rentalApplications", "qa-application", {
+      landlordId: "qa-pr1509-landlord",
+      propertyId: "qa-property",
+      title: "QA Application",
+      updatedAt: "2026-08-06T21:00:00.000Z",
+    });
+    seedDoc("screeningOrders", "qa-screening", {
+      landlordId: "qa-pr1509-landlord",
+      applicationId: "qa-application",
+      title: "QA Screening",
+      updatedAt: "2026-08-06T22:00:00.000Z",
+    });
+    seedDoc("workOrders", "qa-work-order", {
+      landlordId: "qa-pr1509-landlord",
+      maintenanceRequestId: "qa-maintenance",
+      status: "assigned",
+      updatedAt: "2026-08-06T23:00:00.000Z",
+    });
+    seedDoc("properties", "qa-foreign-property", { landlordId: "qa-other-landlord" });
+    seedDoc("leases", "qa-forged-lease", {
+      landlordId: "qa-pr1509-landlord",
+      propertyId: "qa-foreign-property",
+      title: "Forged lease must not appear",
+    });
+    seedDoc("units", "qa-forged-unit", {
+      landlordId: "qa-pr1509-landlord",
+      propertyId: "qa-foreign-property",
+    });
+    seedDoc("leases", "qa-forged-unit-lease", {
+      landlordId: "qa-pr1509-landlord",
+      propertyId: "qa-property",
+      unitId: "qa-forged-unit",
+      title: "Forged unit lease must not appear",
+    });
+    seedDoc("screeningOrders", "qa-orphan-screening", {
+      landlordId: "qa-pr1509-landlord",
+      applicationId: "qa-missing-application",
+      title: "Orphan screening must not appear",
+    });
+    seedDoc("workOrders", "qa-orphan-work-order", {
+      landlordId: "qa-pr1509-landlord",
+      maintenanceRequestId: "qa-missing-maintenance",
+      title: "Orphan work order must not appear",
+    });
+    for (let index = 1; index <= 2; index += 1) {
+      seedDoc("conversations", `qa-conversation-${index}`, {
+        landlordId: "qa-pr1509-landlord",
+        propertyId: "qa-property",
+        tenantDisplayName: `QA Tenant ${index}`,
+        lastMessageAt: `2026-08-06T0${index}:00:00.000Z`,
+      });
+      seedDoc("messages", `qa-message-${index}`, {
+        conversationId: `qa-conversation-${index}`,
+        senderRole: "tenant",
+        body: `Synthetic QA message ${index}`,
+        createdAt: `2026-08-06T0${index}:00:00.000Z`,
+      });
+    }
+
+    const router = (await import("./landlordInboxRoutes")).default;
+    const res = await invokeRouter(router, {
+      url: "/inbox?limit=100",
+      headers: { "x-rentchain-preview-qa-identity": "pr1509-landlord" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.total).toBe(25);
+    const counts = res.body.items.reduce((result: Record<string, number>, item: any) => {
+      result[item.sourceKind] = (result[item.sourceKind] || 0) + 1;
+      return result;
+    }, {});
+    expect(counts).toEqual({
+      "landlord.application": 1,
+      "landlord.screening": 1,
+      "landlord.lease": 19,
+      "landlord.maintenance": 1,
+      "landlord.message": 2,
+      "landlord.work_order": 1,
+    });
+    expect(JSON.stringify(res.body)).not.toContain("must not appear");
     expectSafeResponse(res.body);
   });
 

--- a/rentchain-api/src/routes/landlord.test.ts
+++ b/rentchain-api/src/routes/landlord.test.ts
@@ -333,7 +333,8 @@ describe("landlord unified inbox route", () => {
     vi.stubEnv("PREVIEW_QA_AUTH_SCOPE", "pr1509-unified-inbox");
     vi.stubEnv("APP_ENV", "preview");
     vi.stubEnv("GOOGLE_CLOUD_PROJECT", "rentchain-preview");
-    vi.stubEnv("K_SERVICE", "rentchain-pr1509-inbox-qa-b82c9914");
+    vi.stubEnv("K_SERVICE", "rentchain-pr1509-inbox-qa-4605bba7");
+    vi.stubEnv("PREVIEW_QA_EXPECTED_SERVICE", "rentchain-pr1509-inbox-qa-4605bba7");
     vi.stubEnv("FIRESTORE_ENABLED", "true");
     vi.stubEnv("FIRESTORE_DATABASE_ID", "(default)");
 

--- a/rentchain-api/src/routes/landlord.test.ts
+++ b/rentchain-api/src/routes/landlord.test.ts
@@ -307,9 +307,13 @@ describe("landlord unified inbox route", () => {
     expect(res.body.ok).toBe(true);
     expect(res.body.limit).toBe(3);
     expect(res.body.offset).toBe(0);
-    expect(res.body.total).toBe(1);
-    expect(res.body.items).toHaveLength(1);
-    expect(res.body.items.map((item: any) => item.sourceKind)).toEqual(["landlord.message"]);
+    expect(res.body.total).toBe(3);
+    expect(res.body.items).toHaveLength(3);
+    expect(res.body.items.map((item: any) => item.sourceKind)).toEqual([
+      "landlord.maintenance",
+      "landlord.message",
+      "landlord.lease",
+    ]);
     expectSafeResponse(res.body);
   });
 
@@ -432,6 +436,73 @@ describe("landlord unified inbox route", () => {
     }));
   });
 
+  it("restores applications, screening, and work orders only through validated owned parents", async () => {
+    seedDoc("rentalApplications", "application-owned", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      title: "Application ready",
+      updatedAt: "2026-06-09T15:00:00.000Z",
+    });
+    seedDoc("screeningOrders", "screening-owned", {
+      landlordId: "landlord-1",
+      applicationId: "application-owned",
+      title: "Screening ready",
+      updatedAt: "2026-06-09T16:00:00.000Z",
+    });
+    seedDoc("workOrders", "work-order-owned", {
+      landlordId: "landlord-1",
+      maintenanceRequestId: "maintenance_raw_1",
+      status: "assigned",
+      updatedAt: "2026-06-09T17:00:00.000Z",
+    });
+    seedDoc("leases", "lease-forged-child", {
+      landlordId: "landlord-1",
+      propertyId: "prop-2",
+      title: "Forged foreign lease",
+      updatedAt: "2026-06-09T18:00:00.000Z",
+    });
+    seedDoc("units", "unit-foreign-parent", { landlordId: "landlord-1", propertyId: "prop-2" });
+    seedDoc("leases", "lease-forged-unit", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitId: "unit-foreign-parent",
+      title: "Forged foreign unit lease",
+      updatedAt: "2026-06-09T18:30:00.000Z",
+    });
+    seedDoc("screeningOrders", "screening-orphan", {
+      landlordId: "landlord-1",
+      applicationId: "missing-application",
+      title: "Orphan screening",
+      updatedAt: "2026-06-09T19:00:00.000Z",
+    });
+    seedDoc("workOrders", "work-order-orphan", {
+      landlordId: "landlord-1",
+      maintenanceRequestId: "missing-request",
+      title: "Orphan work order",
+      updatedAt: "2026-06-09T20:00:00.000Z",
+    });
+    const router = (await import("./landlordInboxRoutes")).default;
+    const res = await invokeRouter(router, {
+      url: "/inbox?limit=100",
+      user: { id: "landlord-1", landlordId: "landlord-1", role: "landlord" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.items.map((item: any) => item.sourceKind)).toEqual(expect.arrayContaining([
+      "landlord.application",
+      "landlord.screening",
+      "landlord.work_order",
+      "landlord.lease",
+      "landlord.maintenance",
+      "landlord.message",
+    ]));
+    expect(JSON.stringify(res.body)).not.toContain("Forged foreign lease");
+    expect(JSON.stringify(res.body)).not.toContain("Forged foreign unit lease");
+    expect(JSON.stringify(res.body)).not.toContain("Orphan screening");
+    expect(JSON.stringify(res.body)).not.toContain("Orphan work order");
+    expectSafeResponse(res.body);
+  });
+
   it("bounds owned conversations and message candidates with deterministic truncation", async () => {
     for (let index = 0; index < 101; index += 1) {
       const conversationId = `bounded-${String(index).padStart(3, "0")}`;
@@ -505,11 +576,34 @@ describe("landlord unified inbox route", () => {
     expect(res.status).toBe(200);
     expect(queryCalls.map((query) => query.collection).sort()).toEqual([
       "conversations",
+      "leases",
+      "maintenanceRequests",
       "messages",
+      "properties",
+      "rentalApplications",
+      "screeningOrders",
       "unifiedInboxReadStates",
+      "units",
+      "workOrders",
     ]);
     expect(queryCalls.every((query) => query.filters.length > 0)).toBe(true);
     expect(queryCalls.every((query) => query.limit !== null && query.limit! > 0)).toBe(true);
+    for (const collection of [
+      "properties",
+      "units",
+      "leases",
+      "maintenanceRequests",
+      "rentalApplications",
+      "screeningOrders",
+      "workOrders",
+    ]) {
+      expect(queryCalls.find((query) => query.collection === collection)).toEqual({
+        collection,
+        filters: [{ field: "landlordId", operator: "==", value: "landlord-1" }],
+        orderBy: [{ field: "__name__", direction: "asc" }],
+        limit: 101,
+      });
+    }
     expect(queryCalls.find((query) => query.collection === "unifiedInboxReadStates")).toEqual({
       collection: "unifiedInboxReadStates",
       filters: [{ field: "landlordId", operator: "==", value: "landlord-1" }],
@@ -554,7 +648,7 @@ describe("landlord unified inbox route", () => {
     warn.mockRestore();
   });
 
-  it("omits unsafe legacy projections with a structured governed warning", async () => {
+  it("restores parent-scoped sources and warns only for unsupported projections", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const router = (await import("./landlordInboxRoutes")).default;
     await invokeRouter(router, {
@@ -563,21 +657,15 @@ describe("landlord unified inbox route", () => {
     });
 
     expect(loadLandlordAnalyticsSnapshot).not.toHaveBeenCalled();
-    expect(warn).toHaveBeenCalledWith("[landlord-inbox] governed projections omitted", {
-      code: "UNIFIED_INBOX_PROJECTIONS_OMITTED",
+    expect(warn).toHaveBeenCalledWith("[landlord-inbox] unsupported projections omitted", {
+      code: "UNIFIED_INBOX_SOURCES_UNSUPPORTED",
       collections: [
-        "leases",
-        "maintenanceRequests",
-        "rentalApplications",
-        "workOrders",
-        "properties",
-        "units",
+        "viewingRequests",
+        "leaseNotices",
         "events",
         "canonicalEvents",
         "financialTransactions",
-        "screeningOrders",
       ],
-      reason: "BOUNDED_CANONICAL_OWNERSHIP_QUERY_UNAVAILABLE",
     });
     warn.mockRestore();
   });

--- a/rentchain-api/src/routes/landlordInboxRoutes.ts
+++ b/rentchain-api/src/routes/landlordInboxRoutes.ts
@@ -3,6 +3,7 @@ import { createHash } from "node:crypto";
 import { db } from "../firebase";
 import { requireAuth } from "../middleware/requireAuth";
 import { requireLandlord } from "../middleware/requireLandlord";
+import { previewQaAuth } from "../middleware/previewQaAuth";
 import {
   deriveLandlordUnifiedInbox,
   buildLandlordConversationInboxRecords,
@@ -423,7 +424,7 @@ async function deriveScopedLandlordInbox(landlordId: string, request: LandlordIn
   return applyPersistedReadStates(safePage.items, readStatesByRecordId);
 }
 
-router.get("/inbox", requireAuth, requireLandlord, async (req: Request, res: Response) => {
+router.get("/inbox", previewQaAuth("landlord-inbox"), requireAuth, requireLandlord, async (req: Request, res: Response) => {
   try {
     const landlordId = asString((req as any).user?.landlordId || (req as any).user?.id, 240);
     if (!landlordId) {

--- a/rentchain-api/src/routes/landlordInboxRoutes.ts
+++ b/rentchain-api/src/routes/landlordInboxRoutes.ts
@@ -20,18 +20,14 @@ const READ_STATES_COLLECTION = "unifiedInboxReadStates";
 const MAX_LANDLORD_CONVERSATIONS = 100;
 const MAX_MESSAGES_PER_CONVERSATION = 20;
 const MAX_READ_STATES = 100;
+const MAX_OPERATIONAL_CANDIDATES = 100;
 const TRUNCATION_SENTINEL = 1;
-const OMITTED_UNSAFE_PROJECTIONS = [
-  "leases",
-  "maintenanceRequests",
-  "rentalApplications",
-  "workOrders",
-  "properties",
-  "units",
+const UNSUPPORTED_PROJECTIONS = [
+  "viewingRequests",
+  "leaseNotices",
   "events",
   "canonicalEvents",
   "financialTransactions",
-  "screeningOrders",
 ] as const;
 
 export type LandlordInboxRequest = {
@@ -68,6 +64,8 @@ const SOURCE_MAP: Record<string, SourceKind> = {
   "landlord.maintenance": "landlord.maintenance",
   message: "landlord.message",
   "landlord.message": "landlord.message",
+  work_order: "landlord.work_order",
+  "landlord.work_order": "landlord.work_order",
 };
 
 function asString(value: unknown, max = 240): string {
@@ -139,7 +137,7 @@ function validateQuery(query: any): ValidationResult {
       ok: false,
       status: 400,
       error: "INVALID_SOURCE",
-      message: "source must be one of application, screening, lease, maintenance, or message",
+      message: "source must be one of application, screening, lease, maintenance, message, or work_order",
     };
   }
 
@@ -269,6 +267,97 @@ async function loadReadStatesByRecordId(landlordId: string) {
   return new Map<string, string>(entries);
 }
 
+type OperationalSource =
+  | "properties"
+  | "units"
+  | "leases"
+  | "maintenanceRequests"
+  | "rentalApplications"
+  | "screeningOrders"
+  | "workOrders";
+
+async function loadBoundedLandlordCandidates(collection: OperationalSource, landlordId: string) {
+  const snap = await db
+    .collection(collection)
+    .where("landlordId", "==", landlordId)
+    .orderBy("__name__", "asc")
+    .limit(MAX_OPERATIONAL_CANDIDATES + TRUNCATION_SENTINEL)
+    .get()
+    .catch(() => null);
+  if (!snap) {
+    console.warn("[landlord-inbox] operational source omitted", {
+      code: "UNIFIED_INBOX_SOURCE_QUERY_FAILED",
+      collection,
+      landlordScope: landlordScopeFingerprint(landlordId),
+    });
+    return [];
+  }
+  const docs = snap.docs || [];
+  if (docs.length > MAX_OPERATIONAL_CANDIDATES) {
+    console.warn("[landlord-inbox] operational source limit reached", {
+      code: "UNIFIED_INBOX_SCOPE_LIMIT_REACHED",
+      collection,
+      limit: MAX_OPERATIONAL_CANDIDATES,
+      observedCappedCount: docs.length,
+      landlordScope: landlordScopeFingerprint(landlordId),
+    });
+  }
+  return docs
+    .slice(0, MAX_OPERATIONAL_CANDIDATES)
+    .map((doc: any) => ({ id: doc.id, ...((doc.data() as any) || {}) }));
+}
+
+function parentScoped(record: any, parents: Map<string, any>, parentField: string) {
+  const parentId = asString(record?.[parentField], 240);
+  return Boolean(parentId && parents.has(parentId));
+}
+
+function propertyAndUnitScoped(record: any, properties: Map<string, any>, units: Map<string, any>) {
+  const propertyId = asString(record?.propertyId, 240);
+  if (!propertyId || !properties.has(propertyId)) return false;
+  const unitId = asString(record?.unitId, 240);
+  if (!unitId) return true;
+  const unit = units.get(unitId);
+  return Boolean(unit && asString(unit.propertyId, 240) === propertyId);
+}
+
+async function loadScopedOperationalSources(landlordId: string, requestedPropertyId: string | null) {
+  const [propertyCandidates, unitCandidates, leases, maintenanceRequests, rentalApplications] = await Promise.all([
+    loadBoundedLandlordCandidates("properties", landlordId),
+    loadBoundedLandlordCandidates("units", landlordId),
+    loadBoundedLandlordCandidates("leases", landlordId),
+    loadBoundedLandlordCandidates("maintenanceRequests", landlordId),
+    loadBoundedLandlordCandidates("rentalApplications", landlordId),
+  ]);
+  const properties = new Map(
+    propertyCandidates
+      .filter((record) => hasLandlordScope(record, landlordId))
+      .filter((record) => !requestedPropertyId || record.id === requestedPropertyId)
+      .map((record) => [asString(record.id, 240), record])
+  );
+  const units = new Map(
+    unitCandidates
+      .filter((record) => parentScoped(record, properties, "propertyId"))
+      .map((record) => [asString(record.id, 240), record])
+  );
+  const scopedLeases = leases.filter((record) => propertyAndUnitScoped(record, properties, units));
+  const scopedMaintenance = maintenanceRequests.filter((record) => propertyAndUnitScoped(record, properties, units));
+  const scopedApplications = rentalApplications.filter((record) => propertyAndUnitScoped(record, properties, units));
+  const applicationsById = new Map(scopedApplications.map((record) => [asString(record.id, 240), record]));
+  const maintenanceById = new Map(scopedMaintenance.map((record) => [asString(record.id, 240), record]));
+  const [screeningOrders, workOrders] = await Promise.all([
+    loadBoundedLandlordCandidates("screeningOrders", landlordId),
+    loadBoundedLandlordCandidates("workOrders", landlordId),
+  ]);
+  return {
+    leases: scopedLeases,
+    maintenanceRequests: scopedMaintenance,
+    rentalApplications: scopedApplications,
+    screeningOrders: screeningOrders.filter((record) => parentScoped(record, applicationsById, "applicationId")),
+    workOrders: workOrders.filter((record) => parentScoped(record, maintenanceById, "maintenanceRequestId")),
+  };
+}
+
 async function resolvePropertyScope(landlordId: string, propertyId: string | null) {
   if (!propertyId) return { ok: true as const };
   const propertyDoc = await db.collection("properties").doc(propertyId).get().catch(() => null);
@@ -308,25 +397,26 @@ function applyPersistedReadStates(items: UnifiedInboxEvent[], readStatesByRecord
 }
 
 async function deriveScopedLandlordInbox(landlordId: string, request: LandlordInboxRequest) {
-  console.warn("[landlord-inbox] governed projections omitted", {
-    code: "UNIFIED_INBOX_PROJECTIONS_OMITTED",
-    collections: OMITTED_UNSAFE_PROJECTIONS,
-    reason: "BOUNDED_CANONICAL_OWNERSHIP_QUERY_UNAVAILABLE",
+  console.warn("[landlord-inbox] unsupported projections omitted", {
+    code: "UNIFIED_INBOX_SOURCES_UNSUPPORTED",
+    collections: UNSUPPORTED_PROJECTIONS,
   });
-  const conversations = await loadLandlordConversations(landlordId);
+  const [operational, conversations] = await Promise.all([
+    loadScopedOperationalSources(landlordId, request.propertyId),
+    loadLandlordConversations(landlordId),
+  ]);
   const messages = await loadRecentMessagesForOwnedConversations(conversations, request.propertyId);
+  const include = (source: SourceKind) => !request.source || request.source === source;
 
   const safePage = await deriveLandlordUnifiedInbox(landlordId, {
-    applicationItems: [],
-    screeningItems: [],
-    leaseItems: [],
-    maintenanceRequests: [],
-    messages: buildLandlordConversationInboxRecords({
-      landlordId,
-      propertyId: request.propertyId,
-      conversations,
-      messages,
-    }),
+    applicationItems: include("landlord.application") ? operational.rentalApplications : [],
+    screeningItems: include("landlord.screening") ? operational.screeningOrders : [],
+    leaseItems: include("landlord.lease") ? operational.leases : [],
+    maintenanceRequests: include("landlord.maintenance") ? operational.maintenanceRequests : [],
+    messages: include("landlord.message")
+      ? buildLandlordConversationInboxRecords({ landlordId, propertyId: request.propertyId, conversations, messages })
+      : [],
+    workOrders: include("landlord.work_order") ? operational.workOrders : [],
     limit: MAX_LIMIT,
   });
   const readStatesByRecordId = await loadReadStatesByRecordId(landlordId);

--- a/rentchain-api/src/routes/messagesRoutes.ts
+++ b/rentchain-api/src/routes/messagesRoutes.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import { authenticateJwt } from "../middleware/authMiddleware";
 import { requireLandlord } from "../middleware/requireLandlord";
 import { requireAuth } from "../middleware/requireAuth";
+import { previewQaAuth } from "../middleware/previewQaAuth";
 import { db, FieldValue } from "../firebase";
 import { buildUpgradeRequiredResponse, requireCapability } from "../services/capabilityGuard";
 import { buildEmailHtml, buildEmailText } from "../email/templates/baseEmailTemplate";
@@ -691,7 +692,7 @@ async function enforceMessagingCapability(req: any, landlordId: string, res: any
 /**
  * Landlord endpoints
  */
-router.get("/landlord/messages/conversations", requireLandlord, async (req: any, res) => {
+router.get("/landlord/messages/conversations", previewQaAuth("landlord-message-list"), requireLandlord, async (req: any, res) => {
   const landlordId = getEffectiveLandlordId(req);
   if (!landlordId) return res.status(401).json({ ok: false, error: "Unauthorized" });
   if (!(await enforceMessagingCapability(req, landlordId, res))) return;
@@ -718,7 +719,7 @@ router.get("/landlord/messages/conversations", requireLandlord, async (req: any,
   }
 });
 
-router.get("/landlord/messages/conversations/:id", requireLandlord, async (req: any, res) => {
+router.get("/landlord/messages/conversations/:id", previewQaAuth("landlord-message-detail"), requireLandlord, async (req: any, res) => {
   const landlordId = getEffectiveLandlordId(req);
   if (!landlordId) return res.status(401).json({ ok: false, error: "Unauthorized" });
   if (!(await enforceMessagingCapability(req, landlordId, res))) return;

--- a/rentchain-api/src/routes/publicRoutes.ts
+++ b/rentchain-api/src/routes/publicRoutes.ts
@@ -21,6 +21,7 @@ import {
   requireDiagnosticAccess,
   safeDiagnosticBuildMetadata,
 } from "../middleware/diagnosticSurfaceGuard";
+import { previewQaAuth } from "../middleware/previewQaAuth";
 
 const router = Router();
 
@@ -1119,7 +1120,7 @@ async function enforceMessagingCapability(req: any, landlordId: string, res: Res
   return true;
 }
 
-router.get("/landlord/messages/conversations", authenticateJwt, requireLandlord, async (req: any, res) => {
+router.get("/landlord/messages/conversations", previewQaAuth("landlord-message-list"), authenticateJwt, requireLandlord, async (req: any, res) => {
   res.setHeader("x-route-source", "publicRoutes.ts");
   const landlordId = req.user?.landlordId || req.user?.id;
   if (!landlordId) return res.status(401).json({ ok: false, error: "Unauthorized" });
@@ -1152,7 +1153,7 @@ router.get("/landlord/messages/conversations", authenticateJwt, requireLandlord,
   }
 });
 
-router.get("/landlord/messages/conversations/:id", authenticateJwt, requireLandlord, async (req: any, res) => {
+router.get("/landlord/messages/conversations/:id", previewQaAuth("landlord-message-detail"), authenticateJwt, requireLandlord, async (req: any, res) => {
   res.setHeader("x-route-source", "publicRoutes.ts");
   const landlordId = req.user?.landlordId || req.user?.id;
   if (!landlordId) return res.status(401).json({ ok: false, error: "Unauthorized" });

--- a/rentchain-frontend/src/pages/UnifiedInboxPage.test.tsx
+++ b/rentchain-frontend/src/pages/UnifiedInboxPage.test.tsx
@@ -32,6 +32,82 @@ function record(overrides: Partial<UnifiedInboxRecord>): UnifiedInboxRecord {
   };
 }
 
+function founderQaRecords(): UnifiedInboxRecord[] {
+  const landlordRecord = (overrides: Partial<UnifiedInboxRecord>) =>
+    record({ audienceRole: "landlord", ...overrides });
+  return [
+    landlordRecord({
+      id: "message-unread",
+      sourceKind: "landlord.message",
+      title: "Message from QA Tenant 7255-1",
+      body: "Synthetic tenant message one",
+      status: "unread",
+      priority: "normal",
+    }),
+    landlordRecord({
+      id: "message-read",
+      sourceKind: "landlord.message",
+      title: "Message from QA Tenant 7255-2",
+      body: "Synthetic tenant message two",
+      status: "read",
+      readAt: "2026-08-07T14:42:30.000Z",
+      priority: "normal",
+    }),
+    landlordRecord({
+      id: "maintenance",
+      sourceKind: "landlord.maintenance",
+      title: "PR1509 Synthetic Maintenance",
+      body: "Status: submitted",
+      status: "unread",
+      priority: "normal",
+    }),
+    landlordRecord({
+      id: "work-order",
+      sourceKind: "landlord.work_order",
+      title: "Work order update",
+      body: "Synthetic work order status: assigned",
+      status: "unread",
+      priority: "normal",
+    }),
+    landlordRecord({
+      id: "application",
+      sourceKind: "landlord.application",
+      title: "PR1509 Synthetic Application",
+      body: "Application update is available.",
+      status: "unread",
+      priority: "normal",
+    }),
+    landlordRecord({
+      id: "screening",
+      sourceKind: "landlord.screening",
+      title: "PR1509 Synthetic Screening",
+      body: "Screening update is available.",
+      status: "resolved",
+      priority: "high",
+    }),
+    ...Array.from({ length: 19 }, (_, index) =>
+      landlordRecord({
+        id: `lease-${index + 1}`,
+        sourceKind: "landlord.lease",
+        title: `PR1509 Lease ${String(index + 1).padStart(2, "0")}`,
+        body: "Lease lifecycle update is available.",
+        status: "unread",
+        priority: "normal",
+      })
+    ),
+  ];
+}
+
+function expectShowing(visible: number, total = 25) {
+  expect(
+    screen.getByText(
+      (_content, element) =>
+        element?.tagName === "SPAN" &&
+        element.textContent?.replace(/\s+/g, " ").trim() === `Showing ${visible} of ${total}`
+    )
+  ).toBeInTheDocument();
+}
+
 describe("UnifiedInboxPage", () => {
   beforeEach(() => {
     mocks.fetchUnifiedInbox.mockReset();
@@ -292,6 +368,73 @@ describe("UnifiedInboxPage", () => {
     expect(screen.getAllByText("System notice").length).toBeGreaterThan(0);
     expect(screen.queryByText("Lease renewal ready")).not.toBeInTheDocument();
     expect(screen.queryByText("Outstanding rent balance")).not.toBeInTheDocument();
+  });
+
+  it("applies canonical mixed-source filters to the exact 25-card Founder QA fixture", async () => {
+    const records = founderQaRecords();
+    mocks.fetchUnifiedInbox.mockResolvedValue({
+      ok: true,
+      role: "landlord",
+      items: records,
+      records,
+      total: 25,
+      limit: 100,
+      offset: 0,
+    });
+
+    render(<UnifiedInboxPage role="landlord" />);
+
+    expect(await screen.findByRole("tab", { name: "All 25" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("tab", { name: "Unread 23" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Maintenance 2" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Lease 19" })).toBeInTheDocument();
+    expectShowing(25);
+
+    fireEvent.change(screen.getByRole("searchbox", { name: "Search inbox" }), {
+      target: { value: "QA Tenant 7255-1" },
+    });
+    expectShowing(1);
+    expect(screen.getByText("Message from QA Tenant 7255-1")).toBeInTheDocument();
+    fireEvent.change(screen.getByRole("searchbox", { name: "Search inbox" }), { target: { value: "" } });
+
+    fireEvent.click(screen.getByRole("tab", { name: "Maintenance 2" }));
+    expectShowing(2);
+    fireEvent.change(screen.getByLabelText("Filter inbox status"), { target: { value: "unread" } });
+    expect(screen.getByRole("tab", { name: "All 25" })).toHaveAttribute("aria-selected", "true");
+    expectShowing(23);
+    expect(screen.getByText("Message from QA Tenant 7255-1")).toBeInTheDocument();
+    expect(screen.queryByText("Message from QA Tenant 7255-2")).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Filter inbox status"), { target: { value: "resolved" } });
+    expectShowing(1);
+    expect(screen.getByText("PR1509 Synthetic Screening")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Filter inbox status"), { target: { value: "all" } });
+    fireEvent.change(screen.getByLabelText("Filter inbox priority"), { target: { value: "normal" } });
+    expectShowing(24);
+    expect(screen.getByText("PR1509 Synthetic Maintenance")).toBeInTheDocument();
+    expect(screen.getByText("Work order update")).toBeInTheDocument();
+    expect(screen.getByText("PR1509 Synthetic Application")).toBeInTheDocument();
+    expect(screen.getByText("PR1509 Lease 19")).toBeInTheDocument();
+    expect(screen.queryByText("PR1509 Synthetic Screening")).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Filter inbox priority"), { target: { value: "high" } });
+    expectShowing(1);
+    expect(screen.getByText("PR1509 Synthetic Screening")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Filter inbox status"), { target: { value: "resolved" } });
+    expectShowing(1);
+    fireEvent.change(screen.getByRole("searchbox", { name: "Search inbox" }), {
+      target: { value: "Screening" },
+    });
+    expectShowing(1);
+    fireEvent.change(screen.getByLabelText("Filter inbox priority"), { target: { value: "all" } });
+    expectShowing(1);
+    expect(screen.getByLabelText("Filter inbox status")).toHaveValue("resolved");
+
+    fireEvent.change(screen.getByRole("searchbox", { name: "Search inbox" }), { target: { value: "" } });
+    fireEvent.change(screen.getByLabelText("Filter inbox status"), { target: { value: "all" } });
+    expectShowing(25);
   });
 
   it("keeps true work-order inbox actions on the work-order workspace", async () => {

--- a/rentchain-frontend/src/pages/UnifiedInboxPage.tsx
+++ b/rentchain-frontend/src/pages/UnifiedInboxPage.tsx
@@ -86,6 +86,14 @@ function isRecordInTab(record: UnifiedInboxRecord, tab: InboxTab) {
   return true;
 }
 
+function matchesCanonicalStatus(record: UnifiedInboxRecord, status: StatusFilter) {
+  return status === "all" || record.status === status;
+}
+
+function matchesCanonicalPriority(record: UnifiedInboxRecord, priority: PriorityFilter) {
+  return priority === "all" || record.priority === priority;
+}
+
 function statusLabel(value: StatusFilter) {
   if (value === "all") return "All statuses";
   return value.replace(/_/g, " ").replace(/\b\w/g, (match) => match.toUpperCase());
@@ -149,8 +157,8 @@ export default function UnifiedInboxPage({ role }: Props) {
     () =>
       safeRecords.filter((record) => {
         const matchesTab = isRecordInTab(record, activeTab);
-        const matchesStatus = statusFilter === "all" || record.status === statusFilter;
-        const matchesPriority = priorityFilter === "all" || record.priority === priorityFilter;
+        const matchesStatus = matchesCanonicalStatus(record, statusFilter);
+        const matchesPriority = matchesCanonicalPriority(record, priorityFilter);
         const matchesSearch = !normalizedSearch || normalize(recordText(record)).includes(normalizedSearch);
         return matchesTab && matchesStatus && matchesPriority && matchesSearch;
       }),
@@ -354,6 +362,7 @@ export default function UnifiedInboxPage({ role }: Props) {
                   value={statusFilter}
                   onChange={(event) => {
                     resetFilterContext();
+                    setActiveTab("all");
                     setStatusFilter(event.target.value as StatusFilter);
                   }}
                   aria-label="Filter inbox status"
@@ -382,6 +391,7 @@ export default function UnifiedInboxPage({ role }: Props) {
                   value={priorityFilter}
                   onChange={(event) => {
                     resetFilterContext();
+                    setActiveTab("all");
                     setPriorityFilter(event.target.value as PriorityFilter);
                   }}
                   aria-label="Filter inbox priority"


### PR DESCRIPTION
## Summary

Production currently serves `rentchain-landlord-api-candidate-5f6e7d95` at 100% and visibly returns 1 Maintenance plus 19 Lease items. Candidate `8faeb636` remains tag-only at 0% and is not promotable because PR #1435 preserved tenant messages by replacing operational arrays with empty arrays.

This correction preserves bounded tenant-message loading and restores Maintenance, Lease, Rental Application, Screening, and Work Order candidates. Every operational query is authenticated-landlord filtered, ordered by document ID before truncation, limited to 101 candidates with 100 retained, and validated against canonical owned parents. A child's landlord field selects bounded candidates but never proves ownership. Missing, foreign, contradictory, and orphaned parents fail closed.

No `in` query is used, so there is no operand batching. Results deduplicate by Firestore document ID and existing derivation provides deterministic priority/read/time/ID ordering and a final cap of 100. Built-in single-field indexes suffice; no index declaration was added. Viewing, lease-notice, event, canonical-event, and financial/payment sources remain explicitly identified as unsupported pending separate projection-contract audits.

## Preview-safe synthetic QA authentication

Preview intentionally has no Production `JWT_SECRET`, so this head adds a narrow synthetic QA path instead of copying or creating a secret. The original implementation was coupled to stale service `rentchain-pr1509-inbox-qa-b82c9914`, which would reject a freshly published exact-head QA service because Cloud Run owns `K_SERVICE`. The corrected guard requires `PREVIEW_QA_EXPECTED_SERVICE` to match the narrow `rentchain-pr1509-inbox-qa-<8 lowercase hex>` form and requires an exact match with `K_SERVICE`. It remains hard-locked to `APP_ENV=preview`, project `rentchain-preview`, `FIRESTORE_ENABLED=true`, database `(default)`, the explicit enable flag, and scope `pr1509-unified-inbox`.

Only selector `pr1509-landlord` is accepted, and it always resolves to the fixed synthetic landlord `qa-pr1509-landlord`. Caller-provided landlord or role headers cannot change that identity. The mechanism is wired only to GET `/api/landlord/inbox`, GET `/api/landlord/messages/conversations`, and GET `/api/landlord/messages/conversations/:id`. Writes and wrong methods remain protected by normal authentication. A supplied Authorization header always takes precedence, and an invalid bearer token cannot fall back to synthetic QA auth.

Production is explicitly rejected by project ID and cannot activate the path. The permanent `rentchain-preview-backend` service, stale or arbitrary services, missing/malformed expected-service values, and uppercase suffixes are also rejected. The exact Preview project, environment, expected service, actual service, Firestore state, database, scope, flag, method, route, and identity guards must all match. No secret, IAM, service-account, Terraform, Cloud Run, Vercel, or other external configuration change is included.

## Security and validation

- Forged foreign property and unit children are excluded.
- Orphan screening and work-order children are excluded.
- Every restored query test asserts exact collection, authenticated-landlord `where`, `orderBy("__name__", "asc")`, and limit 101.
- Preview QA/auth/Inbox/message focused matrix: 88/88 passed, including 32 guard tests and 12 route/method boundary tests.
- Exact 25-record mixed-source synthetic route fixture passed with foreign and orphan records excluded.
- Backend build: passed.
- Complete backend: 3,069/3,098 passed; the same 29 unrelated baseline failures remain in fixed-date/global-state suites, with no auth, inbox, or query-shape regression.
- Frontend: 1,651/1,651 passed with the required local API base.
- Frontend build: passed.
- Local synthetic Playwright desktop/tablet/mobile matrix: 3/3 passed; no horizontal overflow, console errors, or HTTP 5xx.
- Preview PR-head governance: 36/36.
- Human-admin pilot: 87/87; release decisions 20/20; build identity 20/20; source reader 20/20; legacy deployer 20/20; Production governance 32/32.
- Backend image runtime Docker build: passed.
- Terraform init (`-backend=false`), validate, and recursive fmt check: passed.
- `git diff --check` and credential/mutation scans: passed.

The next step is a separately authorized exact-head Preview image publication and isolated QA service update using the new head. This PR remains draft. No image was published and no service was deployed or updated in this mission.

No cloud, data, IAM, HCP, Terraform, Preview, Vercel, build publication, deployment, revision, or traffic mutation occurred during this correction.

## Message route-precedence correction

The exact-head QA run revealed that `publicRoutes.ts`, mounted earlier at `/api`, also owns the landlord conversation list and detail paths. Those handlers preempted the later `messagesRoutes.ts` handlers and returned 401 before Preview QA authentication could run.

The narrow correction preserves the earlier route implementations and their Production response contract. It prepends the existing fail-closed `previewQaAuth` middleware only to the two earlier GET handlers, before normal JWT authentication. With no QA selector, or whenever an Authorization header is supplied, the middleware delegates unchanged to normal authentication. Production, permanent Preview, disabled or misconfigured QA, unknown identity, and invalid bearer cases remain rejected. Message send and read-state writes do not receive synthetic QA authentication.

Regression coverage now exercises the actually preempting routes for successful isolated-Preview list/detail reads, Production and permanent-Preview lockout, missing flag, service mismatch, unknown identity, invalid bearer precedence, normal authenticated behavior, foreign/missing conversation denial, and write denial. A static route-scope guard covers both the earlier compatibility handlers and later canonical handlers.

Updated validation: focused backend 98/98; complete backend 3,079/3,108 with the same 29 unrelated baseline failures; frontend 1,651/1,651; local Chromium Messages matrix 6/6 across desktop, wide/narrow desktop, tablet, mobile, and real deep-link interaction; backend/frontend builds, governance validations, Docker runtime contract, Terraform backend-disabled validation, diff check, and credential/mutation scans passed. Production, permanent Preview, the current `7255f05e` QA service, and all 39 fixture documents remained unchanged.

## Unified Inbox status/priority filter correction

Codex Desktop QA on exact head `fe13f3a8729dec21afe25bcd5c3b5712ab8a6098` found that selecting Status or Priority while the Maintenance grouped tab remained active intersected the canonical filter with that retained category. This made Unread and Normal appear to return only the Maintenance card and made Resolved and High appear empty, even though the mixed-source records already carried the correct canonical lowercase `status` and `priority` values.

The narrow frontend correction makes the canonical status/priority predicates explicit and resets only the category tab to All when either dropdown changes. Search and the other dropdown remain intact, so combined filters still use deterministic intersection semantics. The intentional Maintenance grouping remains two records (one Maintenance and one Work Order), and `/messages` list/detail behavior is unchanged.

An exact deterministic 25-card regression covers two tenant messages, one Maintenance item, one Work Order, one Application, one resolved/high Screening, and 19 Lease items. Verified counts are All 25, Unread 23, Resolved 1, Normal 24, High 1, Maintenance grouped 2, Lease 19, and tenant messages 2. Focused frontend passed 15/15, full frontend passed 1,652/1,652, affected backend passed 81/81, both builds passed, and local Playwright passed desktop 1440x900, tablet 768x1024, and mobile 390x844 with no console errors, HTTP 5xx, or horizontal overflow.

No image publication, Cloud Run deployment/update, fixture mutation, Production mutation, permanent Preview mutation, Terraform/HCP operation, or Vercel redeployment occurred. This PR remains draft and requires a separately authorized fresh exact-head image publication and Codex Desktop re-verification.
