### PR TITLE
Add landlord message compose flow

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -91,7 +91,7 @@ import landlordApplicationLinksRoutes from "./routes/landlordApplicationLinksRou
 import publicApplicationLinksRoutes from "./routes/publicApplicationLinksRoutes";
 import tenantsRoutes from "./routes/tenantsRoutes";
 import tenanciesRoutes from "./routes/tenanciesRoutes";
-import messagesRoutes from "./routes/messagesRoutes";
+import messagesRoutes, { previewQaComposeRoutes } from "./routes/messagesRoutes";
 import rentalApplicationsRoutes from "./routes/rentalApplicationsRoutes";
 import verifiedScreeningRoutes from "./routes/verifiedScreeningRoutes";
 import stripeScreeningOrdersWebhookRoutes, {
@@ -431,6 +431,7 @@ app.use("/api/internal", routeSource("internalReportsRoutes.ts"), internalReport
 app.use("/api/internal", routeSource("identityOracleInternalRoutes.ts"), identityOracleInternalRoutes);
 app.use("/api/internal", routeSource("applicationReminderInternalRoutes.ts"), applicationReminderInternalRoutes);
 app.use("/api", routeSource("providerNeutralScreeningRoutes.ts"), providerNeutralScreeningRoutes);
+app.use("/api", routeSource("messagesRoutes.previewQaCompose"), previewQaComposeRoutes);
 
 // Auth decode (non-blocking if header missing)
 app.use(authenticateJwt);

--- a/rentchain-api/src/middleware/__tests__/previewQaAuth.test.ts
+++ b/rentchain-api/src/middleware/__tests__/previewQaAuth.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   PREVIEW_QA_IDENTITY_ALIAS,
   PREVIEW_QA_LANDLORD_ID,
+  PR1510_PREVIEW_QA_IDENTITY_ALIAS,
+  PR1510_PREVIEW_QA_LANDLORD_ID,
   decidePreviewQaAuth,
   isPreviewQaAuthenticatedRequest,
   previewQaAuth,
@@ -16,6 +18,13 @@ const enabledEnv = {
   PREVIEW_QA_EXPECTED_SERVICE: "rentchain-pr1509-inbox-qa-4605bba7",
   FIRESTORE_ENABLED: "true",
   FIRESTORE_DATABASE_ID: "(default)",
+} as NodeJS.ProcessEnv;
+
+const pr1510EnabledEnv = {
+  ...enabledEnv,
+  PREVIEW_QA_AUTH_SCOPE: "pr1510-landlord-messaging",
+  K_SERVICE: "rentchain-pr1510-messaging-qa-759205cd",
+  PREVIEW_QA_EXPECTED_SERVICE: "rentchain-pr1510-messaging-qa-759205cd",
 } as NodeJS.ProcessEnv;
 
 function decide(overrides: Partial<Parameters<typeof decidePreviewQaAuth>[0]> = {}) {
@@ -88,6 +97,80 @@ describe("previewQaAuth", () => {
       plan: "starter",
       capabilities: ["messaging"],
     });
+  });
+
+  it.each([
+    ["GET", "landlord-message-recipients"],
+    ["GET", "landlord-message-list"],
+    ["GET", "landlord-message-detail"],
+    ["POST", "landlord-message-compose"],
+  ] as const)("allows PR #1510 %s %s only under its fixed contract", (method, route) => {
+    expect(decide({
+      env: pr1510EnabledEnv,
+      method,
+      route,
+      selector: PR1510_PREVIEW_QA_IDENTITY_ALIAS,
+    })).toEqual({ kind: "allow" });
+  });
+
+  it("injects only the server-owned PR #1510 landlord identity", () => {
+    process.env = { ...pr1510EnabledEnv };
+    const headers = {
+      "x-rentchain-preview-qa-identity": PR1510_PREVIEW_QA_IDENTITY_ALIAS,
+      "x-landlord-id": "arbitrary-landlord",
+      "x-role": "admin",
+    };
+    const req: any = { method: "GET", headers, header: (name: string) => headers[name.toLowerCase() as keyof typeof headers] };
+    const res: any = { status: () => res, json: () => res };
+    let nextCalled = false;
+    previewQaAuth("landlord-message-recipients")(req, res, () => { nextCalled = true; });
+    expect(nextCalled).toBe(true);
+    expect(req.user).toMatchObject({
+      id: PR1510_PREVIEW_QA_LANDLORD_ID,
+      landlordId: PR1510_PREVIEW_QA_LANDLORD_ID,
+      role: "landlord",
+    });
+  });
+
+  it.each([
+    ["wrong service", { ...pr1510EnabledEnv, K_SERVICE: "rentchain-pr1510-messaging-qa-deadbeef" }],
+    ["malformed service", { ...pr1510EnabledEnv, K_SERVICE: "rentchain-pr1510-messaging-qa-head7592", PREVIEW_QA_EXPECTED_SERVICE: "rentchain-pr1510-messaging-qa-head7592" }],
+    ["PR #1509 service", { ...pr1510EnabledEnv, K_SERVICE: enabledEnv.K_SERVICE, PREVIEW_QA_EXPECTED_SERVICE: enabledEnv.PREVIEW_QA_EXPECTED_SERVICE }],
+    ["Production", { ...pr1510EnabledEnv, GOOGLE_CLOUD_PROJECT: "project-0d9658de-af29-4dc0-a99" }],
+    ["permanent Preview", { ...pr1510EnabledEnv, K_SERVICE: "rentchain-preview-backend", PREVIEW_QA_EXPECTED_SERVICE: "rentchain-preview-backend" }],
+    ["disabled", { ...pr1510EnabledEnv, PREVIEW_QA_AUTH_ENABLED: "false" }],
+  ])("rejects PR #1510 with %s", (_label, env) => {
+    expect(decide({
+      env,
+      route: "landlord-message-recipients",
+      selector: PR1510_PREVIEW_QA_IDENTITY_ALIAS,
+    })).toEqual({ kind: "reject" });
+  });
+
+  it("rejects cross-contract selectors and scopes", () => {
+    expect(decide({ env: pr1510EnabledEnv, selector: PREVIEW_QA_IDENTITY_ALIAS })).toEqual({ kind: "reject" });
+    expect(decide({
+      env: enabledEnv,
+      route: "landlord-message-list",
+      selector: PR1510_PREVIEW_QA_IDENTITY_ALIAS,
+    })).toEqual({ kind: "reject" });
+  });
+
+  it.each([
+    ["POST", "landlord-message-list"],
+    ["POST", "landlord-message-detail"],
+    ["POST", "landlord-inbox"],
+    ["POST", "landlord-message-recipients"],
+    ["PUT", "landlord-message-compose"],
+    ["PATCH", "landlord-message-compose"],
+    ["DELETE", "landlord-message-compose"],
+  ] as const)("rejects non-allowlisted PR #1510 operation %s %s", (method, route) => {
+    expect(decide({
+      env: pr1510EnabledEnv,
+      method,
+      route,
+      selector: PR1510_PREVIEW_QA_IDENTITY_ALIAS,
+    })).toEqual({ kind: "reject" });
   });
 
   it.each([

--- a/rentchain-api/src/middleware/__tests__/previewQaAuthRouteScope.test.ts
+++ b/rentchain-api/src/middleware/__tests__/previewQaAuthRouteScope.test.ts
@@ -3,7 +3,12 @@ import jwt from "jsonwebtoken";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { requireAuth } from "../requireAuth";
 import { requireLandlord } from "../requireLandlord";
-import { PREVIEW_QA_IDENTITY_ALIAS, previewQaAuth } from "../previewQaAuth";
+import {
+  PREVIEW_QA_IDENTITY_ALIAS,
+  PR1510_PREVIEW_QA_IDENTITY_ALIAS,
+  previewQaAuth,
+  type PreviewQaRoute,
+} from "../previewQaAuth";
 
 vi.mock("../../services/sessionUserService", () => ({
   buildCanonicalSessionUserFromClaims: async (claims: any) => ({
@@ -45,7 +50,7 @@ async function invoke(options: {
   selector?: string;
   authorization?: string;
   useQaMiddleware?: boolean;
-  route?: "landlord-inbox" | "landlord-message-list" | "landlord-message-detail";
+  route?: PreviewQaRoute;
 }) {
   const headers: Record<string, string> = {};
   if (options.selector) headers["x-rentchain-preview-qa-identity"] = options.selector;
@@ -130,6 +135,24 @@ describe("Preview QA auth route scope", () => {
     expect(result.body).toMatchObject({ ok: false, error: "unauthenticated" });
   });
 
+  it("keeps invalid bearer precedence for the PR #1510 Compose mutation", async () => {
+    process.env = {
+      ...process.env,
+      PREVIEW_QA_AUTH_SCOPE: "pr1510-landlord-messaging",
+      K_SERVICE: "rentchain-pr1510-messaging-qa-759205cd",
+      PREVIEW_QA_EXPECTED_SERVICE: "rentchain-pr1510-messaging-qa-759205cd",
+    };
+    const result = await invoke({
+      method: "POST",
+      route: "landlord-message-compose",
+      selector: PR1510_PREVIEW_QA_IDENTITY_ALIAS,
+      authorization: "Bearer invalid-token",
+      useQaMiddleware: true,
+    });
+    expect(result.status).toBe(401);
+    expect(result.body).toMatchObject({ ok: false, error: "unauthenticated" });
+  });
+
   it("keeps missing JWT_SECRET fail-closed when QA auth is disabled", async () => {
     process.env.PREVIEW_QA_AUTH_ENABLED = "false";
     const result = await invoke({ selector: PREVIEW_QA_IDENTITY_ALIAS, useQaMiddleware: true });
@@ -154,19 +177,27 @@ describe("Preview QA auth route scope", () => {
     });
   });
 
-  it("wires QA auth only to the three approved GET operations, including preempting public routes", () => {
+  it("wires QA auth only to the approved operations, including preempting public read routes", () => {
     const inboxSource = readFileSync(new URL("../../routes/landlordInboxRoutes.ts", import.meta.url), "utf8");
     const messagesSource = readFileSync(new URL("../../routes/messagesRoutes.ts", import.meta.url), "utf8");
     const publicSource = readFileSync(new URL("../../routes/publicRoutes.ts", import.meta.url), "utf8");
     expect(inboxSource).toContain('router.get("/inbox", previewQaAuth("landlord-inbox")');
     expect(inboxSource).not.toMatch(/router\.post\([^\n]+previewQaAuth/);
     expect(messagesSource).toContain(
+      'router.get("/landlord/messages/recipients", previewQaAuth("landlord-message-recipients")'
+    );
+    expect(messagesSource).toContain(
+      'router.post("/landlord/messages/conversations", previewQaAuth("landlord-message-compose")'
+    );
+    expect(messagesSource).toContain(
       'router.get("/landlord/messages/conversations", previewQaAuth("landlord-message-list")'
     );
     expect(messagesSource).toContain(
       'router.get("/landlord/messages/conversations/:id", previewQaAuth("landlord-message-detail")'
     );
-    expect(messagesSource).not.toMatch(/router\.post\([^\n]+previewQaAuth/);
+    expect(messagesSource.match(/router\.post\([^\n]+previewQaAuth/g)).toEqual([
+      'router.post("/landlord/messages/conversations", previewQaAuth',
+    ]);
     expect(publicSource).toMatch(
       /router\.get\(\s*"\/landlord\/messages\/conversations",\s*previewQaAuth\("landlord-message-list"\)/
     );

--- a/rentchain-api/src/middleware/__tests__/previewQaAuthRouteScope.test.ts
+++ b/rentchain-api/src/middleware/__tests__/previewQaAuthRouteScope.test.ts
@@ -181,13 +181,14 @@ describe("Preview QA auth route scope", () => {
     const inboxSource = readFileSync(new URL("../../routes/landlordInboxRoutes.ts", import.meta.url), "utf8");
     const messagesSource = readFileSync(new URL("../../routes/messagesRoutes.ts", import.meta.url), "utf8");
     const publicSource = readFileSync(new URL("../../routes/publicRoutes.ts", import.meta.url), "utf8");
+    const appSource = readFileSync(new URL("../../app.build.ts", import.meta.url), "utf8");
     expect(inboxSource).toContain('router.get("/inbox", previewQaAuth("landlord-inbox")');
     expect(inboxSource).not.toMatch(/router\.post\([^\n]+previewQaAuth/);
     expect(messagesSource).toContain(
-      'router.get("/landlord/messages/recipients", previewQaAuth("landlord-message-recipients")'
+      'target.get("/landlord/messages/recipients", previewQaAuth("landlord-message-recipients")'
     );
     expect(messagesSource).toContain(
-      'router.post("/landlord/messages/conversations", previewQaAuth("landlord-message-compose")'
+      'target.post("/landlord/messages/conversations", previewQaAuth("landlord-message-compose")'
     );
     expect(messagesSource).toContain(
       'router.get("/landlord/messages/conversations", previewQaAuth("landlord-message-list")'
@@ -195,9 +196,20 @@ describe("Preview QA auth route scope", () => {
     expect(messagesSource).toContain(
       'router.get("/landlord/messages/conversations/:id", previewQaAuth("landlord-message-detail")'
     );
-    expect(messagesSource.match(/router\.post\([^\n]+previewQaAuth/g)).toEqual([
-      'router.post("/landlord/messages/conversations", previewQaAuth',
+    expect(messagesSource.match(/target\.post\([^\n]+previewQaAuth/g)).toEqual([
+      'target.post("/landlord/messages/conversations", previewQaAuth',
     ]);
+    const composeMount = appSource.indexOf(
+      'app.use("/api", routeSource("messagesRoutes.previewQaCompose"), previewQaComposeRoutes);'
+    );
+    const globalAuthMount = appSource.indexOf("app.use(authenticateJwt);");
+    const defaultMessagesMount = appSource.indexOf(
+      'app.use("/api", routeSource("messagesRoutes.ts"), messagesRoutes);'
+    );
+    expect(composeMount).toBeGreaterThan(-1);
+    expect(composeMount).toBeLessThan(globalAuthMount);
+    expect(globalAuthMount).toBeLessThan(defaultMessagesMount);
+    expect(appSource.match(/previewQaComposeRoutes/g)).toHaveLength(2);
     expect(publicSource).toMatch(
       /router\.get\(\s*"\/landlord\/messages\/conversations",\s*previewQaAuth\("landlord-message-list"\)/
     );

--- a/rentchain-api/src/middleware/previewQaAuth.ts
+++ b/rentchain-api/src/middleware/previewQaAuth.ts
@@ -4,15 +4,57 @@ import type { UserEntitlements } from "../services/entitlementsService";
 export const PREVIEW_QA_IDENTITY_HEADER = "x-rentchain-preview-qa-identity";
 export const PREVIEW_QA_IDENTITY_ALIAS = "pr1509-landlord";
 export const PREVIEW_QA_LANDLORD_ID = "qa-pr1509-landlord";
+export const PR1510_PREVIEW_QA_IDENTITY_ALIAS = "pr1510-landlord";
+export const PR1510_PREVIEW_QA_LANDLORD_ID = "qa-pr1510-landlord";
 
 const PREVIEW_PROJECT_ID = "rentchain-preview";
 const PRODUCTION_PROJECT_ID = "project-0d9658de-af29-4dc0-a99";
 const PERMANENT_PREVIEW_SERVICE = "rentchain-preview-backend";
-const PREVIEW_QA_SERVICE_PATTERN = /^rentchain-pr1509-inbox-qa-[a-f0-9]{8}$/;
-const PREVIEW_QA_SCOPE = "pr1509-unified-inbox";
 const previewQaAuthenticated = Symbol("previewQaAuthenticated");
 
-export type PreviewQaRoute = "landlord-inbox" | "landlord-message-list" | "landlord-message-detail";
+export type PreviewQaRoute =
+  | "landlord-inbox"
+  | "landlord-message-recipients"
+  | "landlord-message-list"
+  | "landlord-message-detail"
+  | "landlord-message-compose";
+
+type PreviewQaContract = {
+  scope: string;
+  servicePattern: RegExp;
+  selector: string;
+  landlordId: string;
+  email: string;
+  allowedOperations: ReadonlySet<string>;
+};
+
+const previewQaContracts: readonly PreviewQaContract[] = [
+  {
+    scope: "pr1509-unified-inbox",
+    servicePattern: /^rentchain-pr1509-inbox-qa-[a-f0-9]{8}$/,
+    selector: PREVIEW_QA_IDENTITY_ALIAS,
+    landlordId: PREVIEW_QA_LANDLORD_ID,
+    email: "qa-pr1509-landlord@example.invalid",
+    allowedOperations: new Set([
+      "GET:landlord-inbox",
+      "GET:landlord-message-list",
+      "GET:landlord-message-detail",
+    ]),
+  },
+  {
+    scope: "pr1510-landlord-messaging",
+    servicePattern: /^rentchain-pr1510-messaging-qa-[a-f0-9]{8}$/,
+    selector: PR1510_PREVIEW_QA_IDENTITY_ALIAS,
+    landlordId: PR1510_PREVIEW_QA_LANDLORD_ID,
+    email: "qa-pr1510-landlord@example.invalid",
+    allowedOperations: new Set([
+      "GET:landlord-message-recipients",
+      "GET:landlord-message-list",
+      "GET:landlord-message-detail",
+      "POST:landlord-message-compose",
+    ]),
+  },
+];
 
 type PreviewQaDecision =
   | { kind: "continue-normal-auth" }
@@ -27,10 +69,6 @@ type PreviewQaDecisionInput = {
   authorizationPresent: boolean;
 };
 
-function isSupportedRoute(route: string): route is PreviewQaRoute {
-  return route === "landlord-inbox" || route === "landlord-message-list" || route === "landlord-message-detail";
-}
-
 export function decidePreviewQaAuth(input: PreviewQaDecisionInput): PreviewQaDecision {
   if (!input.selector) return { kind: "continue-normal-auth" };
   if (input.authorizationPresent) return { kind: "continue-normal-auth" };
@@ -43,33 +81,34 @@ export function decidePreviewQaAuth(input: PreviewQaDecisionInput): PreviewQaDec
   const expectedService = String(input.env.PREVIEW_QA_EXPECTED_SERVICE || "").trim();
   const firestoreEnabled = String(input.env.FIRESTORE_ENABLED || "").trim().toLowerCase();
   const firestoreDatabaseId = String(input.env.FIRESTORE_DATABASE_ID || "").trim();
+  const contract = previewQaContracts.find((candidate) => candidate.scope === scope);
 
   const isolatedPreviewQa =
     enabled === "true" &&
-    scope === PREVIEW_QA_SCOPE &&
+    Boolean(contract) &&
     appEnvironment === "preview" &&
     projectId !== PRODUCTION_PROJECT_ID &&
     projectId === PREVIEW_PROJECT_ID &&
     service !== PERMANENT_PREVIEW_SERVICE &&
     expectedService !== PERMANENT_PREVIEW_SERVICE &&
-    PREVIEW_QA_SERVICE_PATTERN.test(expectedService) &&
+    Boolean(contract?.servicePattern.test(expectedService)) &&
     service === expectedService &&
     firestoreEnabled === "true" &&
     firestoreDatabaseId === "(default)";
 
-  if (!isolatedPreviewQa) return { kind: "reject" };
-  if (input.method.toUpperCase() !== "GET" || !isSupportedRoute(input.route)) return { kind: "reject" };
-  if (input.selector !== PREVIEW_QA_IDENTITY_ALIAS) return { kind: "reject" };
+  if (!isolatedPreviewQa || !contract) return { kind: "reject" };
+  if (input.selector !== contract?.selector) return { kind: "reject" };
+  if (!contract.allowedOperations.has(`${input.method.toUpperCase()}:${input.route}`)) return { kind: "reject" };
   return { kind: "allow" };
 }
 
-function syntheticLandlordEntitlements(): UserEntitlements {
+function syntheticLandlordEntitlements(landlordId: string): UserEntitlements {
   return {
-    userId: PREVIEW_QA_LANDLORD_ID,
+    userId: landlordId,
     role: "landlord",
     plan: "starter",
     capabilities: ["messaging"],
-    landlordId: PREVIEW_QA_LANDLORD_ID,
+    landlordId,
   };
 }
 
@@ -93,12 +132,15 @@ export function previewQaAuth(route: PreviewQaRoute): RequestHandler {
       return res.status(401).json({ ok: false, error: "unauthenticated" });
     }
 
-    const entitlements = syntheticLandlordEntitlements();
+    const scope = String(process.env.PREVIEW_QA_AUTH_SCOPE || "").trim();
+    const contract = previewQaContracts.find((candidate) => candidate.scope === scope);
+    if (!contract) return res.status(401).json({ ok: false, error: "unauthenticated" });
+    const entitlements = syntheticLandlordEntitlements(contract.landlordId);
     (req as any).user = {
-      id: PREVIEW_QA_LANDLORD_ID,
-      email: "qa-pr1509-landlord@example.invalid",
+      id: contract.landlordId,
+      email: contract.email,
       role: "landlord",
-      landlordId: PREVIEW_QA_LANDLORD_ID,
+      landlordId: contract.landlordId,
       plan: "starter",
       capabilities: [...entitlements.capabilities],
       entitlements,

--- a/rentchain-api/src/routes/__tests__/messagesRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/messagesRoutes.test.ts
@@ -142,6 +142,10 @@ async function createRouter() {
   return (await import("../messagesRoutes")).default;
 }
 
+async function createPreviewQaComposeRouter() {
+  return (await import("../messagesRoutes")).previewQaComposeRoutes;
+}
+
 async function invokeRouter(router: any, options: {
   method: string;
   url: string;
@@ -221,6 +225,109 @@ describe("messagesRoutes notifications", () => {
     ensureCollection("users").set("landlord-1", {
       email: "landlord@example.com",
     });
+  });
+
+  it("reaches the exact recipient and Compose handlers through the pre-global PR #1510 QA router", async () => {
+    const previousEnv = process.env;
+    process.env = {
+      ...previousEnv,
+      PREVIEW_QA_AUTH_ENABLED: "true",
+      PREVIEW_QA_AUTH_SCOPE: "pr1510-landlord-messaging",
+      APP_ENV: "preview",
+      GOOGLE_CLOUD_PROJECT: "rentchain-preview",
+      K_SERVICE: "rentchain-pr1510-messaging-qa-14a551d2",
+      PREVIEW_QA_EXPECTED_SERVICE: "rentchain-pr1510-messaging-qa-14a551d2",
+      FIRESTORE_ENABLED: "true",
+      FIRESTORE_DATABASE_ID: "(default)",
+    };
+    ensureCollection("leases").set("lease-qa", {
+      landlordId: "qa-pr1510-landlord",
+      tenantId: "tenant-qa",
+      propertyId: "property-qa",
+      unitId: "unit-qa",
+      status: "active",
+    });
+    ensureCollection("tenants").set("tenant-qa", {
+      landlordId: "qa-pr1510-landlord",
+      fullName: "Synthetic Tenant",
+    });
+    ensureCollection("properties").set("property-qa", {
+      landlordId: "qa-pr1510-landlord",
+      name: "Synthetic Property",
+    });
+    ensureCollection("units").set("unit-qa", {
+      landlordId: "qa-pr1510-landlord",
+      propertyId: "property-qa",
+      unitNumber: "QA-1",
+    });
+
+    try {
+      const previewRouter = await createPreviewQaComposeRouter();
+      const headers = { "x-rentchain-preview-qa-identity": "pr1510-landlord" };
+      const recipients = await invokeRouter(previewRouter, {
+        method: "GET",
+        url: "/landlord/messages/recipients",
+        headers,
+      });
+      expect(recipients.status).toBe(200);
+      expect(recipients.body.recipients).toEqual([
+        expect.objectContaining({ leaseId: "lease-qa", tenantId: "tenant-qa" }),
+      ]);
+
+      const compose = await invokeRouter(previewRouter, {
+        method: "POST",
+        url: "/landlord/messages/conversations",
+        headers,
+        body: {
+          tenantId: "tenant-qa",
+          leaseId: "lease-qa",
+          body: "Synthetic first message",
+          requestId: "qa-route-order-request-0001",
+        },
+      });
+      expect(compose.status).toBe(201);
+      expect(compose.body).toEqual(expect.objectContaining({
+        conversationId: "qa-pr1510-landlord__tenant-qa__unit-qa",
+        created: true,
+      }));
+      expect(Array.from(ensureCollection("messages").values())).toEqual(
+        expect.arrayContaining([expect.objectContaining({ senderRole: "landlord" })])
+      );
+    } finally {
+      process.env = previousEnv;
+    }
+  });
+
+  it.each([
+    ["Production", { GOOGLE_CLOUD_PROJECT: "project-0d9658de-af29-4dc0-a99" }, undefined],
+    ["permanent Preview", { K_SERVICE: "rentchain-preview-backend" }, undefined],
+    ["wrong service", { K_SERVICE: "rentchain-pr1510-messaging-qa-deadbeef" }, undefined],
+    ["wrong scope", { PREVIEW_QA_AUTH_SCOPE: "pr1509-unified-inbox" }, undefined],
+    ["wrong selector", {}, "wrong-landlord"],
+  ])("keeps the pre-global Compose router fail-closed for %s", async (_label, overrides, selector) => {
+    const previousEnv = process.env;
+    process.env = {
+      ...previousEnv,
+      PREVIEW_QA_AUTH_ENABLED: "true",
+      PREVIEW_QA_AUTH_SCOPE: "pr1510-landlord-messaging",
+      APP_ENV: "preview",
+      GOOGLE_CLOUD_PROJECT: "rentchain-preview",
+      K_SERVICE: "rentchain-pr1510-messaging-qa-14a551d2",
+      PREVIEW_QA_EXPECTED_SERVICE: "rentchain-pr1510-messaging-qa-14a551d2",
+      FIRESTORE_ENABLED: "true",
+      FIRESTORE_DATABASE_ID: "(default)",
+      ...overrides,
+    };
+    try {
+      const result = await invokeRouter(await createPreviewQaComposeRouter(), {
+        method: "GET",
+        url: "/landlord/messages/recipients",
+        headers: { "x-rentchain-preview-qa-identity": selector || "pr1510-landlord" },
+      });
+      expect(result.status).toBe(401);
+    } finally {
+      process.env = previousEnv;
+    }
   });
 
   it("lists only bounded, independently owned current-lease recipients", async () => {

--- a/rentchain-api/src/routes/__tests__/messagesRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/messagesRoutes.test.ts
@@ -11,6 +11,7 @@ const { sendEmailMock } = vi.hoisted(() => ({
 const collections = new Map<string, Map<string, any>>();
 const failingDocGets = new Set<string>();
 const queryLimits: Array<{ collection: string; field: string; op: string; count: number }> = [];
+let transactionTail: Promise<void> = Promise.resolve();
 
 function ensureCollection(name: string) {
   if (!collections.has(name)) collections.set(name, new Map<string, any>());
@@ -21,7 +22,28 @@ function clone<T>(value: T): T {
   return value === undefined ? value : JSON.parse(JSON.stringify(value));
 }
 
+function seedEligibleLease() {
+  ensureCollection("leases").set("lease-1", {
+    landlordId: "landlord-1",
+    tenantId: "tenant-1",
+    tenantIds: ["tenant-1"],
+    propertyId: "prop-1",
+    unitId: "unit-1",
+    status: "active",
+  });
+}
+
 const dbMock = {
+  runTransaction: async (handler: (transaction: any) => Promise<any>) => {
+    const run = transactionTail.then(() =>
+      handler({
+        get: (ref: any) => ref.get(),
+        set: (ref: any, value: any, options?: any) => ref.set(value, options),
+      })
+    );
+    transactionTail = run.then(() => undefined, () => undefined);
+    return run;
+  },
   collection: (name: string) => ({
     doc: (id?: string) => {
       const docId = id || `doc_${ensureCollection(name).size + 1}`;
@@ -163,6 +185,7 @@ describe("messagesRoutes notifications", () => {
     collections.clear();
     failingDocGets.clear();
     queryLimits.length = 0;
+    transactionTail = Promise.resolve();
     sendEmailMock.mockReset();
     sendEmailMock.mockResolvedValue(undefined);
     process.env.EMAIL_FROM = "noreply@example.com";
@@ -186,16 +209,210 @@ describe("messagesRoutes notifications", () => {
       fullName: "Taylor Tenant",
     });
     ensureCollection("properties").set("prop-1", {
+      landlordId: "landlord-1",
       name: "Harbour View",
       units: [{ id: "unit-1", unitNumber: "2A" }],
     });
     ensureCollection("units").set("unit-1", {
+      landlordId: "landlord-1",
       propertyId: "prop-1",
       unitNumber: "2A",
     });
     ensureCollection("users").set("landlord-1", {
       email: "landlord@example.com",
     });
+  });
+
+  it("lists only bounded, independently owned current-lease recipients", async () => {
+    seedEligibleLease();
+    ensureCollection("tenants").set("tenant-ended", {
+      landlordId: "landlord-1",
+      fullName: "Ended Tenant",
+    });
+    ensureCollection("leases").set("lease-ended", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-ended",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      status: "ended",
+    });
+    ensureCollection("tenants").set("tenant-forged", {
+      landlordId: "landlord-1",
+      fullName: "Forged Tenant",
+    });
+    ensureCollection("leases").set("lease-forged", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-forged",
+      propertyId: "foreign-property",
+      unitId: "foreign-unit",
+      status: "active",
+    });
+    ensureCollection("properties").set("foreign-property", { landlordId: "landlord-2" });
+    ensureCollection("units").set("foreign-unit", { landlordId: "landlord-2", propertyId: "foreign-property" });
+
+    const router = await createRouter();
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/landlord/messages/recipients",
+      headers: { "x-test-user": JSON.stringify({ id: "landlord-1", landlordId: "landlord-1", role: "landlord" }) },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.recipients).toEqual([
+      expect.objectContaining({
+        leaseId: "lease-1",
+        tenantId: "tenant-1",
+        tenantDisplayName: "Taylor Tenant",
+        propertyDisplayLabel: "Harbour View",
+        unitDisplayLabel: "Unit 2A",
+      }),
+    ]);
+    expect(queryLimits).toContainEqual({
+      collection: "leases",
+      field: "landlordId",
+      op: "==",
+      count: 100,
+    });
+  });
+
+  it("atomically creates the canonical conversation and first landlord message", async () => {
+    seedEligibleLease();
+    ensureCollection("conversations").delete("conv-1");
+    const router = await createRouter();
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/landlord/messages/conversations",
+      headers: { "x-test-user": JSON.stringify({ id: "landlord-1", landlordId: "landlord-1", role: "landlord" }) },
+      body: {
+        tenantId: "tenant-1",
+        leaseId: "lease-1",
+        body: "Welcome to your message thread.",
+        requestId: "request-first-message-0001",
+      },
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual(expect.objectContaining({
+      conversationId: "landlord-1__tenant-1__unit-1",
+      created: true,
+    }));
+    expect(ensureCollection("conversations").get("landlord-1__tenant-1__unit-1")).toEqual(
+      expect.objectContaining({
+        landlordId: "landlord-1",
+        tenantId: "tenant-1",
+        unitId: "unit-1",
+        lastReadAtLandlord: "__server_timestamp__",
+      })
+    );
+    expect(Array.from(ensureCollection("messages").values()).filter((item) => item.body === "Welcome to your message thread.")).toEqual([
+      expect.objectContaining({ senderRole: "landlord" }),
+    ]);
+    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("reuses the canonical conversation and deduplicates a retried first-message request", async () => {
+    seedEligibleLease();
+    ensureCollection("conversations").set("landlord-1__tenant-1__unit-1", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      unitId: "unit-1",
+    });
+    const router = await createRouter();
+    const request = {
+      method: "POST",
+      url: "/landlord/messages/conversations",
+      headers: { "x-test-user": JSON.stringify({ id: "landlord-1", landlordId: "landlord-1", role: "landlord" }) },
+      body: {
+        tenantId: "tenant-1",
+        leaseId: "lease-1",
+        body: "A single retried message.",
+        requestId: "request-retry-message-0001",
+      },
+    };
+
+    const first = await invokeRouter(router, request);
+    const second = await invokeRouter(router, request);
+
+    expect(first.body).toEqual(expect.objectContaining({ created: false }));
+    expect(second.body).toEqual(expect.objectContaining({ created: false, conversationId: first.body.conversationId }));
+    expect(Array.from(ensureCollection("messages").values()).filter((item) => item.body === "A single retried message.")).toHaveLength(1);
+    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("reuses a matching legacy conversation instead of creating a deterministic duplicate", async () => {
+    seedEligibleLease();
+    ensureCollection("conversations").delete("conv-1");
+    ensureCollection("conversations").set("legacy-conversation-1", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+    });
+    const router = await createRouter();
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/landlord/messages/conversations",
+      headers: { "x-test-user": JSON.stringify({ id: "landlord-1", landlordId: "landlord-1", role: "landlord" }) },
+      body: {
+        tenantId: "tenant-1",
+        leaseId: "lease-1",
+        body: "Continue the existing thread.",
+        requestId: "request-legacy-message-0001",
+      },
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual(expect.objectContaining({
+      conversationId: "legacy-conversation-1",
+      created: false,
+    }));
+    expect(ensureCollection("conversations").has("landlord-1__tenant-1__unit-1")).toBe(false);
+    expect(Array.from(ensureCollection("messages").values()).filter((message) => message.body === "Continue the existing thread.")).toEqual([
+      expect.objectContaining({ conversationId: "legacy-conversation-1", senderRole: "landlord" }),
+    ]);
+  });
+
+  it("serializes concurrent first sends onto one canonical conversation", async () => {
+    seedEligibleLease();
+    ensureCollection("conversations").delete("conv-1");
+    const router = await createRouter();
+    const base = {
+      method: "POST",
+      url: "/landlord/messages/conversations",
+      headers: { "x-test-user": JSON.stringify({ id: "landlord-1", landlordId: "landlord-1", role: "landlord" }) },
+    };
+    const [first, second] = await Promise.all([
+      invokeRouter(router, { ...base, body: { tenantId: "tenant-1", leaseId: "lease-1", body: "First concurrent message", requestId: "concurrent-request-0001" } }),
+      invokeRouter(router, { ...base, body: { tenantId: "tenant-1", leaseId: "lease-1", body: "Second concurrent message", requestId: "concurrent-request-0002" } }),
+    ]);
+
+    expect(first.status).toBe(201);
+    expect(second.status).toBe(201);
+    expect(first.body.conversationId).toBe(second.body.conversationId);
+    expect(Array.from(ensureCollection("conversations").keys()).filter((id) => id === "landlord-1__tenant-1__unit-1")).toHaveLength(1);
+  });
+
+  it("fails closed for foreign, ended, orphan, malformed, and invalid message requests", async () => {
+    seedEligibleLease();
+    const router = await createRouter();
+    const auth = { "x-test-user": JSON.stringify({ id: "landlord-1", landlordId: "landlord-1", role: "landlord" }) };
+    ensureCollection("leases").set("lease-ended", {
+      landlordId: "landlord-1", tenantId: "tenant-1", propertyId: "prop-1", unitId: "unit-1", status: "ended",
+    });
+    ensureCollection("leases").set("lease-foreign", {
+      landlordId: "landlord-2", tenantId: "tenant-1", propertyId: "prop-1", unitId: "unit-1", status: "active",
+    });
+    ensureCollection("leases").set("lease-orphan", {
+      landlordId: "landlord-1", tenantId: "missing-tenant", propertyId: "prop-1", unitId: "unit-1", status: "active",
+    });
+    const send = (body: any) => invokeRouter(router, { method: "POST", url: "/landlord/messages/conversations", headers: auth, body });
+
+    expect((await send({ tenantId: "tenant-1", leaseId: "lease-ended", body: "No", requestId: "request-ended-0001" })).status).toBe(403);
+    expect((await send({ tenantId: "tenant-1", leaseId: "lease-foreign", body: "No", requestId: "request-foreign-0001" })).status).toBe(403);
+    expect((await send({ tenantId: "missing-tenant", leaseId: "lease-orphan", body: "No", requestId: "request-orphan-0001" })).status).toBe(403);
+    expect((await send({ tenantId: "tenant-1", leaseId: "lease-1", body: "", requestId: "request-empty-0001" })).status).toBe(400);
+    expect((await send({ tenantId: "tenant-1", leaseId: "lease-1", body: "x".repeat(4001), requestId: "request-long-0001" })).status).toBe(400);
+    expect((await send({ tenantId: "tenant-1", leaseId: "lease-1", body: "No", requestId: "short" })).status).toBe(400);
   });
 
   it("emails tenant when landlord sends a message", async () => {

--- a/rentchain-api/src/routes/messagesRoutes.ts
+++ b/rentchain-api/src/routes/messagesRoutes.ts
@@ -776,7 +776,8 @@ async function enforceMessagingCapability(req: any, landlordId: string, res: any
 /**
  * Landlord endpoints
  */
-router.get("/landlord/messages/recipients", previewQaAuth("landlord-message-recipients"), requireLandlord, async (req: any, res) => {
+function registerLandlordComposeRoutes(target: Router) {
+target.get("/landlord/messages/recipients", previewQaAuth("landlord-message-recipients"), requireLandlord, async (req: any, res) => {
   const landlordId = getEffectiveLandlordId(req);
   if (!landlordId) return res.status(401).json({ ok: false, error: "Unauthorized" });
   if (!(await enforceMessagingCapability(req, landlordId, res))) return;
@@ -815,7 +816,7 @@ router.get("/landlord/messages/recipients", previewQaAuth("landlord-message-reci
   }
 });
 
-router.post("/landlord/messages/conversations", previewQaAuth("landlord-message-compose"), requireLandlord, async (req: any, res) => {
+target.post("/landlord/messages/conversations", previewQaAuth("landlord-message-compose"), requireLandlord, async (req: any, res) => {
   const landlordId = getEffectiveLandlordId(req);
   if (!landlordId) return res.status(401).json({ ok: false, error: "Unauthorized" });
   if (!(await enforceMessagingCapability(req, landlordId, res))) return;
@@ -949,6 +950,11 @@ router.post("/landlord/messages/conversations", previewQaAuth("landlord-message-
     return res.status(500).json({ ok: false, error: "Failed to send message" });
   }
 });
+}
+
+export const previewQaComposeRoutes = Router();
+registerLandlordComposeRoutes(previewQaComposeRoutes);
+registerLandlordComposeRoutes(router);
 
 router.get("/landlord/messages/conversations", previewQaAuth("landlord-message-list"), requireLandlord, async (req: any, res) => {
   const landlordId = getEffectiveLandlordId(req);

--- a/rentchain-api/src/routes/messagesRoutes.ts
+++ b/rentchain-api/src/routes/messagesRoutes.ts
@@ -776,7 +776,7 @@ async function enforceMessagingCapability(req: any, landlordId: string, res: any
 /**
  * Landlord endpoints
  */
-router.get("/landlord/messages/recipients", requireLandlord, async (req: any, res) => {
+router.get("/landlord/messages/recipients", previewQaAuth("landlord-message-recipients"), requireLandlord, async (req: any, res) => {
   const landlordId = getEffectiveLandlordId(req);
   if (!landlordId) return res.status(401).json({ ok: false, error: "Unauthorized" });
   if (!(await enforceMessagingCapability(req, landlordId, res))) return;
@@ -815,7 +815,7 @@ router.get("/landlord/messages/recipients", requireLandlord, async (req: any, re
   }
 });
 
-router.post("/landlord/messages/conversations", requireLandlord, async (req: any, res) => {
+router.post("/landlord/messages/conversations", previewQaAuth("landlord-message-compose"), requireLandlord, async (req: any, res) => {
   const landlordId = getEffectiveLandlordId(req);
   if (!landlordId) return res.status(401).json({ ok: false, error: "Unauthorized" });
   if (!(await enforceMessagingCapability(req, landlordId, res))) return;

--- a/rentchain-api/src/routes/messagesRoutes.ts
+++ b/rentchain-api/src/routes/messagesRoutes.ts
@@ -8,6 +8,8 @@ import { buildUpgradeRequiredResponse, requireCapability } from "../services/cap
 import { buildEmailHtml, buildEmailText } from "../email/templates/baseEmailTemplate";
 import { sendEmail } from "../services/emailService";
 import { getEffectiveLandlordId, getEffectiveTenantId, resolveRequestAuthority } from "../auth/requestAuthority";
+import { createHash } from "node:crypto";
+import { isCurrentLeaseStatus } from "../services/leaseCanonicalizationService";
 
 const router = Router();
 router.use(authenticateJwt);
@@ -16,6 +18,7 @@ type Role = "landlord" | "tenant";
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const MAX_LEASE_LOOKUP_CANDIDATES = 10;
 const MAX_TENANT_LOOKUP_CANDIDATES = 2;
+const MAX_MESSAGE_RECIPIENT_LEASES = 100;
 const CURRENT_LEASE_STATUSES = new Set([
   "active",
   "current",
@@ -490,6 +493,87 @@ function stringOrNull(value: any) {
   return next || null;
 }
 
+function tenantIdsForLease(raw: any) {
+  return Array.from(
+    new Set(
+      [raw?.tenantId, ...(Array.isArray(raw?.tenantIds) ? raw.tenantIds : [])]
+        .map(stringOrNull)
+        .filter((value): value is string => Boolean(value))
+    )
+  );
+}
+
+function canonicalConversationId(landlordId: string, tenantId: string, unitId: string) {
+  return `${landlordId}__${tenantId}__${unitId}`;
+}
+
+function idempotentMessageId(conversationId: string, requestId: string) {
+  return `outbound_${createHash("sha256").update(`${conversationId}:${requestId}`).digest("hex")}`;
+}
+
+function conversationMatchesRecipient(conversation: any, recipient: {
+  landlordId: string;
+  tenantId: string;
+  propertyId: string;
+  unitId: string;
+}) {
+  return (
+    stringOrNull(conversation?.landlordId) === recipient.landlordId &&
+    stringOrNull(conversation?.tenantId) === recipient.tenantId &&
+    stringOrNull(conversation?.unitId) === recipient.unitId &&
+    (!stringOrNull(conversation?.propertyId) || stringOrNull(conversation?.propertyId) === recipient.propertyId)
+  );
+}
+
+async function resolveEligibleRecipient(params: {
+  landlordId: string;
+  leaseId: string;
+  tenantId: string;
+  reader?: { get: (ref: any) => Promise<any> };
+}) {
+  const read = params.reader?.get
+    ? (ref: any) => params.reader!.get(ref)
+    : (ref: any) => ref.get();
+  const leaseRef = db.collection("leases").doc(params.leaseId);
+  const leaseSnap = await read(leaseRef);
+  if (!leaseSnap.exists) return null;
+  const lease = leaseSnap.data() as any;
+  if (stringOrNull(lease?.landlordId) !== params.landlordId) return null;
+  if (!isCurrentLeaseStatus(lease?.status)) return null;
+  if (!tenantIdsForLease(lease).includes(params.tenantId)) return null;
+
+  const propertyId = stringOrNull(lease?.propertyId);
+  const unitId = stringOrNull(lease?.unitId);
+  if (!propertyId || !unitId) return null;
+
+  const [tenantSnap, propertySnap, unitSnap] = await Promise.all([
+    read(db.collection("tenants").doc(params.tenantId)),
+    read(db.collection("properties").doc(propertyId)),
+    read(db.collection("units").doc(unitId)),
+  ]);
+  if (!tenantSnap.exists || !propertySnap.exists || !unitSnap.exists) return null;
+  const tenant = tenantSnap.data() as any;
+  const property = propertySnap.data() as any;
+  const unit = unitSnap.data() as any;
+  if (stringOrNull(property?.landlordId) !== params.landlordId) return null;
+  if (stringOrNull(unit?.propertyId) !== propertyId) return null;
+  const unitLandlordId = stringOrNull(unit?.landlordId);
+  if (unitLandlordId && unitLandlordId !== params.landlordId) return null;
+  const tenantLandlordId = stringOrNull(tenant?.landlordId);
+  if (tenantLandlordId && tenantLandlordId !== params.landlordId) return null;
+
+  return {
+    leaseId: leaseSnap.id,
+    tenantId: tenantSnap.id,
+    tenantEmail: buildTenantEmail(tenant),
+    tenantDisplayName: stringOrNull(tenant?.fullName) || stringOrNull(tenant?.name) || "Tenant",
+    propertyId,
+    propertyDisplayLabel: buildPropertyLabel(property),
+    unitId,
+    unitDisplayLabel: normalizeUnitLabel(unit?.unitNumber || unit?.unitLabel || unit?.label || unit?.name),
+  };
+}
+
 async function lookupUserEmail(userId: string | null) {
   const id = stringOrNull(userId);
   if (!id) return null;
@@ -618,8 +702,8 @@ async function sendConversationMessageEmail(params: {
   const threadPath = params.senderRole === "landlord" ? "/tenant/messages" : "/messages";
   const subjectPrefix = params.senderRole === "landlord" ? "New message from your landlord" : "New tenant message";
   const contextBits = [
-    stringOrNull(params.conversation.propertyId),
-    stringOrNull(params.conversation.unitId),
+    stringOrNull(params.conversation.propertyDisplayLabel),
+    stringOrNull(params.conversation.unitDisplayLabel),
   ].filter(Boolean);
   const preview = params.body.length > 280 ? `${params.body.slice(0, 280)}...` : params.body;
 
@@ -692,6 +776,180 @@ async function enforceMessagingCapability(req: any, landlordId: string, res: any
 /**
  * Landlord endpoints
  */
+router.get("/landlord/messages/recipients", requireLandlord, async (req: any, res) => {
+  const landlordId = getEffectiveLandlordId(req);
+  if (!landlordId) return res.status(401).json({ ok: false, error: "Unauthorized" });
+  if (!(await enforceMessagingCapability(req, landlordId, res))) return;
+
+  try {
+    const leaseSnap = await db
+      .collection("leases")
+      .where("landlordId", "==", landlordId)
+      .limit(MAX_MESSAGE_RECIPIENT_LEASES)
+      .get();
+    const candidates = leaseSnap.docs.flatMap((doc: any) =>
+      tenantIdsForLease(doc.data()).map((tenantId) => ({ leaseId: doc.id, tenantId }))
+    );
+    const resolved = await Promise.all(
+      candidates.map((candidate) => resolveEligibleRecipient({ landlordId, ...candidate }))
+    );
+    const recipients = resolved
+      .filter((recipient): recipient is NonNullable<typeof recipient> => Boolean(recipient))
+      .sort((left, right) =>
+        [left.tenantDisplayName, left.propertyDisplayLabel, left.unitDisplayLabel, left.leaseId]
+          .map((value) => String(value || ""))
+          .join("\u0000")
+          .localeCompare(
+            [right.tenantDisplayName, right.propertyDisplayLabel, right.unitDisplayLabel, right.leaseId]
+              .map((value) => String(value || ""))
+              .join("\u0000")
+          )
+      );
+    return res.json({ ok: true, recipients });
+  } catch (err: any) {
+    console.error("[messages] landlord recipient list error", {
+      landlordId,
+      code: stringOrNull(err?.code) || "recipient_list_failed",
+    });
+    return res.status(500).json({ ok: false, error: "Failed to list message recipients" });
+  }
+});
+
+router.post("/landlord/messages/conversations", requireLandlord, async (req: any, res) => {
+  const landlordId = getEffectiveLandlordId(req);
+  if (!landlordId) return res.status(401).json({ ok: false, error: "Unauthorized" });
+  if (!(await enforceMessagingCapability(req, landlordId, res))) return;
+  const tenantId = stringOrNull(req.body?.tenantId);
+  const leaseId = stringOrNull(req.body?.leaseId);
+  const body = String(req.body?.body || "").trim();
+  const requestId = stringOrNull(req.body?.requestId);
+  if (!tenantId || !leaseId) return res.status(400).json({ ok: false, error: "recipient required" });
+  if (!body) return res.status(400).json({ ok: false, error: "body required" });
+  if (body.length > 4000) return res.status(400).json({ ok: false, error: "body too long" });
+  if (!requestId || !/^[A-Za-z0-9_-]{16,100}$/.test(requestId)) {
+    return res.status(400).json({ ok: false, error: "valid requestId required" });
+  }
+
+  try {
+    const result = await db.runTransaction(async (transaction: any) => {
+      const recipient = await resolveEligibleRecipient({
+        landlordId,
+        leaseId,
+        tenantId,
+        reader: transaction,
+      });
+      if (!recipient) return { forbidden: true } as const;
+
+      const deterministicConversationId = canonicalConversationId(landlordId, recipient.tenantId, recipient.unitId);
+      const deterministicConversationRef = db.collection("conversations").doc(deterministicConversationId);
+      const legacyConversationQuery = db
+        .collection("conversations")
+        .where("tenantId", "==", recipient.tenantId)
+        .limit(25);
+      const [deterministicConversationSnap, legacyConversationSnap] = await Promise.all([
+        transaction.get(deterministicConversationRef),
+        transaction.get(legacyConversationQuery),
+      ]);
+      const matchingLegacyConversation = legacyConversationSnap.docs
+        .map((doc: any) => ({ id: doc.id, data: doc.data() }))
+        .filter((candidate: any) =>
+          conversationMatchesRecipient(candidate.data, { landlordId, ...recipient })
+        )
+        .sort((left: any, right: any) => left.id.localeCompare(right.id))[0];
+      const conversationId = deterministicConversationSnap.exists
+        ? deterministicConversationId
+        : matchingLegacyConversation?.id || deterministicConversationId;
+      const conversationRef = db.collection("conversations").doc(conversationId);
+      const messageRef = db.collection("messages").doc(idempotentMessageId(conversationId, requestId));
+      const messageSnap = await transaction.get(messageRef);
+      if (messageSnap.exists) {
+        return {
+          forbidden: false,
+          conversationId,
+          created: false,
+          message: { id: messageSnap.id, ...(messageSnap.data() as any) },
+          recipient,
+          shouldNotify: false,
+        } as const;
+      }
+
+      const created = !deterministicConversationSnap.exists && !matchingLegacyConversation;
+      const now = Date.now();
+      if (created) {
+        transaction.set(conversationRef, {
+          landlordId,
+          tenantId: recipient.tenantId,
+          tenantEmail: recipient.tenantEmail,
+          tenantName: recipient.tenantDisplayName,
+          leaseId: recipient.leaseId,
+          propertyId: recipient.propertyId,
+          propertyDisplayLabel: recipient.propertyDisplayLabel,
+          unitId: recipient.unitId,
+          unitDisplayLabel: recipient.unitDisplayLabel,
+          createdAt: FieldValue.serverTimestamp(),
+          lastMessageAt: FieldValue.serverTimestamp(),
+          lastReadAtLandlord: FieldValue.serverTimestamp(),
+          lastReadAtTenant: null,
+        });
+      } else {
+        transaction.set(
+          conversationRef,
+          {
+            lastMessageAt: FieldValue.serverTimestamp(),
+            lastReadAtLandlord: FieldValue.serverTimestamp(),
+          },
+          { merge: true }
+        );
+      }
+      const message = {
+        conversationId,
+        senderRole: "landlord" as const,
+        body,
+        createdAt: FieldValue.serverTimestamp(),
+        createdAtMs: now,
+      };
+      transaction.set(messageRef, message);
+      return {
+        forbidden: false,
+        conversationId,
+        created,
+        message: { id: messageRef.id, ...message },
+        recipient,
+        shouldNotify: true,
+      } as const;
+    });
+
+    if (result.forbidden) return res.status(403).json({ ok: false, error: "Recipient unavailable" });
+    if (result.shouldNotify) {
+      try {
+        await sendConversationMessageEmail({
+          conversation: { id: result.conversationId, landlordId, ...result.recipient },
+          senderRole: "landlord",
+          body,
+        });
+      } catch (err: any) {
+        console.error("[messages] landlord first-message email failed", {
+          conversationId: result.conversationId,
+          landlordId,
+          code: stringOrNull(err?.code) || "send_failed",
+        });
+      }
+    }
+    return res.status(201).json({
+      ok: true,
+      conversationId: result.conversationId,
+      created: result.created,
+      message: result.message,
+    });
+  } catch (err: any) {
+    console.error("[messages] landlord first-message error", {
+      landlordId,
+      code: stringOrNull(err?.code) || "first_message_failed",
+    });
+    return res.status(500).json({ ok: false, error: "Failed to send message" });
+  }
+});
+
 router.get("/landlord/messages/conversations", previewQaAuth("landlord-message-list"), requireLandlord, async (req: any, res) => {
   const landlordId = getEffectiveLandlordId(req);
   if (!landlordId) return res.status(401).json({ ok: false, error: "Unauthorized" });

--- a/rentchain-frontend/src/api/messagesApi.test.ts
+++ b/rentchain-frontend/src/api/messagesApi.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createLandlordConversationMessage, fetchLandlordMessageRecipients } from "./messagesApi";
+
+const apiFetchMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/apiClient", () => ({
+  apiFetch: apiFetchMock,
+}));
+
+describe("landlord message compose API", () => {
+  beforeEach(() => apiFetchMock.mockReset());
+
+  it("loads the bounded server-projected recipient list", async () => {
+    apiFetchMock.mockResolvedValue({ recipients: [{ leaseId: "lease-1", tenantId: "tenant-1" }] });
+
+    await expect(fetchLandlordMessageRecipients()).resolves.toEqual([
+      { leaseId: "lease-1", tenantId: "tenant-1" },
+    ]);
+    expect(apiFetchMock).toHaveBeenCalledWith("/landlord/messages/recipients");
+  });
+
+  it("sends only the selected lease, tenant, body, and idempotency request id", async () => {
+    apiFetchMock.mockResolvedValue({ conversationId: "conversation-1", created: true, message: {} });
+    const input = {
+      leaseId: "lease-1",
+      tenantId: "tenant-1",
+      body: "First message",
+      requestId: "request-first-message-1",
+    };
+
+    await createLandlordConversationMessage(input);
+
+    expect(apiFetchMock).toHaveBeenCalledWith("/landlord/messages/conversations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(input),
+    });
+  });
+});

--- a/rentchain-frontend/src/api/messagesApi.ts
+++ b/rentchain-frontend/src/api/messagesApi.ts
@@ -23,9 +23,37 @@ export type Message = {
   createdAtMs?: number | null;
 };
 
+export type MessageRecipient = {
+  leaseId: string;
+  tenantId: string;
+  tenantDisplayName: string;
+  propertyId: string;
+  propertyDisplayLabel?: string | null;
+  unitId: string;
+  unitDisplayLabel?: string | null;
+};
+
 export async function fetchLandlordConversations(): Promise<Conversation[]> {
   const res = await apiFetch("/landlord/messages/conversations");
   return Array.isArray((res as any)?.conversations) ? (res as any).conversations : [];
+}
+
+export async function fetchLandlordMessageRecipients(): Promise<MessageRecipient[]> {
+  const res = await apiFetch("/landlord/messages/recipients");
+  return Array.isArray((res as any)?.recipients) ? (res as any).recipients : [];
+}
+
+export async function createLandlordConversationMessage(input: {
+  tenantId: string;
+  leaseId: string;
+  body: string;
+  requestId: string;
+}): Promise<{ conversationId: string; created: boolean; message: Message }> {
+  return apiFetch("/landlord/messages/conversations", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  }) as Promise<{ conversationId: string; created: boolean; message: Message }>;
 }
 
 export async function fetchLandlordConversationMessages(

--- a/rentchain-frontend/src/components/DebugPanel.test.tsx
+++ b/rentchain-frontend/src/components/DebugPanel.test.tsx
@@ -82,9 +82,9 @@ describe("DebugPanel", () => {
     expect(await screen.findByText("Debug (dev only)")).toBeInTheDocument();
     expect(screen.getByTestId("debug-panel-expanded")).toHaveStyle({
       position: "fixed",
-      top: "220px",
+      bottom: "160px",
       right: "10px",
-      maxHeight: "calc(100vh - 380px)",
+      maxHeight: "calc(100vh - 440px)",
       overflowY: "auto",
     });
     expect(screen.getByText("Plan: elite")).toBeInTheDocument();

--- a/rentchain-frontend/src/components/DebugPanel.test.tsx
+++ b/rentchain-frontend/src/components/DebugPanel.test.tsx
@@ -80,6 +80,13 @@ describe("DebugPanel", () => {
     fireEvent.click(toggle);
 
     expect(await screen.findByText("Debug (dev only)")).toBeInTheDocument();
+    expect(screen.getByTestId("debug-panel-expanded")).toHaveStyle({
+      position: "fixed",
+      top: "220px",
+      right: "10px",
+      maxHeight: "calc(100vh - 380px)",
+      overflowY: "auto",
+    });
     expect(screen.getByText("Plan: elite")).toBeInTheDocument();
     expect(screen.getByText("Properties: 2")).toBeInTheDocument();
     expect(screen.getByText("Team Invites: no")).toBeInTheDocument();

--- a/rentchain-frontend/src/components/DebugPanel.test.tsx
+++ b/rentchain-frontend/src/components/DebugPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DebugPanel } from "./DebugPanel";
@@ -52,7 +52,7 @@ describe("DebugPanel", () => {
     expect(screen.queryByText("Debug (dev only)")).not.toBeInTheDocument();
   });
 
-  it("renders account limits on authenticated desktop dev sessions", async () => {
+  it("starts minimized and expands account limits on authenticated desktop dev sessions", async () => {
     setAuthToken("demo-token");
     vi.mocked(fetchAccountLimits).mockResolvedValue({
       status: "ok",
@@ -73,9 +73,19 @@ describe("DebugPanel", () => {
 
     renderDebugPanel();
 
+    const toggle = await screen.findByRole("button", { name: "Expand debug panel" });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("Debug (dev only)")).not.toBeInTheDocument();
+
+    fireEvent.click(toggle);
+
     expect(await screen.findByText("Debug (dev only)")).toBeInTheDocument();
     expect(screen.getByText("Plan: elite")).toBeInTheDocument();
     expect(screen.getByText("Properties: 2")).toBeInTheDocument();
     expect(screen.getByText("Team Invites: no")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Collapse debug panel" }));
+    await waitFor(() => expect(screen.queryByText("Debug (dev only)")).not.toBeInTheDocument());
+    expect(screen.getByRole("button", { name: "Expand debug panel" })).toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/components/DebugPanel.tsx
+++ b/rentchain-frontend/src/components/DebugPanel.tsx
@@ -8,7 +8,7 @@ const lastApiError: unknown = null;
 
 const expandedPanelStyle: React.CSSProperties = {
   position: "fixed",
-  top: 220,
+  bottom: 160,
   right: 10,
   padding: "10px 12px",
   borderRadius: 10,
@@ -18,7 +18,7 @@ const expandedPanelStyle: React.CSSProperties = {
   zIndex: 5000,
   border: "1px solid rgba(148,163,184,0.4)",
   maxWidth: 320,
-  maxHeight: "calc(100vh - 380px)",
+  maxHeight: "calc(100vh - 440px)",
   overflowY: "auto",
   overscrollBehavior: "contain",
 };

--- a/rentchain-frontend/src/components/DebugPanel.tsx
+++ b/rentchain-frontend/src/components/DebugPanel.tsx
@@ -18,6 +18,7 @@ export const DebugPanel: React.FC = () => {
   const [limits, setLimits] = useState<AccountLimits | null>(null);
   const [hasAuthToken, setHasAuthToken] = useState(false);
   const [isMobileViewport, setIsMobileViewport] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(false);
   const isPublicRoute = isPublicRoutePath(location.pathname);
 
   useEffect(() => {
@@ -46,6 +47,34 @@ export const DebugPanel: React.FC = () => {
 
   if (!import.meta.env.DEV || !hasAuthToken || isMobileViewport || isPublicRoute) return null;
 
+  if (!isExpanded) {
+    return (
+      <button
+        type="button"
+        aria-expanded="false"
+        aria-label="Expand debug panel"
+        data-testid="debug-panel-toggle"
+        onClick={() => setIsExpanded(true)}
+        style={{
+          position: "fixed",
+          bottom: 10,
+          right: 10,
+          padding: "8px 12px",
+          borderRadius: 999,
+          background: "rgba(15,23,42,0.9)",
+          color: "#e2e8f0",
+          fontSize: 12,
+          fontWeight: 800,
+          zIndex: 5000,
+          border: "1px solid rgba(148,163,184,0.4)",
+          cursor: "pointer",
+        }}
+      >
+        Debug
+      </button>
+    );
+  }
+
   // Normalize data to avoid crashes when limits are missing/shape differs
   const limitsData = limits || null;
 
@@ -66,7 +95,25 @@ export const DebugPanel: React.FC = () => {
           maxWidth: 320,
         }}
       >
-        <div style={{ fontWeight: 800, marginBottom: 6 }}>Debug (dev only)</div>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12 }}>
+          <div style={{ fontWeight: 800 }}>Debug (dev only)</div>
+          <button
+            type="button"
+            aria-label="Collapse debug panel"
+            onClick={() => setIsExpanded(false)}
+            style={{
+              minHeight: 28,
+              padding: "2px 8px",
+              borderRadius: 999,
+              border: "1px solid rgba(148,163,184,0.5)",
+              background: "transparent",
+              color: "inherit",
+              cursor: "pointer",
+            }}
+          >
+            Hide
+          </button>
+        </div>
         <div>Loading limits…</div>
         {lastApiError ? (
           <div style={{ marginTop: 8, color: "#fca5a5" }}>
@@ -108,7 +155,33 @@ export const DebugPanel: React.FC = () => {
         maxWidth: 320,
       }}
     >
-      <div style={{ fontWeight: 800, marginBottom: 6 }}>Debug (dev only)</div>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 12,
+          marginBottom: 6,
+        }}
+      >
+        <div style={{ fontWeight: 800 }}>Debug (dev only)</div>
+        <button
+          type="button"
+          aria-label="Collapse debug panel"
+          onClick={() => setIsExpanded(false)}
+          style={{
+            minHeight: 28,
+            padding: "2px 8px",
+            borderRadius: 999,
+            border: "1px solid rgba(148,163,184,0.5)",
+            background: "transparent",
+            color: "inherit",
+            cursor: "pointer",
+          }}
+        >
+          Hide
+        </button>
+      </div>
       <div style={{ display: "grid", gap: 4 }}>
         <div>Plan: {plan}</div>
         <div title={integrityTooltip}>

--- a/rentchain-frontend/src/components/DebugPanel.tsx
+++ b/rentchain-frontend/src/components/DebugPanel.tsx
@@ -6,6 +6,23 @@ import { isPublicRoutePath } from "../lib/publicRoute";
 
 const lastApiError: unknown = null;
 
+const expandedPanelStyle: React.CSSProperties = {
+  position: "fixed",
+  top: 220,
+  right: 10,
+  padding: "10px 12px",
+  borderRadius: 10,
+  background: "rgba(15,23,42,0.9)",
+  color: "#e2e8f0",
+  fontSize: 12,
+  zIndex: 5000,
+  border: "1px solid rgba(148,163,184,0.4)",
+  maxWidth: 320,
+  maxHeight: "calc(100vh - 380px)",
+  overflowY: "auto",
+  overscrollBehavior: "contain",
+};
+
 function formatApiError(err: unknown) {
   if (typeof err === "object" && err !== null && "message" in err && typeof err.message === "string") {
     return err.message;
@@ -81,19 +98,8 @@ export const DebugPanel: React.FC = () => {
   if (!limitsData) {
     return (
       <div
-        style={{
-          position: "fixed",
-          bottom: 10,
-          right: 10,
-          padding: "10px 12px",
-          borderRadius: 10,
-          background: "rgba(15,23,42,0.9)",
-          color: "#e2e8f0",
-          fontSize: 12,
-          zIndex: 5000,
-          border: "1px solid rgba(148,163,184,0.4)",
-          maxWidth: 320,
-        }}
+        data-testid="debug-panel-expanded"
+        style={expandedPanelStyle}
       >
         <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12 }}>
           <div style={{ fontWeight: 800 }}>Debug (dev only)</div>
@@ -141,19 +147,8 @@ export const DebugPanel: React.FC = () => {
 
   return (
     <div
-      style={{
-        position: "fixed",
-        bottom: 10,
-        right: 10,
-        padding: "10px 12px",
-        borderRadius: 10,
-        background: "rgba(15,23,42,0.9)",
-        color: "#e2e8f0",
-        fontSize: 12,
-        zIndex: 5000,
-        border: "1px solid rgba(148,163,184,0.4)",
-        maxWidth: 320,
-      }}
+      data-testid="debug-panel-expanded"
+      style={expandedPanelStyle}
     >
       <div
         style={{

--- a/rentchain-frontend/src/components/layout/LandlordNav.test.tsx
+++ b/rentchain-frontend/src/components/layout/LandlordNav.test.tsx
@@ -314,7 +314,7 @@ describe("LandlordNav mobile drawer", () => {
     );
   });
 
-  it("shows one landlord drawer inbox entry pointing to the unified inbox", async () => {
+  it("shows distinct landlord drawer entries for the unified inbox and direct messages", async () => {
     renderLandlordNav();
 
     fireEvent.click(screen.getByRole("button", { name: "Open workspace pages" }));
@@ -322,12 +322,23 @@ describe("LandlordNav mobile drawer", () => {
     const drawer = screen.getByRole("dialog", { name: "Navigation menu" });
     const inboxButtons = within(drawer).getAllByRole("button", { name: "Inbox" });
     expect(inboxButtons).toHaveLength(1);
-    expect(within(drawer).queryByRole("button", { name: "Messages" })).not.toBeInTheDocument();
+    expect(within(drawer).getByRole("button", { name: "Messages" })).toBeInTheDocument();
 
     fireEvent.click(inboxButtons[0]);
 
     await waitFor(() => {
       expect(screen.getByTestId("current-path")).toHaveTextContent("/landlord/unified-inbox");
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Open workspace pages" }));
+    fireEvent.click(
+      within(screen.getByRole("dialog", { name: "Navigation menu" })).getByRole("button", {
+        name: "Messages",
+      })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("current-path")).toHaveTextContent("/messages");
     });
   });
 

--- a/rentchain-frontend/src/components/layout/WorkspaceDrawer.test.tsx
+++ b/rentchain-frontend/src/components/layout/WorkspaceDrawer.test.tsx
@@ -60,6 +60,27 @@ describe("WorkspaceDrawer", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  it("shows direct Messages navigation to landlords and keeps it landlord-only", () => {
+    const onClose = vi.fn();
+    const { rerender } = render(
+      <MemoryRouter initialEntries={["/dashboard"]}>
+        <WorkspaceDrawer open onClose={onClose} userRole="landlord" />
+        <CurrentPath />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Messages" }));
+    expect(screen.getByTestId("current-path")).toHaveTextContent("/messages");
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <MemoryRouter initialEntries={["/dashboard"]}>
+        <WorkspaceDrawer open onClose={vi.fn()} userRole="admin" />
+      </MemoryRouter>
+    );
+    expect(screen.queryByRole("button", { name: "Messages" })).not.toBeInTheDocument();
+  });
+
   it("shows governed review workspace navigation only for admins", () => {
     const { rerender } = render(
       <MemoryRouter initialEntries={["/dashboard"]}>

--- a/rentchain-frontend/src/components/layout/navConfig.ts
+++ b/rentchain-frontend/src/components/layout/navConfig.ts
@@ -118,9 +118,10 @@ export const NAV_ITEMS: NavItem[] = [
     label: "Messages",
     to: "/messages",
     icon: MessagesSquare,
-    showInDrawer: false,
+    showInDrawer: true,
     showInTabs: false,
     requiresFeature: "messaging",
+    requiresRoles: ["landlord"],
   },
   {
     id: "payments",

--- a/rentchain-frontend/src/pages/MessagesPage.css
+++ b/rentchain-frontend/src/pages/MessagesPage.css
@@ -445,11 +445,16 @@
 
   .rc-messages-compose-overlay {
     align-items: end;
-    padding: 12px;
+    padding: 12px 12px calc(12px + var(--rc-mobile-bottom-nav-height) + env(safe-area-inset-bottom, 0px));
   }
 
   .rc-messages-compose-panel {
-    max-height: calc(100dvh - 24px);
+    max-height: calc(
+      100dvh -
+      24px -
+      var(--rc-mobile-bottom-nav-height) -
+      env(safe-area-inset-bottom, 0px)
+    );
     padding: 16px;
   }
 }

--- a/rentchain-frontend/src/pages/MessagesPage.css
+++ b/rentchain-frontend/src/pages/MessagesPage.css
@@ -13,6 +13,154 @@
   overflow-x: hidden;
 }
 
+.rc-messages-page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.rc-messages-page-header h1,
+.rc-messages-compose-heading h2,
+.rc-messages-compose-heading p {
+  margin: 0;
+}
+
+.rc-messages-new-button,
+.rc-messages-empty-detail button,
+.rc-messages-compose-actions .is-primary {
+  border: 1px solid #1d4ed8;
+  border-radius: 12px;
+  background: #2563eb;
+  color: #ffffff;
+  cursor: pointer;
+  font-weight: 750;
+  min-height: 44px;
+  padding: 10px 16px;
+}
+
+.rc-messages-compose-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 4100;
+  display: grid;
+  place-items: center;
+  padding: 20px;
+  background: rgba(15, 23, 42, 0.48);
+}
+
+.rc-messages-compose-panel {
+  box-sizing: border-box;
+  width: min(620px, 100%);
+  max-height: min(760px, calc(100dvh - 40px));
+  overflow-y: auto;
+  display: grid;
+  gap: 16px;
+  padding: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  border-radius: 18px;
+  background: #ffffff;
+  box-shadow: 0 24px 70px rgba(15, 23, 42, 0.24);
+}
+
+.rc-messages-compose-heading,
+.rc-messages-compose-actions {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.rc-messages-compose-heading p {
+  margin-top: 4px;
+  color: #64748b;
+}
+
+.rc-messages-compose-heading button,
+.rc-messages-compose-actions button:not(.is-primary) {
+  border: 1px solid rgba(148, 163, 184, 0.55);
+  border-radius: 10px;
+  background: #ffffff;
+  cursor: pointer;
+  min-height: 40px;
+  padding: 8px 12px;
+}
+
+.rc-messages-compose-field {
+  display: grid;
+  gap: 6px;
+  color: #0f172a;
+  font-weight: 700;
+}
+
+.rc-messages-compose-field input,
+.rc-messages-compose-field textarea {
+  box-sizing: border-box;
+  width: 100%;
+  min-width: 0;
+  border: 1px solid rgba(148, 163, 184, 0.55);
+  border-radius: 12px;
+  padding: 10px 12px;
+  font: inherit;
+}
+
+.rc-messages-compose-field textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+
+.rc-messages-recipient-list {
+  display: grid;
+  gap: 8px;
+  max-height: 240px;
+  overflow-y: auto;
+}
+
+.rc-messages-recipient-list button {
+  display: grid;
+  gap: 4px;
+  width: 100%;
+  min-width: 0;
+  padding: 10px 12px;
+  text-align: left;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  border-radius: 12px;
+  background: #ffffff;
+  cursor: pointer;
+}
+
+.rc-messages-recipient-list button.is-selected {
+  border-color: #2563eb;
+  background: rgba(37, 99, 235, 0.1);
+}
+
+.rc-messages-recipient-list span {
+  color: #64748b;
+  overflow-wrap: anywhere;
+}
+
+.rc-messages-compose-actions {
+  justify-content: flex-end;
+}
+
+.rc-messages-compose-actions button:disabled,
+.rc-messages-compose-heading button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.rc-messages-compose-error {
+  color: #b91c1c;
+}
+
+.rc-messages-empty-detail {
+  display: grid;
+  justify-items: start;
+  gap: 12px;
+  color: #64748b;
+}
+
 .rc-messages-grid {
   flex: 1;
   min-height: 0;
@@ -289,5 +437,19 @@
 
   .rc-messages-composer-input {
     min-height: 50px;
+  }
+
+  .rc-messages-page-header {
+    align-items: flex-start;
+  }
+
+  .rc-messages-compose-overlay {
+    align-items: end;
+    padding: 12px;
+  }
+
+  .rc-messages-compose-panel {
+    max-height: calc(100dvh - 24px);
+    padding: 16px;
   }
 }

--- a/rentchain-frontend/src/pages/MessagesPage.test.tsx
+++ b/rentchain-frontend/src/pages/MessagesPage.test.tsx
@@ -575,6 +575,12 @@ describe("MessagesPage", () => {
     expect(css).toMatch(/\.rc-messages-thread\s*\{[\s\S]*?height:\s*100%;[\s\S]*?overflow:\s*hidden;/);
     expect(css).toMatch(/\.rc-messages-thread-body\s*\{[\s\S]*?overflow-y:\s*auto;/);
     expect(css).toMatch(/\.rc-messages-composer-input\s*\{[\s\S]*?min-width:\s*0;/);
+    expect(css).toMatch(
+      /\.rc-messages-compose-overlay\s*\{[\s\S]*?padding:\s*12px 12px calc\(12px \+ var\(--rc-mobile-bottom-nav-height\) \+ env\(safe-area-inset-bottom, 0px\)\);/
+    );
+    expect(css).toMatch(
+      /\.rc-messages-compose-panel\s*\{[\s\S]*?max-height:\s*calc\([\s\S]*?var\(--rc-mobile-bottom-nav-height\)[\s\S]*?env\(safe-area-inset-bottom, 0px\)[\s\S]*?\);/
+    );
   });
 
   it("keeps the composer usable and sends through the selected conversation", async () => {

--- a/rentchain-frontend/src/pages/MessagesPage.test.tsx
+++ b/rentchain-frontend/src/pages/MessagesPage.test.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import { MemoryRouter, useLocation } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { readFileSync } from "node:fs";
@@ -10,6 +10,8 @@ const mocks = vi.hoisted(() => ({
   fetchLandlordConversationMessagesMock: vi.fn(),
   markLandlordConversationReadMock: vi.fn(),
   sendLandlordMessageMock: vi.fn(),
+  fetchLandlordMessageRecipientsMock: vi.fn(),
+  createLandlordConversationMessageMock: vi.fn(),
   useCapabilitiesMock: vi.fn(),
   openUpgradeMock: vi.fn(),
 }));
@@ -19,6 +21,8 @@ vi.mock("@/api/messagesApi", () => ({
   fetchLandlordConversationMessages: mocks.fetchLandlordConversationMessagesMock,
   markLandlordConversationRead: mocks.markLandlordConversationReadMock,
   sendLandlordMessage: mocks.sendLandlordMessageMock,
+  fetchLandlordMessageRecipients: mocks.fetchLandlordMessageRecipientsMock,
+  createLandlordConversationMessage: mocks.createLandlordConversationMessageMock,
 }));
 
 vi.mock("@/hooks/useCapabilities", () => ({
@@ -63,6 +67,8 @@ describe("MessagesPage", () => {
     mocks.fetchLandlordConversationMessagesMock.mockReset();
     mocks.markLandlordConversationReadMock.mockReset();
     mocks.sendLandlordMessageMock.mockReset();
+    mocks.fetchLandlordMessageRecipientsMock.mockReset();
+    mocks.createLandlordConversationMessageMock.mockReset();
     mocks.useCapabilitiesMock.mockReturnValue({
       features: { messaging: true },
       loading: false,
@@ -88,6 +94,22 @@ describe("MessagesPage", () => {
     });
     mocks.markLandlordConversationReadMock.mockResolvedValue(undefined);
     mocks.sendLandlordMessageMock.mockResolvedValue(undefined);
+    mocks.fetchLandlordMessageRecipientsMock.mockResolvedValue([
+      {
+        leaseId: "lease-1",
+        tenantId: "tenant-1",
+        tenantDisplayName: "Taylor Tenant",
+        propertyId: "prop-1",
+        propertyDisplayLabel: "Harbour View",
+        unitId: "unit-1",
+        unitDisplayLabel: "Unit 2A",
+      },
+    ]);
+    mocks.createLandlordConversationMessageMock.mockResolvedValue({
+      conversationId: "landlord-1__tenant-1__unit-1",
+      created: true,
+      message: {},
+    });
   });
 
   async function flushTimers(ms: number) {
@@ -116,6 +138,75 @@ describe("MessagesPage", () => {
     expect(screen.getAllByText("Harbour View / Unit 2A").length).toBeGreaterThan(0);
     expect(screen.getByText("TT")).toBeInTheDocument();
     expect(screen.queryByText(/Tenant tenant-/i)).not.toBeInTheDocument();
+  });
+
+  it("supports first-message compose when the landlord has no conversations", async () => {
+    mocks.fetchLandlordConversationsMock.mockResolvedValue([]);
+    mocks.fetchLandlordConversationMessagesMock.mockResolvedValue({
+      conversation: {
+        id: "landlord-1__tenant-1__unit-1",
+        tenantDisplayName: "Taylor Tenant",
+        propertyDisplayLabel: "Harbour View",
+        unitDisplayLabel: "Unit 2A",
+      },
+      messages: [],
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/messages"]}>
+        <LocationProbe />
+        <MessagesPage />
+      </MemoryRouter>
+    );
+    await flushAsync();
+    expect(screen.getByText("No conversations yet.")).toBeInTheDocument();
+
+    fireEvent.click(screen.getAllByRole("button", { name: "New Message" })[0]);
+    await flushAsync();
+    expect(mocks.fetchLandlordMessageRecipientsMock).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("dialog", { name: "New message" })).toBeInTheDocument();
+    expect(screen.getByText("Harbour View / Unit 2A")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText("Search by tenant, property, or unit"), { target: { value: "2A" } });
+    fireEvent.click(screen.getByRole("button", { name: /Taylor Tenant/ }));
+    fireEvent.change(screen.getByPlaceholderText("Write your message"), { target: { value: "Welcome to RentChain." } });
+    fireEvent.click(screen.getByRole("button", { name: "Send Message" }));
+    await flushAsync();
+
+    expect(mocks.createLandlordConversationMessageMock).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId: "tenant-1",
+      leaseId: "lease-1",
+      body: "Welcome to RentChain.",
+      requestId: expect.any(String),
+    }));
+    expect(screen.getByTestId("location")).toHaveTextContent(
+      "/messages?threadId=landlord-1__tenant-1__unit-1"
+    );
+  });
+
+  it("prevents double submission while a first message is in flight", async () => {
+    let resolveRequest: ((value: any) => void) | undefined;
+    mocks.createLandlordConversationMessageMock.mockReturnValue(new Promise((resolve) => {
+      resolveRequest = resolve;
+    }));
+
+    render(
+      <MemoryRouter>
+        <MessagesPage />
+      </MemoryRouter>
+    );
+    await flushAsync();
+    fireEvent.click(screen.getAllByRole("button", { name: "New Message" })[0]);
+    await flushAsync();
+    fireEvent.click(within(screen.getByRole("dialog", { name: "New message" })).getByRole("button", { name: /Taylor Tenant/ }));
+    fireEvent.change(screen.getByPlaceholderText("Write your message"), { target: { value: "One send only" } });
+    const send = screen.getByRole("button", { name: "Send Message" });
+    fireEvent.click(send);
+    fireEvent.click(send);
+    expect(mocks.createLandlordConversationMessageMock).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("button", { name: "Sending…" })).toBeDisabled();
+    resolveRequest?.({ conversationId: "landlord-1__tenant-1__unit-1", created: true, message: {} });
+    await flushAsync();
   });
 
   it("shows a locked messages state without loading conversations when messaging is unavailable", async () => {

--- a/rentchain-frontend/src/pages/MessagesPage.tsx
+++ b/rentchain-frontend/src/pages/MessagesPage.tsx
@@ -5,8 +5,11 @@ import {
   fetchLandlordConversationMessages,
   sendLandlordMessage,
   markLandlordConversationRead,
+  fetchLandlordMessageRecipients,
+  createLandlordConversationMessage,
   type Conversation,
   type Message,
+  type MessageRecipient,
 } from "@/api/messagesApi";
 import { spacing, colors, text } from "@/styles/tokens";
 import { ResponsiveMasterDetail } from "@/components/layout/ResponsiveMasterDetail";
@@ -166,6 +169,14 @@ export default function MessagesPage() {
   const [loadingList, setLoadingList] = useState(false);
   const [loadingThread, setLoadingThread] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [composeOpen, setComposeOpen] = useState(false);
+  const [recipients, setRecipients] = useState<MessageRecipient[]>([]);
+  const [recipientSearch, setRecipientSearch] = useState("");
+  const [selectedRecipientKey, setSelectedRecipientKey] = useState<string | null>(null);
+  const [firstMessage, setFirstMessage] = useState("");
+  const [loadingRecipients, setLoadingRecipients] = useState(false);
+  const [submittingFirstMessage, setSubmittingFirstMessage] = useState(false);
+  const [composeError, setComposeError] = useState<string | null>(null);
   const location = useLocation();
   const navigate = useNavigate();
   const { features, loading: capsLoading } = useCapabilities();
@@ -362,11 +373,77 @@ export default function MessagesPage() {
     await loadThread(selectedId);
     await loadConversations(selectedId, { background: true });
   };
+  const recipientKey = (recipient: MessageRecipient) => `${recipient.leaseId}:${recipient.tenantId}`;
+  const selectedRecipient = recipients.find((recipient) => recipientKey(recipient) === selectedRecipientKey) || null;
+  const filteredRecipients = recipients.filter((recipient) =>
+    [recipient.tenantDisplayName, recipient.propertyDisplayLabel, recipient.unitDisplayLabel]
+      .map((value) => String(value || "").toLowerCase())
+      .join(" ")
+      .includes(recipientSearch.trim().toLowerCase())
+  );
+
+  const openCompose = async () => {
+    setComposeOpen(true);
+    setComposeError(null);
+    setLoadingRecipients(true);
+    try {
+      setRecipients(await fetchLandlordMessageRecipients());
+    } catch (err: any) {
+      setComposeError(err?.message || "Failed to load eligible tenants");
+    } finally {
+      setLoadingRecipients(false);
+    }
+  };
+
+  const closeCompose = () => {
+    if (submittingFirstMessage) return;
+    setComposeOpen(false);
+    setRecipientSearch("");
+    setSelectedRecipientKey(null);
+    setFirstMessage("");
+    setComposeError(null);
+  };
+
+  const handleFirstMessage = async () => {
+    const body = firstMessage.trim();
+    if (!selectedRecipient || !body || submittingFirstMessage) return;
+    setSubmittingFirstMessage(true);
+    setComposeError(null);
+    try {
+      const requestId = globalThis.crypto?.randomUUID?.() || `compose-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      const result = await createLandlordConversationMessage({
+        tenantId: selectedRecipient.tenantId,
+        leaseId: selectedRecipient.leaseId,
+        body,
+        requestId,
+      });
+      setComposeOpen(false);
+      setFirstMessage("");
+      setRecipientSearch("");
+      setSelectedRecipientKey(null);
+      selectedIdRef.current = result.conversationId;
+      setSelectedId(result.conversationId);
+      navigate(`/messages?threadId=${encodeURIComponent(result.conversationId)}`);
+      await loadConversations(result.conversationId, { background: true });
+      await loadThread(result.conversationId);
+    } catch (err: any) {
+      setComposeError(err?.message || "Failed to send first message");
+    } finally {
+      setSubmittingFirstMessage(false);
+    }
+  };
   const selectedConversationTitle = buildConversationTitle(selectedConversation);
 
   return (
     <div className="rc-messages-page">
-      <h1 style={{ marginBottom: spacing.md }}>Messages</h1>
+      <div className="rc-messages-page-header">
+        <h1>Messages</h1>
+        {!capsLoading && messagingEnabled ? (
+          <button type="button" className="rc-messages-new-button" onClick={() => void openCompose()}>
+            New Message
+          </button>
+        ) : null}
+      </div>
       {error && <div style={{ color: colors.danger, marginBottom: spacing.sm }}>{error}</div>}
       {!capsLoading && !messagingEnabled ? (
         <LockedFeature
@@ -374,6 +451,73 @@ export default function MessagesPage() {
           ctaLabel="Upgrade to Starter"
         />
       ) : (
+      <>
+      {composeOpen ? (
+        <div className="rc-messages-compose-overlay" role="dialog" aria-modal="true" aria-label="New message">
+          <div className="rc-messages-compose-panel">
+            <div className="rc-messages-compose-heading">
+              <div>
+                <h2>New Message</h2>
+                <p>Select a current tenant and send the first message.</p>
+              </div>
+              <button type="button" onClick={closeCompose} disabled={submittingFirstMessage} aria-label="Close new message">
+                Close
+              </button>
+            </div>
+            {composeError ? <div className="rc-messages-compose-error" role="alert">{composeError}</div> : null}
+            <label className="rc-messages-compose-field">
+              <span>Search tenants</span>
+              <input
+                value={recipientSearch}
+                onChange={(event) => setRecipientSearch(event.target.value)}
+                placeholder="Search by tenant, property, or unit"
+              />
+            </label>
+            <div className="rc-messages-recipient-list" aria-label="Eligible tenants">
+              {loadingRecipients ? (
+                <div>Loading eligible tenants…</div>
+              ) : filteredRecipients.length === 0 ? (
+                <div>No eligible current tenants found.</div>
+              ) : filteredRecipients.map((recipient) => {
+                const key = recipientKey(recipient);
+                const selected = key === selectedRecipientKey;
+                return (
+                  <button
+                    type="button"
+                    key={key}
+                    className={selected ? "is-selected" : ""}
+                    aria-pressed={selected}
+                    onClick={() => setSelectedRecipientKey(key)}
+                  >
+                    <strong>{recipient.tenantDisplayName}</strong>
+                    <span>{[recipient.propertyDisplayLabel, recipient.unitDisplayLabel].filter(Boolean).join(" / ")}</span>
+                  </button>
+                );
+              })}
+            </div>
+            <label className="rc-messages-compose-field">
+              <span>Message</span>
+              <textarea
+                value={firstMessage}
+                onChange={(event) => setFirstMessage(event.target.value)}
+                maxLength={4000}
+                placeholder="Write your message"
+              />
+            </label>
+            <div className="rc-messages-compose-actions">
+              <button type="button" onClick={closeCompose} disabled={submittingFirstMessage}>Cancel</button>
+              <button
+                type="button"
+                className="is-primary"
+                onClick={() => void handleFirstMessage()}
+                disabled={!selectedRecipient || !firstMessage.trim() || submittingFirstMessage}
+              >
+                {submittingFirstMessage ? "Sending…" : "Send Message"}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
       <div className="rc-messages-grid" data-testid="messages-layout">
         <ResponsiveMasterDetail
           masterTitle="Conversations"
@@ -535,12 +679,16 @@ export default function MessagesPage() {
                   </div>
                 </>
               ) : (
-                <div style={{ color: text.muted }}>Select a conversation.</div>
+                <div className="rc-messages-empty-detail">
+                  <span>Select a conversation or start a new one.</span>
+                  <button type="button" onClick={() => void openCompose()}>New Message</button>
+                </div>
               )}
             </div>
           }
         />
       </div>
+      </>
       )}
     </div>
   );

--- a/rentchain-frontend/tests/playwright/messages-layout.spec.ts
+++ b/rentchain-frontend/tests/playwright/messages-layout.spec.ts
@@ -163,6 +163,15 @@ test("real Messages page preserves deep links, Back, composer access, and bounde
     if (response.status() >= 400) failedResponses.push(`${response.status()} ${response.url()}`);
   });
 
+  await page.route("**/src/api/baseUrl.ts", async (route) => {
+    const response = await route.fetch();
+    const body = (await response.text())
+      .replace("import.meta?.env?.VITE_API_BASE_URL", '"http://127.0.0.1:5173"')
+      .replace("import.meta?.env?.VITE_DEPLOY_ENV", '"development"')
+      .replace("import.meta?.env?.DEV", "true");
+    await route.fulfill({ response, body });
+  });
+
   await installLegacySmokeHarness(page, { devPreviewUnlock: true });
   await page.route("**/api/account/limits", async (route) => {
     await route.fulfill({
@@ -182,7 +191,38 @@ test("real Messages page preserves deep links, Back, composer access, and bounde
   }));
   await page.route("**/api/landlord/messages/**", async (route) => {
     const url = new URL(route.request().url());
+    if (url.pathname === "/api/landlord/messages/recipients") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          recipients: [{
+            leaseId: "lease-synthetic-1",
+            tenantId: "tenant-synthetic-1",
+            tenantDisplayName: "Synthetic Active Tenant",
+            propertyId: "property-synthetic-1",
+            propertyDisplayLabel: "Harbour Synthetic Property",
+            unitId: "unit-synthetic-1",
+            unitDisplayLabel: "Unit 4B",
+          }],
+        }),
+      });
+      return;
+    }
     if (url.pathname === "/api/landlord/messages/conversations") {
+      if (route.request().method() === "POST") {
+        await route.fulfill({
+          status: 201,
+          contentType: "application/json",
+          body: JSON.stringify({
+            ok: true,
+            conversationId: "conv-1",
+            created: false,
+            message: { id: "synthetic-first-message" },
+          }),
+        });
+        return;
+      }
       await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ conversations }) });
       return;
     }
@@ -219,6 +259,16 @@ test("real Messages page preserves deep links, Back, composer access, and bounde
   }
   await expect(page.getByRole("heading", { name: "Messages" })).toBeVisible();
   await expect(page.getByText(/QA Tenant With An Intentionally Long Governed Display Label 1/).first()).toBeVisible();
+
+  await page.getByRole("button", { name: "New Message" }).first().click();
+  const compose = page.getByRole("dialog", { name: "New message" });
+  await expect(compose).toBeVisible();
+  await compose.getByPlaceholder("Search by tenant, property, or unit").fill("4B");
+  await compose.getByRole("button", { name: /Synthetic Active Tenant/ }).click();
+  await compose.getByPlaceholder("Write your message").fill("Synthetic first outbound message");
+  await compose.getByRole("button", { name: "Send Message" }).click();
+  await expect(compose).not.toBeVisible();
+  await expect(page).toHaveURL(/threadId=conv-1/);
 
   await expectConversationCardsContained(page);
 


### PR DESCRIPTION
## Problem

Landlords can reply to tenant-originated conversations, but `/messages` has no direct Workspace entry and cannot initiate the first outbound conversation.

The first isolated Preview QA deployment also exposed a route-order blocker: recipient GET and Compose POST were mounted only after global JWT authentication, so their route-local fail-closed Preview QA authentication never ran.

## Implementation

- Adds a landlord-only, messaging-capability-gated `Messages` Workspace drawer link.
- Adds a `New Message` flow to `/messages`, including empty-state access, local search, property/unit disambiguation, validation, loading, submission, and error states.
- Adds a bounded landlord-scoped recipient projection based on current canonical leases.
- Adds an atomic first-message endpoint that revalidates ownership server-side, reuses an existing canonical or matching legacy conversation, or creates exactly one deterministic conversation.
- Uses canonical identity `landlordId + tenantId + unitId`, consistent with tenant communications.
- Uses deterministic message IDs derived from conversation + request ID to prevent duplicate retry writes and notifications.
- Preserves existing landlord reply email semantics and sets landlord read state so an outbound send does not create false landlord unread activity.
- Preserves PR #1509 Unified Inbox projections, filters, deep links, and tenant-reply behavior.
- Registers only the exact eligible-recipient GET and Compose POST handlers on a dedicated pre-global router, reusing the same canonical handler registrations that remain on the normal messages router.

## Eligibility and security

- Requires a current lease status recognized by the canonical lease service.
- Requires matching lease landlord, tenant membership, landlord-owned property, and unit-to-property relationship.
- Fails closed for ended, foreign, orphaned, malformed, or ambiguously linked recipients.
- Recipient discovery is landlord-scoped and capped at 100 leases.
- Legacy thread lookup is tenant-scoped and capped at 25 conversations.
- Landlord identity and sender role are server-derived; the client cannot provide either.
- No unrestricted collection read was introduced on the messaging request path.
- Valid Production JWT behavior is unchanged.
- Invalid bearer tokens retain precedence and cannot fall through to synthetic QA authentication.
- Synthetic QA remains limited to the exact PR #1510 scope, service, selector, routes, and methods; Production and permanent Preview remain locked out.
- Unrelated routes remain behind global JWT authentication.

## Validation

- Backend focused route/auth/messaging: 144/144 passed.
- Backend build: passed.
- Full backend suite: 3,111/3,140 passed; the known 29 failures remain confined to unrelated baseline suites, with no branch-only failure.
- Frontend focused Messages/navigation: 111/111 passed.
- Full frontend suite: 1,657/1,657 passed.
- Frontend production build: passed.
- Synthetic local Playwright: 6/6 passed across desktop, tablet, and mobile.
- Backend immutable-image runtime contract: passed with process liveness, `0.0.0.0:8080`, and `/health` HTTP 200.
- Production deployment governance: 32 boundaries passed.
- Preview PR-head image governance: 36/36 passed.
- Package-manager governance: passed.
- Terraform: `init -backend=false`, `validate`, and `fmt -check -recursive` passed; no plan/apply.
- `git diff --check`: passed.
- Credential and mutation scan: clean.

## Containment

- No Production or permanent Preview mutation.
- No real tenant message or production data mutation.
- No image publication, Cloud Run deployment/update, traffic mutation, workflow dispatch, IAM/secret change, Vercel mutation, HCP mutation, Terraform plan/apply, or merge.
- Production remains on `rentchain-landlord-api-candidate-dfd1a2d7` at 100%, with 5/5 health probes and 1,077 revisions; rollback remains retained at 0%.
- Permanent Preview remains `rentchain-preview-backend-00003-42c` at 100%, `FIRESTORE_ENABLED=false`, with required indexes READY.
- The stale isolated QA service remains unchanged on `rentchain-pr1510-messaging-qa-14a551d2-14a551d2` and was not reused for changed-head validation.

## QA hold

Keep this PR in draft. Fresh exact-head isolated Preview publication, deployment, fixture setup, and Codex Desktop Browser QA require separate authorization.
