### PR TITLE
fix: allow minimal Preview Firestore messaging writes

### DIFF
--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -42,8 +42,10 @@ check "b7_preview_datastore_boundary" {
   assert {
     condition = local.preview_runtime_firestore_permissions == toset([
       "datastore.databases.get",
+      "datastore.entities.create",
       "datastore.entities.get",
       "datastore.entities.list",
+      "datastore.entities.update",
     ])
     error_message = "B7 Preview runtime Firestore permissions changed outside the exact data-plane set."
   }

--- a/infra/environments/preview-foundation/datastore_auth.tf
+++ b/infra/environments/preview-foundation/datastore_auth.tf
@@ -6,8 +6,10 @@ locals {
 
   preview_runtime_firestore_permissions = toset([
     "datastore.databases.get",
+    "datastore.entities.create",
     "datastore.entities.get",
     "datastore.entities.list",
+    "datastore.entities.update",
   ])
 
   preview_runtime_auth_permissions = toset([

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -134,8 +134,10 @@ grep -Fq "resource.name == 'projects/\${var.project_id}/databases/\${local.previ
 
 expected_runtime_firestore_permissions="$(cat <<'EOF'
 datastore.databases.get
+datastore.entities.create
 datastore.entities.get
 datastore.entities.list
+datastore.entities.update
 EOF
 )"
 actual_runtime_firestore_permissions="$(
@@ -163,7 +165,7 @@ rg -q 'name         = "preview-backend-auth"' "$root_dir/datastore_auth.tf"
 rg -q 'display_name = "Preview Backend Identity Toolkit"' "$root_dir/datastore_auth.tf"
 rg -U -q '(?s)resource "google_apikeys_key" "preview_backend_auth" \{.*lifecycle \{\n    prevent_destroy = true\n  \}' "$root_dir/datastore_auth.tf"
 
-if rg -n 'firebaseauth\.users\.(create|delete|update|sendEmail)|datastore\.(databases\.(delete|update)|entities\.(create|delete|update)|indexes\.|operations\.)|roles/(datastore|firebase|identityplatform)' "$root_dir/datastore_auth.tf"; then
+if rg -n 'firebaseauth\.users\.(create|delete|update|sendEmail)|datastore\.(databases\.(delete|update)|entities\.delete|indexes\.|operations\.)|roles/(datastore|firebase|identityplatform)' "$root_dir/datastore_auth.tf"; then
   echo "B7 runtime IAM broadening or destructive datastore permission found" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary
- add only datastore.entities.create and datastore.entities.update to the existing Preview runtime Firestore custom role
- preserve the existing runtime service account and default-database IAM condition
- update exact Terraform checks and scope validation

## Validation
- terraform fmt -check -recursive
- terraform init -backend=false
- terraform validate
- bash infra/environments/preview-foundation/tests/validate_scope.sh
- HCP speculative plan run-rMUXW6dpMSHMFKX3: 0 add, 1 change, 0 destroy

## Boundaries
- Preview project only
- no delete/admin/broad Firestore role
- no Cloud Run, database, index, secret, WIF, or Production change
- opened draft for governed PR #1510 synthetic QA IAM unblock