### PR TITLE
infra: remove temporary PR #1512 invoker

### DIFF
--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -418,18 +418,3 @@ check "b7_vercel_preview_proxy_identity_boundary" {
     error_message = "Run Invoker must remain service-scoped to the private Preview backend and dedicated Vercel proxy identity."
   }
 }
-
-check "pr1512_vercel_proxy_invoker_boundary" {
-  assert {
-    condition = (
-      google_cloud_run_v2_service_iam_member.pr1512_vercel_proxy_invoker.project == "rentchain-preview" &&
-      google_cloud_run_v2_service_iam_member.pr1512_vercel_proxy_invoker.location == "northamerica-northeast1" &&
-      basename(
-        google_cloud_run_v2_service_iam_member.pr1512_vercel_proxy_invoker.name
-      ) == "rentchain-pr1512-notices-qa-fff3a2dc" &&
-      google_cloud_run_v2_service_iam_member.pr1512_vercel_proxy_invoker.role == "roles/run.invoker" &&
-      google_cloud_run_v2_service_iam_member.pr1512_vercel_proxy_invoker.member == "serviceAccount:vercel-preview-proxy@rentchain-preview.iam.gserviceaccount.com"
-    )
-    error_message = "PR #1512 Vercel proxy access must remain an exact service-level Invoker member on only the isolated Notices QA service."
-  }
-}

--- a/infra/environments/preview-foundation/pr1512_vercel_proxy_invoker.tf
+++ b/infra/environments/preview-foundation/pr1512_vercel_proxy_invoker.tf
@@ -1,9 +1,0 @@
-# Temporary service-level access for the PR #1512 read-only Notices QA proxy.
-# Remove after browser QA is complete and the isolated QA service is retired.
-resource "google_cloud_run_v2_service_iam_member" "pr1512_vercel_proxy_invoker" {
-  project  = "rentchain-preview"
-  location = "northamerica-northeast1"
-  name     = "rentchain-pr1512-notices-qa-fff3a2dc"
-  role     = "roles/run.invoker"
-  member   = google_service_account.vercel_preview_proxy.member
-}

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -10,7 +10,6 @@ apply_permissions_file="$root_dir/tests/hcp_apply_permissions.txt"
 b4_apply_delta_file="$root_dir/tests/hcp_b4_apply_permission_delta.txt"
 b7_plan_delta_file="$root_dir/tests/hcp_b7_plan_permission_delta.txt"
 b7_apply_delta_file="$root_dir/tests/hcp_b7_apply_permission_delta.txt"
-pr1512_invoker_file="$root_dir/pr1512_vercel_proxy_invoker.tf"
 
 expected_resources="$(cat <<'EOF'
 google_apikeys_key
@@ -121,19 +120,6 @@ rg -q 'member   = google_service_account\.vercel_preview_proxy\.member' "$vercel
 
 if rg -n 'principalSet://|roles/iam\.(serviceAccountTokenCreator|serviceAccountUser)|google_service_account_key|google_project_iam_(member|binding)|allUsers|allAuthenticatedUsers|project-0d9658de-af29-4dc0-a99' "$vercel_identity_file"; then
   echo "Broad federation, token, project IAM, public, static-key, or production scope found in Vercel Preview identity" >&2
-  exit 1
-fi
-
-test "$(rg -No '^resource "google_cloud_run_v2_service_iam_member" "pr1512_vercel_proxy_invoker"' "$pr1512_invoker_file" | wc -l | tr -d ' ')" = "1"
-rg -q 'project  = "rentchain-preview"' "$pr1512_invoker_file"
-rg -q 'location = "northamerica-northeast1"' "$pr1512_invoker_file"
-rg -q 'name     = "rentchain-pr1512-notices-qa-fff3a2dc"' "$pr1512_invoker_file"
-rg -q 'role     = "roles/run.invoker"' "$pr1512_invoker_file"
-rg -q 'member   = google_service_account\.vercel_preview_proxy\.member' "$pr1512_invoker_file"
-rg -U -q 'basename\(\n        google_cloud_run_v2_service_iam_member\.pr1512_vercel_proxy_invoker\.name\n      \) == "rentchain-pr1512-notices-qa-fff3a2dc"' "$root_dir/checks.tf"
-
-if rg -n 'google_(project|folder|organization)_iam|allUsers|allAuthenticatedUsers|project-0d9658de-af29-4dc0-a99|rentchain-preview-backend' "$pr1512_invoker_file"; then
-  echo "PR #1512 Invoker scope is broader than the exact isolated service member" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- remove the temporary service-level PR #1512 Cloud Run Invoker binding
- remove only its dedicated Terraform check and scope-test assertions

## Validation
- terraform fmt -check -recursive
- terraform init -backend=false -input=false
- terraform validate
- bash tests/validate_scope.sh
- git diff --check

## Scope
Expected HCP plan: 0 add, 0 change, 1 destroy for google_cloud_run_v2_service_iam_member.pr1512_vercel_proxy_invoker only. No Production, permanent Preview, project IAM, service account, WIF, or unrelated resource changes.