### PR TITLE
Polish communications header and message recipient spacing

### DIFF
--- a/rentchain-frontend/src/components/layout/CommunicationsMenu.css
+++ b/rentchain-frontend/src/components/layout/CommunicationsMenu.css
@@ -43,15 +43,15 @@
 }
 
 .rc-communications-menu__panel {
-  position: absolute;
-  top: calc(100% + 8px);
-  right: 0;
+  position: fixed;
   z-index: 4300;
   display: grid;
   gap: 4px;
   width: max-content;
   min-width: 210px;
   max-width: min(280px, calc(100vw - 24px));
+  max-height: calc(100dvh - 12px);
+  overflow-y: auto;
   padding: 8px;
   border: 1px solid rgba(91, 70, 48, 0.18);
   border-radius: 14px;
@@ -90,9 +90,5 @@
     min-height: 38px;
     padding: 7px 9px;
     font-size: 0.72rem;
-  }
-
-  .rc-communications-menu--mobile .rc-communications-menu__panel {
-    right: -52px;
   }
 }

--- a/rentchain-frontend/src/components/layout/CommunicationsMenu.css
+++ b/rentchain-frontend/src/components/layout/CommunicationsMenu.css
@@ -1,0 +1,98 @@
+.rc-communications-menu {
+  position: relative;
+  flex: 0 0 auto;
+}
+
+.rc-communications-menu__trigger {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-height: 40px;
+  padding: 8px 12px;
+  border: 1px solid rgba(91, 70, 48, 0.16);
+  border-radius: 999px;
+  background: #fffaf1;
+  color: #211c17;
+  box-shadow: 0 6px 16px rgba(59, 44, 28, 0.08);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.82rem;
+  font-weight: 750;
+  white-space: nowrap;
+}
+
+.rc-communications-menu__trigger:hover,
+.rc-communications-menu__trigger:focus-visible,
+.rc-communications-menu__trigger[aria-expanded="true"] {
+  border-color: rgba(36, 88, 66, 0.42);
+  background: #fff6e8;
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(36, 88, 66, 0.14);
+}
+
+.rc-communications-menu__unread {
+  position: absolute;
+  top: 7px;
+  right: 7px;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #a33a2f;
+}
+
+.rc-communications-menu__panel {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 4300;
+  display: grid;
+  gap: 4px;
+  width: max-content;
+  min-width: 210px;
+  max-width: min(280px, calc(100vw - 24px));
+  padding: 8px;
+  border: 1px solid rgba(91, 70, 48, 0.18);
+  border-radius: 14px;
+  background: #fffcf6;
+  box-shadow: 0 18px 42px rgba(59, 44, 28, 0.18);
+}
+
+.rc-communications-menu__panel a {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  min-height: 42px;
+  padding: 9px 11px;
+  border-radius: 10px;
+  color: #40372f;
+  font-size: 0.9rem;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.rc-communications-menu__panel a:hover,
+.rc-communications-menu__panel a:focus-visible {
+  background: rgba(36, 88, 66, 0.09);
+  color: #245842;
+  outline: none;
+}
+
+.rc-communications-menu__panel a.is-active {
+  background: rgba(36, 88, 66, 0.14);
+  color: #245842;
+}
+
+@media (max-width: 820px) {
+  .rc-communications-menu--mobile .rc-communications-menu__trigger {
+    min-height: 38px;
+    padding: 7px 9px;
+    font-size: 0.72rem;
+  }
+
+  .rc-communications-menu--mobile .rc-communications-menu__panel {
+    right: -52px;
+  }
+}

--- a/rentchain-frontend/src/components/layout/CommunicationsMenu.tsx
+++ b/rentchain-frontend/src/components/layout/CommunicationsMenu.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { createPortal } from "react-dom";
 import { Check, ChevronDown } from "lucide-react";
 import { Link, useLocation } from "react-router-dom";
 import { isNavRouteActive } from "./navConfig";
@@ -19,8 +20,20 @@ export function CommunicationsMenu({ className = "", hasUnread = false }: Props)
   const location = useLocation();
   const [open, setOpen] = React.useState(false);
   const rootRef = React.useRef<HTMLDivElement | null>(null);
+  const panelRef = React.useRef<HTMLDivElement | null>(null);
   const triggerRef = React.useRef<HTMLButtonElement | null>(null);
   const menuId = React.useId();
+  const [panelPosition, setPanelPosition] = React.useState({ top: 0, right: 12 });
+
+  const updatePanelPosition = React.useCallback(() => {
+    const trigger = triggerRef.current;
+    if (!trigger) return;
+    const rect = trigger.getBoundingClientRect();
+    setPanelPosition({
+      top: rect.bottom + 8,
+      right: Math.max(12, window.innerWidth - rect.right),
+    });
+  }, []);
 
   const isActive = React.useCallback(
     (item: (typeof COMMUNICATION_LINKS)[number]) =>
@@ -35,7 +48,8 @@ export function CommunicationsMenu({ className = "", hasUnread = false }: Props)
   React.useEffect(() => {
     if (!open) return undefined;
     const handlePointerDown = (event: MouseEvent | TouchEvent) => {
-      if (!rootRef.current?.contains(event.target as Node)) setOpen(false);
+      const target = event.target as Node;
+      if (!rootRef.current?.contains(target) && !panelRef.current?.contains(target)) setOpen(false);
     };
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key !== "Escape") return;
@@ -52,10 +66,21 @@ export function CommunicationsMenu({ className = "", hasUnread = false }: Props)
     };
   }, [open]);
 
+  React.useLayoutEffect(() => {
+    if (!open) return undefined;
+    updatePanelPosition();
+    window.addEventListener("resize", updatePanelPosition);
+    window.addEventListener("scroll", updatePanelPosition, true);
+    return () => {
+      window.removeEventListener("resize", updatePanelPosition);
+      window.removeEventListener("scroll", updatePanelPosition, true);
+    };
+  }, [open, updatePanelPosition]);
+
   React.useEffect(() => {
     if (!open) return;
-    const current = rootRef.current?.querySelector<HTMLElement>('[aria-current="page"]');
-    const first = rootRef.current?.querySelector<HTMLElement>('[role="menuitem"]');
+    const current = panelRef.current?.querySelector<HTMLElement>('[aria-current="page"]');
+    const first = panelRef.current?.querySelector<HTMLElement>('[role="menuitem"]');
     (current || first)?.focus();
   }, [open]);
 
@@ -69,14 +94,24 @@ export function CommunicationsMenu({ className = "", hasUnread = false }: Props)
         aria-haspopup="menu"
         aria-expanded={open}
         aria-controls={open ? menuId : undefined}
-        onClick={() => setOpen((current) => !current)}
+        onClick={() => {
+          if (!open) updatePanelPosition();
+          setOpen((current) => !current);
+        }}
       >
         <span>Communications</span>
         <ChevronDown size={15} aria-hidden="true" />
         {hasUnread ? <span className="rc-communications-menu__unread" aria-hidden="true" /> : null}
       </button>
-      {open ? (
-        <div id={menuId} className="rc-communications-menu__panel" role="menu" aria-label="Communications destinations">
+      {open ? createPortal(
+        <div
+          ref={panelRef}
+          id={menuId}
+          className="rc-communications-menu__panel"
+          role="menu"
+          aria-label="Communications destinations"
+          style={{ top: panelPosition.top, right: panelPosition.right }}
+        >
           {COMMUNICATION_LINKS.map((item) => {
             const active = isActive(item);
             return (
@@ -93,7 +128,8 @@ export function CommunicationsMenu({ className = "", hasUnread = false }: Props)
               </Link>
             );
           })}
-        </div>
+        </div>,
+        document.body
       ) : null}
     </div>
   );

--- a/rentchain-frontend/src/components/layout/CommunicationsMenu.tsx
+++ b/rentchain-frontend/src/components/layout/CommunicationsMenu.tsx
@@ -1,0 +1,100 @@
+import React from "react";
+import { Check, ChevronDown } from "lucide-react";
+import { Link, useLocation } from "react-router-dom";
+import { isNavRouteActive } from "./navConfig";
+import "./CommunicationsMenu.css";
+
+const COMMUNICATION_LINKS = [
+  { label: "Unified Inbox", to: "/landlord/unified-inbox", matchPaths: ["/landlord/inbox"] },
+  { label: "Messages", to: "/messages", matchPaths: [] },
+  { label: "Notices", to: "/notices", matchPaths: [] },
+] as const;
+
+type Props = {
+  className?: string;
+  hasUnread?: boolean;
+};
+
+export function CommunicationsMenu({ className = "", hasUnread = false }: Props) {
+  const location = useLocation();
+  const [open, setOpen] = React.useState(false);
+  const rootRef = React.useRef<HTMLDivElement | null>(null);
+  const triggerRef = React.useRef<HTMLButtonElement | null>(null);
+  const menuId = React.useId();
+
+  const isActive = React.useCallback(
+    (item: (typeof COMMUNICATION_LINKS)[number]) =>
+      [item.to, ...item.matchPaths].some((target) => isNavRouteActive(location.pathname, target)),
+    [location.pathname]
+  );
+
+  React.useEffect(() => {
+    setOpen(false);
+  }, [location.pathname]);
+
+  React.useEffect(() => {
+    if (!open) return undefined;
+    const handlePointerDown = (event: MouseEvent | TouchEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) setOpen(false);
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      setOpen(false);
+      triggerRef.current?.focus();
+    };
+    document.addEventListener("mousedown", handlePointerDown);
+    document.addEventListener("touchstart", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+      document.removeEventListener("touchstart", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open]);
+
+  React.useEffect(() => {
+    if (!open) return;
+    const current = rootRef.current?.querySelector<HTMLElement>('[aria-current="page"]');
+    const first = rootRef.current?.querySelector<HTMLElement>('[role="menuitem"]');
+    (current || first)?.focus();
+  }, [open]);
+
+  return (
+    <div ref={rootRef} className={`rc-communications-menu ${className}`.trim()}>
+      <button
+        ref={triggerRef}
+        type="button"
+        className="rc-communications-menu__trigger"
+        aria-label={hasUnread ? "Communications (unread)" : "Communications"}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-controls={open ? menuId : undefined}
+        onClick={() => setOpen((current) => !current)}
+      >
+        <span>Communications</span>
+        <ChevronDown size={15} aria-hidden="true" />
+        {hasUnread ? <span className="rc-communications-menu__unread" aria-hidden="true" /> : null}
+      </button>
+      {open ? (
+        <div id={menuId} className="rc-communications-menu__panel" role="menu" aria-label="Communications destinations">
+          {COMMUNICATION_LINKS.map((item) => {
+            const active = isActive(item);
+            return (
+              <Link
+                key={item.to}
+                to={item.to}
+                role="menuitem"
+                className={active ? "is-active" : ""}
+                aria-current={active ? "page" : undefined}
+                onClick={() => setOpen(false)}
+              >
+                <span>{item.label}</span>
+                {active ? <Check size={16} aria-hidden="true" /> : null}
+              </Link>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/rentchain-frontend/src/components/layout/LandlordNav.css
+++ b/rentchain-frontend/src/components/layout/LandlordNav.css
@@ -192,28 +192,6 @@
   box-shadow: inset 0 -2px 0 rgba(36, 88, 66, 0.28);
 }
 
-.rc-landlord-workspace-group {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  flex: 0 0 auto;
-  padding-left: 8px;
-  border-left: 1px solid var(--rc-landlord-border-strong);
-}
-
-.rc-landlord-workspace-group-label {
-  color: var(--rc-landlord-muted);
-  font-size: 11px;
-  font-weight: 800;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  white-space: nowrap;
-}
-
-.rc-landlord-workspace-group.active .rc-landlord-workspace-group-label {
-  color: var(--rc-landlord-pine);
-}
-
 @media (min-width: 821px) and (max-width: 1180px) {
   .rc-landlord-workspace-bar {
     gap: 8px 12px;
@@ -554,6 +532,10 @@
     color: var(--rc-landlord-muted);
     font-size: 12px;
     font-weight: 800;
+    max-width: 90px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .rc-landlord-mobile-menu {

--- a/rentchain-frontend/src/components/layout/LandlordNav.test.tsx
+++ b/rentchain-frontend/src/components/layout/LandlordNav.test.tsx
@@ -118,10 +118,10 @@ describe("LandlordNav mobile drawer", () => {
     expect(within(workspaceNav).getByRole("link", { name: "Tenants" })).toHaveAttribute("href", "/tenants");
     expect(within(workspaceNav).getByRole("link", { name: "Leases" })).toHaveAttribute("href", "/leases");
     expect(within(workspaceNav).getByRole("link", { name: "Payments" })).toHaveClass("active");
-    const communications = within(workspaceNav).getByRole("group", { name: "Communications" });
-    expect(within(communications).getByRole("link", { name: "Unified Inbox" })).toHaveAttribute("href", "/landlord/unified-inbox");
-    expect(within(communications).getByRole("link", { name: "Messages" })).toHaveAttribute("href", "/messages");
-    expect(within(communications).getByRole("link", { name: "Notices" })).toHaveAttribute("href", "/notices");
+    expect(within(workspaceNav).queryByRole("group", { name: "Communications" })).not.toBeInTheDocument();
+    expect(within(workspaceNav).queryByRole("link", { name: "Unified Inbox" })).not.toBeInTheDocument();
+    expect(within(workspaceNav).queryByRole("link", { name: "Messages" })).not.toBeInTheDocument();
+    expect(within(workspaceNav).queryByRole("link", { name: "Notices" })).not.toBeInTheDocument();
     expect(within(workspaceNav).getByRole("link", { name: "Work Orders" })).toHaveAttribute("href", "/work-orders");
   });
 
@@ -168,8 +168,7 @@ describe("LandlordNav mobile drawer", () => {
     const workspaceNav = screen.getByRole("navigation", { name: "Workspace navigation" });
 
     expect(context).toHaveTextContent("Unified Inbox");
-    expect(within(workspaceNav).getByRole("link", { name: "Unified Inbox" })).toHaveClass("active");
-    expect(within(workspaceNav).getByRole("link", { name: "Unified Inbox" })).toHaveAttribute("aria-current", "page");
+    expect(within(workspaceNav).queryByRole("link", { name: "Unified Inbox" })).not.toBeInTheDocument();
     expect(screen.getByText("Unified Inbox", { selector: ".rc-landlord-mobile-role" })).toBeInTheDocument();
   });
 
@@ -385,16 +384,16 @@ describe("LandlordNav mobile drawer", () => {
     ["/landlord/unified-inbox", "Unified Inbox"],
     ["/messages", "Messages"],
     ["/notices", "Notices"],
-  ])("selects the Communications child and header for %s", (path, label) => {
+  ])("keeps route-specific titles and active Communications menu items for %s", (path, label) => {
     renderLandlordNav(path);
 
     const context = screen.getByLabelText("Workspace context");
     const workspaceNav = screen.getByRole("navigation", { name: "Workspace navigation" });
-    const communications = within(workspaceNav).getByRole("group", { name: "Communications" });
-    const activeChild = within(communications).getByRole("link", { name: label });
+    fireEvent.click(screen.getByRole("button", { name: "Communications" }));
+    const communications = screen.getByRole("menu", { name: "Communications destinations" });
+    const activeChild = within(communications).getByRole("menuitem", { name: label });
 
-    expect(communications).toHaveClass("active");
-    expect(activeChild).toHaveClass("active");
+    expect(within(workspaceNav).queryByRole("group", { name: "Communications" })).not.toBeInTheDocument();
     expect(activeChild).toHaveAttribute("aria-current", "page");
     expect(context.querySelector("strong")).toHaveTextContent(label);
     expect(screen.getByText(label, { selector: ".rc-landlord-mobile-role" })).toBeInTheDocument();
@@ -417,16 +416,15 @@ describe("LandlordNav mobile drawer", () => {
     renderLandlordNav(path);
 
     const context = screen.getByLabelText("Workspace context");
-    const communications = within(screen.getByRole("navigation", { name: "Workspace navigation" })).getByRole("group", {
-      name: "Communications",
-    });
+    fireEvent.click(screen.getByRole("button", { name: "Communications" }));
+    const communications = screen.getByRole("menu", { name: "Communications destinations" });
 
-    expect(within(communications).getAllByRole("link").map((link) => link.textContent)).toEqual([
+    expect(within(communications).getAllByRole("menuitem").map((link) => link.textContent?.replace("✓", ""))).toEqual([
       "Unified Inbox",
       "Messages",
       "Notices",
     ]);
-    expect(within(communications).getByRole("link", { name: label })).toHaveAttribute("aria-current", "page");
+    expect(within(communications).getByRole("menuitem", { name: label })).toHaveAttribute("aria-current", "page");
     expect(context.querySelector("strong")).toHaveTextContent(label);
     expect(context.querySelector("strong")).not.toHaveTextContent("Workspace");
   });

--- a/rentchain-frontend/src/components/layout/LandlordNav.test.tsx
+++ b/rentchain-frontend/src/components/layout/LandlordNav.test.tsx
@@ -284,14 +284,12 @@ describe("LandlordNav mobile drawer", () => {
     expect(within(tabbar).getByText("Dashboard")).toBeInTheDocument();
     expect(within(tabbar).getByText("Properties")).toBeInTheDocument();
     expect(within(tabbar).getByText("Applicants")).toBeInTheDocument();
-    expect(within(tabbar).getByText("Unified Inbox")).toBeInTheDocument();
     expect(within(tabbar).getByText("Operations")).toBeInTheDocument();
     expect(within(tabbar).getByText("More")).toBeInTheDocument();
     expect(within(tabbar).getAllByRole("button").map((button) => button.textContent)).toEqual([
       "Dashboard",
       "Properties",
       "Applicants",
-      "Unified Inbox",
       "Operations",
       "More",
     ]);
@@ -307,7 +305,6 @@ describe("LandlordNav mobile drawer", () => {
       "Dashboard",
       "Properties",
       "Applications",
-      "Unified Inbox",
     ]);
     expect(NAV_ITEMS.find((item) => item.id === "operations")).toEqual(
       expect.objectContaining({
@@ -318,34 +315,16 @@ describe("LandlordNav mobile drawer", () => {
     );
   });
 
-  it("shows distinct landlord drawer entries for the unified inbox and direct messages", async () => {
+  it("keeps communication destinations out of the Workspace drawer", () => {
     renderLandlordNav();
 
     fireEvent.click(screen.getByRole("button", { name: "Open workspace pages" }));
 
     const drawer = screen.getByRole("dialog", { name: "Navigation menu" });
-    const communications = within(drawer).getByRole("group", { name: "Communications" });
-    const inboxButtons = within(communications).getAllByRole("button", { name: "Unified Inbox" });
-    expect(inboxButtons).toHaveLength(1);
-    expect(within(communications).getByRole("button", { name: "Messages" })).toBeInTheDocument();
-    expect(within(communications).getByRole("button", { name: "Notices" })).toBeInTheDocument();
-
-    fireEvent.click(inboxButtons[0]);
-
-    await waitFor(() => {
-      expect(screen.getByTestId("current-path")).toHaveTextContent("/landlord/unified-inbox");
-    });
-
-    fireEvent.click(screen.getByRole("button", { name: "Open workspace pages" }));
-    fireEvent.click(
-      within(screen.getByRole("dialog", { name: "Navigation menu" })).getByRole("button", {
-        name: "Messages",
-      })
-    );
-
-    await waitFor(() => {
-      expect(screen.getByTestId("current-path")).toHaveTextContent("/messages");
-    });
+    expect(within(drawer).queryByRole("group", { name: "Communications" })).not.toBeInTheDocument();
+    expect(within(drawer).queryByRole("button", { name: "Unified Inbox" })).not.toBeInTheDocument();
+    expect(within(drawer).queryByRole("button", { name: "Messages" })).not.toBeInTheDocument();
+    expect(within(drawer).queryByRole("button", { name: "Notices" })).not.toBeInTheDocument();
   });
 
   it("navigates landlord mobile tabs to canonical routes", () => {
@@ -358,9 +337,6 @@ describe("LandlordNav mobile drawer", () => {
     fireEvent.click(within(tabbar).getByRole("button", { name: "Applicants" }));
     expect(screen.getByTestId("current-path")).toHaveTextContent("/applications");
 
-    fireEvent.click(within(tabbar).getByRole("button", { name: "Unified Inbox" }));
-    expect(screen.getByTestId("current-path")).toHaveTextContent("/landlord/unified-inbox");
-
     fireEvent.click(within(tabbar).getByRole("button", { name: "Operations" }));
     expect(screen.getByTestId("current-path")).toHaveTextContent("/operations");
   });
@@ -372,12 +348,13 @@ describe("LandlordNav mobile drawer", () => {
     expect(within(tabbar).getByRole("button", { name: "Operations" })).toHaveClass("active");
   });
 
-  it("marks the unified inbox tab active on the landlord unified inbox route", () => {
+  it("keeps communication destinations out of the mobile tab bar", () => {
     renderLandlordNav("/landlord/unified-inbox");
 
     const tabbar = screen.getByRole("navigation", { name: "Bottom navigation" });
-    expect(within(tabbar).getByRole("button", { name: "Unified Inbox" })).toHaveClass("active");
-    expect(within(tabbar).getByRole("button", { name: "Unified Inbox" })).toHaveAttribute("aria-current", "page");
+    expect(within(tabbar).queryByRole("button", { name: "Unified Inbox" })).not.toBeInTheDocument();
+    expect(within(tabbar).queryByRole("button", { name: "Messages" })).not.toBeInTheDocument();
+    expect(within(tabbar).queryByRole("button", { name: "Notices" })).not.toBeInTheDocument();
   });
 
   it.each([
@@ -429,17 +406,15 @@ describe("LandlordNav mobile drawer", () => {
     expect(context.querySelector("strong")).not.toHaveTextContent("Workspace");
   });
 
-  it("marks the active Communications child in the responsive drawer", () => {
+  it("keeps the active communication route out of the responsive drawer", () => {
     renderLandlordNav("/notices");
 
     fireEvent.click(screen.getByRole("button", { name: "Open workspace pages" }));
-    const communications = within(screen.getByRole("dialog", { name: "Navigation menu" })).getByRole("group", {
-      name: "Communications",
-    });
-
-    expect(within(communications).getByRole("button", { name: "Notices" })).toHaveAttribute("aria-current", "page");
-    expect(within(communications).getByRole("button", { name: "Messages" })).not.toHaveAttribute("aria-current");
-    expect(within(communications).getByRole("button", { name: "Unified Inbox" })).not.toHaveAttribute("aria-current");
+    const drawer = within(screen.getByRole("dialog", { name: "Navigation menu" }));
+    expect(drawer.queryByRole("group", { name: "Communications" })).not.toBeInTheDocument();
+    expect(drawer.queryByRole("button", { name: "Notices" })).not.toBeInTheDocument();
+    expect(drawer.queryByRole("button", { name: "Messages" })).not.toBeInTheDocument();
+    expect(drawer.queryByRole("button", { name: "Unified Inbox" })).not.toBeInTheDocument();
   });
 
   it("does not render the landlord bottom nav for admin role contexts", () => {

--- a/rentchain-frontend/src/components/layout/LandlordNav.tsx
+++ b/rentchain-frontend/src/components/layout/LandlordNav.tsx
@@ -1,13 +1,11 @@
 import React, { useEffect, useRef, useState } from "react";
-import { Building2, ClipboardList, Inbox, LayoutDashboard, Menu, ScrollText, X } from "lucide-react";
+import { Building2, ClipboardList, LayoutDashboard, Menu, ScrollText, X } from "lucide-react";
 import { Link, Navigate, useLocation, useNavigate } from "react-router-dom";
 import TopNav from "./TopNav";
 import { useAuth } from "../../context/useAuth";
 import { fetchLandlordConversations } from "../../api/messagesApi";
 import {
   COMMUNICATIONS_GROUP_ID,
-  COMMUNICATIONS_GROUP_LABEL,
-  NAV_ITEMS,
   getVisibleNavItems,
   isNavItemActive,
   resolveNavItem,
@@ -25,17 +23,10 @@ type Props = {
   unreadMessages?: boolean;
 };
 
-const unifiedInboxNavItem = NAV_ITEMS.find((item) => item.id === "unified-inbox");
-
 const landlordMobileTabs = [
   { to: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
   { to: "/properties", label: "Properties", icon: Building2 },
   { to: "/applications", label: "Applicants", icon: ScrollText },
-  {
-    to: unifiedInboxNavItem?.to || "/landlord/unified-inbox",
-    label: unifiedInboxNavItem?.label || "Unified Inbox",
-    icon: unifiedInboxNavItem?.icon || Inbox,
-  },
   { to: "/operations", label: "Operations", icon: ClipboardList },
 ];
 
@@ -122,10 +113,10 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
     });
   }
   const visibleItems = navLoading || !isLandlordWorkspace ? [] : getVisibleNavItems(effectiveRole, features);
-  const drawerItems = visibleItems.filter((item) => item.showInDrawer !== false);
-  const workspaceItems = visibleItems.filter((item) => stickyWorkspaceIds.has(item.id));
-  const standardWorkspaceItems = workspaceItems.filter((item) => item.groupId !== COMMUNICATIONS_GROUP_ID);
-  const communicationsItems = workspaceItems.filter((item) => item.groupId === COMMUNICATIONS_GROUP_ID);
+  const workspaceVisibleItems = visibleItems.filter((item) => item.showInWorkspace !== false);
+  const drawerItems = workspaceVisibleItems.filter((item) => item.showInDrawer !== false);
+  const standardWorkspaceItems = workspaceVisibleItems.filter((item) => stickyWorkspaceIds.has(item.id));
+  const communicationsItems = visibleItems.filter((item) => item.groupId === COMMUNICATIONS_GROUP_ID);
   const primaryDrawerItems = drawerItems.filter((item) => !item.requiresAdmin);
   const adminDrawerItems = drawerItems.filter((item) => item.requiresAdmin);
   const orderedPrimaryDrawerItems = React.useMemo(
@@ -243,7 +234,7 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
       window.removeEventListener("resize", syncStickyOffset);
       observer?.disconnect();
     };
-  }, [workspaceItems.length, workspaceLabel]);
+  }, [standardWorkspaceItems.length, workspaceLabel]);
 
   if (navLoading) {
     return (
@@ -348,7 +339,7 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
                 </div>
               ) : (
                 <div className="rc-landlord-drawer-links">
-                  {orderedPrimaryDrawerItems.filter((item) => item.groupId !== COMMUNICATIONS_GROUP_ID).map((item) => (
+                  {orderedPrimaryDrawerItems.map((item) => (
                     <button
                       key={item.id}
                       type="button"
@@ -359,22 +350,6 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
                       {item.label}
                     </button>
                   ))}
-                  {communicationsItems.length ? (
-                    <div className="rc-landlord-drawer-group" role="group" aria-label={COMMUNICATIONS_GROUP_LABEL}>
-                      <div className="rc-landlord-drawer-group-label">{COMMUNICATIONS_GROUP_LABEL}</div>
-                      {communicationsItems.map((item) => (
-                        <button
-                          key={item.id}
-                          type="button"
-                          onClick={() => handleDrawerNavigation(item.to)}
-                          className={isNavItemActive(loc.pathname, item) ? "active" : ""}
-                          aria-current={isNavItemActive(loc.pathname, item) ? "page" : undefined}
-                        >
-                          {item.label}
-                        </button>
-                      ))}
-                    </div>
-                  ) : null}
                 </div>
               )}
               <div className="rc-landlord-drawer-divider" />

--- a/rentchain-frontend/src/components/layout/LandlordNav.tsx
+++ b/rentchain-frontend/src/components/layout/LandlordNav.tsx
@@ -18,6 +18,7 @@ import { UpgradeNudgeHost } from "@/features/upgradeNudges/UpgradeNudgeHost";
 import { getRoleDefaultDestination } from "@/lib/authDestination";
 import { RentChainLogo } from "../brand/RentChainLogo";
 import "./LandlordNav.css";
+import { CommunicationsMenu } from "./CommunicationsMenu";
 
 type Props = {
   children: React.ReactNode;
@@ -125,7 +126,6 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
   const workspaceItems = visibleItems.filter((item) => stickyWorkspaceIds.has(item.id));
   const standardWorkspaceItems = workspaceItems.filter((item) => item.groupId !== COMMUNICATIONS_GROUP_ID);
   const communicationsItems = workspaceItems.filter((item) => item.groupId === COMMUNICATIONS_GROUP_ID);
-  const communicationsActive = communicationsItems.some((item) => isNavItemActive(loc.pathname, item));
   const primaryDrawerItems = drawerItems.filter((item) => !item.requiresAdmin);
   const adminDrawerItems = drawerItems.filter((item) => item.requiresAdmin);
   const orderedPrimaryDrawerItems = React.useMemo(
@@ -280,25 +280,6 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
                 {item.label}
               </Link>
             ))}
-            {communicationsItems.length ? (
-              <div
-                className={`rc-landlord-workspace-group${communicationsActive ? " active" : ""}`}
-                role="group"
-                aria-label={COMMUNICATIONS_GROUP_LABEL}
-              >
-                <span className="rc-landlord-workspace-group-label">{COMMUNICATIONS_GROUP_LABEL}</span>
-                {communicationsItems.map((item) => (
-                  <Link
-                    key={item.id}
-                    to={item.to}
-                    className={isNavItemActive(loc.pathname, item) ? "active" : ""}
-                    aria-current={isNavItemActive(loc.pathname, item) ? "page" : undefined}
-                  >
-                    {item.label}
-                  </Link>
-                ))}
-              </div>
-            ) : null}
           </nav>
         </div>
       </div>
@@ -306,6 +287,7 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
       <div className="rc-landlord-mobile-topbar">
         <RentChainLogo href="/dashboard" size="sm" />
         <span className="rc-landlord-mobile-role">{workspaceLabel}</span>
+        {communicationsItems.length ? <CommunicationsMenu className="rc-communications-menu--mobile" hasUnread={unreadFlag} /> : null}
         <button
           type="button"
           className="rc-landlord-mobile-menu"

--- a/rentchain-frontend/src/components/layout/TopNav.css
+++ b/rentchain-frontend/src/components/layout/TopNav.css
@@ -6,7 +6,7 @@
 .rc-top-nav {
   width: 100%;
   max-width: 100%;
-  overflow-x: hidden;
+  overflow: visible;
 }
 
 .rc-top-nav-inner,

--- a/rentchain-frontend/src/components/layout/TopNav.test.tsx
+++ b/rentchain-frontend/src/components/layout/TopNav.test.tsx
@@ -89,6 +89,7 @@ describe("TopNav", () => {
     expect(screen.getByRole("menuitem", { name: "Messages" })).toHaveAttribute("aria-current", "page");
     expect(screen.getByRole("menuitem", { name: "Notices" })).toHaveAttribute("href", "/notices");
     expect(menu).toBeInTheDocument();
+    expect(menu.parentElement).toBe(document.body);
   });
 
   it("replaces the prominent account text action with a scheduling shortcut", async () => {

--- a/rentchain-frontend/src/components/layout/TopNav.test.tsx
+++ b/rentchain-frontend/src/components/layout/TopNav.test.tsx
@@ -1,6 +1,7 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import TopNav from "./TopNav";
+import { MemoryRouter } from "react-router-dom";
 
 const mocks = vi.hoisted(() => ({
   navigateMock: vi.fn(),
@@ -46,6 +47,14 @@ vi.mock("../brand/RentChainLogo", () => ({
 }));
 
 describe("TopNav", () => {
+  function renderTopNav(path = "/dashboard") {
+    return render(
+      <MemoryRouter initialEntries={[path]}>
+        <TopNav />
+      </MemoryRouter>
+    );
+  }
+
   afterEach(() => {
     cleanup();
   });
@@ -67,17 +76,23 @@ describe("TopNav", () => {
     });
   });
 
-  it("renders a landlord inbox shortcut and routes to the unified inbox", async () => {
-    render(<TopNav />);
+  it("replaces the Inbox shortcut with an accessible Communications menu", async () => {
+    renderTopNav("/messages");
 
-    const messagesButton = await screen.findByRole("button", { name: "Inbox" });
-    fireEvent.click(messagesButton);
+    expect(screen.queryByRole("button", { name: /^Inbox/ })).not.toBeInTheDocument();
+    const communicationsButton = await screen.findByRole("button", { name: "Communications" });
+    fireEvent.click(communicationsButton);
 
-    expect(mocks.navigateMock).toHaveBeenCalledWith("/landlord/inbox");
+    const menu = screen.getByRole("menu", { name: "Communications destinations" });
+    expect(screen.getByRole("menuitem", { name: "Unified Inbox" })).toHaveAttribute("href", "/landlord/unified-inbox");
+    expect(screen.getByRole("menuitem", { name: "Messages" })).toHaveAttribute("href", "/messages");
+    expect(screen.getByRole("menuitem", { name: "Messages" })).toHaveAttribute("aria-current", "page");
+    expect(screen.getByRole("menuitem", { name: "Notices" })).toHaveAttribute("href", "/notices");
+    expect(menu).toBeInTheDocument();
   });
 
   it("replaces the prominent account text action with a scheduling shortcut", async () => {
-    render(<TopNav />);
+    renderTopNav();
 
     const scheduleButton = await screen.findByRole("button", { name: /Scheduling/i });
     fireEvent.click(scheduleButton);
@@ -101,7 +116,7 @@ describe("TopNav", () => {
       authStatus: "authed",
     });
 
-    render(<TopNav />);
+    renderTopNav();
 
     const accountButton = await screen.findByRole("button", { name: "Account menu for Paul Chater" });
     expect(accountButton).toHaveTextContent("PC");
@@ -126,7 +141,7 @@ describe("TopNav", () => {
       authStatus: "authed",
     });
 
-    render(<TopNav />);
+    renderTopNav();
 
     expect(await screen.findByRole("button", { name: "Account menu" })).toHaveTextContent("PM");
     expect(screen.queryByText("My Account")).not.toBeInTheDocument();
@@ -135,10 +150,23 @@ describe("TopNav", () => {
   it("shows unread indicator from existing conversation unread data", async () => {
     mocks.fetchLandlordConversationsMock.mockResolvedValue([{ id: "conv-1", hasUnread: true }]);
 
-    render(<TopNav />);
+    renderTopNav();
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Inbox (unread)" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Communications (unread)" })).toBeInTheDocument();
     });
+  });
+
+  it("closes the Communications menu on Escape and restores trigger focus", async () => {
+    renderTopNav();
+
+    const trigger = screen.getByRole("button", { name: "Communications" });
+    fireEvent.click(trigger);
+    expect(screen.getByRole("menu", { name: "Communications destinations" })).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    await waitFor(() => expect(screen.queryByRole("menu", { name: "Communications destinations" })).not.toBeInTheDocument());
+    expect(trigger).toHaveFocus();
   });
 });

--- a/rentchain-frontend/src/components/layout/TopNav.tsx
+++ b/rentchain-frontend/src/components/layout/TopNav.tsx
@@ -9,6 +9,7 @@ import { colors, radius, shadows, spacing, text, layout, blur } from "../../styl
 import { RentChainLogo } from "../brand/RentChainLogo";
 import { fetchLandlordConversations } from "../../api/messagesApi";
 import { useCapabilities } from "@/hooks/useCapabilities";
+import { CommunicationsMenu } from "./CommunicationsMenu";
 import "./TopNav.css";
 
 function roleLabel(raw: string): string {
@@ -71,13 +72,13 @@ const TopNav: React.FC = () => {
   const accountInitials = userInitials(user);
   const accountButtonLabel = accountName ? `Account menu for ${accountName}` : "Account menu";
   const canShowSchedulingShortcut = authResolved && (effectiveRole === "landlord" || effectiveRole === "admin");
-  const canShowMessagesShortcut =
+  const canShowCommunications =
     authResolved &&
-    (effectiveRole === "landlord" || effectiveRole === "admin") &&
-    features?.messaging !== false;
+    (effectiveRole === "landlord" || effectiveRole === "admin");
+  const canLoadUnreadMessages = canShowCommunications && features?.messaging !== false;
 
   React.useEffect(() => {
-    if (!canShowMessagesShortcut) {
+    if (!canLoadUnreadMessages) {
       setHasUnreadMessages(false);
       return;
     }
@@ -98,7 +99,7 @@ const TopNav: React.FC = () => {
       mounted = false;
       window.clearInterval(interval);
     };
-  }, [canShowMessagesShortcut]);
+  }, [canLoadUnreadMessages]);
 
   return (
     <>
@@ -144,40 +145,7 @@ const TopNav: React.FC = () => {
             >
               Role: {roleBadge}
             </span>
-            {canShowMessagesShortcut ? (
-              <Button
-                className="rc-top-nav-optional-action"
-                variant="secondary"
-                onClick={() => navigate("/landlord/inbox")}
-                aria-label={hasUnreadMessages ? "Inbox (unread)" : "Inbox"}
-                style={{
-                  position: "relative",
-                  borderRadius: radius.pill,
-                  border: `1px solid ${colors.border}`,
-                  background: colors.panel,
-                  color: text.primary,
-                  boxShadow: shadows.sm,
-                  fontWeight: 700,
-                  paddingRight: hasUnreadMessages ? "16px" : undefined,
-                }}
-              >
-                Inbox
-                {hasUnreadMessages ? (
-                  <span
-                    aria-hidden="true"
-                    style={{
-                      position: "absolute",
-                      top: 8,
-                      right: 8,
-                      width: 8,
-                      height: 8,
-                      borderRadius: 999,
-                      background: colors.accent,
-                    }}
-                  />
-                ) : null}
-              </Button>
-            ) : null}
+            {canShowCommunications ? <CommunicationsMenu hasUnread={hasUnreadMessages} /> : null}
             {canShowSchedulingShortcut ? (
               <Button
                 className="rc-top-nav-optional-action"

--- a/rentchain-frontend/src/components/layout/navConfig.ts
+++ b/rentchain-frontend/src/components/layout/navConfig.ts
@@ -9,6 +9,7 @@ export type NavItem = {
   icon?: ComponentType<{ size?: number; strokeWidth?: number }>;
   showInDrawer?: boolean;
   showInTabs?: boolean;
+  showInWorkspace?: boolean;
   requiresAdmin?: boolean;
   requiresLandlordOrAdmin?: boolean;
   requiresFeature?: string;
@@ -118,7 +119,8 @@ export const NAV_ITEMS: NavItem[] = [
     matchPaths: ["/landlord/inbox"],
     icon: Inbox,
     showInDrawer: true,
-    showInTabs: true,
+    showInTabs: false,
+    showInWorkspace: false,
     requiresLandlordOrAdmin: true,
     groupId: COMMUNICATIONS_GROUP_ID,
     groupLabel: COMMUNICATIONS_GROUP_LABEL,
@@ -147,6 +149,7 @@ export const NAV_ITEMS: NavItem[] = [
     icon: MessagesSquare,
     showInDrawer: true,
     showInTabs: false,
+    showInWorkspace: false,
     requiresRoles: ["landlord"],
     groupId: COMMUNICATIONS_GROUP_ID,
     groupLabel: COMMUNICATIONS_GROUP_LABEL,
@@ -158,6 +161,7 @@ export const NAV_ITEMS: NavItem[] = [
     icon: Megaphone,
     showInDrawer: true,
     showInTabs: false,
+    showInWorkspace: false,
     requiresRoles: ["landlord"],
     groupId: COMMUNICATIONS_GROUP_ID,
     groupLabel: COMMUNICATIONS_GROUP_LABEL,

--- a/rentchain-frontend/src/pages/MessagesPage.css
+++ b/rentchain-frontend/src/pages/MessagesPage.css
@@ -112,17 +112,20 @@
 
 .rc-messages-recipient-list {
   display: grid;
-  gap: 8px;
+  grid-auto-rows: max-content;
+  gap: 12px;
   max-height: 240px;
   overflow-y: auto;
 }
 
 .rc-messages-recipient-list button {
   display: grid;
-  gap: 4px;
+  align-content: center;
+  gap: 7px;
   width: 100%;
   min-width: 0;
-  padding: 10px 12px;
+  min-height: 72px;
+  padding: 13px 14px;
   text-align: left;
   border: 1px solid rgba(148, 163, 184, 0.45);
   border-radius: 12px;
@@ -130,14 +133,35 @@
   cursor: pointer;
 }
 
+.rc-messages-recipient-list button:hover,
+.rc-messages-recipient-list button:focus-visible {
+  border-color: rgba(37, 99, 235, 0.62);
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.12);
+}
+
 .rc-messages-recipient-list button.is-selected {
   border-color: #2563eb;
   background: rgba(37, 99, 235, 0.1);
 }
 
-.rc-messages-recipient-list span {
-  color: #64748b;
+.rc-messages-recipient-name,
+.rc-messages-recipient-context {
+  display: block;
+  min-width: 0;
   overflow-wrap: anywhere;
+  word-break: normal;
+}
+
+.rc-messages-recipient-name {
+  color: #0f172a;
+  line-height: 1.35;
+}
+
+.rc-messages-recipient-context {
+  color: #64748b;
+  font-size: 0.9rem;
+  line-height: 1.45;
 }
 
 .rc-messages-compose-actions {

--- a/rentchain-frontend/src/pages/MessagesPage.css
+++ b/rentchain-frontend/src/pages/MessagesPage.css
@@ -140,17 +140,55 @@
   box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.12);
 }
 
-.rc-messages-recipient-list button.is-selected {
-  border-color: #2563eb;
-  background: rgba(37, 99, 235, 0.1);
-}
-
 .rc-messages-recipient-name,
 .rc-messages-recipient-context {
   display: block;
   min-width: 0;
   overflow-wrap: anywhere;
   word-break: normal;
+}
+
+.rc-messages-selected-recipient {
+  display: grid;
+  gap: 8px;
+}
+
+.rc-messages-selected-recipient-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  color: #0f172a;
+  font-weight: 700;
+}
+
+.rc-messages-selected-recipient-heading button {
+  min-height: 40px;
+  padding: 8px 12px;
+  border: 1px solid rgba(37, 99, 235, 0.48);
+  border-radius: 10px;
+  background: #ffffff;
+  color: #1d4ed8;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 700;
+}
+
+.rc-messages-selected-recipient-heading button:hover,
+.rc-messages-selected-recipient-heading button:focus-visible {
+  border-color: #2563eb;
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.12);
+}
+
+.rc-messages-selected-recipient-card {
+  display: grid;
+  gap: 7px;
+  min-width: 0;
+  padding: 14px;
+  border: 1px solid rgba(37, 99, 235, 0.48);
+  border-radius: 12px;
+  background: rgba(37, 99, 235, 0.08);
 }
 
 .rc-messages-recipient-name {

--- a/rentchain-frontend/src/pages/MessagesPage.test.tsx
+++ b/rentchain-frontend/src/pages/MessagesPage.test.tsx
@@ -166,6 +166,9 @@ describe("MessagesPage", () => {
     expect(mocks.fetchLandlordMessageRecipientsMock).toHaveBeenCalledTimes(1);
     expect(screen.getByRole("dialog", { name: "New message" })).toBeInTheDocument();
     expect(screen.getByText("Harbour View / Unit 2A")).toBeInTheDocument();
+    const recipient = screen.getByRole("button", { name: /Taylor Tenant/ });
+    expect(within(recipient).getByText("Taylor Tenant")).toHaveClass("rc-messages-recipient-name");
+    expect(within(recipient).getByText("Harbour View / Unit 2A")).toHaveClass("rc-messages-recipient-context");
 
     fireEvent.change(screen.getByPlaceholderText("Search by tenant, property, or unit"), { target: { value: "2A" } });
     fireEvent.click(screen.getByRole("button", { name: /Taylor Tenant/ }));
@@ -182,6 +185,33 @@ describe("MessagesPage", () => {
     expect(screen.getByTestId("location")).toHaveTextContent(
       "/messages?threadId=landlord-1__tenant-1__unit-1"
     );
+  });
+
+  it("keeps long recipient names and property context in distinct wrapping-safe elements", async () => {
+    mocks.fetchLandlordMessageRecipientsMock.mockResolvedValue([
+      {
+        leaseId: "lease-long",
+        tenantId: "tenant-long",
+        tenantDisplayName: "Alexandria Montgomery-Wellington With A Long Tenant Display Name",
+        propertyId: "prop-long",
+        propertyDisplayLabel: "The Residences at an Intentionally Long Waterfront Property Name",
+        unitId: "unit-long",
+        unitDisplayLabel: "Unit PH-1208 East Wing With Extended Label",
+      },
+    ]);
+
+    render(
+      <MemoryRouter initialEntries={["/messages"]}>
+        <MessagesPage />
+      </MemoryRouter>
+    );
+    await flushAsync();
+    fireEvent.click(screen.getAllByRole("button", { name: "New Message" })[0]);
+    await flushAsync();
+
+    const row = screen.getByRole("button", { name: /Alexandria Montgomery-Wellington/ });
+    expect(within(row).getByText(/Alexandria Montgomery-Wellington/)).toHaveClass("rc-messages-recipient-name");
+    expect(within(row).getByText(/The Residences.*Extended Label/)).toHaveClass("rc-messages-recipient-context");
   });
 
   it("prevents double submission while a first message is in flight", async () => {

--- a/rentchain-frontend/src/pages/MessagesPage.test.tsx
+++ b/rentchain-frontend/src/pages/MessagesPage.test.tsx
@@ -142,6 +142,26 @@ describe("MessagesPage", () => {
 
   it("supports first-message compose when the landlord has no conversations", async () => {
     mocks.fetchLandlordConversationsMock.mockResolvedValue([]);
+    mocks.fetchLandlordMessageRecipientsMock.mockResolvedValue([
+      {
+        leaseId: "lease-1",
+        tenantId: "tenant-1",
+        tenantDisplayName: "Taylor Tenant",
+        propertyId: "prop-1",
+        propertyDisplayLabel: "Harbour View",
+        unitId: "unit-1",
+        unitDisplayLabel: "Unit 2A",
+      },
+      {
+        leaseId: "lease-2",
+        tenantId: "tenant-2",
+        tenantDisplayName: "Jordan Tenant",
+        propertyId: "prop-2",
+        propertyDisplayLabel: "North Point",
+        unitId: "unit-2",
+        unitDisplayLabel: "Unit 9",
+      },
+    ]);
     mocks.fetchLandlordConversationMessagesMock.mockResolvedValue({
       conversation: {
         id: "landlord-1__tenant-1__unit-1",
@@ -172,7 +192,15 @@ describe("MessagesPage", () => {
 
     fireEvent.change(screen.getByPlaceholderText("Search by tenant, property, or unit"), { target: { value: "2A" } });
     fireEvent.click(screen.getByRole("button", { name: /Taylor Tenant/ }));
+    expect(screen.getByText("Selected recipient")).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText("Search by tenant, property, or unit")).not.toBeInTheDocument();
+    expect(screen.queryByText("Jordan Tenant")).not.toBeInTheDocument();
     fireEvent.change(screen.getByPlaceholderText("Write your message"), { target: { value: "Welcome to RentChain." } });
+    fireEvent.click(screen.getByRole("button", { name: "Change" }));
+    expect(screen.getByPlaceholderText("Search by tenant, property, or unit")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Write your message")).toHaveValue("Welcome to RentChain.");
+    expect(screen.getByText("Jordan Tenant")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Taylor Tenant/ }));
     fireEvent.click(screen.getByRole("button", { name: "Send Message" }));
     await flushAsync();
 

--- a/rentchain-frontend/src/pages/MessagesPage.tsx
+++ b/rentchain-frontend/src/pages/MessagesPage.tsx
@@ -187,6 +187,8 @@ export default function MessagesPage() {
   const hasLoadedThreadRef = useRef(false);
   const selectedIdRef = useRef<string | null>(null);
   const lastMarkedReadRef = useRef<Record<string, number>>({});
+  const recipientSearchRef = useRef<HTMLInputElement | null>(null);
+  const firstMessageRef = useRef<HTMLTextAreaElement | null>(null);
 
   useEffect(() => {
     selectedIdRef.current = selectedId;
@@ -382,6 +384,17 @@ export default function MessagesPage() {
       .includes(recipientSearch.trim().toLowerCase())
   );
 
+  const selectRecipient = (key: string) => {
+    setSelectedRecipientKey(key);
+    window.requestAnimationFrame(() => firstMessageRef.current?.focus());
+  };
+
+  const changeRecipient = () => {
+    setSelectedRecipientKey(null);
+    setRecipientSearch("");
+    window.requestAnimationFrame(() => recipientSearchRef.current?.focus());
+  };
+
   const openCompose = async () => {
     setComposeOpen(true);
     setComposeError(null);
@@ -465,41 +478,57 @@ export default function MessagesPage() {
               </button>
             </div>
             {composeError ? <div className="rc-messages-compose-error" role="alert">{composeError}</div> : null}
-            <label className="rc-messages-compose-field">
-              <span>Search tenants</span>
-              <input
-                value={recipientSearch}
-                onChange={(event) => setRecipientSearch(event.target.value)}
-                placeholder="Search by tenant, property, or unit"
-              />
-            </label>
-            <div className="rc-messages-recipient-list" aria-label="Eligible tenants">
-              {loadingRecipients ? (
-                <div>Loading eligible tenants…</div>
-              ) : filteredRecipients.length === 0 ? (
-                <div>No eligible current tenants found.</div>
-              ) : filteredRecipients.map((recipient) => {
-                const key = recipientKey(recipient);
-                const selected = key === selectedRecipientKey;
-                return (
-                  <button
-                    type="button"
-                    key={key}
-                    className={selected ? "is-selected" : ""}
-                    aria-pressed={selected}
-                    onClick={() => setSelectedRecipientKey(key)}
-                  >
-                    <strong className="rc-messages-recipient-name">{recipient.tenantDisplayName}</strong>
-                    <span className="rc-messages-recipient-context">
-                      {[recipient.propertyDisplayLabel, recipient.unitDisplayLabel].filter(Boolean).join(" / ")}
-                    </span>
-                  </button>
-                );
-              })}
-            </div>
+            {selectedRecipient ? (
+              <section className="rc-messages-selected-recipient" aria-labelledby="selected-recipient-label">
+                <div className="rc-messages-selected-recipient-heading">
+                  <span id="selected-recipient-label">Selected recipient</span>
+                  <button type="button" onClick={changeRecipient}>Change</button>
+                </div>
+                <div className="rc-messages-selected-recipient-card">
+                  <strong className="rc-messages-recipient-name">{selectedRecipient.tenantDisplayName}</strong>
+                  <span className="rc-messages-recipient-context">
+                    {[selectedRecipient.propertyDisplayLabel, selectedRecipient.unitDisplayLabel].filter(Boolean).join(" / ")}
+                  </span>
+                </div>
+              </section>
+            ) : (
+              <>
+                <label className="rc-messages-compose-field">
+                  <span>Search tenants</span>
+                  <input
+                    ref={recipientSearchRef}
+                    value={recipientSearch}
+                    onChange={(event) => setRecipientSearch(event.target.value)}
+                    placeholder="Search by tenant, property, or unit"
+                  />
+                </label>
+                <div className="rc-messages-recipient-list" aria-label="Eligible tenants">
+                  {loadingRecipients ? (
+                    <div>Loading eligible tenants…</div>
+                  ) : filteredRecipients.length === 0 ? (
+                    <div>No eligible current tenants found.</div>
+                  ) : filteredRecipients.map((recipient) => {
+                    const key = recipientKey(recipient);
+                    return (
+                      <button
+                        type="button"
+                        key={key}
+                        onClick={() => selectRecipient(key)}
+                      >
+                        <strong className="rc-messages-recipient-name">{recipient.tenantDisplayName}</strong>
+                        <span className="rc-messages-recipient-context">
+                          {[recipient.propertyDisplayLabel, recipient.unitDisplayLabel].filter(Boolean).join(" / ")}
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+              </>
+            )}
             <label className="rc-messages-compose-field">
               <span>Message</span>
               <textarea
+                ref={firstMessageRef}
                 value={firstMessage}
                 onChange={(event) => setFirstMessage(event.target.value)}
                 maxLength={4000}

--- a/rentchain-frontend/src/pages/MessagesPage.tsx
+++ b/rentchain-frontend/src/pages/MessagesPage.tsx
@@ -489,8 +489,10 @@ export default function MessagesPage() {
                     aria-pressed={selected}
                     onClick={() => setSelectedRecipientKey(key)}
                   >
-                    <strong>{recipient.tenantDisplayName}</strong>
-                    <span>{[recipient.propertyDisplayLabel, recipient.unitDisplayLabel].filter(Boolean).join(" / ")}</span>
+                    <strong className="rc-messages-recipient-name">{recipient.tenantDisplayName}</strong>
+                    <span className="rc-messages-recipient-context">
+                      {[recipient.propertyDisplayLabel, recipient.unitDisplayLabel].filter(Boolean).join(" / ")}
+                    </span>
                   </button>
                 );
               })}

--- a/rentchain-frontend/tests/playwright/messages-layout.spec.ts
+++ b/rentchain-frontend/tests/playwright/messages-layout.spec.ts
@@ -196,15 +196,19 @@ test("real Messages page preserves deep links, Back, composer access, and bounde
         status: 200,
         contentType: "application/json",
         body: JSON.stringify({
-          recipients: [{
-            leaseId: "lease-synthetic-1",
-            tenantId: "tenant-synthetic-1",
-            tenantDisplayName: "Synthetic Active Tenant",
-            propertyId: "property-synthetic-1",
-            propertyDisplayLabel: "Harbour Synthetic Property",
-            unitId: "unit-synthetic-1",
-            unitDisplayLabel: "Unit 4B",
-          }],
+          recipients: Array.from({ length: 6 }, (_, index) => ({
+            leaseId: `lease-synthetic-${index + 1}`,
+            tenantId: `tenant-synthetic-${index + 1}`,
+            tenantDisplayName: index === 0
+              ? "Synthetic Active Tenant With An Intentionally Long Wrapping Display Name"
+              : `Synthetic Active Tenant ${index + 1}`,
+            propertyId: `property-synthetic-${index + 1}`,
+            propertyDisplayLabel: index === 0
+              ? "Harbour Synthetic Property With An Intentionally Long Waterfront Name"
+              : "Harbour Synthetic Property",
+            unitId: `unit-synthetic-${index + 1}`,
+            unitDisplayLabel: index === 0 ? "Unit 4B East Wing With Extended Label" : `Unit ${index + 1}`,
+          })),
         }),
       });
       return;
@@ -263,8 +267,34 @@ test("real Messages page preserves deep links, Back, composer access, and bounde
   await page.getByRole("button", { name: "New Message" }).first().click();
   const compose = page.getByRole("dialog", { name: "New message" });
   await expect(compose).toBeVisible();
+  const recipientRows = compose.locator(".rc-messages-recipient-list button");
+  await expect(recipientRows).toHaveCount(6);
+  const rowGeometry = await recipientRows.evaluateAll((rows) => rows.map((row, index) => {
+    const rect = row.getBoundingClientRect();
+    const name = row.querySelector<HTMLElement>(".rc-messages-recipient-name")?.getBoundingClientRect();
+    const context = row.querySelector<HTMLElement>(".rc-messages-recipient-context")?.getBoundingClientRect();
+    const next = rows[index + 1]?.getBoundingClientRect();
+    return {
+      rowTop: rect.top,
+      rowBottom: rect.bottom,
+      nameTop: name?.top,
+      nameBottom: name?.bottom,
+      contextTop: context?.top,
+      contextBottom: context?.bottom,
+      nextTop: next?.top,
+    };
+  }));
+  for (const geometry of rowGeometry) {
+    expect(geometry.nameTop).toBeGreaterThanOrEqual(geometry.rowTop);
+    expect(geometry.nameBottom).toBeLessThanOrEqual(geometry.contextTop ?? Infinity);
+    expect(geometry.contextBottom).toBeLessThanOrEqual(geometry.rowBottom);
+    if (geometry.nextTop !== undefined) expect(geometry.rowBottom).toBeLessThan(geometry.nextTop);
+  }
+  await expect(compose.getByPlaceholder("Write your message")).toBeVisible();
+  await expect(compose.getByRole("button", { name: "Cancel" })).toBeVisible();
+  await expect(compose.getByRole("button", { name: "Send Message" })).toBeVisible();
   await compose.getByPlaceholder("Search by tenant, property, or unit").fill("4B");
-  await compose.getByRole("button", { name: /Synthetic Active Tenant/ }).click();
+  await compose.getByRole("button", { name: /Synthetic Active Tenant With/ }).click();
   await compose.getByPlaceholder("Write your message").fill("Synthetic first outbound message");
   await compose.getByRole("button", { name: "Send Message" }).click();
   await expect(compose).not.toBeVisible();

--- a/rentchain-frontend/tests/playwright/messages-layout.spec.ts
+++ b/rentchain-frontend/tests/playwright/messages-layout.spec.ts
@@ -295,8 +295,20 @@ test("real Messages page preserves deep links, Back, composer access, and bounde
   await expect(compose.getByRole("button", { name: "Send Message" })).toBeVisible();
   await compose.getByPlaceholder("Search by tenant, property, or unit").fill("4B");
   await compose.getByRole("button", { name: /Synthetic Active Tenant With/ }).click();
-  await compose.getByPlaceholder("Write your message").fill("Synthetic first outbound message");
-  await compose.getByRole("button", { name: "Send Message" }).click();
+  await expect(compose.getByText("Selected recipient")).toBeVisible();
+  await expect(compose.getByPlaceholder("Search by tenant, property, or unit")).toHaveCount(0);
+  await expect(compose.locator(".rc-messages-recipient-list button")).toHaveCount(0);
+  await expect(compose.getByText(/Synthetic Active Tenant With/)).toBeVisible();
+  await expect(compose.getByText(/Harbour Synthetic Property With An Intentionally Long Waterfront Name/)).toBeVisible();
+  await compose.getByPlaceholder("Write your message").fill("Harmless unsent draft retained during recipient change");
+  await compose.getByRole("button", { name: "Change" }).click();
+  await expect(compose.getByPlaceholder("Search by tenant, property, or unit")).toBeFocused();
+  await expect(compose.getByPlaceholder("Write your message")).toHaveValue("Harmless unsent draft retained during recipient change");
+  await expect(compose.locator(".rc-messages-recipient-list button")).toHaveCount(6);
+  await compose.getByRole("button", { name: /Synthetic Active Tenant 2/ }).click();
+  await expect(compose.getByText("Selected recipient")).toBeVisible();
+  await expect(compose.getByText("Synthetic Active Tenant 2")).toBeVisible();
+  await compose.getByRole("button", { name: "Cancel" }).click();
   await expect(compose).not.toBeVisible();
   await expect(page).toHaveURL(/threadId=conv-1/);
 

--- a/rentchain-frontend/tests/playwright/workspace-communications-layout.spec.ts
+++ b/rentchain-frontend/tests/playwright/workspace-communications-layout.spec.ts
@@ -38,39 +38,38 @@ for (const route of communicationsRoutes) {
       await page.goto(route.path);
 
       const workspaceNav = page.getByRole("navigation", { name: "Workspace navigation" });
-      const communications = workspaceNav.getByRole("group", { name: "Communications" });
-      await expect(communications.getByRole("link")).toHaveCount(3);
-      await expect(communications.getByRole("link", { name: "Unified Inbox" })).toBeVisible();
-      await expect(communications.getByRole("link", { name: "Messages" })).toBeVisible();
-      await expect(communications.getByRole("link", { name: "Notices" })).toBeVisible();
-      await expect(communications.getByRole("link", { name: route.title })).toHaveAttribute("aria-current", "page");
+      await expect(workspaceNav.getByRole("group", { name: "Communications" })).toHaveCount(0);
+      await expect(workspaceNav.getByText("COMMUNICATIONS")).toHaveCount(0);
+      await page.getByRole("button", { name: "Communications" }).click();
+      const communications = page.getByRole("menu", { name: "Communications destinations" });
+      await expect(communications.getByRole("menuitem")).toHaveCount(3);
+      await expect(communications.getByRole("menuitem", { name: "Unified Inbox" })).toBeVisible();
+      await expect(communications.getByRole("menuitem", { name: "Messages" })).toBeVisible();
+      await expect(communications.getByRole("menuitem", { name: "Notices" })).toBeVisible();
+      await expect(communications.getByRole("menuitem", { name: route.title })).toHaveAttribute("aria-current", "page");
       await expect(page.locator(".rc-landlord-workspace-context strong")).toHaveText(route.title);
 
       const geometry = await workspaceNav.evaluate((nav) => {
-        const group = nav.querySelector<HTMLElement>(".rc-landlord-workspace-group");
-        const active = nav.querySelector<HTMLElement>('[aria-current="page"]');
         const navRect = nav.getBoundingClientRect();
-        const groupRect = group?.getBoundingClientRect();
-        const activeRect = active?.getBoundingClientRect();
         return {
           clientWidth: nav.clientWidth,
           scrollWidth: nav.scrollWidth,
           navLeft: navRect.left,
           navRight: navRect.right,
-          groupLeft: groupRect?.left,
-          groupRight: groupRect?.right,
-          activeLeft: activeRect?.left,
-          activeRight: activeRect?.right,
           viewportWidth: window.innerWidth,
         };
       });
 
       test.info().annotations.push({ type: "geometry", description: JSON.stringify(geometry) });
       expect(geometry.scrollWidth).toBeLessThanOrEqual(geometry.clientWidth + 1);
-      expect(geometry.groupLeft).toBeGreaterThanOrEqual(geometry.navLeft);
-      expect(geometry.groupRight).toBeLessThanOrEqual(geometry.viewportWidth);
-      expect(geometry.activeLeft).toBeGreaterThanOrEqual(geometry.navLeft);
-      expect(geometry.activeRight).toBeLessThanOrEqual(geometry.viewportWidth);
+      const menuGeometry = await communications.evaluate((menu) => {
+        const rect = menu.getBoundingClientRect();
+        return { left: rect.left, right: rect.right, top: rect.top, bottom: rect.bottom, viewportWidth: innerWidth, viewportHeight: innerHeight };
+      });
+      expect(menuGeometry.left).toBeGreaterThanOrEqual(0);
+      expect(menuGeometry.right).toBeLessThanOrEqual(menuGeometry.viewportWidth);
+      expect(menuGeometry.top).toBeGreaterThanOrEqual(0);
+      expect(menuGeometry.bottom).toBeLessThanOrEqual(menuGeometry.viewportHeight);
     });
   }
 }
@@ -213,11 +212,12 @@ test("redirects the legacy landlord inbox into the canonical Communications shel
   await page.goto("/landlord/inbox?status=unread#updates");
 
   await expect(page).toHaveURL(/\/landlord\/unified-inbox\?status=unread#updates$/);
-  const communications = page.getByRole("navigation", { name: "Workspace navigation" }).getByRole("group", {
-    name: "Communications",
-  });
-  await expect(communications.getByRole("link")).toHaveCount(3);
-  await expect(communications.getByRole("link", { name: "Unified Inbox" })).toHaveAttribute("aria-current", "page");
+  const workspaceNav = page.getByRole("navigation", { name: "Workspace navigation" });
+  await expect(workspaceNav.getByRole("group", { name: "Communications" })).toHaveCount(0);
+  await page.getByRole("button", { name: "Communications" }).click();
+  const communications = page.getByRole("menu", { name: "Communications destinations" });
+  await expect(communications.getByRole("menuitem")).toHaveCount(3);
+  await expect(communications.getByRole("menuitem", { name: "Unified Inbox" })).toHaveAttribute("aria-current", "page");
   await expect(page.locator(".rc-landlord-workspace-context strong")).toHaveText("Unified Inbox");
 });
 
@@ -232,6 +232,14 @@ for (const route of communicationsRoutes) {
       await page.goto(route.path);
 
       await expect(page.locator(".rc-landlord-mobile-role")).toHaveText(route.title);
+      await page.getByRole("button", { name: "Communications" }).click();
+      const headerMenu = page.getByRole("menu", { name: "Communications destinations" });
+      await expect(headerMenu.getByRole("menuitem", { name: "Unified Inbox" })).toBeVisible();
+      await expect(headerMenu.getByRole("menuitem", { name: "Messages" })).toBeVisible();
+      await expect(headerMenu.getByRole("menuitem", { name: "Notices" })).toBeVisible();
+      await expect(headerMenu.getByRole("menuitem", { name: route.title })).toHaveAttribute("aria-current", "page");
+      await page.keyboard.press("Escape");
+      await expect(headerMenu).not.toBeAttached();
       await page.getByRole("button", { name: "Open workspace pages" }).first().click();
       const drawer = page.getByRole("dialog", { name: "Navigation menu" });
       const communications = drawer.getByRole("group", { name: "Communications" });

--- a/rentchain-frontend/tests/playwright/workspace-communications-layout.spec.ts
+++ b/rentchain-frontend/tests/playwright/workspace-communications-layout.spec.ts
@@ -40,7 +40,8 @@ for (const route of communicationsRoutes) {
       const workspaceNav = page.getByRole("navigation", { name: "Workspace navigation" });
       await expect(workspaceNav.getByRole("group", { name: "Communications" })).toHaveCount(0);
       await expect(workspaceNav.getByText("COMMUNICATIONS")).toHaveCount(0);
-      await page.getByRole("button", { name: "Communications" }).click();
+      const trigger = page.getByRole("button", { name: "Communications" });
+      await trigger.click();
       const communications = page.getByRole("menu", { name: "Communications destinations" });
       await expect(communications.getByRole("menuitem")).toHaveCount(3);
       await expect(communications.getByRole("menuitem", { name: "Unified Inbox" })).toBeVisible();
@@ -64,12 +65,28 @@ for (const route of communicationsRoutes) {
       expect(geometry.scrollWidth).toBeLessThanOrEqual(geometry.clientWidth + 1);
       const menuGeometry = await communications.evaluate((menu) => {
         const rect = menu.getBoundingClientRect();
-        return { left: rect.left, right: rect.right, top: rect.top, bottom: rect.bottom, viewportWidth: innerWidth, viewportHeight: innerHeight };
+        const first = menu.querySelector<HTMLElement>('[role="menuitem"]');
+        const firstRect = first?.getBoundingClientRect();
+        const topElement = firstRect ? document.elementFromPoint(firstRect.left + firstRect.width / 2, firstRect.top + firstRect.height / 2) : null;
+        return {
+          left: rect.left,
+          right: rect.right,
+          top: rect.top,
+          bottom: rect.bottom,
+          viewportWidth: innerWidth,
+          viewportHeight: innerHeight,
+          firstItemReceivesPointer: Boolean(topElement?.closest('[role="menuitem"]') === first),
+          portalParent: menu.parentElement?.tagName,
+        };
       });
+      const triggerBottom = await trigger.evaluate((element) => element.getBoundingClientRect().bottom);
       expect(menuGeometry.left).toBeGreaterThanOrEqual(0);
       expect(menuGeometry.right).toBeLessThanOrEqual(menuGeometry.viewportWidth);
       expect(menuGeometry.top).toBeGreaterThanOrEqual(0);
       expect(menuGeometry.bottom).toBeLessThanOrEqual(menuGeometry.viewportHeight);
+      expect(menuGeometry.top).toBeGreaterThanOrEqual(triggerBottom + 7);
+      expect(menuGeometry.firstItemReceivesPointer).toBe(true);
+      expect(menuGeometry.portalParent).toBe("BODY");
     });
   }
 }

--- a/rentchain-frontend/tests/playwright/workspace-communications-layout.spec.ts
+++ b/rentchain-frontend/tests/playwright/workspace-communications-layout.spec.ts
@@ -91,109 +91,38 @@ for (const route of communicationsRoutes) {
   }
 }
 
-test("scrolls the real mobile Workspace menu to Communications above the bottom navigation", async ({ page }) => {
+test("keeps communication destinations out of the mobile Workspace drawer and tab bar", async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 });
   await installWorkspaceHarness(page);
   await page.goto("/messages");
 
   await page.getByRole("button", { name: "Open workspace pages" }).first().click();
   const drawer = page.getByRole("dialog", { name: "Navigation menu" });
-  const scrollRegion = drawer.locator(".rc-landlord-drawer-scroll");
-  const communications = drawer.getByRole("group", { name: "Communications" });
-  await expect(communications).toBeAttached();
   await expect(drawer.getByRole("button", { name: "Close menu" })).toBeVisible();
-
-  const before = await scrollRegion.evaluate((element) => {
-    const styles = getComputedStyle(element);
-    const drawerRect = element.parentElement?.getBoundingClientRect();
-    const headerRect = element.previousElementSibling?.getBoundingClientRect();
-    const communicationsRect = element.querySelector('[role="group"][aria-label="Communications"]')?.getBoundingClientRect();
-    const bottomNavRect = document.querySelector('[aria-label="Bottom navigation"]')?.getBoundingClientRect();
-    return {
-      viewportHeight: window.innerHeight,
-      drawerTop: drawerRect?.top,
-      drawerBottom: drawerRect?.bottom,
-      drawerHeight: drawerRect?.height,
-      headerHeight: headerRect?.height,
-      clientHeight: element.clientHeight,
-      scrollHeight: element.scrollHeight,
-      scrollTop: element.scrollTop,
-      overflowY: styles.overflowY,
-      minHeight: styles.minHeight,
-      communicationsTop: communicationsRect?.top,
-      communicationsBottom: communicationsRect?.bottom,
-      bottomNavTop: bottomNavRect?.top,
-    };
-  });
-  test.info().annotations.push({ type: "mobile-menu-before-scroll", description: JSON.stringify(before) });
-
-  expect(before.scrollHeight).toBeGreaterThan(before.clientHeight);
-  await scrollRegion.evaluate((element) => element.scrollTo({ top: element.scrollHeight, behavior: "instant" }));
-  await expect.poll(() => scrollRegion.evaluate((element) => element.scrollTop)).toBeGreaterThan(0);
-
-  const after = await scrollRegion.evaluate((element) => {
-    const regionRect = element.getBoundingClientRect();
-    const noticesRect = Array.from(element.querySelectorAll("button"))
-      .find((button) => button.textContent?.trim() === "Notices")
-      ?.getBoundingClientRect();
-    const bottomNavRect = document.querySelector('[aria-label="Bottom navigation"]')?.getBoundingClientRect();
-    return {
-      clientWidth: element.clientWidth,
-      scrollWidth: element.scrollWidth,
-      scrollTop: element.scrollTop,
-      regionTop: regionRect.top,
-      regionBottom: regionRect.bottom,
-      noticesTop: noticesRect?.top,
-      noticesBottom: noticesRect?.bottom,
-      bottomNavTop: bottomNavRect?.top,
-    };
-  });
-  test.info().annotations.push({ type: "mobile-menu-after-scroll", description: JSON.stringify(after) });
-
-  expect(after.scrollWidth).toBeLessThanOrEqual(after.clientWidth + 1);
-  expect(after.noticesTop).toBeGreaterThanOrEqual(after.regionTop);
-  expect(after.noticesBottom).toBeLessThanOrEqual(after.regionBottom);
-  expect(after.noticesBottom).toBeLessThanOrEqual(after.bottomNavTop);
-  await expect(communications.getByRole("button", { name: "Unified Inbox" })).toBeInViewport();
-  await expect(communications.getByRole("button", { name: "Messages" })).toBeInViewport();
-  await expect(communications.getByRole("button", { name: "Notices" })).toBeInViewport();
-
-  await communications.getByRole("button", { name: "Notices" }).click();
-  await expect(page).toHaveURL(/\/notices$/);
-  await expect(drawer).not.toBeAttached();
-  await expect(page.locator(".rc-landlord-mobile-role")).toHaveText("Notices");
-
-  await page.getByRole("button", { name: "Open workspace pages" }).first().click();
-  const reopenedCommunications = page.getByRole("dialog", { name: "Navigation menu" }).getByRole("group", {
-    name: "Communications",
-  });
-  await expect(reopenedCommunications.getByRole("button", { name: "Notices" })).toHaveAttribute("aria-current", "page");
+  await expect(drawer.getByRole("group", { name: "Communications" })).toHaveCount(0);
+  await expect(drawer.getByRole("button", { name: "Unified Inbox" })).toHaveCount(0);
+  await expect(drawer.getByRole("button", { name: "Messages" })).toHaveCount(0);
+  await expect(drawer.getByRole("button", { name: "Notices" })).toHaveCount(0);
+  const tabbar = page.getByRole("navigation", { name: "Bottom navigation" });
+  await expect(tabbar.getByRole("button", { name: "Unified Inbox" })).toHaveCount(0);
+  await expect(tabbar.getByRole("button", { name: "Messages" })).toHaveCount(0);
+  await expect(tabbar.getByRole("button", { name: "Notices" })).toHaveCount(0);
 });
 
 for (const destination of communicationsRoutes) {
-  test(`navigates to ${destination.title} from the scrolled mobile Workspace menu`, async ({ page }) => {
+  test(`navigates to ${destination.title} from the mobile Communications menu`, async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 });
     await installWorkspaceHarness(page);
     await page.goto("/messages");
 
-    await page.getByRole("button", { name: "Open workspace pages" }).first().click();
-    const target = page
-      .getByRole("dialog", { name: "Navigation menu" })
-      .getByRole("group", { name: "Communications" })
-      .getByRole("button", { name: destination.title });
-    await target.scrollIntoViewIfNeeded();
-    await expect(target).toBeInViewport();
+    await page.getByRole("button", { name: "Communications" }).click();
+    const target = page.getByRole("menu", { name: "Communications destinations" }).getByRole("menuitem", { name: destination.title });
     await target.click();
 
     await expect(page).toHaveURL(new RegExp(`${destination.path.replaceAll("/", "\\/")}$`));
     await expect(page.locator(".rc-landlord-mobile-role")).toHaveText(destination.title);
-    await page.getByRole("button", { name: "Open workspace pages" }).first().click();
-    await expect(
-      page
-        .getByRole("dialog", { name: "Navigation menu" })
-        .getByRole("group", { name: "Communications" })
-        .getByRole("button", { name: destination.title }),
-    ).toHaveAttribute("aria-current", "page");
+    await page.getByRole("button", { name: "Communications" }).click();
+    await expect(page.getByRole("menuitem", { name: destination.title })).toHaveAttribute("aria-current", "page");
   });
 }
 
@@ -202,23 +131,20 @@ for (const viewport of [
   { width: 360, height: 800 },
   { width: 430, height: 932 },
 ]) {
-  test(`keeps Communications scroll-reachable at ${viewport.width}x${viewport.height}`, async ({ page }) => {
+  test(`keeps Communications exclusive to the header at ${viewport.width}x${viewport.height}`, async ({ page }) => {
     await page.setViewportSize(viewport);
     await installWorkspaceHarness(page);
     await page.goto("/notices");
 
     await page.getByRole("button", { name: "Open workspace pages" }).first().click();
     const drawer = page.getByRole("dialog", { name: "Navigation menu" });
-    const scrollRegion = drawer.getByLabel("Workspace destinations");
-    const communications = drawer.getByRole("group", { name: "Communications" });
-    await scrollRegion.evaluate((element) => element.scrollTo({ top: element.scrollHeight, behavior: "instant" }));
-
-    await expect.poll(() => scrollRegion.evaluate((element) => element.scrollTop)).toBeGreaterThan(0);
-    await expect(communications.getByRole("button", { name: "Unified Inbox" })).toBeInViewport();
-    await expect(communications.getByRole("button", { name: "Messages" })).toBeInViewport();
-    await expect(communications.getByRole("button", { name: "Notices" })).toBeInViewport();
-    expect(await scrollRegion.evaluate((element) => element.scrollWidth)).toBeLessThanOrEqual(
-      await scrollRegion.evaluate((element) => element.clientWidth + 1),
+    await expect(drawer.getByRole("group", { name: "Communications" })).toHaveCount(0);
+    await drawer.getByRole("button", { name: "Close menu" }).click();
+    await page.getByRole("button", { name: "Communications" }).click();
+    const communications = page.getByRole("menu", { name: "Communications destinations" });
+    await expect(communications.getByRole("menuitem")).toHaveCount(3);
+    expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(
+      await page.evaluate(() => document.documentElement.clientWidth + 1),
     );
   });
 }
@@ -243,7 +169,7 @@ for (const route of communicationsRoutes) {
     { name: "tablet", width: 820, height: 1180 },
     { name: "mobile", width: 390, height: 844 },
   ]) {
-    test(`keeps ${route.title} Communications state usable in the ${viewport.name} drawer`, async ({ page }) => {
+    test(`keeps ${route.title} in the header menu but out of the ${viewport.name} Workspace drawer`, async ({ page }) => {
       await page.setViewportSize(viewport);
       await installWorkspaceHarness(page);
       await page.goto(route.path);
@@ -259,11 +185,10 @@ for (const route of communicationsRoutes) {
       await expect(headerMenu).not.toBeAttached();
       await page.getByRole("button", { name: "Open workspace pages" }).first().click();
       const drawer = page.getByRole("dialog", { name: "Navigation menu" });
-      const communications = drawer.getByRole("group", { name: "Communications" });
-      await expect(communications.getByRole("button", { name: "Unified Inbox" })).toBeVisible();
-      await expect(communications.getByRole("button", { name: "Messages" })).toBeVisible();
-      await expect(communications.getByRole("button", { name: "Notices" })).toBeVisible();
-      await expect(communications.getByRole("button", { name: route.title })).toHaveAttribute("aria-current", "page");
+      await expect(drawer.getByRole("group", { name: "Communications" })).toHaveCount(0);
+      await expect(drawer.getByRole("button", { name: "Unified Inbox" })).toHaveCount(0);
+      await expect(drawer.getByRole("button", { name: "Messages" })).toHaveCount(0);
+      await expect(drawer.getByRole("button", { name: "Notices" })).toHaveCount(0);
       expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(
         await page.evaluate(() => document.documentElement.clientWidth + 1),
       );


### PR DESCRIPTION
## Summary

- replaces the desktop Inbox shortcut with an accessible Communications dropdown for Unified Inbox, Messages, and Notices
- removes the redundant inline Communications strip while preserving route-specific Workspace titles and the legacy inbox redirect
- gives New Message recipient rows adaptive height, clearer tenant/context spacing, and safe long-content wrapping
- adds component and Playwright regression coverage across desktop, tablet, and mobile

## Founder QA follow-up

Founder QA confirmed Notices functional delivery and the recipient-row spacing fix, then found two remaining presentation issues:

1. the first Communications dropdown item was overlapped by the Workspace quick-select bar
2. the selected Messages tenant remained within the full list and left the one-recipient state visually ambiguous

This follow-up portals the dropdown into the document overlay layer so Unified Inbox, Messages, and Notices remain unobstructed and pointer-accessible. After selecting a tenant, the full selector now collapses into a single **Selected recipient** card with tenant and property/unit context. **Change** restores the full selector while preserving the unsent message draft. Messaging remains one-to-one and the existing adaptive recipient-row spacing is preserved.

Notices behavior and delivery semantics were not changed.

## Final Founder QA and Workspace cleanup

Founder QA passed the Communications dropdown, including all three destinations and corrected layering, and passed the Messages selected-recipient flow. The final frontend-only cleanup removes the duplicate Unified Inbox, Messages, and Notices entries from the Workspace quick-select row, responsive Workspace drawer, and mobile tab bar. The canonical routes and their route-specific titles remain unchanged, and `/landlord/inbox` still redirects to `/landlord/unified-inbox`.

## Validation

- `VITE_API_BASE_URL=http://127.0.0.1:3001 npm test -- --maxWorkers=2 --reporter=dot` — 348 files / 1697 tests passed
- focused navigation and Messages component tests — 57 tests passed
- targeted Workspace/Communications Playwright — 32 tests passed across desktop, tablet, and mobile
- production frontend build — passed
- package, Preview, Production governance, and release-control guards — passed
- `git diff --check` and credential-pattern scan — passed
- scoped ESLint has no new findings; six existing LandlordNav findings remain outside this cleanup

## Scope and containment

Frontend-only. Unified Inbox, Messages, and Notices routes are unchanged. No backend, API, data-semantic, Cloud Run, IAM, Terraform, Firestore, provider, message-send, or Production traffic changes.

This PR remains draft pending exact-head CI and Vercel Preview verification.
