### PR TITLE
Modernize Messages color system

### DIFF
--- a/rentchain-frontend/src/pages/MessagesPage.css
+++ b/rentchain-frontend/src/pages/MessagesPage.css
@@ -1,4 +1,8 @@
 .rc-messages-page {
+  --rc-messages-accent: var(--rc-landlord-pine, #245842);
+  --rc-messages-accent-soft: var(--rc-landlord-pine-soft, rgba(36, 88, 66, 0.12));
+  --rc-messages-accent-border: rgba(36, 88, 66, 0.48);
+  --rc-messages-focus-ring: rgba(36, 88, 66, 0.28);
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
@@ -30,14 +34,32 @@
 .rc-messages-new-button,
 .rc-messages-empty-detail button,
 .rc-messages-compose-actions .is-primary {
-  border: 1px solid #1d4ed8;
+  border: 1px solid var(--rc-messages-accent);
   border-radius: 12px;
-  background: #2563eb;
+  background: var(--rc-messages-accent);
   color: #ffffff;
   cursor: pointer;
   font-weight: 750;
   min-height: 44px;
   padding: 10px 16px;
+}
+
+.rc-messages-new-button:hover,
+.rc-messages-empty-detail button:hover,
+.rc-messages-compose-actions .is-primary:hover {
+  filter: brightness(0.9);
+}
+
+.rc-messages-new-button:focus-visible,
+.rc-messages-empty-detail button:focus-visible,
+.rc-messages-compose-actions .is-primary:focus-visible,
+.rc-messages-compose-heading button:focus-visible,
+.rc-messages-compose-actions button:not(.is-primary):focus-visible,
+.rc-messages-back:focus-visible,
+.rc-messages-composer-send:focus-visible,
+.rc-messages-list-item:focus-visible {
+  outline: 3px solid var(--rc-messages-focus-ring);
+  outline-offset: 2px;
 }
 
 .rc-messages-compose-overlay {
@@ -105,6 +127,14 @@
   font: inherit;
 }
 
+.rc-messages-compose-field input:focus-visible,
+.rc-messages-compose-field textarea:focus-visible,
+.rc-messages-composer-input:focus-visible {
+  border-color: var(--rc-messages-accent);
+  outline: none;
+  box-shadow: 0 0 0 3px var(--rc-messages-focus-ring);
+}
+
 .rc-messages-compose-field textarea {
   min-height: 120px;
   resize: vertical;
@@ -135,9 +165,9 @@
 
 .rc-messages-recipient-list button:hover,
 .rc-messages-recipient-list button:focus-visible {
-  border-color: rgba(37, 99, 235, 0.62);
+  border-color: var(--rc-messages-accent);
   outline: none;
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.12);
+  box-shadow: 0 0 0 3px var(--rc-messages-focus-ring);
 }
 
 .rc-messages-recipient-name,
@@ -165,10 +195,10 @@
 .rc-messages-selected-recipient-heading button {
   min-height: 40px;
   padding: 8px 12px;
-  border: 1px solid rgba(37, 99, 235, 0.48);
+  border: 1px solid var(--rc-messages-accent-border);
   border-radius: 10px;
   background: #ffffff;
-  color: #1d4ed8;
+  color: var(--rc-messages-accent);
   cursor: pointer;
   font: inherit;
   font-weight: 700;
@@ -176,9 +206,9 @@
 
 .rc-messages-selected-recipient-heading button:hover,
 .rc-messages-selected-recipient-heading button:focus-visible {
-  border-color: #2563eb;
+  border-color: var(--rc-messages-accent);
   outline: none;
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.12);
+  box-shadow: 0 0 0 3px var(--rc-messages-focus-ring);
 }
 
 .rc-messages-selected-recipient-card {
@@ -186,9 +216,9 @@
   gap: 7px;
   min-width: 0;
   padding: 14px;
-  border: 1px solid rgba(37, 99, 235, 0.48);
+  border: 1px solid var(--rc-messages-accent-border);
   border-radius: 12px;
-  background: rgba(37, 99, 235, 0.08);
+  background: var(--rc-messages-accent-soft);
 }
 
 .rc-messages-recipient-name {
@@ -271,6 +301,11 @@
   min-height: 44px;
 }
 
+.rc-messages-list-item:hover {
+  border-color: var(--rc-messages-accent) !important;
+  background: var(--rc-messages-accent-soft) !important;
+}
+
 .rc-messages-list-item-body {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);
@@ -285,8 +320,8 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background: rgba(37, 99, 235, 0.12);
-  color: #1d4ed8;
+  background: var(--rc-messages-accent-soft);
+  color: var(--rc-messages-accent);
   font-size: 0.86rem;
   font-weight: 800;
   flex-shrink: 0;
@@ -316,9 +351,9 @@
 }
 
 .rc-messages-tenant-profile-button {
-  border: 1px solid rgba(37, 99, 235, 0.35);
-  background: rgba(37, 99, 235, 0.08);
-  color: #1d4ed8;
+  border: 1px solid var(--rc-messages-accent-border);
+  background: var(--rc-messages-accent-soft);
+  color: var(--rc-messages-accent);
   border-radius: 999px;
   cursor: pointer;
   font: inherit;
@@ -331,8 +366,8 @@
 
 .rc-messages-tenant-profile-button:hover,
 .rc-messages-tenant-profile-button:focus-visible {
-  background: rgba(37, 99, 235, 0.14);
-  outline: 2px solid rgba(37, 99, 235, 0.25);
+  background: rgba(36, 88, 66, 0.18);
+  outline: 2px solid var(--rc-messages-focus-ring);
   outline-offset: 2px;
 }
 
@@ -354,7 +389,7 @@
   width: 10px;
   height: 10px;
   border-radius: 999px;
-  background: #2563eb;
+  background: var(--rc-messages-accent);
 }
 
 .rc-messages-thread {

--- a/rentchain-frontend/src/pages/MessagesPage.test.tsx
+++ b/rentchain-frontend/src/pages/MessagesPage.test.tsx
@@ -633,6 +633,10 @@ describe("MessagesPage", () => {
     expect(css).toMatch(/\.rc-messages-thread\s*\{[\s\S]*?height:\s*100%;[\s\S]*?overflow:\s*hidden;/);
     expect(css).toMatch(/\.rc-messages-thread-body\s*\{[\s\S]*?overflow-y:\s*auto;/);
     expect(css).toMatch(/\.rc-messages-composer-input\s*\{[\s\S]*?min-width:\s*0;/);
+    expect(css).toContain("--rc-messages-accent: var(--rc-landlord-pine, #245842)");
+    expect(css).toContain("--rc-messages-accent-soft: var(--rc-landlord-pine-soft, rgba(36, 88, 66, 0.12))");
+    expect(css).toMatch(/\.rc-messages-composer-input:focus-visible\s*\{[\s\S]*?var\(--rc-messages-focus-ring\)/);
+    expect(css).not.toMatch(/#(?:1d4ed8|2563eb|3b82f6)|rgba\(37,\s*99,\s*235/);
     expect(css).toMatch(
       /\.rc-messages-compose-overlay\s*\{[\s\S]*?padding:\s*12px 12px calc\(12px \+ var\(--rc-mobile-bottom-nav-height\) \+ env\(safe-area-inset-bottom, 0px\)\);/
     );

--- a/rentchain-frontend/src/pages/MessagesPage.tsx
+++ b/rentchain-frontend/src/pages/MessagesPage.tsx
@@ -608,8 +608,8 @@ export default function MessagesPage() {
                         navigate(`/messages?threadId=${c.id}`);
                       }}
                       style={{
-                        border: `1px solid ${isActive ? colors.accent : colors.border}`,
-                        background: isActive ? colors.accentSoft : colors.panel,
+                        border: `1px solid ${isActive ? colors.pine : colors.border}`,
+                        background: isActive ? colors.pineSoft : colors.panel,
                       }}
                     >
                       <div className="rc-messages-list-item-body">
@@ -673,7 +673,7 @@ export default function MessagesPage() {
                               className={`rc-messages-bubble ${isSender ? "is-sent" : "is-received"}`}
                               style={{
                                 alignSelf: isSender ? "flex-end" : "flex-start",
-                                background: isSender ? colors.accentSoft : colors.panel,
+                                background: isSender ? colors.pineSoft : colors.panel,
                                 border: `1px solid ${colors.border}`,
                               }}
                             >
@@ -699,7 +699,7 @@ export default function MessagesPage() {
                       disabled={!composer.trim()}
                       className="rc-messages-composer-send"
                       style={{
-                        background: colors.accent,
+                        background: colors.pine,
                         border: `1px solid ${colors.border}`,
                         cursor: composer.trim() ? "pointer" : "not-allowed",
                         opacity: composer.trim() ? 1 : 0.6,

--- a/rentchain-frontend/tests/playwright/messages-layout.spec.ts
+++ b/rentchain-frontend/tests/playwright/messages-layout.spec.ts
@@ -263,6 +263,8 @@ test("real Messages page preserves deep links, Back, composer access, and bounde
   }
   await expect(page.getByRole("heading", { name: "Messages" })).toBeVisible();
   await expect(page.getByText(/QA Tenant With An Intentionally Long Governed Display Label 1/).first()).toBeVisible();
+  await expect(page.locator(".rc-messages-list-item").first()).toHaveCSS("border-color", "rgb(30, 95, 78)");
+  await expect(page.locator(".rc-messages-composer-send")).toHaveCSS("background-color", "rgb(30, 95, 78)");
 
   await page.getByRole("button", { name: "New Message" }).first().click();
   const compose = page.getByRole("dialog", { name: "New message" });
@@ -296,11 +298,19 @@ test("real Messages page preserves deep links, Back, composer access, and bounde
   await compose.getByPlaceholder("Search by tenant, property, or unit").fill("4B");
   await compose.getByRole("button", { name: /Synthetic Active Tenant With/ }).click();
   await expect(compose.getByText("Selected recipient")).toBeVisible();
+  await expect(compose.locator(".rc-messages-selected-recipient-card")).toHaveCSS(
+    "background-color",
+    "rgba(36, 88, 66, 0.12)",
+  );
   await expect(compose.getByPlaceholder("Search by tenant, property, or unit")).toHaveCount(0);
   await expect(compose.locator(".rc-messages-recipient-list button")).toHaveCount(0);
   await expect(compose.getByText(/Synthetic Active Tenant With/)).toBeVisible();
   await expect(compose.getByText(/Harbour Synthetic Property With An Intentionally Long Waterfront Name/)).toBeVisible();
   await compose.getByPlaceholder("Write your message").fill("Harmless unsent draft retained during recipient change");
+  await expect(compose.getByPlaceholder("Write your message")).toHaveCSS(
+    "border-color",
+    "rgb(36, 88, 66)",
+  );
   await compose.getByRole("button", { name: "Change" }).click();
   await expect(compose.getByPlaceholder("Search by tenant, property, or unit")).toBeFocused();
   await expect(compose.getByPlaceholder("Write your message")).toHaveValue("Harmless unsent draft retained during recipient change");


### PR DESCRIPTION
## Summary

- replaces legacy blue Messages interaction styling with the existing landlord Workspace pine and pine-soft color system
- modernizes active conversations, primary actions, selected recipients, profile pills, unread indicators, sent bubbles, hover states, and visible focus rings
- preserves semantic error and disabled states, Communications navigation, recipient selection, draft retention, and one-to-one messaging behavior

## Validation

- focused Messages/navigation tests: 57 passed
- full frontend suite: 348 files / 1697 tests passed
- Messages and Communications Playwright: 38 passed across desktop, tablet, and mobile; no message sent
- production frontend build: passed
- package, Preview, Production, and release-control governance: passed
- `git diff --check` and credential-pattern scan: passed
- scoped ESLint: no new findings; seven existing `no-explicit-any` findings remain in MessagesPage and its test

## Scope and containment

Frontend-only. No backend, API, routing, Communications dropdown, persistence, provider, infrastructure, data, message-send, or Production traffic changes.
