### PR TITLE
Add multi-property mass Notices

### DIFF
--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -418,3 +418,16 @@ check "b7_vercel_preview_proxy_identity_boundary" {
     error_message = "Run Invoker must remain service-scoped to the private Preview backend and dedicated Vercel proxy identity."
   }
 }
+
+check "pr1516_vercel_preview_proxy_invoker_boundary" {
+  assert {
+    condition = (
+      google_cloud_run_v2_service_iam_member.pr1516_vercel_proxy_invoker.project == "rentchain-preview" &&
+      google_cloud_run_v2_service_iam_member.pr1516_vercel_proxy_invoker.location == "northamerica-northeast1" &&
+      basename(google_cloud_run_v2_service_iam_member.pr1516_vercel_proxy_invoker.name) == "rentchain-pr1516-notices-qa-a2695c6c" &&
+      google_cloud_run_v2_service_iam_member.pr1516_vercel_proxy_invoker.role == "roles/run.invoker" &&
+      google_cloud_run_v2_service_iam_member.pr1516_vercel_proxy_invoker.member == "serviceAccount:vercel-preview-proxy@rentchain-preview.iam.gserviceaccount.com"
+    )
+    error_message = "PR #1516 Vercel Invoker must remain service-scoped to the exact isolated Notices QA service and existing proxy identity."
+  }
+}

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -82,12 +82,13 @@ if rg -n 'allUsers|allAuthenticatedUsers|google_storage_bucket|google_firestore_
 fi
 
 vercel_identity_file="$root_dir/vercel_preview_identity.tf"
-test "$(rg -No '^resource "' "$vercel_identity_file" | wc -l | tr -d ' ')" = "6"
+test "$(rg -No '^resource "' "$vercel_identity_file" | wc -l | tr -d ' ')" = "7"
 test "$(rg -No '^resource "google_iam_workload_identity_pool" "vercel_preview_proxy"' "$vercel_identity_file" | wc -l | tr -d ' ')" = "1"
 test "$(rg -No '^resource "google_iam_workload_identity_pool_provider" "vercel_preview"' "$vercel_identity_file" | wc -l | tr -d ' ')" = "1"
 test "$(rg -No '^resource "google_service_account" "vercel_preview_proxy"' "$vercel_identity_file" | wc -l | tr -d ' ')" = "1"
 test "$(rg -No '^resource "google_service_account_iam_member" "vercel_preview_proxy_(workload_identity_user|openid_token_creator)"' "$vercel_identity_file" | wc -l | tr -d ' ')" = "2"
 test "$(rg -No '^resource "google_cloud_run_v2_service_iam_member" "vercel_preview_proxy_invoker"' "$vercel_identity_file" | wc -l | tr -d ' ')" = "1"
+test "$(rg -No '^resource "google_cloud_run_v2_service_iam_member" "pr1516_vercel_proxy_invoker"' "$vercel_identity_file" | wc -l | tr -d ' ')" = "1"
 
 rg -q 'workload_identity_pool_id = "vercel-preview-proxy"' "$vercel_identity_file"
 rg -q 'workload_identity_pool_provider_id = "vercel-preview"' "$vercel_identity_file"
@@ -95,6 +96,13 @@ rg -q 'vercel_preview_issuer[[:space:]]*=[[:space:]]*"https://oidc\.vercel\.com/
 test "$(rg -No 'allowed_audiences' "$vercel_identity_file" | wc -l | tr -d ' ')" = "0"
 test "$(rg -No 'google_service_account_iam_member\.vercel_preview_proxy_(workload_identity_user|openid_token_creator)\.service_account_id' "$root_dir/checks.tf" | wc -l | tr -d ' ')" = "0"
 rg -U -q 'basename\(\n        google_cloud_run_v2_service_iam_member\.vercel_preview_proxy_invoker\.name\n      \) == "rentchain-preview-backend"' "$root_dir/checks.tf"
+rg -q 'name     = "rentchain-pr1516-notices-qa-a2695c6c"' "$vercel_identity_file"
+rg -q 'google_cloud_run_v2_service_iam_member\.pr1516_vercel_proxy_invoker\.project == "rentchain-preview"' "$root_dir/checks.tf"
+rg -q 'google_cloud_run_v2_service_iam_member\.pr1516_vercel_proxy_invoker\.location == "northamerica-northeast1"' "$root_dir/checks.tf"
+rg -q 'basename\(google_cloud_run_v2_service_iam_member\.pr1516_vercel_proxy_invoker\.name\) == "rentchain-pr1516-notices-qa-a2695c6c"' "$root_dir/checks.tf"
+rg -q 'google_cloud_run_v2_service_iam_member\.pr1516_vercel_proxy_invoker\.role == "roles/run.invoker"' "$root_dir/checks.tf"
+rg -q 'google_cloud_run_v2_service_iam_member\.pr1516_vercel_proxy_invoker\.member == "serviceAccount:vercel-preview-proxy@rentchain-preview.iam.gserviceaccount.com"' "$root_dir/checks.tf"
+test "$(rg -No 'role     = "roles/run\.invoker"' "$vercel_identity_file" | wc -l | tr -d ' ')" = "2"
 grep -Fq 'length(google_iam_workload_identity_pool_provider.vercel_preview.attribute_mapping) == 4' "$root_dir/checks.tf"
 grep -Fq 'attribute_mapping["google.subject"] == "assertion.sub"' "$root_dir/checks.tf"
 grep -Fq 'attribute_mapping["attribute.owner_id"] == "assertion.owner_id"' "$root_dir/checks.tf"

--- a/infra/environments/preview-foundation/vercel_preview_identity.tf
+++ b/infra/environments/preview-foundation/vercel_preview_identity.tf
@@ -92,3 +92,13 @@ resource "google_cloud_run_v2_service_iam_member" "vercel_preview_proxy_invoker"
   role     = "roles/run.invoker"
   member   = google_service_account.vercel_preview_proxy.member
 }
+
+# Temporary service-level access for PR #1516 isolated multi-property Notices
+# browser QA. Remove through Terraform/HCP after the PR QA/release lifecycle.
+resource "google_cloud_run_v2_service_iam_member" "pr1516_vercel_proxy_invoker" {
+  project  = var.project_id
+  location = local.preview_deployment_region
+  name     = "rentchain-pr1516-notices-qa-a2695c6c"
+  role     = "roles/run.invoker"
+  member   = google_service_account.vercel_preview_proxy.member
+}

--- a/rentchain-api/src/middleware/__tests__/previewQaAuth.test.ts
+++ b/rentchain-api/src/middleware/__tests__/previewQaAuth.test.ts
@@ -7,6 +7,9 @@ import {
   PR1512_PREVIEW_QA_IDENTITY_ALIAS,
   PR1512_PREVIEW_QA_LANDLORD_ID,
   PR1512_PREVIEW_QA_SCOPE,
+  PR1516_PREVIEW_QA_IDENTITY_ALIAS,
+  PR1516_PREVIEW_QA_LANDLORD_ID,
+  PR1516_PREVIEW_QA_SCOPE,
   decidePreviewQaAuth,
   isPreviewQaAuthenticatedRequest,
   previewQaAuth,
@@ -35,6 +38,13 @@ const pr1512EnabledEnv = {
   PREVIEW_QA_AUTH_SCOPE: PR1512_PREVIEW_QA_SCOPE,
   K_SERVICE: "rentchain-pr1512-notices-qa-590e0ecb",
   PREVIEW_QA_EXPECTED_SERVICE: "rentchain-pr1512-notices-qa-590e0ecb",
+} as NodeJS.ProcessEnv;
+
+const pr1516EnabledEnv = {
+  ...enabledEnv,
+  PREVIEW_QA_AUTH_SCOPE: PR1516_PREVIEW_QA_SCOPE,
+  K_SERVICE: "rentchain-pr1516-notices-qa-252bf576",
+  PREVIEW_QA_EXPECTED_SERVICE: "rentchain-pr1516-notices-qa-252bf576",
 } as NodeJS.ProcessEnv;
 
 function decide(overrides: Partial<Parameters<typeof decidePreviewQaAuth>[0]> = {}) {
@@ -173,6 +183,48 @@ describe("previewQaAuth", () => {
       landlordId: PR1512_PREVIEW_QA_LANDLORD_ID,
       role: "landlord",
     });
+  });
+
+  it.each([
+    ["GET", "landlord-notice-recipients"],
+    ["GET", "landlord-notice-list"],
+    ["GET", "landlord-notice-detail"],
+    ["POST", "landlord-notice-create"],
+  ] as const)("allows PR #1516 %s %s only under its fixed contract", (method, route) => {
+    expect(decide({
+      env: pr1516EnabledEnv,
+      method,
+      route,
+      selector: PR1516_PREVIEW_QA_IDENTITY_ALIAS,
+    })).toEqual({ kind: "allow" });
+  });
+
+  it("injects only the server-owned PR #1516 landlord identity", () => {
+    process.env = { ...pr1516EnabledEnv };
+    const headers = { "x-rentchain-preview-qa-identity": PR1516_PREVIEW_QA_IDENTITY_ALIAS };
+    const req: any = { method: "GET", headers, header: (name: string) => headers[name.toLowerCase() as keyof typeof headers] };
+    const res: any = { status: () => res, json: () => res };
+    let nextCalled = false;
+    previewQaAuth("landlord-notice-recipients")(req, res, () => { nextCalled = true; });
+    expect(nextCalled).toBe(true);
+    expect(req.user).toMatchObject({
+      id: PR1516_PREVIEW_QA_LANDLORD_ID,
+      landlordId: PR1516_PREVIEW_QA_LANDLORD_ID,
+      role: "landlord",
+    });
+  });
+
+  it.each([
+    ["wrong service", { ...pr1516EnabledEnv, K_SERVICE: "rentchain-pr1516-notices-qa-deadbeef" }],
+    ["Production", { ...pr1516EnabledEnv, GOOGLE_CLOUD_PROJECT: "project-0d9658de-af29-4dc0-a99" }],
+    ["permanent Preview", { ...pr1516EnabledEnv, K_SERVICE: "rentchain-preview-backend", PREVIEW_QA_EXPECTED_SERVICE: "rentchain-preview-backend" }],
+    ["wrong scope", { ...pr1516EnabledEnv, PREVIEW_QA_AUTH_SCOPE: PR1512_PREVIEW_QA_SCOPE }],
+  ])("rejects PR #1516 with %s", (_label, env) => {
+    expect(decide({
+      env,
+      route: "landlord-notice-recipients",
+      selector: PR1516_PREVIEW_QA_IDENTITY_ALIAS,
+    })).toEqual({ kind: "reject" });
   });
 
   it.each([

--- a/rentchain-api/src/middleware/previewQaAuth.ts
+++ b/rentchain-api/src/middleware/previewQaAuth.ts
@@ -10,6 +10,10 @@ export const PR1512_PREVIEW_QA_SCOPE = "pr1512-property-notices";
 export const PR1512_PREVIEW_QA_IDENTITY_ALIAS = "pr1512-landlord";
 export const PR1512_PREVIEW_QA_LANDLORD_ID = "qa-pr1512-landlord";
 export const PR1512_PREVIEW_QA_SERVICE_PATTERN = /^rentchain-pr1512-notices-qa-[a-f0-9]{8}$/;
+export const PR1516_PREVIEW_QA_SCOPE = "pr1516-multi-property-notices";
+export const PR1516_PREVIEW_QA_IDENTITY_ALIAS = "pr1516-landlord";
+export const PR1516_PREVIEW_QA_LANDLORD_ID = "qa-pr1516-landlord";
+export const PR1516_PREVIEW_QA_SERVICE_PATTERN = /^rentchain-pr1516-notices-qa-[a-f0-9]{8}$/;
 
 const PREVIEW_PROJECT_ID = "rentchain-preview";
 const PRODUCTION_PROJECT_ID = "project-0d9658de-af29-4dc0-a99";
@@ -75,6 +79,19 @@ const previewQaContracts: readonly PreviewQaContract[] = [
       "POST:landlord-notice-create",
     ]),
   },
+  {
+    scope: PR1516_PREVIEW_QA_SCOPE,
+    servicePattern: PR1516_PREVIEW_QA_SERVICE_PATTERN,
+    selector: PR1516_PREVIEW_QA_IDENTITY_ALIAS,
+    landlordId: PR1516_PREVIEW_QA_LANDLORD_ID,
+    email: "qa-pr1516-landlord@example.invalid",
+    allowedOperations: new Set([
+      "GET:landlord-notice-recipients",
+      "GET:landlord-notice-list",
+      "GET:landlord-notice-detail",
+      "POST:landlord-notice-create",
+    ]),
+  },
 ];
 
 type PreviewQaDecision =
@@ -123,18 +140,24 @@ export function decidePreviewQaAuth(input: PreviewQaDecisionInput): PreviewQaDec
   return { kind: "allow" };
 }
 
-export function isPr1512PreviewQaRuntime(env: NodeJS.ProcessEnv = process.env): boolean {
+export function isPropertyNoticesPreviewQaRuntime(env: NodeJS.ProcessEnv = process.env): boolean {
   const service = String(env.K_SERVICE || "").trim();
   const expectedService = String(env.PREVIEW_QA_EXPECTED_SERVICE || "").trim();
+  const scope = String(env.PREVIEW_QA_AUTH_SCOPE || "").trim();
+  const servicePattern = scope === PR1512_PREVIEW_QA_SCOPE
+    ? PR1512_PREVIEW_QA_SERVICE_PATTERN
+    : scope === PR1516_PREVIEW_QA_SCOPE
+      ? PR1516_PREVIEW_QA_SERVICE_PATTERN
+      : null;
   return (
     String(env.PREVIEW_QA_AUTH_ENABLED || "").trim().toLowerCase() === "true" &&
-    String(env.PREVIEW_QA_AUTH_SCOPE || "").trim() === PR1512_PREVIEW_QA_SCOPE &&
+    Boolean(servicePattern) &&
     String(env.APP_ENV || "").trim().toLowerCase() === "preview" &&
     String(env.GOOGLE_CLOUD_PROJECT || env.GCLOUD_PROJECT || "").trim() === PREVIEW_PROJECT_ID &&
     service !== PERMANENT_PREVIEW_SERVICE &&
     expectedService !== PERMANENT_PREVIEW_SERVICE &&
     service === expectedService &&
-    PR1512_PREVIEW_QA_SERVICE_PATTERN.test(service) &&
+    Boolean(servicePattern?.test(service)) &&
     String(env.FIRESTORE_ENABLED || "").trim().toLowerCase() === "true" &&
     String(env.FIRESTORE_DATABASE_ID || "").trim() === "(default)"
   );

--- a/rentchain-api/src/routes/__tests__/propertyNoticesRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/propertyNoticesRoutes.test.ts
@@ -64,17 +64,22 @@ const landlord = { id: "landlord-1", role: "landlord" };
 function seed() {
   collection("properties").set("property-1", { landlordId: "landlord-1", name: "Harbour House", status: "active" });
   collection("properties").set("foreign-property", { landlordId: "landlord-2", name: "Foreign" });
+  collection("properties").set("property-2", { landlordId: "landlord-1", name: "Queen Court", status: "active" });
   collection("units").set("unit-1", { landlordId: "landlord-1", propertyId: "property-1", unitNumber: "1A" });
   collection("units").set("unit-2", { landlordId: "landlord-1", propertyId: "property-1", unitNumber: "2B" });
+  collection("units").set("unit-3", { landlordId: "landlord-1", propertyId: "property-2", unitNumber: "3C" });
   collection("tenants").set("tenant-1", { landlordId: "landlord-1", fullName: "Alex Current", email: "alex@example.test" });
   collection("tenants").set("tenant-2", { landlordId: "landlord-1", fullName: "Blair Missing" });
   collection("tenants").set("tenant-ended", { landlordId: "landlord-1", fullName: "Former Tenant", email: "former@example.test" });
   collection("tenants").set("tenant-foreign", { landlordId: "landlord-2", fullName: "Foreign Tenant", email: "foreign@example.test" });
+  collection("tenants").set("tenant-3", { landlordId: "landlord-1", fullName: "Casey Current", email: "casey@example.test" });
   collection("leases").set("lease-1", { landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantIds: ["tenant-1", "tenant-2"], status: "active" });
   collection("leases").set("lease-duplicate", { landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-2", tenantId: "tenant-1", status: "active" });
   collection("leases").set("lease-ended", { landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-2", tenantId: "tenant-ended", status: "ended" });
   collection("leases").set("lease-foreign", { landlordId: "landlord-2", propertyId: "property-1", unitId: "unit-2", tenantId: "tenant-ended", status: "active" });
   collection("leases").set("lease-foreign-tenant", { landlordId: "landlord-2", propertyId: "property-1", unitId: "unit-2", tenantId: "tenant-foreign", status: "active" });
+  collection("leases").set("lease-property-2-shared", { landlordId: "landlord-1", propertyId: "property-2", unitId: "unit-3", tenantId: "tenant-1", status: "active" });
+  collection("leases").set("lease-property-2", { landlordId: "landlord-1", propertyId: "property-2", unitId: "unit-3", tenantId: "tenant-3", status: "active" });
 }
 
 describe("propertyNoticesRoutes", () => {
@@ -151,8 +156,33 @@ describe("propertyNoticesRoutes", () => {
     expect(multipleUnits.body.recipients).toHaveLength(2);
 
     const emptyUnit = await invoke({ method: "GET", url: "/landlord/notices/recipients?propertyId=property-1&unitIds=unit-unknown", user: landlord });
-    expect(emptyUnit.status).toBe(200);
-    expect(emptyUnit.body.recipients).toEqual([]);
+    expect(emptyUnit.status).toBe(403);
+    expect(emptyUnit.body.code).toBe("notice_recipient_not_eligible");
+  });
+
+  it("aggregates selected properties with deterministic cross-property tenant dedupe and context", async () => {
+    const response = await invoke({ method: "GET", url: "/landlord/notices/recipients?propertyIds=property-2,property-1,property-2", user: landlord });
+    expect(response.status).toBe(200);
+    expect(response.body.properties).toEqual([{ id: "property-1", label: "Harbour House" }, { id: "property-2", label: "Queen Court" }]);
+    expect(response.body.recipients.map((item: any) => item.tenantId)).toEqual(["tenant-1", "tenant-2", "tenant-3"]);
+    const shared = response.body.recipients.find((item: any) => item.tenantId === "tenant-1");
+    expect(shared.propertyIds).toEqual(["property-1", "property-2"]);
+    expect(shared.units.map((unit: any) => `${unit.propertyLabel}:${unit.label}`)).toEqual(["Harbour House:1A", "Harbour House:2B", "Queen Court:3C"]);
+    expect(response.body.propertyBreakdown).toEqual([
+      { id: "property-1", label: "Harbour House", recipientCount: 2 },
+      { id: "property-2", label: "Queen Court", recipientCount: 2 },
+    ]);
+  });
+
+  it.each([
+    ["empty", ""],
+    ["malformed", "property-1,bad/property"],
+    ["unknown", "property-1,property-unknown"],
+    ["foreign", "property-1,foreign-property"],
+  ])("fails closed for %s multi-property selection", async (_label, propertyIds) => {
+    const response = await invoke({ method: "GET", url: `/landlord/notices/recipients?propertyIds=${encodeURIComponent(propertyIds)}`, user: landlord });
+    expect([400, 403, 404]).toContain(response.status);
+    expect(sendEmailMock).not.toHaveBeenCalled();
   });
 
   it.each(["tenant-ended", "tenant-foreign", "tenant-unknown"])(
@@ -229,6 +259,33 @@ describe("propertyNoticesRoutes", () => {
     expect(sendEmailMock).not.toHaveBeenCalled();
   });
 
+  it("allows exactly 100 aggregated recipients and rejects 101 without truncation", async () => {
+    collection("leases").clear();
+    collection("tenants").clear();
+    for (let index = 0; index < 100; index += 1) {
+      collection("tenants").set(`bounded-tenant-${index}`, { landlordId: "landlord-1", fullName: `Bounded ${String(index).padStart(3, "0")}`, email: `bounded-${index}@example.test` });
+      collection("leases").set(`bounded-lease-${index}`, { landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: `bounded-tenant-${index}`, status: "active" });
+    }
+    const exact = await invoke({ method: "GET", url: "/landlord/notices/recipients?propertyIds=property-1,property-2", user: landlord });
+    expect(exact.status).toBe(200);
+    expect(exact.body.recipients).toHaveLength(100);
+    collection("tenants").set("bounded-tenant-100", { landlordId: "landlord-1", fullName: "Bounded 100", email: "bounded-100@example.test" });
+    collection("leases").set("bounded-lease-100", { landlordId: "landlord-1", propertyId: "property-2", unitId: "unit-3", tenantId: "bounded-tenant-100", status: "active" });
+    const over = await invoke({ method: "GET", url: "/landlord/notices/recipients?propertyIds=property-1,property-2", user: landlord });
+    expect(over.status).toBe(422);
+    expect(over.body).toEqual({ ok: false, error: "Recipient limit exceeded", maxRecipients: 100 });
+    expect(sendEmailMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects empty and over-cap property arrays", async () => {
+    const empty = await invoke({ method: "POST", url: "/landlord/notices", user: landlord, body: { propertyIds: [], subject: "Empty", body: "No properties.", idempotencyKey: "request_empty_properties_123" } });
+    expect(empty.status).toBe(400);
+    for (let index = 0; index < 26; index += 1) collection("properties").set(`many-property-${index}`, { landlordId: "landlord-1", name: `Property ${index}` });
+    const over = await invoke({ method: "GET", url: `/landlord/notices/recipients?propertyIds=${Array.from({ length: 26 }, (_, index) => `many-property-${index}`).join(",")}`, user: landlord });
+    expect(over.status).toBe(400);
+    expect(over.body.maxProperties).toBe(25);
+  });
+
   it("creates one private delivery per deduped recipient and is idempotent", async () => {
     const request = { propertyId: "property-1", subject: "Water shutdown", body: "Water is off at noon.", idempotencyKey: "request_1234567890" };
     const first = await invoke({ method: "POST", url: "/landlord/notices", user: landlord, body: request });
@@ -255,6 +312,44 @@ describe("propertyNoticesRoutes", () => {
     expect(collection("propertyNotices")).toHaveLength(1);
     expect(collection("propertyNoticeDeliveries")).toHaveLength(2);
     expect(sendEmailMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("canonicalizes reordered multi-property and filter inputs into one campaign snapshot", async () => {
+    const base = { subject: "Portfolio update", body: "Shared operational update.", idempotencyKey: "request_multi_order_123" };
+    const first = await invoke({ method: "POST", url: "/landlord/notices", user: landlord, body: { ...base, propertyIds: ["property-2", "property-1"], selectedTenantIds: ["tenant-3", "tenant-1"] } });
+    const replay = await invoke({ method: "POST", url: "/landlord/notices", user: landlord, body: { ...base, propertyIds: ["property-1", "property-2", "property-1"], selectedTenantIds: ["tenant-1", "tenant-3"] } });
+    expect([first.status, replay.status]).toEqual([201, 200]);
+    expect(first.body.notice.id).toBe(replay.body.notice.id);
+    expect(first.body.notice.properties).toEqual([{ id: "property-1", label: "Harbour House" }, { id: "property-2", label: "Queen Court" }]);
+    expect(first.body.notice.propertyCount).toBe(2);
+    expect(collection("propertyNotices")).toHaveLength(1);
+    expect(collection("propertyNoticeDeliveries")).toHaveLength(2);
+    expect(sendEmailMock).toHaveBeenCalledTimes(2);
+    for (const [input] of sendEmailMock.mock.calls) {
+      expect(input.subject).toBe("Operational Notice: Portfolio update");
+      expect(input.subject).not.toContain(base.body);
+      expect(input.cc).toBeUndefined();
+      expect(input.bcc).toBeUndefined();
+    }
+  });
+
+  it("serializes identical concurrent multi-property requests", async () => {
+    const request = { propertyIds: ["property-2", "property-1"], selectedTenantIds: ["tenant-1", "tenant-3"], subject: "Concurrent portfolio", body: "Synthetic only.", idempotencyKey: "request_multi_concurrent_123" };
+    const responses = await Promise.all([
+      invoke({ method: "POST", url: "/landlord/notices", user: landlord, body: request }),
+      invoke({ method: "POST", url: "/landlord/notices", user: landlord, body: { ...request, propertyIds: [...request.propertyIds].reverse(), selectedTenantIds: [...request.selectedTenantIds].reverse() } }),
+    ]);
+    expect(responses.map((response) => response.status).sort()).toEqual([200, 201]);
+    expect(collection("propertyNotices")).toHaveLength(1);
+    expect(collection("propertyNoticeDeliveries")).toHaveLength(2);
+    expect(sendEmailMock).toHaveBeenCalledTimes(2);
+  });
+
+  it.each(["Line one\nBcc: injected@example.test", "Line one\rLine two"])("rejects unsafe subject %j before persistence or delivery", async (subject) => {
+    const response = await invoke({ method: "POST", url: "/landlord/notices", user: landlord, body: { propertyIds: ["property-1"], subject, body: "Body only", idempotencyKey: "request_subject_safe_123" } });
+    expect(response.status).toBe(400);
+    expect(collection("propertyNotices")).toHaveLength(0);
+    expect(sendEmailMock).not.toHaveBeenCalled();
   });
 
   it("records normalized partial failure without exposing the provider error", async () => {

--- a/rentchain-api/src/routes/propertyNoticesRoutes.ts
+++ b/rentchain-api/src/routes/propertyNoticesRoutes.ts
@@ -14,6 +14,7 @@ export const previewQaPropertyNoticesRoutes = Router();
 
 const MAX_NOTICE_RECIPIENTS = 100;
 const MAX_NOTICE_LEASES = 101;
+const MAX_NOTICE_PROPERTIES = 25;
 const MAX_NOTICE_HISTORY = 50;
 const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const documentIdPattern = /^[A-Za-z0-9_-]{1,1500}$/;
@@ -66,8 +67,8 @@ function unitLabel(raw: any): string {
   return text(raw?.unitNumber || raw?.unitLabel || raw?.label || raw?.name) || "Unit";
 }
 
-function noticeId(landlordId: string, idempotencyKey: string): string {
-  return `notice_${createHash("sha256").update(`${landlordId}:${idempotencyKey}`).digest("hex")}`;
+function noticeId(landlordId: string, idempotencyKey: string, canonicalRequest: string): string {
+  return `notice_${createHash("sha256").update(`${landlordId}:${idempotencyKey}:${canonicalRequest}`).digest("hex")}`;
 }
 
 function deliveryId(campaignId: string, tenantId: string): string {
@@ -88,44 +89,51 @@ type ResolvedRecipient = {
   unitIds: string[];
   unitLabels: string[];
   leaseIds: string[];
+  propertyIds: string[];
+  propertyLabels: string[];
+  units: Array<{ id: string; label: string; propertyId: string; propertyLabel: string }>;
   deliveryAvailability: "available" | "missing_email" | "duplicate_destination";
 };
 
 async function resolveRecipients(params: {
   landlordId: string;
-  propertyId: string;
+  propertyIds: string[];
   selectedUnitIds?: string[];
   selectedTenantIds?: string[];
   tenantFilterProvided?: boolean;
   tenantFilterMalformed?: boolean;
 }) {
-  const propertySnap = await db.collection("properties").doc(params.propertyId).get();
-  if (!propertySnap.exists) return { kind: "not_found" as const };
-  const property = propertySnap.data() as any;
-  if (text(property?.landlordId) !== params.landlordId || isArchived(property)) {
-    return { kind: "forbidden" as const };
-  }
+  const propertyEntries = await Promise.all(params.propertyIds.map(async (id) => [id, await db.collection("properties").doc(id).get()] as const));
+  if (propertyEntries.some(([, snap]) => !snap.exists)) return { kind: "not_found" as const };
+  const properties = propertyEntries.map(([id, snap]) => ({ id, raw: snap.data() as any }));
+  if (properties.some(({ raw }) => text(raw?.landlordId) !== params.landlordId || isArchived(raw))) return { kind: "forbidden" as const };
+  const propertyLabels = new Map(properties.map(({ id, raw }) => [id, propertyLabel(raw)]));
   if (params.tenantFilterProvided && params.tenantFilterMalformed) {
     return { kind: "recipient_not_eligible" as const };
   }
 
-  const leaseSnap = await db.collection("leases")
-    .where("propertyId", "==", params.propertyId)
-    .limit(MAX_NOTICE_LEASES)
-    .get();
-  if (leaseSnap.docs.length >= MAX_NOTICE_LEASES) return { kind: "too_many" as const };
-
   const selectedUnits = new Set(params.selectedUnitIds || []);
   const selectedTenants = new Set(params.selectedTenantIds || []);
-  const candidates: Array<{ leaseId: string; tenantId: string; unitId: string }> = [];
-  for (const leaseDoc of leaseSnap.docs) {
-    const lease = leaseDoc.data() as any;
-    const unitId = text(lease?.unitId);
-    if (text(lease?.landlordId) !== params.landlordId || !isCurrentLeaseStatus(lease?.status) || !unitId) continue;
-    if (selectedUnits.size && !selectedUnits.has(unitId)) continue;
-    for (const tenantId of tenantIdsForLease(lease)) {
-      candidates.push({ leaseId: leaseDoc.id, tenantId, unitId });
+  const candidates: Array<{ leaseId: string; tenantId: string; unitId: string; propertyId: string }> = [];
+  for (const propertyId of params.propertyIds) {
+    const leaseSnap = await db.collection("leases").where("propertyId", "==", propertyId).limit(MAX_NOTICE_LEASES).get();
+    if (leaseSnap.docs.length >= MAX_NOTICE_LEASES) return { kind: "too_many" as const };
+    for (const leaseDoc of leaseSnap.docs) {
+      const lease = leaseDoc.data() as any;
+      const unitId = text(lease?.unitId);
+      if (text(lease?.landlordId) !== params.landlordId || !isCurrentLeaseStatus(lease?.status) || !unitId) continue;
+      if (selectedUnits.size && !selectedUnits.has(unitId)) continue;
+      for (const tenantId of tenantIdsForLease(lease)) candidates.push({ leaseId: leaseDoc.id, tenantId, unitId, propertyId });
     }
+  }
+
+  if (selectedUnits.size) {
+    const selectedUnitEntries = await Promise.all(Array.from(selectedUnits).map(async (id) => [id, await db.collection("units").doc(id).get()] as const));
+    if (selectedUnitEntries.some(([, snap]) => !snap.exists)) return { kind: "recipient_not_eligible" as const };
+    if (selectedUnitEntries.some(([, snap]) => {
+      const unit = snap.data() as any;
+      return !params.propertyIds.includes(text(unit?.propertyId) || "") || (text(unit?.landlordId) && text(unit?.landlordId) !== params.landlordId);
+    })) return { kind: "recipient_not_eligible" as const };
   }
 
   const eligibleLeaseTenantIds = new Set(candidates.map((candidate) => candidate.tenantId));
@@ -153,7 +161,7 @@ async function resolveRecipients(params: {
     if (!unitSnap?.exists || !tenantSnap?.exists) continue;
     const unit = unitSnap.data() as any;
     const tenant = tenantSnap.data() as any;
-    if (text(unit?.propertyId) !== params.propertyId) continue;
+    if (text(unit?.propertyId) !== candidate.propertyId) continue;
     if (text(unit?.landlordId) && text(unit?.landlordId) !== params.landlordId) continue;
     if (text(tenant?.landlordId) && text(tenant?.landlordId) !== params.landlordId) continue;
     if (isArchived(tenant)) continue;
@@ -165,11 +173,22 @@ async function resolveRecipients(params: {
       unitIds: [],
       unitLabels: [],
       leaseIds: [],
+      propertyIds: [],
+      propertyLabels: [],
+      units: [],
       deliveryAvailability: tenantEmail(tenant) ? "available" as const : "missing_email" as const,
     };
     existing.unitIds = Array.from(new Set([...existing.unitIds, candidate.unitId])).sort();
     existing.unitLabels = Array.from(new Set([...existing.unitLabels, unitLabel(unit)])).sort();
     existing.leaseIds = Array.from(new Set([...existing.leaseIds, candidate.leaseId])).sort();
+    existing.propertyIds = Array.from(new Set([...existing.propertyIds, candidate.propertyId])).sort();
+    existing.propertyLabels = existing.propertyIds.map((id) => propertyLabels.get(id) || "Property");
+    existing.units = [...existing.units.filter((item) => item.id !== candidate.unitId), {
+      id: candidate.unitId,
+      label: unitLabel(unit),
+      propertyId: candidate.propertyId,
+      propertyLabel: propertyLabels.get(candidate.propertyId) || "Property",
+    }].sort((a, b) => [a.propertyLabel, a.label, a.id].join("\0").localeCompare([b.propertyLabel, b.label, b.id].join("\0")));
     byTenant.set(candidate.tenantId, existing);
   }
 
@@ -188,7 +207,12 @@ async function resolveRecipients(params: {
     else destinationOwner.set(recipient.email, recipient.tenantId);
   }
   if (recipients.length > MAX_NOTICE_RECIPIENTS) return { kind: "too_many" as const };
-  return { kind: "ok" as const, propertyLabel: propertyLabel(property), recipients };
+  const propertySnapshots = params.propertyIds.map((id) => ({ id, label: propertyLabels.get(id) || "Property" }));
+  const propertyBreakdown = propertySnapshots.map((property) => ({
+    ...property,
+    recipientCount: recipients.filter((recipient) => recipient.propertyIds.includes(property.id)).length,
+  }));
+  return { kind: "ok" as const, properties: propertySnapshots, propertyBreakdown, recipients };
 }
 
 function parseFilters(value: any) {
@@ -204,6 +228,9 @@ function publicRecipient(recipient: ResolvedRecipient) {
     tenantDisplayName: recipient.tenantDisplayName,
     unitIds: recipient.unitIds,
     unitLabels: recipient.unitLabels,
+    propertyIds: recipient.propertyIds,
+    propertyLabels: recipient.propertyLabels,
+    units: recipient.units,
     deliveryAvailability: recipient.deliveryAvailability,
   };
 }
@@ -215,9 +242,17 @@ function publicNotice(id: string, raw: any) {
 
 async function requireResolved(req: any, res: any) {
   const landlordId = getEffectiveLandlordId(req);
-  const propertyId = text(req.method === "GET" ? req.query?.propertyId : req.body?.propertyId);
   if (!landlordId) { res.status(401).json({ ok: false, error: "Unauthorized" }); return null; }
-  if (!propertyId) { res.status(400).json({ ok: false, error: "propertyId required" }); return null; }
+  const rawPropertyIds = req.method === "GET"
+    ? (hasOwn(req.query, "propertyIds") ? String(req.query?.propertyIds ?? "").split(",") : [req.query?.propertyId])
+    : (hasOwn(req.body, "propertyIds") ? req.body?.propertyIds : [req.body?.propertyId]);
+  if (!Array.isArray(rawPropertyIds) || rawPropertyIds.length === 0 || rawPropertyIds.some((item) => typeof item !== "string" || !documentIdPattern.test(item.trim()))) {
+    res.status(400).json({ ok: false, error: "Valid propertyIds required" }); return null;
+  }
+  const propertyIds = ids(rawPropertyIds);
+  if (!propertyIds.length || propertyIds.length > MAX_NOTICE_PROPERTIES) {
+    res.status(400).json({ ok: false, error: "Valid propertyIds required", maxProperties: MAX_NOTICE_PROPERTIES }); return null;
+  }
   const tenantFilterProvided = req.method === "GET"
     ? hasOwn(req.query, "tenantIds")
     : hasOwn(req.body, "selectedTenantIds");
@@ -227,7 +262,7 @@ async function requireResolved(req: any, res: any) {
   } : req.body;
   const filters = parseFilters(filterSource);
   const tenantValidation = explicitTenantFilter(filterSource?.selectedTenantIds, tenantFilterProvided);
-  const result = await resolveRecipients({ landlordId, propertyId, ...filters, ...tenantValidation });
+  const result = await resolveRecipients({ landlordId, propertyIds, ...filters, ...tenantValidation });
   if (result.kind === "not_found") { res.status(404).json({ ok: false, error: "Property not found" }); return null; }
   if (result.kind === "forbidden") { res.status(403).json({ ok: false, error: "Property unavailable" }); return null; }
   if (result.kind === "recipient_not_eligible") {
@@ -238,7 +273,7 @@ async function requireResolved(req: any, res: any) {
     res.status(422).json({ ok: false, error: "Recipient limit exceeded", maxRecipients: MAX_NOTICE_RECIPIENTS });
     return null;
   }
-  return { landlordId, propertyId, ...result };
+  return { landlordId, propertyIds, ...result };
 }
 
 const handleNoticeRecipients = async (req: any, res: any) => {
@@ -248,10 +283,13 @@ const handleNoticeRecipients = async (req: any, res: any) => {
     const availableCount = resolved.recipients.filter((recipient) => recipient.deliveryAvailability === "available").length;
     return res.json({
       ok: true,
-      property: { id: resolved.propertyId, label: resolved.propertyLabel },
+      properties: resolved.properties,
+      property: resolved.properties.length === 1 ? resolved.properties[0] : undefined,
+      propertyBreakdown: resolved.propertyBreakdown,
       recipients: resolved.recipients.map(publicRecipient),
       counts: { total: resolved.recipients.length, available: availableCount, skipped: resolved.recipients.length - availableCount },
       maxRecipients: MAX_NOTICE_RECIPIENTS,
+      maxProperties: MAX_NOTICE_PROPERTIES,
     });
   } catch (error: any) {
     console.error("[property-notices] preview failed", { code: text(error?.code) || "preview_failed" });
@@ -266,7 +304,7 @@ const handleNoticeCreate = async (req: any, res: any) => {
   const subject = text(req.body?.subject);
   const body = text(req.body?.body);
   const idempotencyKey = text(req.body?.idempotencyKey);
-  if (!subject || subject.length > 160) return res.status(400).json({ ok: false, error: "Valid subject required" });
+  if (!subject || subject.length > 160 || /[\r\n]/.test(subject)) return res.status(400).json({ ok: false, error: "Valid subject required" });
   if (!body || body.length > 10000) return res.status(400).json({ ok: false, error: "Valid body required" });
   if (!idempotencyKey || !/^[A-Za-z0-9_-]{16,100}$/.test(idempotencyKey)) {
     return res.status(400).json({ ok: false, error: "Valid idempotencyKey required" });
@@ -278,7 +316,15 @@ const handleNoticeCreate = async (req: any, res: any) => {
     if (!resolved.recipients.length || !resolved.recipients.some((item) => item.deliveryAvailability === "available")) {
       return res.status(422).json({ ok: false, error: "No deliverable recipients" });
     }
-    const campaignId = noticeId(resolved.landlordId, idempotencyKey);
+    const filters = parseFilters(req.body);
+    const canonicalRequest = JSON.stringify({
+      propertyIds: resolved.propertyIds,
+      selectedUnitIds: filters.selectedUnitIds,
+      selectedTenantIds: filters.selectedTenantIds,
+      subject,
+      body,
+    });
+    const campaignId = noticeId(resolved.landlordId, idempotencyKey, canonicalRequest);
     const campaignRef = db.collection("propertyNotices").doc(campaignId);
     const now = Date.now();
     const actorId = resolveRequestAuthority(req).actorId;
@@ -287,8 +333,11 @@ const handleNoticeCreate = async (req: any, res: any) => {
       if (existing.exists) return false;
       transaction.set(campaignRef, {
         landlordId: resolved.landlordId,
-        propertyId: resolved.propertyId,
-        propertyLabel: resolved.propertyLabel,
+        propertyIds: resolved.propertyIds,
+        properties: resolved.properties,
+        propertyCount: resolved.properties.length,
+        propertyId: resolved.properties.length === 1 ? resolved.properties[0].id : null,
+        propertyLabel: resolved.properties.length === 1 ? resolved.properties[0].label : null,
         subject,
         body,
         createdBy: actorId,
@@ -297,7 +346,7 @@ const handleNoticeCreate = async (req: any, res: any) => {
         updatedAt: FieldValue.serverTimestamp(),
         status: "sending",
         idempotencyKeyHash: createHash("sha256").update(idempotencyKey).digest("hex"),
-        filters: parseFilters(req.body),
+        filters,
         recipientCount: resolved.recipients.length,
         sentCount: 0,
         failedCount: 0,
@@ -307,7 +356,10 @@ const handleNoticeCreate = async (req: any, res: any) => {
         transaction.set(db.collection("propertyNoticeDeliveries").doc(deliveryId(campaignId, recipient.tenantId)), {
           noticeId: campaignId,
           landlordId: resolved.landlordId,
-          propertyId: resolved.propertyId,
+          propertyIds: recipient.propertyIds,
+          propertyLabels: recipient.propertyLabels,
+          units: recipient.units,
+          propertyId: recipient.propertyIds.length === 1 ? recipient.propertyIds[0] : null,
           tenantId: recipient.tenantId,
           tenantDisplayName: recipient.tenantDisplayName,
           unitIds: recipient.unitIds,
@@ -359,7 +411,7 @@ const handleNoticeCreate = async (req: any, res: any) => {
     }
     const skippedCount = resolved.recipients.length - sentCount - failedCount;
     const status = failedCount === 0 && skippedCount === 0 ? "completed" : sentCount > 0 ? "partially_failed" : "failed";
-    await campaignRef.set({ status, sentCount, failedCount, skippedCount, updatedAt: FieldValue.serverTimestamp(), completedAt: FieldValue.serverTimestamp() }, { merge: true });
+    await campaignRef.set({ status, sentCount, failedCount, skippedCount, updatedAt: FieldValue.serverTimestamp(), completedAt: FieldValue.serverTimestamp(), completedAtMs: Date.now() }, { merge: true });
     const final = await campaignRef.get();
     return res.status(201).json({ ok: true, created: true, notice: publicNotice(campaignId, final.data()) });
   } catch (error: any) {

--- a/rentchain-api/src/services/__tests__/previewQaFakeEmailProvider.test.ts
+++ b/rentchain-api/src/services/__tests__/previewQaFakeEmailProvider.test.ts
@@ -8,16 +8,16 @@ import {
 
 const originalEnv = process.env;
 
-function exactQaEnv() {
+function exactQaEnv(scope = "pr1512-property-notices", service = "rentchain-pr1512-notices-qa-590e0ecb") {
   process.env = {
     ...originalEnv,
     EMAIL_PROVIDER: PREVIEW_QA_FAKE_EMAIL_PROVIDER,
     PREVIEW_QA_AUTH_ENABLED: "true",
-    PREVIEW_QA_AUTH_SCOPE: "pr1512-property-notices",
+    PREVIEW_QA_AUTH_SCOPE: scope,
     APP_ENV: "preview",
     GOOGLE_CLOUD_PROJECT: "rentchain-preview",
-    K_SERVICE: "rentchain-pr1512-notices-qa-590e0ecb",
-    PREVIEW_QA_EXPECTED_SERVICE: "rentchain-pr1512-notices-qa-590e0ecb",
+    K_SERVICE: service,
+    PREVIEW_QA_EXPECTED_SERVICE: service,
     FIRESTORE_ENABLED: "true",
     FIRESTORE_DATABASE_ID: "(default)",
   };
@@ -60,6 +60,14 @@ describe("PR #1512 non-networking fake email provider", () => {
     await expect(sendEmail(message(PREVIEW_QA_FAKE_FAILURE_DESTINATION))).rejects.toThrow(
       "preview_qa_fake_provider_rejected"
     );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("supports the exact PR #1516 isolated Notices runtime without network", async () => {
+    exactQaEnv("pr1516-multi-property-notices", "rentchain-pr1516-notices-qa-252bf576");
+    const fetchMock = vi.fn(() => { throw new Error("network forbidden"); });
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(sendEmail(message())).resolves.toMatchObject({ provider: PREVIEW_QA_FAKE_EMAIL_PROVIDER });
     expect(fetchMock).not.toHaveBeenCalled();
   });
 

--- a/rentchain-api/src/services/emailService.ts
+++ b/rentchain-api/src/services/emailService.ts
@@ -1,5 +1,5 @@
 import { buildEmailHtml, buildEmailText } from "../email/templates/baseEmailTemplate";
-import { isPr1512PreviewQaRuntime } from "../middleware/previewQaAuth";
+import { isPropertyNoticesPreviewQaRuntime } from "../middleware/previewQaAuth";
 import {
   PREVIEW_QA_FAKE_EMAIL_PROVIDER,
   sendViaPreviewQaFake,
@@ -244,7 +244,7 @@ export async function sendLandlordWelcomeEmail(params: {
 export async function sendEmail(message: EmailMessage): Promise<EmailSendResult> {
   const provider = safeStr(process.env.EMAIL_PROVIDER || "mailgun").toLowerCase();
   if (provider === PREVIEW_QA_FAKE_EMAIL_PROVIDER) {
-    if (!isPr1512PreviewQaRuntime(process.env)) {
+    if (!isPropertyNoticesPreviewQaRuntime(process.env)) {
       throw new Error("PREVIEW_QA_FAKE_PROVIDER_INVALID_RUNTIME");
     }
     return sendViaPreviewQaFake(message);

--- a/rentchain-frontend/api/pr1516-bootstrap.ts
+++ b/rentchain-frontend/api/pr1516-bootstrap.ts
@@ -1,0 +1,9 @@
+import {
+  handlePr1516BrowserQaBootstrap,
+  type Pr1516BootstrapRequest,
+  type Pr1516BootstrapResponseWriter,
+} from "../server/pr1516BrowserQaBootstrap.js";
+
+export default async function handler(req: Pr1516BootstrapRequest, res: Pr1516BootstrapResponseWriter) {
+  return handlePr1516BrowserQaBootstrap(req, res);
+}

--- a/rentchain-frontend/api/pr1516-notices/[...path].ts
+++ b/rentchain-frontend/api/pr1516-notices/[...path].ts
@@ -1,0 +1,5 @@
+import { handlePr1516NoticesQaProxy } from "../../server/pr1516NoticesQaProxy.js";
+
+export default async function handler(req: any, res: any) {
+  return handlePr1516NoticesQaProxy(req, res);
+}

--- a/rentchain-frontend/scripts/build.mjs
+++ b/rentchain-frontend/scripts/build.mjs
@@ -24,6 +24,15 @@ if (
   env.VITE_PR1512_NOTICES_QA = "true";
 }
 
+if (
+  process.env.VERCEL_ENV === "preview" &&
+  process.env.VERCEL_GIT_COMMIT_REF === "feat/multi-property-notices-v1"
+) {
+  env.VITE_API_BASE_URL = "/api/pr1516-notices";
+  env.VITE_DEPLOY_ENV = "preview";
+  env.VITE_PR1516_NOTICES_QA = "true";
+}
+
 function run(cmd, args) {
   const result = spawnSync(cmd, args, { stdio: "inherit", env });
   if (result.error) {

--- a/rentchain-frontend/scripts/build.mjs
+++ b/rentchain-frontend/scripts/build.mjs
@@ -26,11 +26,16 @@ if (
 
 if (
   process.env.VERCEL_ENV === "preview" &&
-  process.env.VERCEL_GIT_COMMIT_REF === "feat/multi-property-notices-v1"
+  process.env.VERCEL_GIT_COMMIT_REF === "feat/multi-property-notices-v1" &&
+  /^[a-f0-9]{40}$/.test(process.env.VERCEL_GIT_COMMIT_SHA || "")
 ) {
   env.VITE_API_BASE_URL = "/api/pr1516-notices";
   env.VITE_DEPLOY_ENV = "preview";
   env.VITE_PR1516_NOTICES_QA = "true";
+  env.VITE_PR1516_QA_BRANCH = process.env.VERCEL_GIT_COMMIT_REF;
+  env.VITE_PR1516_QA_COMMIT_SHA = process.env.VERCEL_GIT_COMMIT_SHA;
+  env.VITE_PR1516_QA_SCOPE = "pr1516-multi-property-notices";
+  env.VITE_PR1516_QA_SELECTOR = "pr1516-landlord";
 }
 
 function run(cmd, args) {

--- a/rentchain-frontend/server/pr1516BrowserQaBootstrap.ts
+++ b/rentchain-frontend/server/pr1516BrowserQaBootstrap.ts
@@ -1,0 +1,30 @@
+const BRANCH = "feat/multi-property-notices-v1";
+const SHA_PATTERN = /^[a-f0-9]{40}$/;
+
+export type Pr1516BootstrapRequest = { method?: string };
+export type Pr1516BootstrapResponseWriter = {
+  setHeader(name: string, value: string): void;
+  status(code: number): Pr1516BootstrapResponseWriter;
+  json(body: unknown): unknown;
+};
+
+export function handlePr1516BrowserQaBootstrap(req: Pr1516BootstrapRequest, res: Pr1516BootstrapResponseWriter) {
+  if (String(req.method || "GET").toUpperCase() !== "GET") {
+    res.setHeader("Allow", "GET");
+    return res.status(405).json({ error: "METHOD_NOT_ALLOWED" });
+  }
+  const commitSha = String(process.env.VERCEL_GIT_COMMIT_SHA || "").trim().toLowerCase();
+  if (process.env.VERCEL_ENV !== "preview" || process.env.VERCEL_GIT_COMMIT_REF !== BRANCH || !SHA_PATTERN.test(commitSha)) {
+    return res.status(404).json({ error: "NOT_FOUND" });
+  }
+  res.setHeader("Cache-Control", "private, no-store");
+  return res.status(200).json({
+    ok: true,
+    branch: BRANCH,
+    commitSha,
+    scope: "pr1516-multi-property-notices",
+    selector: "pr1516-landlord",
+    apiBase: "/api/pr1516-notices",
+    landingPath: "/notices",
+  });
+}

--- a/rentchain-frontend/server/pr1516NoticesQaProxy.ts
+++ b/rentchain-frontend/server/pr1516NoticesQaProxy.ts
@@ -1,0 +1,152 @@
+import {
+  acquireVercelOidcToken,
+  exchangeVercelToken,
+  generateCloudRunIdToken,
+  PreviewAuthBridgeError,
+  type PreviewAuthConfig,
+} from "./previewAuthBridge.js";
+
+export const PR1516_QA = {
+  branch: "feat/multi-property-notices-v1",
+  projectNumber: "501298948635",
+  poolId: "vercel-preview-proxy",
+  providerId: "vercel-preview",
+  serviceAccount: "vercel-preview-proxy@rentchain-preview.iam.gserviceaccount.com",
+  serviceUrl: "https://rentchain-pr1516-notices-qa-a2695c6c-glistw4pya-nn.a.run.app",
+  selector: "pr1516-landlord",
+  propertyIds: ["qa-pr1516-property-a", "qa-pr1516-property-b", "qa-pr1516-property-c"],
+} as const;
+
+const providerPath = `projects/${PR1516_QA.projectNumber}/locations/global/workloadIdentityPools/${PR1516_QA.poolId}/providers/${PR1516_QA.providerId}`;
+export const PR1516_QA_AUTH: PreviewAuthConfig = {
+  vercelOidcTokenAudience: `https://iam.googleapis.com/${providerPath}`,
+  googleStsAudience: `//iam.googleapis.com/${providerPath}`,
+  cloudRunIdTokenAudience: PR1516_QA.serviceUrl,
+  serviceAccountEmail: PR1516_QA.serviceAccount,
+  cloudRunServiceUrl: PR1516_QA.serviceUrl,
+  expectedSpikeCommit: "",
+};
+
+const DETAIL = /^\/api\/landlord\/notices\/notice_[a-f0-9]{64}$/;
+const FILTER_ID = /^qa-pr1516-(?:unit|tenant)-[a-z0-9-]+$/;
+const SAFE_RESPONSE_HEADERS = new Set(["cache-control", "content-type", "x-request-id", "x-route-source"]);
+type FetchLike = typeof fetch;
+
+export type Pr1516ProxyDependencies = {
+  fetchImpl?: FetchLike;
+  getVercelOidcToken?: (options: { audience: string }) => Promise<string>;
+};
+
+function fail(res: any, status: number, error: string) {
+  res.setHeader("cache-control", "no-store");
+  return res.status(status).json({ ok: false, error });
+}
+
+function requestPath(req: any) {
+  const raw = String(req?.url || "");
+  const [path, query = ""] = raw.split("?", 2);
+  const prefix = "/api/pr1516-notices";
+  if (!path.startsWith(`${prefix}/`) || /%2f|%5c|\\|\0/i.test(path)) return null;
+  const backendPath = path.slice(prefix.length);
+  const params = new URLSearchParams(query);
+  const routedSuffix = backendPath.slice(1);
+  if (params.get("path") === routedSuffix) params.delete("path");
+  return { backendPath, query: params.toString() };
+}
+
+function exactSubset(value: string | null, allowed: readonly string[]) {
+  if (!value) return false;
+  const ids = value.split(",");
+  return ids.length > 0 && ids.length <= allowed.length && new Set(ids).size === ids.length && ids.every((id) => allowed.includes(id));
+}
+
+function safeQuery(path: string, query: string) {
+  const params = new URLSearchParams(query);
+  if (path === "/api/landlord/notices") return params.size === 0 || (params.size === 1 && params.get("limit") === "50");
+  if (path === "/api/properties") return params.size === 0 || (params.size === 1 && params.get("status") === "active");
+  if (path === "/api/me") return params.size === 0;
+  if (path === "/api/landlord/notices/recipients") {
+    if (!exactSubset(params.get("propertyIds"), PR1516_QA.propertyIds)) return false;
+    for (const key of params.keys()) if (!["propertyIds", "unitIds", "tenantIds"].includes(key)) return false;
+    return [params.get("unitIds"), params.get("tenantIds")].filter(Boolean).every((value) =>
+      String(value).split(",").every((id) => FILTER_ID.test(id)),
+    );
+  }
+  return DETAIL.test(path) && params.size === 0;
+}
+
+export function classifyPr1516Request(req: any) {
+  const method = String(req?.method || "GET").toUpperCase();
+  if (method !== "GET") return { allowed: false as const, status: 405, error: "PR1516_QA_METHOD_NOT_ALLOWED" };
+  const parsed = requestPath(req);
+  if (!parsed) return { allowed: false as const, status: 404, error: "PR1516_QA_ROUTE_NOT_ALLOWED" };
+  const allowedPath = parsed.backendPath === "/api/properties" || parsed.backendPath === "/api/me" ||
+    parsed.backendPath === "/api/landlord/notices" || parsed.backendPath === "/api/landlord/notices/recipients" || DETAIL.test(parsed.backendPath);
+  if (!allowedPath || !safeQuery(parsed.backendPath, parsed.query)) {
+    return { allowed: false as const, status: 404, error: "PR1516_QA_ROUTE_NOT_ALLOWED" };
+  }
+  return { allowed: true as const, ...parsed };
+}
+
+export async function handlePr1516NoticesQaProxy(req: any, res: any, dependencies: Pr1516ProxyDependencies = {}) {
+  if (process.env.VERCEL_ENV !== "preview" || process.env.VERCEL_GIT_COMMIT_REF !== PR1516_QA.branch) {
+    return fail(res, 403, "PR1516_QA_CONTEXT_REJECTED");
+  }
+  const decision = classifyPr1516Request(req);
+  if (!decision.allowed) {
+    if (decision.status === 405) res.setHeader("allow", "GET");
+    return fail(res, decision.status, decision.error);
+  }
+  if (decision.backendPath === "/api/me") {
+    res.setHeader("x-rentchain-api-proxy", "pr1516-notices-readonly");
+    return res.status(200).json({ user: { id: "qa-pr1516-landlord", landlordId: "qa-pr1516-landlord", email: "qa-pr1516-landlord@example.invalid", role: "landlord", plan: "starter", approved: true } });
+  }
+
+  const fetchImpl = dependencies.fetchImpl ?? fetch;
+  try {
+    const oidc = await acquireVercelOidcToken(PR1516_QA_AUTH, dependencies.getVercelOidcToken);
+    const access = await exchangeVercelToken(oidc, PR1516_QA_AUTH, fetchImpl);
+    const identity = await generateCloudRunIdToken(access, PR1516_QA_AUTH, PR1516_QA.serviceUrl, fetchImpl);
+    const upstreamPath = decision.backendPath === "/api/properties"
+      ? `/api/landlord/notices/recipients?propertyIds=${PR1516_QA.propertyIds.join(",")}`
+      : `${decision.backendPath}${decision.query ? `?${decision.query}` : ""}`;
+    const upstream = await fetchImpl(`${PR1516_QA.serviceUrl}${upstreamPath}`, {
+      method: "GET",
+      redirect: "manual",
+      headers: {
+        accept: "application/json",
+        "X-Serverless-Authorization": `Bearer ${identity}`,
+        "x-rentchain-preview-qa-identity": PR1516_QA.selector,
+      },
+    });
+    const payload = await upstream.arrayBuffer();
+    if (decision.backendPath === "/api/properties" && upstream.ok) {
+      const data = JSON.parse(Buffer.from(payload).toString("utf8"));
+      const units = new Map<string, { id: string; unitNumber: string; propertyId: string }>();
+      for (const recipient of data.recipients || []) {
+        for (const unit of recipient.units || []) units.set(unit.id, { id: unit.id, unitNumber: unit.label, propertyId: unit.propertyId });
+      }
+      const items = (data.properties || []).map((property: { id: string; label: string }) => ({
+        id: property.id,
+        name: property.label,
+        addressLine1: property.label,
+        status: "active",
+        units: [...units.values()].filter((unit) => unit.propertyId === property.id).map(({ propertyId: _propertyId, ...unit }) => ({ ...unit, status: "occupied" })),
+      })).map((property: any) => ({ ...property, totalUnits: property.units.length }));
+      res.setHeader("content-type", "application/json; charset=utf-8");
+      res.setHeader("x-rentchain-api-proxy", "pr1516-notices-readonly");
+      return res.status(200).json({ items });
+    }
+    for (const [name, value] of upstream.headers.entries()) if (SAFE_RESPONSE_HEADERS.has(name.toLowerCase())) res.setHeader(name, value);
+    res.setHeader("x-rentchain-api-proxy", "pr1516-notices-readonly");
+    return res.status(upstream.status).send(Buffer.from(payload));
+  } catch (error) {
+    const code = error instanceof PreviewAuthBridgeError && error.code.startsWith("STS_")
+      ? "PR1516_QA_STS_FAILED"
+      : error instanceof PreviewAuthBridgeError && error.code.startsWith("IAM_")
+        ? "PR1516_QA_IDENTITY_FAILED"
+        : "PR1516_QA_BACKEND_UNAVAILABLE";
+    console.error("[pr1516-qa-proxy] request failed", { code });
+    return fail(res, 502, code);
+  }
+}

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -11,6 +11,7 @@ import ApplicantApplyPage from "./pages/ApplicantApplyPage";
 import CosignPage from "./pages/CosignPage";
 import PricingPage from "./pages/PricingPage";
 import LoginPage from "./pages/LoginPage";
+import Pr1516QaBootstrapPage from "./pages/Pr1516QaBootstrapPage";
 import SignupPage from "./pages/SignupPage";
 import ForgotPasswordPage from "./pages/ForgotPasswordPage";
 import AuthActionPage from "./pages/AuthActionPage";
@@ -415,6 +416,7 @@ function App() {
   return (
     <>
       <Routes>
+        <Route path="/__qa/pr1516" element={<Pr1516QaBootstrapPage />} />
         <Route path="/" element={suspensePage(<LandingPage />)} />
         <Route path="/site" element={suspensePage(<LandingPage />)} />
         <Route path="/login" element={<LoginPage />} />

--- a/rentchain-frontend/src/api/baseUrl.test.ts
+++ b/rentchain-frontend/src/api/baseUrl.test.ts
@@ -2,12 +2,14 @@ import { describe, expect, it, vi } from "vitest";
 import {
   PREVIEW_API_BASE_URL,
   PR1512_NOTICES_QA_API_BASE_URL,
+  PR1516_NOTICES_QA_API_BASE_URL,
   PRODUCTION_API_BASE_URL,
   PreviewApiRouteUnavailableError,
   assertPreviewBrowserRequestAvailable,
   isPreviewAuthPath,
   isPreviewAuthRequest,
   isPr1512QaReadRequest,
+  isPr1516QaReadRequest,
   resolveConfiguredApiBase,
 } from "./baseUrl";
 
@@ -34,6 +36,10 @@ describe("resolveConfiguredApiBase", () => {
 
   it("accepts the exact PR #1512 Preview-only proxy base", () => {
     expect(resolveConfiguredApiBase({ apiBaseUrl: PR1512_NOTICES_QA_API_BASE_URL, deployEnv: "preview", isDevelopment: false })).toBe(PR1512_NOTICES_QA_API_BASE_URL);
+  });
+
+  it("accepts the exact PR #1516 Preview-only proxy base", () => {
+    expect(resolveConfiguredApiBase({ apiBaseUrl: PR1516_NOTICES_QA_API_BASE_URL, deployEnv: "preview", isDevelopment: false })).toBe(PR1516_NOTICES_QA_API_BASE_URL);
   });
 
   it.each([
@@ -86,6 +92,20 @@ describe("PR #1512 QA read scope", () => {
 
   it.each([["/api/landlord/notices", "POST"], ["/api/admin/users", "GET"], ["/api/properties", "DELETE"]])(
     "rejects %s with %s", (path, method) => expect(isPr1512QaReadRequest(path, method)).toBe(false),
+  );
+});
+
+describe("PR #1516 QA read scope", () => {
+  it.each([
+    ["/api/me", "GET"],
+    ["/api/properties?status=active", "GET"],
+    ["/api/landlord/notices?limit=50", "GET"],
+    ["/api/landlord/notices/recipients?propertyIds=fixed-a,fixed-b", "GET"],
+    [`/api/landlord/notices/notice_${"a".repeat(64)}`, "GET"],
+  ])("allows %s with %s", (path, method) => expect(isPr1516QaReadRequest(path, method)).toBe(true));
+
+  it.each([["/api/landlord/notices", "POST"], ["/api/admin/users", "GET"], ["/api/properties", "DELETE"]])(
+    "rejects %s with %s", (path, method) => expect(isPr1516QaReadRequest(path, method)).toBe(false),
   );
 });
 

--- a/rentchain-frontend/src/api/baseUrl.ts
+++ b/rentchain-frontend/src/api/baseUrl.ts
@@ -2,6 +2,7 @@ export const PREVIEW_DEPLOY_ENV = "preview";
 export const PRODUCTION_DEPLOY_ENV = "production";
 export const PREVIEW_API_BASE_URL = "/api/preview-backend";
 export const PR1512_NOTICES_QA_API_BASE_URL = "/api/pr1512-notices";
+export const PR1516_NOTICES_QA_API_BASE_URL = "/api/pr1516-notices";
 export const PRODUCTION_API_BASE_URL =
   "https://rentchain-landlord-api-cyaabkl54a-uc.a.run.app";
 export const PREVIEW_API_ROUTE_NOT_AVAILABLE = "PREVIEW_API_ROUTE_NOT_AVAILABLE";
@@ -14,6 +15,14 @@ const PREVIEW_AUTH_OPERATIONS = new Map([
 ]);
 
 const PR1512_READ_OPERATIONS = [
+  /^GET:\/api\/me$/,
+  /^GET:\/api\/properties$/,
+  /^GET:\/api\/landlord\/notices$/,
+  /^GET:\/api\/landlord\/notices\/recipients$/,
+  /^GET:\/api\/landlord\/notices\/notice_[a-f0-9]{64}$/,
+];
+
+const PR1516_READ_OPERATIONS = [
   /^GET:\/api\/me$/,
   /^GET:\/api\/properties$/,
   /^GET:\/api\/landlord\/notices$/,
@@ -71,6 +80,10 @@ export function isPr1512QaReadRequest(input: string, method = "GET"): boolean {
   return PR1512_READ_OPERATIONS.some((pattern) => pattern.test(`${String(method).toUpperCase()}:${normalizeBackendPath(input)}`));
 }
 
+export function isPr1516QaReadRequest(input: string, method = "GET"): boolean {
+  return PR1516_READ_OPERATIONS.some((pattern) => pattern.test(`${String(method).toUpperCase()}:${normalizeBackendPath(input)}`));
+}
+
 export function resolveConfiguredApiBase({
   apiBaseUrl,
   deployEnv,
@@ -84,7 +97,7 @@ export function resolveConfiguredApiBase({
   }
 
   if (rawDeployEnv === PREVIEW_DEPLOY_ENV) {
-    if (![PREVIEW_API_BASE_URL, PR1512_NOTICES_QA_API_BASE_URL].includes(rawBase)) {
+    if (![PREVIEW_API_BASE_URL, PR1512_NOTICES_QA_API_BASE_URL, PR1516_NOTICES_QA_API_BASE_URL].includes(rawBase)) {
       throw new Error(
         "Preview API configuration is invalid: use the authorized same-origin proxy"
       );
@@ -96,7 +109,7 @@ export function resolveConfiguredApiBase({
     throw new Error("VITE_DEPLOY_ENV is not recognized");
   }
 
-  if (rawBase === PREVIEW_API_BASE_URL || rawBase === PR1512_NOTICES_QA_API_BASE_URL) {
+  if (rawBase === PREVIEW_API_BASE_URL || rawBase === PR1512_NOTICES_QA_API_BASE_URL || rawBase === PR1516_NOTICES_QA_API_BASE_URL) {
     throw new Error("The Preview API proxy requires VITE_DEPLOY_ENV=preview");
   }
 
@@ -150,6 +163,10 @@ export function getApiBaseUrlForRequest(input: string, method = "GET"): string {
     if (isPr1512QaReadRequest(input, method)) return configuredBase;
     throw new PreviewApiRouteUnavailableError(input, method);
   }
+  if (configuredBase === PR1516_NOTICES_QA_API_BASE_URL) {
+    if (isPr1516QaReadRequest(input, method)) return configuredBase;
+    throw new PreviewApiRouteUnavailableError(input, method);
+  }
   if (configuredBase !== PREVIEW_API_BASE_URL) return configuredBase;
   if (isPreviewAuthRequest(input, method)) return PREVIEW_API_BASE_URL;
   throw new PreviewApiRouteUnavailableError(input, method);
@@ -189,6 +206,7 @@ export function assertPreviewBrowserRequestAvailable(inputUrl: string, method = 
   if (parsed.origin === origin && parsed.pathname.startsWith(prefix)) {
     const backendPath = parsed.pathname.slice(configuredBase.length);
     if (configuredBase === PR1512_NOTICES_QA_API_BASE_URL && isPr1512QaReadRequest(backendPath, method)) return;
+    if (configuredBase === PR1516_NOTICES_QA_API_BASE_URL && isPr1516QaReadRequest(backendPath, method)) return;
     if (configuredBase === PREVIEW_API_BASE_URL && isPreviewAuthRequest(backendPath, method)) return;
     throw new PreviewApiRouteUnavailableError(backendPath, method);
   }

--- a/rentchain-frontend/src/api/baseUrl.ts
+++ b/rentchain-frontend/src/api/baseUrl.ts
@@ -202,6 +202,12 @@ export function assertPreviewBrowserRequestAvailable(inputUrl: string, method = 
   if (!isProductionApi && !isSameOriginApi) return;
 
   const configuredBase = getApiBaseUrl();
+  if (
+    configuredBase === PR1516_NOTICES_QA_API_BASE_URL &&
+    parsed.origin === origin &&
+    parsed.pathname === "/api/pr1516-bootstrap" &&
+    String(method || "GET").toUpperCase() === "GET"
+  ) return;
   const prefix = `${configuredBase}/`;
   if (parsed.origin === origin && parsed.pathname.startsWith(prefix)) {
     const backendPath = parsed.pathname.slice(configuredBase.length);

--- a/rentchain-frontend/src/api/propertyNoticesApi.ts
+++ b/rentchain-frontend/src/api/propertyNoticesApi.ts
@@ -5,13 +5,19 @@ export type NoticeRecipient = {
   tenantDisplayName: string;
   unitIds: string[];
   unitLabels: string[];
+  propertyIds: string[];
+  propertyLabels: string[];
+  units: Array<{ id: string; label: string; propertyId: string; propertyLabel: string }>;
   deliveryAvailability: "available" | "missing_email" | "duplicate_destination";
 };
 
 export type NoticeSummary = {
   id: string;
-  propertyId: string;
-  propertyLabel: string;
+  propertyId?: string | null;
+  propertyLabel?: string | null;
+  propertyIds: string[];
+  properties: Array<{ id: string; label: string }>;
+  propertyCount: number;
   subject: string;
   body?: string;
   status: "sending" | "completed" | "partially_failed" | "failed";
@@ -20,6 +26,7 @@ export type NoticeSummary = {
   failedCount: number;
   skippedCount: number;
   createdAtMs?: number;
+  completedAtMs?: number;
 };
 
 export type NoticeDelivery = {
@@ -28,17 +35,21 @@ export type NoticeDelivery = {
   tenantDisplayName: string;
   unitIds: string[];
   unitLabels: string[];
+  propertyIds: string[];
+  propertyLabels: string[];
+  units: Array<{ id: string; label: string; propertyId: string; propertyLabel: string }>;
   channel: "email";
   status: "pending" | "sent" | "failed" | "skipped";
   errorCategory?: string | null;
 };
 
-export async function fetchNoticeRecipients(propertyId: string, filters?: { unitIds?: string[]; tenantIds?: string[] }) {
-  const params = new URLSearchParams({ propertyId });
+export async function fetchNoticeRecipients(propertyIds: string[], filters?: { unitIds?: string[]; tenantIds?: string[] }) {
+  const params = new URLSearchParams({ propertyIds: propertyIds.join(",") });
   if (filters?.unitIds?.length) params.set("unitIds", filters.unitIds.join(","));
   if (filters?.tenantIds?.length) params.set("tenantIds", filters.tenantIds.join(","));
   return apiFetch(`/landlord/notices/recipients?${params.toString()}`) as Promise<{
-    property: { id: string; label: string };
+    properties: Array<{ id: string; label: string }>;
+    propertyBreakdown: Array<{ id: string; label: string; recipientCount: number }>;
     recipients: NoticeRecipient[];
     counts: { total: number; available: number; skipped: number };
     maxRecipients: number;
@@ -46,8 +57,8 @@ export async function fetchNoticeRecipients(propertyId: string, filters?: { unit
 }
 
 export async function fetchPropertyNotices(): Promise<NoticeSummary[]> {
-  const response = await apiFetch("/landlord/notices?limit=50");
-  return Array.isArray((response as any)?.notices) ? (response as any).notices : [];
+  const response = await apiFetch("/landlord/notices?limit=50") as { notices?: NoticeSummary[] };
+  return Array.isArray(response.notices) ? response.notices : [];
 }
 
 export async function fetchPropertyNotice(id: string): Promise<{ notice: NoticeSummary; deliveries: NoticeDelivery[] }> {
@@ -55,7 +66,7 @@ export async function fetchPropertyNotice(id: string): Promise<{ notice: NoticeS
 }
 
 export async function sendPropertyNotice(input: {
-  propertyId: string;
+  propertyIds: string[];
   subject: string;
   body: string;
   selectedUnitIds?: string[];

--- a/rentchain-frontend/src/context/AuthContext.tsx
+++ b/rentchain-frontend/src/context/AuthContext.tsx
@@ -17,6 +17,7 @@ import {
 import { DEBUG_AUTH_KEY, JUST_LOGGED_IN_KEY, TENANT_TOKEN_KEY } from "../lib/authKeys";
 import { clearAuthToken, setAuthToken, TOKEN_KEY } from "../lib/authToken";
 import { isPublicRoutePath } from "../lib/publicRoute";
+import { clearPr1516BrowserQaSession, resolvePr1516BrowserQaUser } from "../runtime/pr1516BrowserQaBootstrap";
 
 const LANDLORD_WELCOME_PENDING_KEY = "rentchain.landlordWelcome.pending";
 
@@ -265,7 +266,12 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         } catch {
           // ignore
         }
-        if (import.meta.env.VITE_PR1512_NOTICES_QA === "true") {
+        const pr1516QaUser = resolvePr1516BrowserQaUser(window.sessionStorage, import.meta.env, window.location.hostname);
+        if (pr1516QaUser) {
+          setUser(pr1516QaUser);
+          setToken(null);
+          setAuthStatus("authed");
+        } else if (import.meta.env.VITE_PR1512_NOTICES_QA === "true") {
           setUser({ id: "qa-pr1512-landlord", landlordId: "qa-pr1512-landlord", email: "qa-pr1512-landlord@example.invalid", role: "landlord", plan: "starter", approved: true });
           setToken(null);
           setAuthStatus("authed");
@@ -509,6 +515,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     const currentToken = getStoredToken();
 
     clearStoredToken();
+    clearPr1516BrowserQaSession();
     setToken(null);
     setUser(null);
     setAuthStatus("guest");

--- a/rentchain-frontend/src/context/__tests__/AuthContext.test.ts
+++ b/rentchain-frontend/src/context/__tests__/AuthContext.test.ts
@@ -10,6 +10,7 @@ vi.mock("../../api/baseUrl", () => ({
   getApiBaseUrlForRequest: () => "https://rentchain.test",
   PREVIEW_API_BASE_URL: "/api/preview-backend",
   PR1512_NOTICES_QA_API_BASE_URL: "/api/pr1512-notices",
+  PR1516_NOTICES_QA_API_BASE_URL: "/api/pr1516-notices",
 }));
 
 vi.mock("../../lib/firebaseAuthToken", () => ({

--- a/rentchain-frontend/src/lib/apiClient.ts
+++ b/rentchain-frontend/src/lib/apiClient.ts
@@ -1,6 +1,7 @@
 import {
   getApiBaseUrlForRequest,
   PR1512_NOTICES_QA_API_BASE_URL,
+  PR1516_NOTICES_QA_API_BASE_URL,
   PREVIEW_API_BASE_URL,
 } from "../api/baseUrl";
 import { clearAuthToken, getAuthToken, setAuthToken } from "./authToken";
@@ -17,6 +18,9 @@ export function isAuthorizedPreviewProxyUrl(url: string): boolean {
     url === PR1512_NOTICES_QA_API_BASE_URL ||
     url.startsWith(`${PR1512_NOTICES_QA_API_BASE_URL}/`) ||
     url.startsWith(`${PR1512_NOTICES_QA_API_BASE_URL}?`)
+    || url === PR1516_NOTICES_QA_API_BASE_URL
+    || url.startsWith(`${PR1516_NOTICES_QA_API_BASE_URL}/`)
+    || url.startsWith(`${PR1516_NOTICES_QA_API_BASE_URL}?`)
   );
 }
 
@@ -35,6 +39,9 @@ export function resolveApiUrl(input: string, method = "GET") {
     sRaw === PR1512_NOTICES_QA_API_BASE_URL ||
     sRaw.startsWith(`${PR1512_NOTICES_QA_API_BASE_URL}/`) ||
     sRaw.startsWith(`${PR1512_NOTICES_QA_API_BASE_URL}?`)
+    || sRaw === PR1516_NOTICES_QA_API_BASE_URL
+    || sRaw.startsWith(`${PR1516_NOTICES_QA_API_BASE_URL}/`)
+    || sRaw.startsWith(`${PR1516_NOTICES_QA_API_BASE_URL}?`)
   ) {
     throw new Error("Preview proxy paths must be resolved from backend API paths");
   }

--- a/rentchain-frontend/src/lib/publicRoute.ts
+++ b/rentchain-frontend/src/lib/publicRoute.ts
@@ -28,6 +28,7 @@ const PUBLIC_PREFIXES = [
   "/tenant/login",
   "/tenant/magic",
   "/tenant/invite",
+  "/__qa",
 ];
 
 export function isPublicRoutePath(pathname?: string | null): boolean {

--- a/rentchain-frontend/src/pages/Pr1516QaBootstrapPage.tsx
+++ b/rentchain-frontend/src/pages/Pr1516QaBootstrapPage.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useState } from "react";
+import {
+  PR1516_QA_BOOTSTRAP_PATH,
+  activatePr1516BrowserQaSession,
+  getPr1516QaBuildContract,
+  isValidPr1516BootstrapResponse,
+} from "../runtime/pr1516BrowserQaBootstrap";
+
+export default function Pr1516QaBootstrapPage() {
+  const [status, setStatus] = useState("Verifying isolated PR #1516 QA access...");
+
+  useEffect(() => {
+    const contract = getPr1516QaBuildContract();
+    if (!contract.valid) {
+      setStatus("This QA bootstrap is unavailable in this deployment.");
+      return;
+    }
+    void (async () => {
+      try {
+        const response = await fetch(PR1516_QA_BOOTSTRAP_PATH, {
+          method: "GET",
+          headers: { Accept: "application/json" },
+          cache: "no-store",
+          credentials: "same-origin",
+        });
+        const body = await response.json().catch(() => null);
+        if (!response.ok || !isValidPr1516BootstrapResponse(body, contract.commitSha)) {
+          throw new Error("bootstrap contract rejected");
+        }
+        activatePr1516BrowserQaSession(window.sessionStorage, contract.commitSha);
+        window.location.replace("/notices");
+      } catch {
+        setStatus("Unable to establish the isolated PR #1516 QA session.");
+      }
+    })();
+  }, []);
+
+  return <main style={{ minHeight: "100vh", display: "grid", placeItems: "center", padding: 24 }}><p>{status}</p></main>;
+}

--- a/rentchain-frontend/src/pages/PropertyNoticesPage.test.tsx
+++ b/rentchain-frontend/src/pages/PropertyNoticesPage.test.tsx
@@ -15,15 +15,15 @@ vi.mock("@/api/propertyNoticesApi", () => ({
 }));
 
 const recipients = [
-  { tenantId: "tenant-1", tenantDisplayName: "Alex Current", unitIds: ["unit-1"], unitLabels: ["1A"], deliveryAvailability: "available" },
-  { tenantId: "tenant-2", tenantDisplayName: "Blair Missing", unitIds: ["unit-2"], unitLabels: ["2B"], deliveryAvailability: "missing_email" },
+  { tenantId: "tenant-1", tenantDisplayName: "Alex Current", unitIds: ["unit-1", "unit-3"], unitLabels: ["1A", "3C"], propertyIds: ["property-1", "property-2"], propertyLabels: ["Harbour House", "Queen Court"], units: [{ id: "unit-1", label: "1A", propertyId: "property-1", propertyLabel: "Harbour House" }, { id: "unit-3", label: "3C", propertyId: "property-2", propertyLabel: "Queen Court" }], deliveryAvailability: "available" },
+  { tenantId: "tenant-2", tenantDisplayName: "Blair Missing", unitIds: ["unit-2"], unitLabels: ["2B"], propertyIds: ["property-1"], propertyLabels: ["Harbour House"], units: [{ id: "unit-2", label: "2B", propertyId: "property-1", propertyLabel: "Harbour House" }], deliveryAvailability: "missing_email" },
 ];
 
 describe("PropertyNoticesPage", () => {
   beforeEach(() => {
-    mocks.fetchProperties.mockResolvedValue({ properties: [{ id: "property-1", name: "Harbour House", addressLine1: "1 Main", totalUnits: 2, createdAt: "now", units: [] }] });
+    mocks.fetchProperties.mockResolvedValue({ properties: [{ id: "property-1", name: "Harbour House", addressLine1: "1 Main", totalUnits: 2, createdAt: "now", units: [] }, { id: "property-2", name: "Queen Court", addressLine1: "2 Main", totalUnits: 1, createdAt: "now", units: [] }] });
     mocks.fetchNotices.mockResolvedValue([]);
-    mocks.fetchRecipients.mockResolvedValue({ property: { id: "property-1", label: "Harbour House" }, recipients, counts: { total: 2, available: 1, skipped: 1 }, maxRecipients: 100 });
+    mocks.fetchRecipients.mockResolvedValue({ properties: [{ id: "property-1", label: "Harbour House" }, { id: "property-2", label: "Queen Court" }], propertyBreakdown: [{ id: "property-1", label: "Harbour House", recipientCount: 2 }, { id: "property-2", label: "Queen Court", recipientCount: 1 }], recipients, counts: { total: 2, available: 1, skipped: 1 }, maxRecipients: 100 });
     mocks.sendNotice.mockResolvedValue({ created: true, notice: { id: "notice-1", status: "completed" } });
   });
   afterEach(() => cleanup());
@@ -37,22 +37,22 @@ describe("PropertyNoticesPage", () => {
   it("resolves current recipients, supports unit filters, and previews skipped recipients", async () => {
     render(<PropertyNoticesPage />);
     fireEvent.click(await screen.findByRole("button", { name: "New Notice" }));
-    fireEvent.change(screen.getByLabelText("Property"), { target: { value: "property-1" } });
+    fireEvent.click(screen.getByLabelText("Harbour House"));
     fireEvent.click(screen.getByRole("button", { name: "Resolve current recipients" }));
     expect(await screen.findByText(/Alex Current/)).toBeInTheDocument();
     expect(screen.queryByText(/Former Tenant/)).not.toBeInTheDocument();
     expect(screen.getByText(/Blair Missing.*missing email/)).toBeInTheDocument();
-    fireEvent.click(screen.getByLabelText("1A"));
+    fireEvent.click(screen.getByLabelText("Harbour House — 1A"));
     expect(screen.getByText(/Preview recipients \(1\)/)).toBeInTheDocument();
     expect(screen.getByText(/1 private deliveries.*0 skipped/)).toBeInTheDocument();
   });
 
   it("requires confirmation, makes one bounded send, and prevents double submit", async () => {
-    let finish!: (value: any) => void;
+    let finish!: (value: unknown) => void;
     mocks.sendNotice.mockReturnValue(new Promise((resolve) => { finish = resolve; }));
     render(<PropertyNoticesPage />);
     fireEvent.click(await screen.findByRole("button", { name: "New Notice" }));
-    fireEvent.change(screen.getByLabelText("Property"), { target: { value: "property-1" } });
+    fireEvent.click(screen.getByLabelText("Harbour House"));
     fireEvent.click(screen.getByRole("button", { name: "Resolve current recipients" }));
     await screen.findByText(/Alex Current/);
     fireEvent.change(screen.getByLabelText("Subject"), { target: { value: "Water shutdown" } });
@@ -64,7 +64,47 @@ describe("PropertyNoticesPage", () => {
     expect(within(dialog).getByRole("button", { name: "Sending…" })).toBeDisabled();
     expect(mocks.sendNotice).toHaveBeenCalledTimes(1);
     expect(mocks.sendNotice.mock.calls[0][0]).not.toHaveProperty("recipientEmails");
+    expect(mocks.sendNotice.mock.calls[0][0].propertyIds).toEqual(["property-1"]);
     finish({ created: true, notice: { id: "notice-1" } });
     await waitFor(() => expect(screen.getByText("No operational notices have been sent.")).toBeInTheDocument());
+  });
+
+  it("selects multiple properties, groups units by property, and confirms portfolio scope", async () => {
+    render(<PropertyNoticesPage />);
+    fireEvent.click(await screen.findByRole("button", { name: "New Notice" }));
+    fireEvent.click(screen.getByLabelText("Queen Court"));
+    fireEvent.click(screen.getByLabelText("Harbour House"));
+    expect(screen.getByText(/2 selected/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Resolve current recipients" }));
+    expect(await screen.findByText(/2 properties · 2 eligible occupants · 1 deliverable · 1 skipped/)).toBeInTheDocument();
+    expect(screen.getByRole("list", { name: "Property recipient breakdown" })).toHaveTextContent("Harbour House — 2 recipients");
+    expect(screen.getByLabelText("Harbour House — 1A")).toBeInTheDocument();
+    expect(screen.getByLabelText("Queen Court — 3C")).toBeInTheDocument();
+    expect(mocks.fetchRecipients).toHaveBeenCalledWith(["property-1", "property-2"]);
+    fireEvent.change(screen.getByLabelText("Subject"), { target: { value: "Portfolio update" } });
+    fireEvent.change(screen.getByLabelText("Message"), { target: { value: "Shared message." } });
+    fireEvent.click(screen.getByRole("button", { name: "Preview Notice" }));
+    expect(within(screen.getByRole("dialog", { name: "Confirm notice" })).getByText(/2 selected properties/)).toBeInTheDocument();
+  });
+
+  it("renders multi-property history and detail snapshots", async () => {
+    mocks.fetchNotices.mockResolvedValue([{ id: "notice-1", subject: "Portfolio update", body: "Shared message.", status: "completed", propertyIds: ["property-1", "property-2"], properties: [{ id: "property-1", label: "Harbour House" }, { id: "property-2", label: "Queen Court" }], propertyCount: 2, recipientCount: 2, sentCount: 2, failedCount: 0, skippedCount: 0 }]);
+    mocks.fetchNotice.mockResolvedValue({ notice: (await mocks.fetchNotices())[0], deliveries: [{ id: "delivery-1", tenantId: "tenant-1", tenantDisplayName: "Alex Current", unitIds: ["unit-1", "unit-3"], unitLabels: ["1A", "3C"], propertyIds: ["property-1", "property-2"], propertyLabels: ["Harbour House", "Queen Court"], units: recipients[0].units, channel: "email", status: "sent" }] });
+    render(<PropertyNoticesPage />);
+    expect(await screen.findByText(/2 properties/)).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Portfolio update"));
+    expect(await screen.findByRole("list", { name: "Selected properties" })).toHaveTextContent("Harbour House");
+    expect(screen.getByText(/Alex Current.*Harbour House — 1A.*Queen Court — 3C.*sent/)).toBeInTheDocument();
+  });
+
+  it("explains how to reduce scope when the aggregate recipient cap is exceeded", async () => {
+    const sendsBefore = mocks.sendNotice.mock.calls.length;
+    mocks.fetchRecipients.mockRejectedValue(Object.assign(new Error("cap"), { status: 422 }));
+    render(<PropertyNoticesPage />);
+    fireEvent.click(await screen.findByRole("button", { name: "New Notice" }));
+    fireEvent.click(screen.getByLabelText("Harbour House"));
+    fireEvent.click(screen.getByRole("button", { name: "Resolve current recipients" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent("Recipient limit exceeded. Reduce selected properties or filter units and tenants.");
+    expect(mocks.sendNotice).toHaveBeenCalledTimes(sendsBefore);
   });
 });

--- a/rentchain-frontend/src/pages/PropertyNoticesPage.tsx
+++ b/rentchain-frontend/src/pages/PropertyNoticesPage.tsx
@@ -25,7 +25,8 @@ export default function PropertyNoticesPage() {
   const [properties, setProperties] = useState<Property[]>([]);
   const [notices, setNotices] = useState<NoticeSummary[]>([]);
   const [mode, setMode] = useState<"history" | "compose">("history");
-  const [propertyId, setPropertyId] = useState("");
+  const [propertyIds, setPropertyIds] = useState<string[]>([]);
+  const [propertyBreakdown, setPropertyBreakdown] = useState<Array<{ id: string; label: string; recipientCount: number }>>([]);
   const [recipients, setRecipients] = useState<NoticeRecipient[]>([]);
   const [selectedUnits, setSelectedUnits] = useState<string[]>([]);
   const [selectedTenants, setSelectedTenants] = useState<string[]>([]);
@@ -47,7 +48,11 @@ export default function PropertyNoticesPage() {
       .catch(() => setError("Notices could not be loaded."));
   }, []);
 
-  const unitOptions = useMemo(() => Array.from(new Map(recipients.flatMap((recipient) => recipient.unitIds.map((id, index) => [id, recipient.unitLabels[index] || "Unit"]))).entries()), [recipients]);
+  const unitGroups = useMemo(() => propertyIds.map((selectedPropertyId) => ({
+    propertyId: selectedPropertyId,
+    propertyLabel: properties.find((property) => property.id === selectedPropertyId)?.name || "Property",
+    units: Array.from(new Map(recipients.flatMap((recipient) => recipient.units || []).filter((unit) => unit.propertyId === selectedPropertyId).map((unit) => [unit.id, unit.label])).entries()),
+  })), [propertyIds, properties, recipients]);
   const visibleRecipients = useMemo(() => selectedUnits.length
     ? recipients.filter((recipient) => recipient.unitIds.some((id) => selectedUnits.includes(id)))
     : recipients, [recipients, selectedUnits]);
@@ -56,26 +61,32 @@ export default function PropertyNoticesPage() {
   const skipped = selected.length - deliverable.length;
 
   const resetCompose = () => {
-    setPropertyId(""); setRecipients([]); setSelectedUnits([]); setSelectedTenants([]);
+    setPropertyIds([]); setPropertyBreakdown([]); setRecipients([]); setSelectedUnits([]); setSelectedTenants([]);
     setSubject(""); setBody(""); setPreviewed(false); setConfirming(false); setError(null);
   };
 
   const resolve = async () => {
     setError(null); setConfirming(false);
     try {
-      const response = await fetchNoticeRecipients(propertyId);
+      const response = await fetchNoticeRecipients(propertyIds);
       setRecipients(response.recipients);
+      setPropertyBreakdown(response.propertyBreakdown);
       setSelectedTenants(response.recipients.map((recipient) => recipient.tenantId));
       setSelectedUnits([]);
       setPreviewed(true);
-    } catch { setError("Eligible recipients could not be resolved."); }
+    } catch (cause: unknown) {
+      const status = cause && typeof cause === "object" && "status" in cause ? (cause as { status?: number }).status : null;
+      setError(status === 422
+        ? "Recipient limit exceeded. Reduce selected properties or filter units and tenants."
+        : "Eligible recipients could not be resolved.");
+    }
   };
 
   const submit = async () => {
     setSending(true); setError(null);
     try {
       await sendPropertyNotice({
-        propertyId, subject: subject.trim(), body: body.trim(),
+        propertyIds, subject: subject.trim(), body: body.trim(),
         selectedUnitIds: selectedUnits,
         selectedTenantIds: selected.map((recipient) => recipient.tenantId),
         idempotencyKey: requestKey(),
@@ -87,7 +98,7 @@ export default function PropertyNoticesPage() {
 
   return <main style={{ maxWidth: 1100, margin: "0 auto", padding: "24px 16px 120px", color: "#211c17" }}>
     <header style={{ display: "flex", justifyContent: "space-between", gap: 16, alignItems: "center", flexWrap: "wrap", marginBottom: 20 }}>
-      <div><h1 style={{ margin: 0 }}>Notices</h1><p>Private operational communications for current occupants of one property.</p></div>
+      <div><h1 style={{ margin: 0 }}>Notices</h1><p>Private operational communications for current occupants of one or more properties.</p></div>
       <button type="button" onClick={() => { resetCompose(); setMode(mode === "compose" ? "history" : "compose"); }}>
         {mode === "compose" ? "Back to history" : "New Notice"}
       </button>
@@ -98,20 +109,28 @@ export default function PropertyNoticesPage() {
     {mode === "history" ? <section aria-label="Notice history" style={{ display: "grid", gap: 12 }}>
       {notices.length === 0 ? <div style={card}>No operational notices have been sent.</div> : notices.map((notice) =>
         <button key={notice.id} type="button" onClick={async () => setDetail(await fetchPropertyNotice(notice.id))} style={{ ...card, textAlign: "left", cursor: "pointer" }}>
-          <strong>{notice.subject}</strong><div>{notice.propertyLabel} · {notice.createdAtMs ? new Date(notice.createdAtMs).toLocaleDateString() : "Pending date"}</div>
+          <strong>{notice.subject}</strong><div>{(notice.propertyCount || notice.properties?.length || 1) > 1 ? `${notice.propertyCount || notice.properties.length} properties` : notice.propertyLabel || notice.properties?.[0]?.label || "Property"} · {notice.createdAtMs ? new Date(notice.createdAtMs).toLocaleDateString() : "Pending date"}</div>
           <small>{statusLabel(notice.status)} · {notice.sentCount}/{notice.recipientCount} sent · {notice.failedCount} failed · {notice.skippedCount} skipped</small>
         </button>)}
-      {detail ? <div style={card}><button type="button" onClick={() => setDetail(null)} style={{ float: "right" }}>Close</button><h2>{detail.notice.subject}</h2><p style={{ whiteSpace: "pre-wrap" }}>{detail.notice.body}</p><h3>Recipient delivery history</h3>
-        <ul>{detail.deliveries.map((delivery) => <li key={delivery.id}>{delivery.tenantDisplayName} · {delivery.unitLabels.join(", ")} · {statusLabel(delivery.status)}{delivery.errorCategory ? ` (${statusLabel(delivery.errorCategory)})` : ""}</li>)}</ul></div> : null}
+      {detail ? <div style={card}><button type="button" onClick={() => setDetail(null)} style={{ float: "right" }}>Close</button><h2>{detail.notice.subject}</h2>
+        <p>{detail.notice.propertyCount || detail.notice.properties?.length || 1} selected {(detail.notice.propertyCount || detail.notice.properties?.length || 1) === 1 ? "property" : "properties"}</p>
+        <ul aria-label="Selected properties">{(detail.notice.properties || []).map((property) => <li key={property.id}>{property.label}</li>)}</ul>
+        <p>{detail.notice.sentCount}/{detail.notice.recipientCount} sent · {detail.notice.failedCount} failed · {detail.notice.skippedCount} skipped</p>
+        <p>Created {detail.notice.createdAtMs ? new Date(detail.notice.createdAtMs).toLocaleString() : "date pending"}{detail.notice.completedAtMs ? ` · Completed ${new Date(detail.notice.completedAtMs).toLocaleString()}` : ""}</p>
+        <p style={{ whiteSpace: "pre-wrap" }}>{detail.notice.body}</p><h3>Recipient delivery history</h3>
+        <ul>{detail.deliveries.map((delivery) => <li key={delivery.id}>{delivery.tenantDisplayName} · {(delivery.units || []).map((unit) => `${unit.propertyLabel} — ${unit.label}`).join(", ") || delivery.unitLabels.join(", ")} · {statusLabel(delivery.status)}{delivery.errorCategory ? ` (${statusLabel(delivery.errorCategory)})` : ""}</li>)}</ul></div> : null}
     </section> : <section style={{ ...card, display: "grid", gap: 16 }}>
-      <label>1. Select property<select aria-label="Property" value={propertyId} onChange={(event) => { setPropertyId(event.target.value); setPreviewed(false); }} style={field}>
-        <option value="">Choose a property</option>{properties.map((property) => <option key={property.id} value={property.id}>{property.name || property.addressLine1}</option>)}
-      </select></label>
-      <button type="button" disabled={!propertyId} onClick={resolve}>Resolve current recipients</button>
+      <fieldset><legend>1. Select one or more properties ({propertyIds.length} selected)</legend>
+        <div style={{ display: "grid", gap: 8 }}>{properties.map((property) => <label key={property.id}><input type="checkbox" aria-label={property.name || property.addressLine1} checked={propertyIds.includes(property.id)} onChange={() => { setPropertyIds((current) => current.includes(property.id) ? current.filter((id) => id !== property.id) : [...current, property.id].sort()); setPreviewed(false); setConfirming(false); }} /> {property.name || property.addressLine1}</label>)}</div>
+        {propertyIds.length ? <button type="button" onClick={() => { setPropertyIds([]); setPreviewed(false); setConfirming(false); }}>Clear all</button> : null}
+      </fieldset>
+      <button type="button" disabled={!propertyIds.length} onClick={resolve}>Resolve current recipients</button>
       {previewed ? <>
-        <fieldset><legend>2. Optional unit filters</legend>{unitOptions.map(([id, label]) => <label key={id} style={{ marginRight: 14 }}><input type="checkbox" checked={selectedUnits.includes(id)} onChange={() => setSelectedUnits((current) => current.includes(id) ? current.filter((item) => item !== id) : [...current, id])} /> {label}</label>)}</fieldset>
+        <p><strong>{propertyIds.length} {propertyIds.length === 1 ? "property" : "properties"} · {recipients.length} eligible occupants · {recipients.filter((recipient) => recipient.deliveryAvailability === "available").length} deliverable · {recipients.filter((recipient) => recipient.deliveryAvailability !== "available").length} skipped</strong></p>
+        <ul aria-label="Property recipient breakdown">{propertyBreakdown.map((property) => <li key={property.id}>{property.label} — {property.recipientCount} recipients</li>)}</ul>
+        <fieldset><legend>2. Optional unit filters</legend>{unitGroups.map((group) => <div key={group.propertyId}><strong>{group.propertyLabel}</strong><div>{group.units.map(([id, label]) => <label key={id} style={{ marginRight: 14 }}><input type="checkbox" aria-label={`${group.propertyLabel} — ${label}`} checked={selectedUnits.includes(id)} onChange={() => setSelectedUnits((current) => current.includes(id) ? current.filter((item) => item !== id) : [...current, id])} /> {label}</label>)}</div></div>)}</fieldset>
         <fieldset><legend>3. Preview recipients ({selected.length})</legend>
-          {visibleRecipients.map((recipient) => <label key={recipient.tenantId} style={{ display: "block", padding: "6px 0" }}><input type="checkbox" checked={selectedTenants.includes(recipient.tenantId)} onChange={() => setSelectedTenants((current) => current.includes(recipient.tenantId) ? current.filter((item) => item !== recipient.tenantId) : [...current, recipient.tenantId])} /> {recipient.tenantDisplayName} · {recipient.unitLabels.join(", ")} · {statusLabel(recipient.deliveryAvailability)}</label>)}
+          {visibleRecipients.map((recipient) => <label key={recipient.tenantId} style={{ display: "block", padding: "6px 0" }}><input type="checkbox" checked={selectedTenants.includes(recipient.tenantId)} onChange={() => setSelectedTenants((current) => current.includes(recipient.tenantId) ? current.filter((item) => item !== recipient.tenantId) : [...current, recipient.tenantId])} /> {recipient.tenantDisplayName} · {(recipient.units || []).map((unit) => `${unit.propertyLabel} — ${unit.label}`).join(", ") || recipient.unitLabels.join(", ")} · {statusLabel(recipient.deliveryAvailability)}</label>)}
           <p>{deliverable.length} private deliveries · {skipped} skipped/unavailable</p>
         </fieldset>
         <label>4. Subject<input aria-label="Subject" maxLength={160} value={subject} onChange={(event) => setSubject(event.target.value)} style={field} /></label>
@@ -119,7 +138,7 @@ export default function PropertyNoticesPage() {
         <button type="button" disabled={!subject.trim() || !body.trim() || deliverable.length === 0} onClick={() => setConfirming(true)}>Preview Notice</button>
       </> : null}
       {confirming ? <div role="dialog" aria-label="Confirm notice" style={{ ...card, background: "#fffaf1" }}><h2>Confirm operational notice</h2>
-        <p><strong>{properties.find((property) => property.id === propertyId)?.name || "Selected property"}</strong> · {deliverable.length} private recipients · {skipped} skipped</p>
+        <p><strong>{propertyIds.length} selected {propertyIds.length === 1 ? "property" : "properties"}</strong> · {deliverable.length} private recipients · {skipped} skipped</p>
         <h3>{subject}</h3><p style={{ whiteSpace: "pre-wrap" }}>{body}</p><p>Each recipient receives a separate private delivery. Recipients cannot see one another.</p>
         <button type="button" onClick={() => setConfirming(false)} disabled={sending}>Edit</button>{" "}<button type="button" onClick={submit} disabled={sending}>{sending ? "Sending…" : "Send Notice"}</button>
       </div> : null}

--- a/rentchain-frontend/src/platform/pr1516NoticesQaProxy.test.ts
+++ b/rentchain-frontend/src/platform/pr1516NoticesQaProxy.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { classifyPr1516Request, handlePr1516NoticesQaProxy, PR1516_QA } from "../../server/pr1516NoticesQaProxy";
+
+function req(url: string, method = "GET", headers: Record<string, string> = {}) {
+  return { url, method, headers };
+}
+
+function recorder() {
+  return {
+    statusCode: 200, body: undefined as any, headers: new Map<string, unknown>(),
+    setHeader(name: string, value: unknown) { this.headers.set(name.toLowerCase(), value); },
+    status(code: number) { this.statusCode = code; return this; },
+    json(body: unknown) { this.body = body; return this; },
+    send(body: unknown) { this.body = body; return this; },
+  };
+}
+
+function dependencies() {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+    const url = String(input); calls.push({ url, init });
+    if (url.includes("sts.googleapis.com")) return new Response(JSON.stringify({ access_token: "access", token_type: "Bearer", expires_in: 300 }), { status: 200 });
+    if (url.includes("iamcredentials.googleapis.com")) return new Response(JSON.stringify({ token: "header.identity.signature" }), { status: 200 });
+    return new Response(JSON.stringify({ ok: true, notices: [] }), { status: 200, headers: { "content-type": "application/json" } });
+  });
+  return { calls, fetchImpl: fetchImpl as typeof fetch, getVercelOidcToken: vi.fn(async () => "header.oidc.signature") };
+}
+
+describe("PR #1516 read-only Notices proxy", () => {
+  beforeEach(() => { process.env.VERCEL_ENV = "preview"; process.env.VERCEL_GIT_COMMIT_REF = PR1516_QA.branch; });
+  afterEach(() => { delete process.env.VERCEL_ENV; delete process.env.VERCEL_GIT_COMMIT_REF; vi.restoreAllMocks(); });
+
+  it.each([
+    "/api/pr1516-notices/api/landlord/notices?limit=50",
+    "/api/pr1516-notices/api/landlord/notices/recipients?propertyIds=qa-pr1516-property-a,qa-pr1516-property-b",
+    `/api/pr1516-notices/api/landlord/notices/notice_${"a".repeat(64)}`,
+    "/api/pr1516-notices/api/properties?status=active",
+    "/api/pr1516-notices/api/me",
+  ])("allows exact read %s", (url) => expect(classifyPr1516Request(req(url))).toMatchObject({ allowed: true }));
+
+  it("accepts only Vercel's exact catch-all routing parameter", () => {
+    expect(classifyPr1516Request(req("/api/pr1516-notices/api/landlord/notices?limit=50&path=api%2Flandlord%2Fnotices"))).toMatchObject({ allowed: true });
+    expect(classifyPr1516Request(req("/api/pr1516-notices/api/landlord/notices?limit=50&path=api%2Fproperties"))).toMatchObject({ allowed: false });
+  });
+
+  it.each([
+    "/api/pr1516-notices/api/admin/users",
+    "/api/pr1516-notices/api/landlord/notices?limit=500",
+    "/api/pr1516-notices/api/landlord/notices/recipients?propertyIds=qa-pr1516-property-foreign",
+    "/api/pr1516-notices/api/landlord/notices/recipients?propertyIds=qa-pr1516-property-a&unitIds=foreign-unit",
+    "/api/pr1516-notices/https://production.invalid",
+  ])("denies unknown or caller-selected read %s", (url) => expect(classifyPr1516Request(req(url))).toMatchObject({ allowed: false, status: 404 }));
+
+  it.each(["POST", "PUT", "PATCH", "DELETE"])("denies %s before token acquisition", async (method) => {
+    const deps = dependencies(); const res = recorder();
+    await handlePr1516NoticesQaProxy(req("/api/pr1516-notices/api/landlord/notices", method), res, deps);
+    expect(res.statusCode).toBe(405); expect(deps.getVercelOidcToken).not.toHaveBeenCalled(); expect(deps.fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("fails closed outside the exact Preview branch", async () => {
+    process.env.VERCEL_GIT_COMMIT_REF = "main"; const deps = dependencies(); const res = recorder();
+    await handlePr1516NoticesQaProxy(req("/api/pr1516-notices/api/landlord/notices"), res, deps);
+    expect(res.statusCode).toBe(403); expect(deps.fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("uses only the fixed target and server-owned identity headers", async () => {
+    const deps = dependencies(); const res = recorder();
+    await handlePr1516NoticesQaProxy(req("/api/pr1516-notices/api/landlord/notices/recipients?propertyIds=qa-pr1516-property-a,qa-pr1516-property-b", "GET", { authorization: "Bearer browser", "x-backend-url": "https://production.invalid", "x-rentchain-preview-qa-identity": "foreign" }), res, deps);
+    expect(res.statusCode).toBe(200);
+    const upstream = deps.calls.at(-1)!;
+    expect(upstream.url).toBe(`${PR1516_QA.serviceUrl}/api/landlord/notices/recipients?propertyIds=qa-pr1516-property-a%2Cqa-pr1516-property-b`);
+    expect(upstream.init?.headers).toMatchObject({ "x-rentchain-preview-qa-identity": PR1516_QA.selector });
+    expect(JSON.stringify(upstream.init?.headers)).not.toContain("browser");
+    expect(JSON.stringify(res.body)).not.toContain("identity.signature");
+  });
+
+  it("sanitizes WIF failure and never falls back", async () => {
+    const res = recorder(); const fetchImpl = vi.fn(async () => new Response(JSON.stringify({ error: "secret-token" }), { status: 403 }));
+    await handlePr1516NoticesQaProxy(req("/api/pr1516-notices/api/landlord/notices"), res, { fetchImpl: fetchImpl as typeof fetch, getVercelOidcToken: vi.fn(async () => "header.secret.signature") });
+    expect(res.statusCode).toBe(502); expect(res.body).toEqual({ ok: false, error: "PR1516_QA_STS_FAILED" });
+    expect(JSON.stringify(res.body)).not.toContain("secret");
+  });
+});

--- a/rentchain-frontend/src/platform/vercelRoutePrecedence.test.ts
+++ b/rentchain-frontend/src/platform/vercelRoutePrecedence.test.ts
@@ -31,6 +31,10 @@ describe("Vercel Preview backend route precedence", () => {
   it("routes the complete Preview suffix to the existing Function before filesystem misses", () => {
     expect(config.routes).toEqual([
       {
+        src: "^/api/pr1516-notices/(.*)$",
+        dest: "/api/pr1516-notices/[...path]?path=$1",
+      },
+      {
         src: "^/api/pr1512-notices/(.*)$",
         dest: "/api/pr1512-notices/[...path]?path=$1",
       },
@@ -49,25 +53,36 @@ describe("Vercel Preview backend route precedence", () => {
     "/api/preview-backend/api/me",
     "/api/preview-backend/api/auth/login",
   ])("reserves %s for the dedicated filesystem Function", (requestPath) => {
-    const functionRoute = config.routes[1];
+    const functionRoute = config.routes[2];
     const match = new RegExp(functionRoute.src as string).exec(requestPath);
 
     expect(match?.[1]).toBe(requestPath.slice("/api/preview-backend/".length));
     expect(functionRoute.dest?.replace("$1", match?.[1] ?? "")).toBe(
       `/api/preview-backend/[...path]?path=${match?.[1]}`,
     );
-    expect(config.routes[2]).toEqual({ handle: "filesystem" });
+    expect(config.routes[3]).toEqual({ handle: "filesystem" });
   });
 
   it("reserves the PR #1512 read-only QA suffix before filesystem misses", () => {
     const requestPath = "/api/pr1512-notices/api/landlord/notices";
-    const functionRoute = config.routes[0];
+    const functionRoute = config.routes[1];
     const match = new RegExp(functionRoute.src as string).exec(requestPath);
     expect(match?.[1]).toBe("api/landlord/notices");
     expect(functionRoute.dest?.replace("$1", match?.[1] ?? "")).toBe(
       "/api/pr1512-notices/[...path]?path=api/landlord/notices",
     );
     expect(existsSync(join(frontendRoot, "api/pr1512-notices/[...path].ts"))).toBe(true);
+  });
+
+  it("reserves the PR #1516 read-only QA suffix before filesystem misses", () => {
+    const requestPath = "/api/pr1516-notices/api/landlord/notices/recipients";
+    const functionRoute = config.routes[0];
+    const match = new RegExp(functionRoute.src as string).exec(requestPath);
+    expect(match?.[1]).toBe("api/landlord/notices/recipients");
+    expect(functionRoute.dest?.replace("$1", match?.[1] ?? "")).toBe(
+      "/api/pr1516-notices/[...path]?path=api/landlord/notices/recipients",
+    );
+    expect(existsSync(join(frontendRoot, "api/pr1516-notices/[...path].ts"))).toBe(true);
   });
 
   it.each(["/api/properties", "/api/tenants"])(

--- a/rentchain-frontend/src/runtime/pr1516BrowserQaBootstrap.test.ts
+++ b/rentchain-frontend/src/runtime/pr1516BrowserQaBootstrap.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  PR1516_QA_SESSION_KEY,
+  activatePr1516BrowserQaSession,
+  clearPr1516BrowserQaSession,
+  getPr1516QaBuildContract,
+  isPr1516BrowserQaSessionActive,
+  isValidPr1516BootstrapResponse,
+  resolvePr1516BrowserQaUser,
+} from "./pr1516BrowserQaBootstrap";
+
+const sha = "a".repeat(40);
+const env = {
+  VITE_DEPLOY_ENV: "preview",
+  VITE_PR1516_NOTICES_QA: "true",
+  VITE_PR1516_QA_BRANCH: "feat/multi-property-notices-v1",
+  VITE_PR1516_QA_COMMIT_SHA: sha,
+  VITE_PR1516_QA_SCOPE: "pr1516-multi-property-notices",
+  VITE_PR1516_QA_SELECTOR: "pr1516-landlord",
+  VITE_API_BASE_URL: "/api/pr1516-notices",
+};
+
+describe("PR #1516 browser QA bootstrap", () => {
+  beforeEach(() => sessionStorage.clear());
+
+  it("accepts only the exact Preview build contract", () => {
+    expect(getPr1516QaBuildContract(env, "rentchain-pr1516-abc.vercel.app").valid).toBe(true);
+    for (const patch of [
+      { VITE_DEPLOY_ENV: "production" },
+      { VITE_PR1516_QA_BRANCH: "main" },
+      { VITE_PR1516_QA_COMMIT_SHA: "short" },
+      { VITE_PR1516_QA_SCOPE: "other" },
+      { VITE_PR1516_QA_SELECTOR: "other" },
+      { VITE_API_BASE_URL: "/api/preview-backend" },
+    ]) expect(getPr1516QaBuildContract({ ...env, ...patch }, "rentchain-pr1516-abc.vercel.app").valid).toBe(false);
+    expect(getPr1516QaBuildContract(env, "rentchain.ca").valid).toBe(false);
+    expect(getPr1516QaBuildContract(env, "rentchain.vercel.app").valid).toBe(false);
+  });
+
+  it("requires a matching session-only marker", () => {
+    expect(isPr1516BrowserQaSessionActive(sessionStorage, env, "qa.vercel.app")).toBe(false);
+    activatePr1516BrowserQaSession(sessionStorage, sha);
+    expect(localStorage.getItem(PR1516_QA_SESSION_KEY)).toBeNull();
+    expect(isPr1516BrowserQaSessionActive(sessionStorage, env, "qa.vercel.app")).toBe(true);
+    expect(isPr1516BrowserQaSessionActive(sessionStorage, { ...env, VITE_PR1516_QA_COMMIT_SHA: "b".repeat(40) }, "qa.vercel.app")).toBe(false);
+    clearPr1516BrowserQaSession(sessionStorage);
+    expect(isPr1516BrowserQaSessionActive(sessionStorage, env, "qa.vercel.app")).toBe(false);
+  });
+
+  it("resolves only the fixed synthetic landlord and ignores browser input", () => {
+    activatePr1516BrowserQaSession(sessionStorage, sha);
+    const user = resolvePr1516BrowserQaUser(sessionStorage, env, "qa.vercel.app");
+    expect(user).toEqual(expect.objectContaining({ id: "qa-pr1516-landlord", landlordId: "qa-pr1516-landlord", role: "landlord" }));
+    expect(resolvePr1516BrowserQaUser(sessionStorage, env, "rentchain.ca")).toBeNull();
+  });
+
+  it("rejects altered server bootstrap fields", () => {
+    const response = { ok: true as const, branch: env.VITE_PR1516_QA_BRANCH, commitSha: sha, scope: env.VITE_PR1516_QA_SCOPE, selector: env.VITE_PR1516_QA_SELECTOR, apiBase: env.VITE_API_BASE_URL, landingPath: "/notices" as const };
+    expect(isValidPr1516BootstrapResponse(response, sha)).toBe(true);
+    expect(isValidPr1516BootstrapResponse({ ...response, selector: "attacker" }, sha)).toBe(false);
+    expect(isValidPr1516BootstrapResponse({ ...response, commitSha: "b".repeat(40) }, sha)).toBe(false);
+  });
+});

--- a/rentchain-frontend/src/runtime/pr1516BrowserQaBootstrap.ts
+++ b/rentchain-frontend/src/runtime/pr1516BrowserQaBootstrap.ts
@@ -1,0 +1,101 @@
+export const PR1516_QA_BRANCH = "feat/multi-property-notices-v1";
+export const PR1516_QA_SCOPE = "pr1516-multi-property-notices";
+export const PR1516_QA_SELECTOR = "pr1516-landlord";
+export const PR1516_QA_API_BASE = "/api/pr1516-notices";
+export const PR1516_QA_BOOTSTRAP_PATH = "/api/pr1516-bootstrap";
+export const PR1516_QA_SESSION_KEY = "rentchain.pr1516.browserQaSession.v1";
+
+export const PR1516_QA_USER = {
+  id: "qa-pr1516-landlord",
+  landlordId: "qa-pr1516-landlord",
+  email: "qa-pr1516-landlord@example.invalid",
+  role: "landlord",
+  plan: "starter",
+  approved: true,
+} as const;
+
+type QaEnvironment = {
+  VITE_DEPLOY_ENV?: string;
+  VITE_PR1516_NOTICES_QA?: string;
+  VITE_PR1516_QA_BRANCH?: string;
+  VITE_PR1516_QA_COMMIT_SHA?: string;
+  VITE_PR1516_QA_SCOPE?: string;
+  VITE_PR1516_QA_SELECTOR?: string;
+  VITE_API_BASE_URL?: string;
+};
+
+export type Pr1516BootstrapResponse = {
+  ok: true;
+  branch: string;
+  commitSha: string;
+  scope: string;
+  selector: string;
+  apiBase: string;
+  landingPath: "/notices";
+};
+
+const SHA_PATTERN = /^[a-f0-9]{40}$/;
+
+export function getPr1516QaBuildContract(
+  env: QaEnvironment = import.meta.env,
+  hostname = typeof window === "undefined" ? "" : window.location.hostname
+) {
+  const commitSha = String(env.VITE_PR1516_QA_COMMIT_SHA || "").trim().toLowerCase();
+  const validHostname = hostname.endsWith(".vercel.app") && hostname !== "rentchain.vercel.app";
+  const valid =
+    validHostname &&
+    env.VITE_DEPLOY_ENV === "preview" &&
+    env.VITE_PR1516_NOTICES_QA === "true" &&
+    env.VITE_PR1516_QA_BRANCH === PR1516_QA_BRANCH &&
+    SHA_PATTERN.test(commitSha) &&
+    env.VITE_PR1516_QA_SCOPE === PR1516_QA_SCOPE &&
+    env.VITE_PR1516_QA_SELECTOR === PR1516_QA_SELECTOR &&
+    env.VITE_API_BASE_URL === PR1516_QA_API_BASE;
+  return { valid, commitSha };
+}
+
+export function isValidPr1516BootstrapResponse(value: unknown, expectedSha: string): value is Pr1516BootstrapResponse {
+  const response = value as Partial<Pr1516BootstrapResponse> | null;
+  return Boolean(
+    response?.ok === true &&
+      response.branch === PR1516_QA_BRANCH &&
+      response.commitSha === expectedSha &&
+      response.scope === PR1516_QA_SCOPE &&
+      response.selector === PR1516_QA_SELECTOR &&
+      response.apiBase === PR1516_QA_API_BASE &&
+      response.landingPath === "/notices"
+  );
+}
+
+export function activatePr1516BrowserQaSession(storage: Storage, commitSha: string): void {
+  storage.setItem(PR1516_QA_SESSION_KEY, JSON.stringify({ version: 1, commitSha }));
+}
+
+export function clearPr1516BrowserQaSession(storage: Storage = window.sessionStorage): void {
+  storage.removeItem(PR1516_QA_SESSION_KEY);
+}
+
+export function isPr1516BrowserQaSessionActive(
+  storage: Storage = window.sessionStorage,
+  env: QaEnvironment = import.meta.env,
+  hostname = typeof window === "undefined" ? "" : window.location.hostname
+): boolean {
+  const contract = getPr1516QaBuildContract(env, hostname);
+  if (!contract.valid) return false;
+  try {
+    const marker = JSON.parse(storage.getItem(PR1516_QA_SESSION_KEY) || "null");
+    return marker?.version === 1 && marker?.commitSha === contract.commitSha;
+  } catch {
+    return false;
+  }
+}
+
+export function resolvePr1516BrowserQaUser(
+  storage: Storage,
+  env: QaEnvironment,
+  hostname: string
+) {
+  return isPr1516BrowserQaSessionActive(storage, env, hostname)
+    ? { ...PR1516_QA_USER }
+    : null;
+}

--- a/rentchain-frontend/src/runtime/pr1516BrowserQaBootstrapServer.test.ts
+++ b/rentchain-frontend/src/runtime/pr1516BrowserQaBootstrapServer.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { handlePr1516BrowserQaBootstrap } from "../../server/pr1516BrowserQaBootstrap";
+
+function response() {
+  const res = { setHeader: vi.fn(), status: vi.fn(), json: vi.fn() };
+  res.status.mockReturnValue(res);
+  res.json.mockReturnValue(res);
+  return res;
+}
+
+describe("PR #1516 bootstrap server gate", () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("returns fixed configuration only for the exact Preview branch", () => {
+    vi.stubEnv("VERCEL_ENV", "preview");
+    vi.stubEnv("VERCEL_GIT_COMMIT_REF", "feat/multi-property-notices-v1");
+    vi.stubEnv("VERCEL_GIT_COMMIT_SHA", "a".repeat(40));
+    const res = response();
+    handlePr1516BrowserQaBootstrap({ method: "GET" }, res);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ selector: "pr1516-landlord", commitSha: "a".repeat(40) }));
+  });
+
+  it.each([
+    ["production", "feat/multi-property-notices-v1", "a".repeat(40)],
+    ["preview", "main", "a".repeat(40)],
+    ["preview", "feat/multi-property-notices-v1", "bad"],
+  ])("fails closed outside its runtime contract", (vercelEnv, branch, commit) => {
+    vi.stubEnv("VERCEL_ENV", vercelEnv);
+    vi.stubEnv("VERCEL_GIT_COMMIT_REF", branch);
+    vi.stubEnv("VERCEL_GIT_COMMIT_SHA", commit);
+    const res = response();
+    handlePr1516BrowserQaBootstrap({ method: "GET" }, res);
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  it("rejects mutation methods", () => {
+    const res = response();
+    handlePr1516BrowserQaBootstrap({ method: "POST" }, res);
+    expect(res.status).toHaveBeenCalledWith(405);
+  });
+});

--- a/rentchain-frontend/src/runtime/previewFetchGuard.ts
+++ b/rentchain-frontend/src/runtime/previewFetchGuard.ts
@@ -26,7 +26,9 @@ function isSameOriginPreviewProxyUrl(url: string, browserOrigin: string): boolea
   return (
     parsed.origin === browserOrigin &&
     (parsed.pathname.startsWith("/api/preview-backend/") ||
-      parsed.pathname.startsWith("/api/pr1512-notices/"))
+      parsed.pathname.startsWith("/api/pr1512-notices/") ||
+      parsed.pathname.startsWith("/api/pr1516-notices/") ||
+      parsed.pathname === "/api/pr1516-bootstrap")
   );
 }
 

--- a/rentchain-frontend/src/vite-env.d.ts
+++ b/rentchain-frontend/src/vite-env.d.ts
@@ -3,6 +3,11 @@
 interface ImportMetaEnv {
   readonly VITE_API_BASE_URL?: string;
   readonly VITE_DEPLOY_ENV?: "development" | "preview" | "production";
+  readonly VITE_PR1516_NOTICES_QA?: string;
+  readonly VITE_PR1516_QA_BRANCH?: string;
+  readonly VITE_PR1516_QA_COMMIT_SHA?: string;
+  readonly VITE_PR1516_QA_SCOPE?: string;
+  readonly VITE_PR1516_QA_SELECTOR?: string;
 }
 
 interface ImportMeta {

--- a/rentchain-frontend/tests/playwright/property-notices.spec.ts
+++ b/rentchain-frontend/tests/playwright/property-notices.spec.ts
@@ -21,9 +21,9 @@ async function installNoticesHarness(page: Page, options: { rejectRecipientPrevi
   await installLegacySmokeHarness(page, { devPreviewUnlock: true });
   await page.route("**/api/account/limits", (route) => route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true, plan: "pro", limits: {}, usage: {} }) }));
   await page.route("**/api/landlord/messages/conversations", (route) => route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ conversations: [] }) }));
-  await page.route(/\/api\/properties(?:\?|$)/, (route) => route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ properties: [{ id: "property-synthetic", name: "Harbour Synthetic Property", addressLine1: "1 QA Street", totalUnits: 2, createdAt: "2026-08-09", units: [] }] }) }));
+  await page.route(/\/api\/properties(?:\?|$)/, (route) => route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ properties: [{ id: "property-synthetic", name: "Harbour Synthetic Property", addressLine1: "1 QA Street", totalUnits: 2, createdAt: "2026-08-09", units: [] }, { id: "property-queen", name: "Queen Synthetic Court", addressLine1: "2 QA Street", totalUnits: 1, createdAt: "2026-08-09", units: [] }] }) }));
 
-  let notices: any[] = [];
+  let notices: Array<Record<string, unknown>> = [];
   await page.route("**/api/landlord/notices**", async (route) => {
     const request = route.request();
     const url = new URL(request.url());
@@ -34,23 +34,24 @@ async function installNoticesHarness(page: Page, options: { rejectRecipientPrevi
         }) }); return;
       }
       await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({
-        property: { id: "property-synthetic", label: "Harbour Synthetic Property" },
+        properties: [{ id: "property-queen", label: "Queen Synthetic Court" }, { id: "property-synthetic", label: "Harbour Synthetic Property" }],
+        propertyBreakdown: [{ id: "property-queen", label: "Queen Synthetic Court", recipientCount: 1 }, { id: "property-synthetic", label: "Harbour Synthetic Property", recipientCount: 3 }],
         recipients: [
-          { tenantId: "tenant-a", tenantDisplayName: "Synthetic Current Tenant A", unitIds: ["unit-a"], unitLabels: ["1A"], deliveryAvailability: "available" },
-          { tenantId: "tenant-b", tenantDisplayName: "Synthetic Current Tenant B", unitIds: ["unit-b"], unitLabels: ["2B"], deliveryAvailability: "available" },
-          { tenantId: "tenant-c", tenantDisplayName: "Synthetic Missing Email", unitIds: ["unit-b"], unitLabels: ["2B"], deliveryAvailability: "missing_email" },
+          { tenantId: "tenant-a", tenantDisplayName: "Synthetic Current Tenant A", unitIds: ["unit-a", "unit-c"], unitLabels: ["1A", "3C"], propertyIds: ["property-synthetic", "property-queen"], propertyLabels: ["Harbour Synthetic Property", "Queen Synthetic Court"], units: [{ id: "unit-a", label: "1A", propertyId: "property-synthetic", propertyLabel: "Harbour Synthetic Property" }, { id: "unit-c", label: "3C", propertyId: "property-queen", propertyLabel: "Queen Synthetic Court" }], deliveryAvailability: "available" },
+          { tenantId: "tenant-b", tenantDisplayName: "Synthetic Current Tenant B", unitIds: ["unit-b"], unitLabels: ["2B"], propertyIds: ["property-synthetic"], propertyLabels: ["Harbour Synthetic Property"], units: [{ id: "unit-b", label: "2B", propertyId: "property-synthetic", propertyLabel: "Harbour Synthetic Property" }], deliveryAvailability: "available" },
+          { tenantId: "tenant-c", tenantDisplayName: "Synthetic Missing Email", unitIds: ["unit-b"], unitLabels: ["2B"], propertyIds: ["property-synthetic"], propertyLabels: ["Harbour Synthetic Property"], units: [{ id: "unit-b", label: "2B", propertyId: "property-synthetic", propertyLabel: "Harbour Synthetic Property" }], deliveryAvailability: "missing_email" },
         ], counts: { total: 3, available: 2, skipped: 1 }, maxRecipients: 100,
       }) }); return;
     }
     if (url.pathname === "/api/landlord/notices" && request.method() === "POST") {
-      notices = [{ id: "notice-synthetic", propertyId: "property-synthetic", propertyLabel: "Harbour Synthetic Property", subject: "Water shutdown", body: "Water will be unavailable at noon.", status: "completed", recipientCount: 1, sentCount: 1, failedCount: 0, skippedCount: 0, createdAtMs: Date.now() }];
+      notices = [{ id: "notice-synthetic", propertyIds: ["property-queen", "property-synthetic"], properties: [{ id: "property-queen", label: "Queen Synthetic Court" }, { id: "property-synthetic", label: "Harbour Synthetic Property" }], propertyCount: 2, subject: "Water shutdown", body: "Water will be unavailable at noon.", status: "completed", recipientCount: 1, sentCount: 1, failedCount: 0, skippedCount: 0, createdAtMs: Date.now() }];
       await route.fulfill({ status: 201, contentType: "application/json", body: JSON.stringify({ ok: true, created: true, notice: notices[0] }) }); return;
     }
     if (url.pathname === "/api/landlord/notices") {
       await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true, notices }) }); return;
     }
     if (url.pathname.endsWith("/notice-synthetic")) {
-      await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true, notice: notices[0], deliveries: [{ id: "delivery-a", tenantId: "tenant-a", tenantDisplayName: "Synthetic Current Tenant A", unitIds: ["unit-a"], unitLabels: ["1A"], channel: "email", status: "sent" }] }) }); return;
+      await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true, notice: notices[0], deliveries: [{ id: "delivery-a", tenantId: "tenant-a", tenantDisplayName: "Synthetic Current Tenant A", unitIds: ["unit-a", "unit-c"], unitLabels: ["1A", "3C"], propertyIds: ["property-synthetic", "property-queen"], propertyLabels: ["Harbour Synthetic Property", "Queen Synthetic Court"], units: [{ id: "unit-a", label: "1A", propertyId: "property-synthetic", propertyLabel: "Harbour Synthetic Property" }, { id: "unit-c", label: "3C", propertyId: "property-queen", propertyLabel: "Queen Synthetic Court" }], channel: "email", status: "sent" }] }) }); return;
     }
     await route.fulfill({ status: 404, contentType: "application/json", body: JSON.stringify({ ok: false }) });
   });
@@ -61,7 +62,7 @@ test("handles fail-closed recipient preview rejection without sending", async ({
   const errors = await installNoticesHarness(page, { rejectRecipientPreview: true });
   await page.goto("/notices");
   await page.getByRole("button", { name: "New Notice" }).click();
-  await page.getByLabel("Property").selectOption("property-synthetic");
+  await page.getByLabel("Harbour Synthetic Property").check();
   await page.getByRole("button", { name: "Resolve current recipients" }).click();
   await expect(page.getByRole("alert")).toHaveText("Eligible recipients could not be resolved.");
   await expect(page.getByRole("button", { name: "Preview Notice" })).toHaveCount(0);
@@ -72,7 +73,10 @@ test("handles fail-closed recipient preview rejection without sending", async ({
 
 for (const viewport of [
   { name: "desktop", width: 1440, height: 900 },
-  { name: "tablet", width: 768, height: 1024 },
+  { name: "desktop-1366", width: 1366, height: 900 },
+  { name: "desktop-1280", width: 1280, height: 900 },
+  { name: "desktop-1180", width: 1180, height: 900 },
+  { name: "tablet", width: 820, height: 1180 },
   { name: "mobile", width: 390, height: 844 },
 ]) {
   test(`${viewport.name} completes the synthetic private Notices flow`, async ({ page }) => {
@@ -81,20 +85,25 @@ for (const viewport of [
     await page.goto("/notices");
     await expect(page.getByRole("heading", { name: "Notices" })).toBeVisible();
     await page.getByRole("button", { name: "New Notice" }).click();
-    await page.getByLabel("Property").selectOption("property-synthetic");
+    await page.getByLabel("Harbour Synthetic Property").check();
+    await page.getByLabel("Queen Synthetic Court").check();
+    await expect(page.getByText(/2 selected/)).toBeVisible();
     await page.getByRole("button", { name: "Resolve current recipients" }).click();
     await expect(page.getByText(/Synthetic Current Tenant A/)).toBeVisible();
     await expect(page.getByText(/Former Tenant/)).toHaveCount(0);
-    await page.getByRole("checkbox", { name: "1A", exact: true }).check();
+    await expect(page.getByText(/2 properties · 3 eligible occupants · 2 deliverable · 1 skipped/)).toBeVisible();
+    await page.getByRole("checkbox", { name: "Harbour Synthetic Property — 1A", exact: true }).check();
     await expect(page.getByText(/Preview recipients \(1\)/)).toBeVisible();
     await page.getByLabel("Subject").fill("Water shutdown");
     await page.getByLabel("Message").fill("Water will be unavailable at noon.");
     await page.getByRole("button", { name: "Preview Notice" }).click();
     const confirmation = page.getByRole("dialog", { name: "Confirm notice" });
+    await expect(confirmation.getByText(/2 selected properties/)).toBeVisible();
     await expect(confirmation.getByText(/separate private delivery/)).toBeVisible();
     await confirmation.getByRole("button", { name: "Send Notice" }).click();
     await expect(page.getByText("Water shutdown")).toBeVisible();
     await page.getByText("Water shutdown").click();
+    await expect(page.getByRole("list", { name: "Selected properties" })).toContainText("Queen Synthetic Court");
     await expect(page.getByText(/Synthetic Current Tenant A.*sent/)).toBeVisible();
     expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(await page.evaluate(() => document.documentElement.clientWidth + 1));
     expect(errors.consoleErrors).toEqual([]);

--- a/rentchain-frontend/vercel.json
+++ b/rentchain-frontend/vercel.json
@@ -83,6 +83,10 @@
   ],
   "routes": [
     {
+      "src": "^/api/pr1516-notices/(.*)$",
+      "dest": "/api/pr1516-notices/[...path]?path=$1"
+    },
+    {
       "src": "^/api/pr1512-notices/(.*)$",
       "dest": "/api/pr1512-notices/[...path]?path=$1"
     },


### PR DESCRIPTION
## Summary

- add canonical `propertyIds` support with single-property request compatibility
- validate every selected property server-side and fail closed on mixed invalid ownership or filters
- aggregate current lease recipients across properties, dedupe by canonical tenant ID, and preserve property-aware unit context
- retain the 100-recipient fail-closed cap and add a 25-property request cap without new datastore indexes
- snapshot selected properties on campaigns and property context on deliveries/history/detail
- canonicalize properties, filters, subject, and body in idempotent campaign identity while preserving concurrent single-winner delivery creation
- preserve one-recipient email calls and `Operational Notice: {Notice Subject}` with newline/header-injection rejection
- add a responsive multi-property selector, portfolio summary, grouped units, and multi-property history/detail presentation

## Validation

- backend Notices: 37 passed
- frontend Notices: 6 passed
- full frontend: 348 files / 1,699 tests passed (with configured non-Production API base)
- backend build: passed
- frontend production build: passed
- scoped backend/frontend ESLint: passed
- synthetic Playwright: 7 passed across 1440, 1366, 1280, 1180, 820x1180, and 390x844; no real provider send
- package-manager governance: passed
- Preview image governance: 36/36
- Production deployment governance: 32 boundaries
- release-control governance: 20/20
- credential scan and `git diff --check`: passed

## Full backend baseline

The full backend run completed with 3,178 passing tests and 29 unrelated failures. The failures are outside the six-file PR diff and are dominated by current-date-expired invitation/trust fixtures plus existing analytics and Firestore test-isolation cases. The focused Notices suite is green.

## Safety / infrastructure

- fake/mock provider only; no real Notice sent
- no Production deployment or traffic mutation
- no data mutation outside test doubles
- no new Firestore index, IAM, Terraform, secret, or Cloud Run configuration required
- live backend QA is intentionally deferred to a separately governed isolated QA mission
