### PR TITLE
Add temporary PR #1516 Preview Invoker

### DIFF
--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -418,3 +418,16 @@ check "b7_vercel_preview_proxy_identity_boundary" {
     error_message = "Run Invoker must remain service-scoped to the private Preview backend and dedicated Vercel proxy identity."
   }
 }
+
+check "pr1516_vercel_preview_proxy_invoker_boundary" {
+  assert {
+    condition = (
+      google_cloud_run_v2_service_iam_member.pr1516_vercel_proxy_invoker.project == "rentchain-preview" &&
+      google_cloud_run_v2_service_iam_member.pr1516_vercel_proxy_invoker.location == "northamerica-northeast1" &&
+      basename(google_cloud_run_v2_service_iam_member.pr1516_vercel_proxy_invoker.name) == "rentchain-pr1516-notices-qa-a2695c6c" &&
+      google_cloud_run_v2_service_iam_member.pr1516_vercel_proxy_invoker.role == "roles/run.invoker" &&
+      google_cloud_run_v2_service_iam_member.pr1516_vercel_proxy_invoker.member == "serviceAccount:vercel-preview-proxy@rentchain-preview.iam.gserviceaccount.com"
+    )
+    error_message = "PR #1516 Vercel Invoker must remain service-scoped to the exact isolated Notices QA service and existing proxy identity."
+  }
+}

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -82,12 +82,13 @@ if rg -n 'allUsers|allAuthenticatedUsers|google_storage_bucket|google_firestore_
 fi
 
 vercel_identity_file="$root_dir/vercel_preview_identity.tf"
-test "$(rg -No '^resource "' "$vercel_identity_file" | wc -l | tr -d ' ')" = "6"
+test "$(rg -No '^resource "' "$vercel_identity_file" | wc -l | tr -d ' ')" = "7"
 test "$(rg -No '^resource "google_iam_workload_identity_pool" "vercel_preview_proxy"' "$vercel_identity_file" | wc -l | tr -d ' ')" = "1"
 test "$(rg -No '^resource "google_iam_workload_identity_pool_provider" "vercel_preview"' "$vercel_identity_file" | wc -l | tr -d ' ')" = "1"
 test "$(rg -No '^resource "google_service_account" "vercel_preview_proxy"' "$vercel_identity_file" | wc -l | tr -d ' ')" = "1"
 test "$(rg -No '^resource "google_service_account_iam_member" "vercel_preview_proxy_(workload_identity_user|openid_token_creator)"' "$vercel_identity_file" | wc -l | tr -d ' ')" = "2"
 test "$(rg -No '^resource "google_cloud_run_v2_service_iam_member" "vercel_preview_proxy_invoker"' "$vercel_identity_file" | wc -l | tr -d ' ')" = "1"
+test "$(rg -No '^resource "google_cloud_run_v2_service_iam_member" "pr1516_vercel_proxy_invoker"' "$vercel_identity_file" | wc -l | tr -d ' ')" = "1"
 
 rg -q 'workload_identity_pool_id = "vercel-preview-proxy"' "$vercel_identity_file"
 rg -q 'workload_identity_pool_provider_id = "vercel-preview"' "$vercel_identity_file"
@@ -95,6 +96,13 @@ rg -q 'vercel_preview_issuer[[:space:]]*=[[:space:]]*"https://oidc\.vercel\.com/
 test "$(rg -No 'allowed_audiences' "$vercel_identity_file" | wc -l | tr -d ' ')" = "0"
 test "$(rg -No 'google_service_account_iam_member\.vercel_preview_proxy_(workload_identity_user|openid_token_creator)\.service_account_id' "$root_dir/checks.tf" | wc -l | tr -d ' ')" = "0"
 rg -U -q 'basename\(\n        google_cloud_run_v2_service_iam_member\.vercel_preview_proxy_invoker\.name\n      \) == "rentchain-preview-backend"' "$root_dir/checks.tf"
+rg -q 'name     = "rentchain-pr1516-notices-qa-a2695c6c"' "$vercel_identity_file"
+rg -q 'google_cloud_run_v2_service_iam_member\.pr1516_vercel_proxy_invoker\.project == "rentchain-preview"' "$root_dir/checks.tf"
+rg -q 'google_cloud_run_v2_service_iam_member\.pr1516_vercel_proxy_invoker\.location == "northamerica-northeast1"' "$root_dir/checks.tf"
+rg -q 'basename\(google_cloud_run_v2_service_iam_member\.pr1516_vercel_proxy_invoker\.name\) == "rentchain-pr1516-notices-qa-a2695c6c"' "$root_dir/checks.tf"
+rg -q 'google_cloud_run_v2_service_iam_member\.pr1516_vercel_proxy_invoker\.role == "roles/run.invoker"' "$root_dir/checks.tf"
+rg -q 'google_cloud_run_v2_service_iam_member\.pr1516_vercel_proxy_invoker\.member == "serviceAccount:vercel-preview-proxy@rentchain-preview.iam.gserviceaccount.com"' "$root_dir/checks.tf"
+test "$(rg -No 'role     = "roles/run\.invoker"' "$vercel_identity_file" | wc -l | tr -d ' ')" = "2"
 grep -Fq 'length(google_iam_workload_identity_pool_provider.vercel_preview.attribute_mapping) == 4' "$root_dir/checks.tf"
 grep -Fq 'attribute_mapping["google.subject"] == "assertion.sub"' "$root_dir/checks.tf"
 grep -Fq 'attribute_mapping["attribute.owner_id"] == "assertion.owner_id"' "$root_dir/checks.tf"

--- a/infra/environments/preview-foundation/vercel_preview_identity.tf
+++ b/infra/environments/preview-foundation/vercel_preview_identity.tf
@@ -92,3 +92,13 @@ resource "google_cloud_run_v2_service_iam_member" "vercel_preview_proxy_invoker"
   role     = "roles/run.invoker"
   member   = google_service_account.vercel_preview_proxy.member
 }
+
+# Temporary service-level access for PR #1516 isolated multi-property Notices
+# browser QA. Remove through Terraform/HCP after the PR QA/release lifecycle.
+resource "google_cloud_run_v2_service_iam_member" "pr1516_vercel_proxy_invoker" {
+  project  = var.project_id
+  location = local.preview_deployment_region
+  name     = "rentchain-pr1516-notices-qa-a2695c6c"
+  role     = "roles/run.invoker"
+  member   = google_service_account.vercel_preview_proxy.member
+}


### PR DESCRIPTION
## Summary

Temporary QA infrastructure only for PR #1516 multi-property Notices browser verification.

- Adds one additive, service-level `roles/run.invoker` member.
- Target service: `rentchain-pr1516-notices-qa-a2695c6c` in `rentchain-preview` / `northamerica-northeast1`.
- Member: `serviceAccount:vercel-preview-proxy@rentchain-preview.iam.gserviceaccount.com`.
- Preserves the existing permanent Preview binding and WIF/OIDC identity foundation.
- Adds exact Terraform boundary checks and scope-test assertions.

## Safety boundaries

- No project-level IAM.
- No Production resource or IAM change.
- No permanent Preview service or IAM mutation.
- No service account, key, WIF provider, secret, Cloud Run deployment, or Firestore change.
- No local Terraform apply.

## Validation

- `terraform fmt -check -recursive`
- `terraform init -backend=false`
- `terraform validate`
- `bash tests/validate_scope.sh`
- `git diff --check main...HEAD`

## Cleanup obligation

After PR #1516 final QA/release, remove this temporary service-level Invoker through a separate Terraform/HCP cleanup PR, then remove the isolated QA service and only its exact synthetic fixtures through separately authorized cleanup.