### PR TITLE
Remove temporary PR #1516 Preview Invoker

### DIFF
--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -418,16 +418,3 @@ check "b7_vercel_preview_proxy_identity_boundary" {
     error_message = "Run Invoker must remain service-scoped to the private Preview backend and dedicated Vercel proxy identity."
   }
 }
-
-check "pr1516_vercel_preview_proxy_invoker_boundary" {
-  assert {
-    condition = (
-      google_cloud_run_v2_service_iam_member.pr1516_vercel_proxy_invoker.project == "rentchain-preview" &&
-      google_cloud_run_v2_service_iam_member.pr1516_vercel_proxy_invoker.location == "northamerica-northeast1" &&
-      basename(google_cloud_run_v2_service_iam_member.pr1516_vercel_proxy_invoker.name) == "rentchain-pr1516-notices-qa-a2695c6c" &&
-      google_cloud_run_v2_service_iam_member.pr1516_vercel_proxy_invoker.role == "roles/run.invoker" &&
-      google_cloud_run_v2_service_iam_member.pr1516_vercel_proxy_invoker.member == "serviceAccount:vercel-preview-proxy@rentchain-preview.iam.gserviceaccount.com"
-    )
-    error_message = "PR #1516 Vercel Invoker must remain service-scoped to the exact isolated Notices QA service and existing proxy identity."
-  }
-}

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -35,7 +35,7 @@ EOF
 actual_resources="$(rg -No 'resource "[^"]+"' "$root_dir" --glob '*.tf' | sed -E 's/.*resource "([^"]+)"/\1/' | sort -u)"
 test "$actual_resources" = "$expected_resources"
 
-test "$(rg -No '^resource "[^"]+"' "$root_dir" --glob '*.tf' | wc -l | tr -d ' ')" = "43"
+test "$(rg -No '^resource "[^"]+"' "$root_dir" --glob '*.tf' | wc -l | tr -d ' ')" = "42"
 
 test "$(rg -No 'service\s*=\s*"[^"]+\.googleapis\.com"' "$root_dir/services.tf" | wc -l | tr -d ' ')" = "0"
 test "$(rg -No '"(apikeys|artifactregistry|cloudresourcemanager|firestore|iam|identitytoolkit|run|secretmanager|serviceusage)\.googleapis\.com"' "$root_dir/services.tf" | sort -u | wc -l | tr -d ' ')" = "9"
@@ -82,13 +82,12 @@ if rg -n 'allUsers|allAuthenticatedUsers|google_storage_bucket|google_firestore_
 fi
 
 vercel_identity_file="$root_dir/vercel_preview_identity.tf"
-test "$(rg -No '^resource "' "$vercel_identity_file" | wc -l | tr -d ' ')" = "7"
+test "$(rg -No '^resource "' "$vercel_identity_file" | wc -l | tr -d ' ')" = "6"
 test "$(rg -No '^resource "google_iam_workload_identity_pool" "vercel_preview_proxy"' "$vercel_identity_file" | wc -l | tr -d ' ')" = "1"
 test "$(rg -No '^resource "google_iam_workload_identity_pool_provider" "vercel_preview"' "$vercel_identity_file" | wc -l | tr -d ' ')" = "1"
 test "$(rg -No '^resource "google_service_account" "vercel_preview_proxy"' "$vercel_identity_file" | wc -l | tr -d ' ')" = "1"
 test "$(rg -No '^resource "google_service_account_iam_member" "vercel_preview_proxy_(workload_identity_user|openid_token_creator)"' "$vercel_identity_file" | wc -l | tr -d ' ')" = "2"
 test "$(rg -No '^resource "google_cloud_run_v2_service_iam_member" "vercel_preview_proxy_invoker"' "$vercel_identity_file" | wc -l | tr -d ' ')" = "1"
-test "$(rg -No '^resource "google_cloud_run_v2_service_iam_member" "pr1516_vercel_proxy_invoker"' "$vercel_identity_file" | wc -l | tr -d ' ')" = "1"
 
 rg -q 'workload_identity_pool_id = "vercel-preview-proxy"' "$vercel_identity_file"
 rg -q 'workload_identity_pool_provider_id = "vercel-preview"' "$vercel_identity_file"
@@ -96,13 +95,7 @@ rg -q 'vercel_preview_issuer[[:space:]]*=[[:space:]]*"https://oidc\.vercel\.com/
 test "$(rg -No 'allowed_audiences' "$vercel_identity_file" | wc -l | tr -d ' ')" = "0"
 test "$(rg -No 'google_service_account_iam_member\.vercel_preview_proxy_(workload_identity_user|openid_token_creator)\.service_account_id' "$root_dir/checks.tf" | wc -l | tr -d ' ')" = "0"
 rg -U -q 'basename\(\n        google_cloud_run_v2_service_iam_member\.vercel_preview_proxy_invoker\.name\n      \) == "rentchain-preview-backend"' "$root_dir/checks.tf"
-rg -q 'name     = "rentchain-pr1516-notices-qa-a2695c6c"' "$vercel_identity_file"
-rg -q 'google_cloud_run_v2_service_iam_member\.pr1516_vercel_proxy_invoker\.project == "rentchain-preview"' "$root_dir/checks.tf"
-rg -q 'google_cloud_run_v2_service_iam_member\.pr1516_vercel_proxy_invoker\.location == "northamerica-northeast1"' "$root_dir/checks.tf"
-rg -q 'basename\(google_cloud_run_v2_service_iam_member\.pr1516_vercel_proxy_invoker\.name\) == "rentchain-pr1516-notices-qa-a2695c6c"' "$root_dir/checks.tf"
-rg -q 'google_cloud_run_v2_service_iam_member\.pr1516_vercel_proxy_invoker\.role == "roles/run.invoker"' "$root_dir/checks.tf"
-rg -q 'google_cloud_run_v2_service_iam_member\.pr1516_vercel_proxy_invoker\.member == "serviceAccount:vercel-preview-proxy@rentchain-preview.iam.gserviceaccount.com"' "$root_dir/checks.tf"
-test "$(rg -No 'role     = "roles/run\.invoker"' "$vercel_identity_file" | wc -l | tr -d ' ')" = "2"
+test "$(rg -No 'role     = "roles/run\.invoker"' "$vercel_identity_file" | wc -l | tr -d ' ')" = "1"
 grep -Fq 'length(google_iam_workload_identity_pool_provider.vercel_preview.attribute_mapping) == 4' "$root_dir/checks.tf"
 grep -Fq 'attribute_mapping["google.subject"] == "assertion.sub"' "$root_dir/checks.tf"
 grep -Fq 'attribute_mapping["attribute.owner_id"] == "assertion.owner_id"' "$root_dir/checks.tf"

--- a/infra/environments/preview-foundation/vercel_preview_identity.tf
+++ b/infra/environments/preview-foundation/vercel_preview_identity.tf
@@ -92,13 +92,3 @@ resource "google_cloud_run_v2_service_iam_member" "vercel_preview_proxy_invoker"
   role     = "roles/run.invoker"
   member   = google_service_account.vercel_preview_proxy.member
 }
-
-# Temporary service-level access for PR #1516 isolated multi-property Notices
-# browser QA. Remove through Terraform/HCP after the PR QA/release lifecycle.
-resource "google_cloud_run_v2_service_iam_member" "pr1516_vercel_proxy_invoker" {
-  project  = var.project_id
-  location = local.preview_deployment_region
-  name     = "rentchain-pr1516-notices-qa-a2695c6c"
-  role     = "roles/run.invoker"
-  member   = google_service_account.vercel_preview_proxy.member
-}


### PR DESCRIPTION
## Summary
- remove the temporary service-level PR #1516 Cloud Run Invoker resource
- remove only its dedicated Terraform check and scope-test assertions
- preserve permanent Preview WIF, proxy identity, and backend Invoker resources

## Validation
- terraform fmt -check -recursive
- terraform init -backend=false
- terraform validate
- preview foundation validate_scope.sh
- git diff --check

## Expected HCP plan
- 0 add
- 0 change
- 1 destroy: google_cloud_run_v2_service_iam_member.pr1516_vercel_proxy_invoker

No local apply, Cloud Run deletion, fixture deletion, Production mutation, or application cleanup is included.