### PR TITLE
Remove duplicate Communications routes from Workspace navigation

### DIFF
--- a/rentchain-frontend/src/components/layout/LandlordNav.tsx
+++ b/rentchain-frontend/src/components/layout/LandlordNav.tsx
@@ -7,6 +7,7 @@ import { fetchLandlordConversations } from "../../api/messagesApi";
 import {
   COMMUNICATIONS_GROUP_ID,
   getVisibleNavItems,
+  getWorkspaceNavItems,
   isNavItemActive,
   resolveNavItem,
   type NavItem,
@@ -113,7 +114,7 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
     });
   }
   const visibleItems = navLoading || !isLandlordWorkspace ? [] : getVisibleNavItems(effectiveRole, features);
-  const workspaceVisibleItems = visibleItems.filter((item) => item.showInWorkspace !== false);
+  const workspaceVisibleItems = getWorkspaceNavItems(visibleItems);
   const drawerItems = workspaceVisibleItems.filter((item) => item.showInDrawer !== false);
   const standardWorkspaceItems = workspaceVisibleItems.filter((item) => stickyWorkspaceIds.has(item.id));
   const communicationsItems = visibleItems.filter((item) => item.groupId === COMMUNICATIONS_GROUP_ID);

--- a/rentchain-frontend/src/components/layout/WorkspaceDrawer.test.tsx
+++ b/rentchain-frontend/src/components/layout/WorkspaceDrawer.test.tsx
@@ -60,46 +60,19 @@ describe("WorkspaceDrawer", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it("shows direct Messages navigation to landlords and keeps it landlord-only", () => {
-    const onClose = vi.fn();
-    const { rerender } = render(
+  it("keeps Communications-owned destinations out of the Workspace drawer", () => {
+    render(
       <MemoryRouter initialEntries={["/dashboard"]}>
-        <WorkspaceDrawer open onClose={onClose} userRole="landlord" />
-        <CurrentPath />
+        <WorkspaceDrawer open onClose={vi.fn()} userRole="landlord" />
       </MemoryRouter>
     );
 
-    fireEvent.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Messages" }));
-    expect(screen.getByTestId("current-path")).toHaveTextContent("/messages");
-    expect(onClose).toHaveBeenCalledTimes(1);
-
-    rerender(
-      <MemoryRouter initialEntries={["/dashboard"]}>
-        <WorkspaceDrawer open onClose={vi.fn()} userRole="admin" />
-      </MemoryRouter>
-    );
-    expect(screen.queryByRole("button", { name: "Messages" })).not.toBeInTheDocument();
-  });
-
-  it("shows property Notices beside Messages for landlords and keeps it landlord-only", () => {
-    const onClose = vi.fn();
-    const { rerender } = render(
-      <MemoryRouter initialEntries={["/dashboard"]}>
-        <WorkspaceDrawer open onClose={onClose} userRole="landlord" />
-        <CurrentPath />
-      </MemoryRouter>
-    );
-
-    fireEvent.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Notices" }));
-    expect(screen.getByTestId("current-path")).toHaveTextContent("/notices");
-    expect(onClose).toHaveBeenCalledTimes(1);
-
-    rerender(
-      <MemoryRouter initialEntries={["/dashboard"]}>
-        <WorkspaceDrawer open onClose={vi.fn()} userRole="admin" />
-      </MemoryRouter>
-    );
-    expect(screen.queryByRole("button", { name: "Notices" })).not.toBeInTheDocument();
+    const drawer = within(screen.getByRole("dialog", { name: "Workspace navigation" }));
+    expect(drawer.queryByRole("button", { name: "Unified Inbox" })).not.toBeInTheDocument();
+    expect(drawer.queryByRole("button", { name: "Messages" })).not.toBeInTheDocument();
+    expect(drawer.queryByRole("button", { name: "Notices" })).not.toBeInTheDocument();
+    expect(drawer.getByRole("button", { name: "Dashboard" })).toBeInTheDocument();
+    expect(drawer.getByRole("button", { name: "Payments" })).toBeInTheDocument();
   });
 
   it("shows governed review workspace navigation only for admins", () => {

--- a/rentchain-frontend/src/components/layout/WorkspaceDrawer.tsx
+++ b/rentchain-frontend/src/components/layout/WorkspaceDrawer.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from "react";
 import { createPortal } from "react-dom";
 import { useLocation, useNavigate } from "react-router-dom";
 import { radius, spacing } from "../../styles/tokens";
-import { getVisibleNavItems } from "./navConfig";
+import { getVisibleNavItems, getWorkspaceNavItems } from "./navConfig";
 import { useCapabilities } from "@/hooks/useCapabilities";
 import { useIsMobile } from "@/hooks/useIsMobile";
 
@@ -43,7 +43,7 @@ export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({
   const isMobile = useIsMobile(WORKSPACE_DRAWER_MOBILE_QUERY);
   const navLoading = !userRole || capsLoading;
   const visibleItems = navLoading ? [] : getVisibleNavItems(userRole, features);
-  const drawerItems = visibleItems.filter((item) => item.showInDrawer !== false);
+  const drawerItems = getWorkspaceNavItems(visibleItems).filter((item) => item.showInDrawer !== false);
   const primaryDrawerItems = drawerItems.filter((item) => !item.requiresAdmin);
   const orderedPrimaryDrawerItems = [...primaryDrawerItems].sort((a, b) => {
     if (a.id === "account") return -1;

--- a/rentchain-frontend/src/components/layout/navConfig.ts
+++ b/rentchain-frontend/src/components/layout/navConfig.ts
@@ -54,6 +54,9 @@ export const getVisibleNavItems = (role?: string | null, features?: Record<strin
   });
 };
 
+export const getWorkspaceNavItems = (items: NavItem[]): NavItem[] =>
+  items.filter((item) => item.showInWorkspace !== false);
+
 export const NAV_ITEMS: NavItem[] = [
   {
     id: "dashboard",


### PR DESCRIPTION
## Summary

- apply the existing Workspace ownership flag consistently to the account-triggered Workspace drawer
- keep Unified Inbox, Messages, and Notices owned exclusively by the Communications menu
- preserve direct routes, route-specific titles, the legacy `/landlord/inbox` redirect, and unrelated Workspace destinations

## Root cause

PR #1514 marked the three routes with `showInWorkspace: false`, and `LandlordNav` honored it. The separate `WorkspaceDrawer` used by the top-nav account control filtered only `showInDrawer`, so it continued rendering the duplicate links at desktop, tablet, and mobile widths.

## Validation

- focused navigation/routes/pages: 141 tests passed
- full frontend: passed
- frontend build: passed
- responsive Communications Playwright: 32 tests passed
- `git diff --check`: passed
- changed-diff credential scan: clean

Full-repository lint retains its existing baseline. Scoped lint reports only pre-existing `LandlordNav.tsx` findings; the new helper, Workspace drawer implementation, and updated drawer test add no lint findings.

## Scope

Frontend navigation only. Bottom navigation and `/properties` layout are intentionally unchanged; C and D remain separate. No backend, Production, Cloud Run, IAM, Terraform, Secret Manager, Firestore, provider, or email behavior changes.