### PR TITLE
Widen Properties layout on mobile

### DIFF
--- a/rentchain-frontend/src/pages/PropertiesPage.css
+++ b/rentchain-frontend/src/pages/PropertiesPage.css
@@ -465,6 +465,25 @@
   }
 }
 
+@media (max-width: 480px) {
+  .rc-properties-page {
+    width: calc(100% + 28px);
+    max-width: calc(100% + 28px);
+    margin-inline: -14px;
+    padding: 10px;
+  }
+
+  .rc-properties-page .rc-properties-detail-card {
+    padding: 0;
+    border: 0 !important;
+    box-shadow: none !important;
+  }
+
+  .rc-properties-page .rc-property-detail-stack {
+    padding: 0;
+  }
+}
+
 @media (max-width: 380px) {
   .rc-units-edit-mobile-grid,
   .rc-modal-footer .rc-wrap-row {

--- a/rentchain-frontend/src/pages/PropertiesPage.responsiveStyles.test.ts
+++ b/rentchain-frontend/src/pages/PropertiesPage.responsiveStyles.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const propertiesPageCss = readFileSync(resolve("src/pages/PropertiesPage.css"), "utf8");
+const propertiesMobileCss = readFileSync(resolve("src/styles/propertiesMobile.css"), "utf8");
+
+describe("Properties mobile layout contract", () => {
+  it("recovers the nested shell gutter only on phones and keeps the page bounded", () => {
+    expect(propertiesPageCss).toContain("@media (max-width: 480px)");
+    expect(propertiesPageCss).toContain("width: calc(100% + 28px)");
+    expect(propertiesPageCss).toContain("margin-inline: -14px");
+    expect(propertiesPageCss).toContain("padding: 10px");
+  });
+
+  it("removes redundant mobile detail insets without changing the desktop card rule", () => {
+    expect(propertiesPageCss).toContain(".rc-properties-page .rc-properties-detail-card");
+    expect(propertiesPageCss).toContain("padding: 0");
+    expect(propertiesPageCss).toContain(".rc-properties-page .rc-property-detail-stack");
+    expect(propertiesPageCss).toContain("width: min(100%, 1180px)");
+  });
+
+  it("gives Unit and Status stable readable columns instead of shrinking flex items", () => {
+    expect(propertiesMobileCss).toContain(
+      "grid-template-columns: minmax(88px, 0.7fr) minmax(0, 1.3fr)"
+    );
+    expect(propertiesMobileCss).toContain(".rc-unit-card-row > *");
+    expect(propertiesMobileCss).toContain("white-space: nowrap");
+    expect(propertiesMobileCss).toContain("overflow-wrap: break-word");
+  });
+
+  it("retains mobile unit action sizing and the existing tablet table breakpoint", () => {
+    expect(propertiesMobileCss).toContain(".rc-unit-actions button");
+    expect(propertiesMobileCss).toContain("width: 100%");
+    expect(propertiesMobileCss).toContain("@media (min-width: 481px) and (max-width: 768px)");
+  });
+});

--- a/rentchain-frontend/src/styles/propertiesMobile.css
+++ b/rentchain-frontend/src/styles/propertiesMobile.css
@@ -437,9 +437,14 @@
   }
 
   .rc-unit-card-row {
-    display: flex;
-    justify-content: space-between;
-    gap: 8px;
+    display: grid;
+    grid-template-columns: minmax(88px, 0.7fr) minmax(0, 1.3fr);
+    align-items: start;
+    gap: 10px 16px;
+  }
+
+  .rc-unit-card-row > * {
+    min-width: 0;
   }
 
   .rc-unit-card-specs {
@@ -451,12 +456,14 @@
   .rc-unit-label {
     font-size: 12px;
     color: #0f172a;
+    white-space: nowrap;
   }
 
   .rc-unit-value {
     font-size: 14px;
     font-weight: 600;
     color: #0f172a;
+    overflow-wrap: break-word;
   }
 
   .rc-unit-actions {

--- a/rentchain-frontend/tests/playwright/properties-mobile-width.spec.ts
+++ b/rentchain-frontend/tests/playwright/properties-mobile-width.spec.ts
@@ -1,0 +1,141 @@
+import { expect, test, type Page } from "@playwright/test";
+import { installLegacySmokeHarness } from "./legacy-smoke-setup";
+
+test.use({ serviceWorkers: "block" });
+
+const viewports = [
+  { width: 390, height: 844 },
+  { width: 393, height: 852 },
+  { width: 414, height: 896 },
+  { width: 430, height: 932 },
+  { width: 768, height: 1024 },
+  { width: 820, height: 1180 },
+  { width: 1024, height: 768 },
+  { width: 1180, height: 900 },
+  { width: 1280, height: 900 },
+  { width: 1366, height: 900 },
+  { width: 1440, height: 900 },
+];
+
+async function installPropertiesHarness(page: Page) {
+  await installLegacySmokeHarness(page, { devPreviewUnlock: true });
+
+  await page.route("**/api/properties**", async (route) => {
+    const url = new URL(route.request().url());
+    const units = [
+      {
+        id: "unit-101",
+        propertyId: "property-mobile",
+        unitNumber: "101",
+        beds: 2,
+        baths: 1,
+        sqft: 850,
+        marketRent: 1850,
+        status: "occupied",
+        occupantName: "Synthetic Mobile Tenant",
+        leaseEndDate: "2027-05-31",
+      },
+    ];
+
+    if (url.pathname === "/api/properties/property-mobile/units") {
+      await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ units }) });
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        items: [
+          {
+            id: "property-mobile",
+            name: "Harbour Mobile House",
+            addressLine1: "101 Waterfront Drive",
+            city: "Halifax",
+            province: "NS",
+            postalCode: "B3H 1A1",
+            totalUnits: 1,
+            unitCount: 1,
+            occupiedCount: 1,
+            occupancyRate: 1,
+            portfolioStatus: "active",
+            createdAt: "2026-01-01T00:00:00.000Z",
+            units,
+          },
+        ],
+      }),
+    });
+  });
+}
+
+for (const viewport of viewports) {
+  test(`keeps Properties cards readable without overflow at ${viewport.width}x${viewport.height}`, async ({ page }) => {
+    const runtimeErrors: string[] = [];
+    page.on("pageerror", (error) => runtimeErrors.push(`pageerror: ${error.message}`));
+    page.on("requestfailed", (request) =>
+      runtimeErrors.push(`requestfailed: ${request.url()} ${request.failure()?.errorText || "unknown"}`)
+    );
+    await page.setViewportSize(viewport);
+    await installPropertiesHarness(page);
+    const response = await page.goto("/properties", { waitUntil: "domcontentloaded" });
+
+    const propertiesPage = page.locator(".rc-properties-page");
+    await expect(
+      propertiesPage,
+      `status=${response?.status() || 0}; url=${page.url()}; runtime=${runtimeErrors.join(" | ") || "none"}`
+    ).toBeVisible();
+    const unitCard = page.locator(".rc-unit-card").first();
+    if (viewport.width <= 430) {
+      await expect(unitCard.getByText("Unit #")).toBeVisible();
+      await expect(unitCard.getByText("101", { exact: true })).toBeVisible();
+      await expect(unitCard.getByText("Status", { exact: true })).toBeVisible();
+    } else {
+      await expect(page.locator(".rc-units-table")).toBeVisible();
+      await expect(page.locator(".rc-units-table").getByText("101", { exact: true })).toBeVisible();
+    }
+
+    const geometry = await page.evaluate(() => {
+      const root = document.documentElement;
+      const pageElement = document.querySelector<HTMLElement>(".rc-properties-page");
+      const card = document.querySelector<HTMLElement>(".rc-unit-card");
+      const row = document.querySelector<HTMLElement>(".rc-unit-card-row");
+      const lastAction = document.querySelector<HTMLElement>(".rc-unit-actions button:last-of-type");
+      const pageRect = pageElement?.getBoundingClientRect();
+      const cardRect = card?.getBoundingClientRect();
+      const rowStyle = row ? getComputedStyle(row) : null;
+      return {
+        viewportWidth: innerWidth,
+        documentScrollWidth: root.scrollWidth,
+        pageLeft: pageRect?.left ?? -1,
+        pageRight: pageRect?.right ?? -1,
+        pageWidth: pageRect?.width ?? 0,
+        cardLeft: cardRect?.left ?? -1,
+        cardRight: cardRect?.right ?? -1,
+        cardWidth: cardRect?.width ?? 0,
+        rowDisplay: rowStyle?.display ?? "",
+        rowColumns: rowStyle?.gridTemplateColumns ?? "",
+        lastActionBottom: lastAction?.getBoundingClientRect().bottom ?? 0,
+        documentHeight: root.scrollHeight,
+      };
+    });
+
+    test.info().annotations.push({ type: "geometry", description: JSON.stringify(geometry) });
+    expect(geometry.documentScrollWidth).toBeLessThanOrEqual(viewport.width + 1);
+    expect(geometry.pageLeft).toBeGreaterThanOrEqual(0);
+    expect(geometry.pageRight).toBeLessThanOrEqual(viewport.width + 1);
+    expect(geometry.cardLeft).toBeGreaterThanOrEqual(0);
+    expect(geometry.cardRight).toBeLessThanOrEqual(viewport.width + 1);
+
+    if (viewport.width <= 430) {
+      expect(geometry.pageWidth).toBeGreaterThanOrEqual(viewport.width - 34);
+      expect(geometry.cardWidth).toBeGreaterThanOrEqual(viewport.width - 80);
+      expect(geometry.rowDisplay).toBe("grid");
+      expect(geometry.rowColumns).not.toBe("none");
+      await expect(unitCard.getByRole("button", { name: "Edit" })).toBeVisible();
+      await expect(unitCard.getByRole("button", { name: /Send application for unit 101/i })).toBeVisible();
+    }
+
+    await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight));
+    expect(geometry.lastActionBottom).toBeLessThanOrEqual(geometry.documentHeight + 1);
+  });
+}


### PR DESCRIPTION
## Summary

- fixes the Founder-observed narrow mobile layout on `/properties`
- recovers the redundant nested phone gutter so property and unit cards use the available viewport with a safe margin
- changes the mobile Unit # / Status row to stable grid columns to prevent awkward wrapping
- preserves existing tablet and desktop table behavior

## Root cause

The phone layout accumulated horizontal padding across the landlord shell, MacShell, page container, detail card, detail stack, and unit card. The Unit # / Status metadata row also used unconstrained `space-between` flex sizing, which compressed and wrapped its contents.

## Validation

- focused Properties tests: 38 passed
- full frontend suite: 349 files / 1705 tests passed
- production build passed
- scoped lint passed
- responsive Playwright: 11/11 viewports passed from 390px mobile through 1440px desktop
- Founder exact-head visual QA: PASS
- `git diff --check` passed

## Scope boundaries

- frontend-only `/properties` layout and directly related tests
- backend unchanged
- Production, IAM, Terraform, and deployment configuration unchanged
- D — Communications bottom navigation: not started
- E — Communications notification clarity: not started
- F — Tenant maintenance attachments: not started

## QA status

Founder visual QA passed against exact head `52efd114d32afd1e9e42ddee4c7f2420ad993fc9` at https://rentchain-git-polish-properties-mobile-width-v1-rent-chain.vercel.app/properties. Exact-head Vercel provenance and substantive checks are green. Ready for review; do not merge without separate Founder authorization.