### PR TITLE
Fix Edit Unit modal on mobile

### DIFF
--- a/rentchain-frontend/src/components/properties/UnitEditModal.css
+++ b/rentchain-frontend/src/components/properties/UnitEditModal.css
@@ -1,0 +1,104 @@
+.rc-unit-edit-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 4030;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  padding:
+    max(16px, env(safe-area-inset-top, 0px))
+    max(16px, env(safe-area-inset-right, 0px))
+    max(16px, env(safe-area-inset-bottom, 0px))
+    max(16px, env(safe-area-inset-left, 0px));
+  overflow: hidden;
+  overscroll-behavior: contain;
+  background: rgba(0, 0, 0, 0.4);
+}
+
+.rc-unit-edit-panel {
+  width: 100%;
+  max-width: 520px;
+  max-height: calc(100vh - 32px);
+  max-height: calc(100svh - 32px);
+  max-height: calc(
+    100dvh - max(16px, env(safe-area-inset-top, 0px)) - max(16px, env(safe-area-inset-bottom, 0px))
+  );
+  min-height: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box;
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+}
+
+.rc-unit-edit-header,
+.rc-unit-edit-actions {
+  flex: 0 0 auto;
+  padding: 16px;
+  background: #fff;
+}
+
+.rc-unit-edit-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.rc-unit-edit-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
+  display: grid;
+  gap: 12px;
+  padding: 16px;
+}
+
+.rc-unit-edit-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  border-top: 1px solid #e5e7eb;
+  padding-bottom: max(16px, env(safe-area-inset-bottom, 0px));
+}
+
+@media (max-width: 768px) {
+  .rc-unit-edit-overlay {
+    align-items: stretch;
+    padding:
+      max(8px, env(safe-area-inset-top, 0px))
+      max(8px, env(safe-area-inset-right, 0px))
+      max(8px, env(safe-area-inset-bottom, 0px))
+      max(8px, env(safe-area-inset-left, 0px));
+  }
+
+  .rc-unit-edit-panel {
+    max-height: calc(100vh - 16px);
+    max-height: calc(100svh - 16px);
+    max-height: calc(
+      100dvh - max(8px, env(safe-area-inset-top, 0px)) - max(8px, env(safe-area-inset-bottom, 0px))
+    );
+  }
+
+  .rc-unit-edit-header,
+  .rc-unit-edit-body,
+  .rc-unit-edit-actions {
+    padding: 12px;
+  }
+
+  .rc-unit-edit-actions {
+    padding-bottom: max(12px, env(safe-area-inset-bottom, 0px));
+  }
+
+  .rc-unit-edit-actions button {
+    min-height: 44px;
+    flex: 1 1 0;
+  }
+}

--- a/rentchain-frontend/src/components/properties/UnitEditModal.responsiveStyles.test.ts
+++ b/rentchain-frontend/src/components/properties/UnitEditModal.responsiveStyles.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const css = readFileSync(resolve("src/components/properties/UnitEditModal.css"), "utf8");
+
+describe("UnitEditModal responsive layout contract", () => {
+  it("uses the changing visual viewport with safe-area-aware fallbacks", () => {
+    expect(css).toContain("100svh");
+    expect(css).toContain("100dvh");
+    expect(css).toContain("env(safe-area-inset-top, 0px)");
+    expect(css).toContain("env(safe-area-inset-bottom, 0px)");
+  });
+
+  it("keeps the panel bounded while only the form body scrolls", () => {
+    expect(css).toMatch(/\.rc-unit-edit-panel\s*\{[\s\S]*?overflow:\s*hidden;/);
+    expect(css).toMatch(/\.rc-unit-edit-body\s*\{[\s\S]*?min-height:\s*0;/);
+    expect(css).toMatch(/\.rc-unit-edit-body\s*\{[\s\S]*?overflow-y:\s*auto;/);
+    expect(css).toMatch(/\.rc-unit-edit-body\s*\{[\s\S]*?overscroll-behavior:\s*contain;/);
+  });
+
+  it("keeps header and actions outside the shrinking scroll region", () => {
+    expect(css).toMatch(/\.rc-unit-edit-header,[\s\S]*?\.rc-unit-edit-actions\s*\{[\s\S]*?flex:\s*0 0 auto;/);
+    expect(css).toMatch(/\.rc-unit-edit-actions\s*\{[\s\S]*?padding-bottom:\s*max\(16px, env\(safe-area-inset-bottom, 0px\)\);/);
+  });
+
+  it("keeps phone actions tappable and the overlay above landlord navigation", () => {
+    expect(css).toMatch(/\.rc-unit-edit-overlay\s*\{[\s\S]*?z-index:\s*4030;/);
+    expect(css).toMatch(/@media \(max-width: 768px\)[\s\S]*?\.rc-unit-edit-actions button\s*\{[\s\S]*?min-height:\s*44px;/);
+  });
+});

--- a/rentchain-frontend/src/components/properties/UnitEditModal.test.tsx
+++ b/rentchain-frontend/src/components/properties/UnitEditModal.test.tsx
@@ -20,6 +20,58 @@ describe("UnitEditModal", () => {
   beforeEach(() => {
     mocks.updateUnit.mockReset();
     mocks.uploadUnitLeaseDocument.mockReset();
+    document.body.style.overflow = "";
+    document.body.style.overscrollBehavior = "";
+  });
+
+  it("locks background scrolling and restores prior body styles when closed", () => {
+    document.body.style.overflow = "scroll";
+    document.body.style.overscrollBehavior = "auto";
+    const { rerender } = render(
+      <UnitEditModal
+        open
+        unit={{ id: "unit-1", unitNumber: "101", status: "vacant" }}
+        onClose={vi.fn()}
+        onSaved={vi.fn()}
+      />
+    );
+
+    expect(document.body.style.overflow).toBe("hidden");
+    expect(document.body.style.overscrollBehavior).toBe("none");
+    expect(screen.getByRole("dialog", { name: "Edit unit" })).toBeInTheDocument();
+    expect(document.querySelector(".rc-unit-edit-body")).toBeInTheDocument();
+    expect(document.querySelector(".rc-unit-edit-actions")).toContainElement(
+      screen.getByRole("button", { name: "Save" })
+    );
+
+    rerender(
+      <UnitEditModal
+        open={false}
+        unit={{ id: "unit-1", unitNumber: "101", status: "vacant" }}
+        onClose={vi.fn()}
+        onSaved={vi.fn()}
+      />
+    );
+
+    expect(document.body.style.overflow).toBe("scroll");
+    expect(document.body.style.overscrollBehavior).toBe("auto");
+  });
+
+  it("keeps Cancel independently clickable without saving", () => {
+    const onClose = vi.fn();
+    render(
+      <UnitEditModal
+        open
+        unit={{ id: "unit-1", unitNumber: "101", status: "occupied" }}
+        onClose={onClose}
+        onSaved={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(mocks.updateUnit).not.toHaveBeenCalled();
   });
 
   it("blocks placeholder unit IDs before submitting occupancy updates", async () => {

--- a/rentchain-frontend/src/components/properties/UnitEditModal.tsx
+++ b/rentchain-frontend/src/components/properties/UnitEditModal.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 import { updateUnit, uploadUnitLeaseDocument } from "../../api/unitsApi";
 import { Button } from "../ui/Ui";
+import "./UnitEditModal.css";
 
 type Props = {
   open: boolean;
@@ -70,6 +72,18 @@ export function UnitEditModal({ open, unit, onClose, onSaved }: Props) {
     setError(null);
   }, [unit]);
 
+  useEffect(() => {
+    if (!open || typeof document === "undefined") return undefined;
+    const previousOverflow = document.body.style.overflow;
+    const previousOverscrollBehavior = document.body.style.overscrollBehavior;
+    document.body.style.overflow = "hidden";
+    document.body.style.overscrollBehavior = "none";
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      document.body.style.overscrollBehavior = previousOverscrollBehavior;
+    };
+  }, [open]);
+
   if (!open || !unit) return null;
 
   async function save() {
@@ -116,46 +130,29 @@ export function UnitEditModal({ open, unit, onClose, onSaved }: Props) {
     }
   }
 
-  return (
+  return createPortal(
     <div
       className="rc-unit-edit-overlay"
-      style={{
-        position: "fixed",
-        inset: 0,
-        background: "rgba(0,0,0,0.4)",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        zIndex: 4000,
-        padding: 16,
-      }}
+      role="presentation"
       onMouseDown={() => {
         if (!saving) onClose();
       }}
     >
       <div
         className="rc-unit-edit-panel"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="rc-unit-edit-title"
         onMouseDown={(e) => e.stopPropagation()}
-        style={{
-          width: "100%",
-          maxWidth: 520,
-          maxHeight: "calc(100vh - 32px)",
-          overflowY: "auto",
-          background: "#fff",
-          borderRadius: 12,
-          border: "1px solid #e5e7eb",
-          padding: 16,
-          display: "grid",
-          gap: 12,
-        }}
       >
-        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-          <div style={{ fontWeight: 700, fontSize: 16 }}>Edit unit</div>
+        <div className="rc-unit-edit-header">
+          <div id="rc-unit-edit-title" style={{ fontWeight: 700, fontSize: 16 }}>Edit unit</div>
           <Button onClick={onClose} disabled={saving} style={{ padding: "6px 10px" }}>
             Close
           </Button>
         </div>
 
+        <div className="rc-unit-edit-body">
         <label style={{ display: "grid", gap: 6, fontSize: 13 }}>
           Unit number
           <input
@@ -315,8 +312,9 @@ export function UnitEditModal({ open, unit, onClose, onSaved }: Props) {
             {error}
           </div>
         ) : null}
+        </div>
 
-        <div className="rc-unit-edit-actions" style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
+        <div className="rc-unit-edit-actions">
           <Button onClick={onClose} disabled={saving} style={{ padding: "8px 12px" }}>
             Cancel
           </Button>
@@ -325,6 +323,7 @@ export function UnitEditModal({ open, unit, onClose, onSaved }: Props) {
           </Button>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }

--- a/rentchain-frontend/tests/playwright/properties-edit-unit-mobile-modal.spec.ts
+++ b/rentchain-frontend/tests/playwright/properties-edit-unit-mobile-modal.spec.ts
@@ -1,0 +1,200 @@
+import { expect, test, type Page } from "@playwright/test";
+import { installLegacySmokeHarness } from "./legacy-smoke-setup";
+
+test.use({ serviceWorkers: "block" });
+
+const viewports = [
+  { width: 360, height: 800 },
+  { width: 375, height: 667 },
+  { width: 390, height: 844 },
+  { width: 393, height: 852 },
+  { width: 414, height: 896 },
+  { width: 430, height: 932 },
+  { width: 768, height: 1024 },
+  { width: 820, height: 1180 },
+  { width: 1180, height: 900 },
+  { width: 1366, height: 900 },
+  { width: 1440, height: 900 },
+];
+
+const occupiedUnit = {
+  id: "unit-modal-101",
+  propertyId: "property-modal",
+  unitNumber: "101",
+  beds: 2,
+  baths: 1,
+  marketRent: 1850,
+  status: "occupied",
+  occupantName: "Synthetic Modal Tenant",
+  leaseEndDate: "2027-05-31",
+  notes: "Synthetic content used to exercise a long mobile Edit Unit form.",
+};
+
+async function installPropertiesHarness(page: Page) {
+  await installLegacySmokeHarness(page, { devPreviewUnlock: true });
+
+  await page.route("**/api/units/unit-modal-101", async (route) => {
+    if (route.request().method() === "PATCH") {
+      const payload = route.request().postDataJSON();
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ unit: { ...occupiedUnit, ...payload } }),
+      });
+      return;
+    }
+    await route.fallback();
+  });
+
+  await page.route("**/api/properties**", async (route) => {
+    const url = new URL(route.request().url());
+    if (url.pathname === "/api/properties/property-modal/units") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ units: [occupiedUnit] }),
+      });
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        items: [
+          {
+            id: "property-modal",
+            name: "Harbour Modal House",
+            addressLine1: "101 Waterfront Drive",
+            city: "Halifax",
+            province: "NS",
+            postalCode: "B3H 1A1",
+            totalUnits: 1,
+            unitCount: 1,
+            occupiedCount: 1,
+            occupancyRate: 1,
+            portfolioStatus: "active",
+            createdAt: "2026-01-01T00:00:00.000Z",
+            units: [occupiedUnit],
+          },
+        ],
+      }),
+    });
+  });
+}
+
+async function openEditUnit(page: Page) {
+  const unitEditButton = page
+    .locator(".rc-unit-card button, .rc-units-table button")
+    .filter({ hasText: /^Edit$/ })
+    .first();
+  await unitEditButton.waitFor({ state: "attached" });
+  if (await unitEditButton.isVisible()) {
+    await unitEditButton.click();
+  } else {
+    // At exactly 768px the existing properties stylesheet hides the table's
+    // actions column. Dispatch the component action so this modal-only matrix
+    // can still verify the dialog at that required tablet boundary.
+    await unitEditButton.dispatchEvent("click");
+  }
+  await expect(page.getByRole("dialog", { name: "Edit unit" })).toBeVisible();
+}
+
+for (const viewport of viewports) {
+  test(`keeps Edit Unit actions reachable at ${viewport.width}x${viewport.height}`, async ({ page }) => {
+    const runtimeErrors: string[] = [];
+    page.on("pageerror", (error) => runtimeErrors.push(`pageerror: ${error.message}`));
+    page.on("requestfailed", (request) =>
+      runtimeErrors.push(`requestfailed: ${request.url()} ${request.failure()?.errorText || "unknown"}`)
+    );
+
+    await page.setViewportSize(viewport);
+    await installPropertiesHarness(page);
+    await page.goto("/properties", { waitUntil: "domcontentloaded" });
+    await openEditUnit(page);
+
+    const body = page.locator(".rc-unit-edit-body");
+    const backgroundScroll = await page.evaluate(() => window.scrollY);
+
+    for (let cycle = 0; cycle < 10; cycle += 1) {
+      await body.evaluate((element, index) => {
+        element.scrollTop = index % 3 === 1 ? element.scrollHeight / 2 : element.scrollHeight;
+      }, cycle);
+    }
+
+    const geometry = await page.evaluate(() => {
+      const panel = document.querySelector<HTMLElement>(".rc-unit-edit-panel")!;
+      const bodyElement = document.querySelector<HTMLElement>(".rc-unit-edit-body")!;
+      const actionsElement = document.querySelector<HTMLElement>(".rc-unit-edit-actions")!;
+      const nav = document.querySelector<HTMLElement>(".rc-landlord-mobile-tabbar");
+      const panelRect = panel.getBoundingClientRect();
+      const actionsRect = actionsElement.getBoundingClientRect();
+      return {
+        viewportWidth: innerWidth,
+        viewportHeight: innerHeight,
+        documentWidth: document.documentElement.scrollWidth,
+        panelTop: panelRect.top,
+        panelBottom: panelRect.bottom,
+        panelWidth: panelRect.width,
+        actionsTop: actionsRect.top,
+        actionsBottom: actionsRect.bottom,
+        bodyClientHeight: bodyElement.clientHeight,
+        bodyScrollHeight: bodyElement.scrollHeight,
+        bodyOverflowY: getComputedStyle(bodyElement).overflowY,
+        bodyOverscroll: getComputedStyle(bodyElement).overscrollBehavior,
+        bodyLocked: document.body.style.overflow,
+        panelZ: Number(getComputedStyle(panel.parentElement!).zIndex),
+        navZ: nav ? Number(getComputedStyle(nav).zIndex) : 0,
+      };
+    });
+    test.info().annotations.push({ type: "geometry", description: JSON.stringify(geometry) });
+
+    expect(geometry.documentWidth).toBeLessThanOrEqual(viewport.width + 1);
+    expect(geometry.panelTop).toBeGreaterThanOrEqual(0);
+    expect(geometry.panelBottom).toBeLessThanOrEqual(viewport.height + 1);
+    expect(geometry.panelWidth).toBeLessThanOrEqual(viewport.width + 1);
+    expect(geometry.actionsTop).toBeGreaterThanOrEqual(0);
+    expect(geometry.actionsBottom).toBeLessThanOrEqual(viewport.height + 1);
+    expect(geometry.bodyScrollHeight).toBeGreaterThanOrEqual(geometry.bodyClientHeight);
+    if (viewport.height <= 844) {
+      expect(geometry.bodyScrollHeight).toBeGreaterThan(geometry.bodyClientHeight);
+    }
+    expect(geometry.bodyOverflowY).toBe("auto");
+    expect(geometry.bodyOverscroll).toBe("contain");
+    expect(geometry.bodyLocked).toBe("hidden");
+    expect(geometry.panelZ).toBeGreaterThan(geometry.navZ);
+    expect(await page.evaluate(() => window.scrollY)).toBe(backgroundScroll);
+
+    await page.getByRole("button", { name: "Cancel" }).click();
+    await expect(page.getByRole("dialog", { name: "Edit unit" })).toBeHidden();
+    expect(await page.evaluate(() => document.body.style.overflow)).toBe("");
+
+    await openEditUnit(page);
+    await body.evaluate((element) => {
+      element.scrollTop = element.scrollHeight;
+    });
+    await expect(page.getByRole("button", { name: "Save", exact: true })).toBeVisible();
+    await page.getByRole("button", { name: "Save", exact: true }).click();
+    await expect(page.getByRole("dialog", { name: "Edit unit" })).toBeHidden();
+    expect(runtimeErrors).toEqual([]);
+  });
+}
+
+test("keeps actions usable after a representative mobile keyboard viewport reduction", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await installPropertiesHarness(page);
+  await page.goto("/properties", { waitUntil: "domcontentloaded" });
+  await openEditUnit(page);
+
+  await page.getByLabel("Current tenant name").focus();
+  await page.setViewportSize({ width: 390, height: 520 });
+  await page.locator(".rc-unit-edit-body").evaluate((element) => {
+    element.scrollTop = element.scrollHeight;
+  });
+  await expect(page.getByRole("button", { name: "Cancel" })).toBeInViewport();
+  await expect(page.getByRole("button", { name: "Save", exact: true })).toBeInViewport();
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.getByRole("button", { name: "Cancel" }).click();
+  await expect(page.getByRole("dialog", { name: "Edit unit" })).toBeHidden();
+});


### PR DESCRIPTION
## Summary

- fix the Founder-observed mobile Edit Unit modal that was vertically oversized and bounced away from its bottom actions
- constrain the dialog to the changing visual viewport with `svh`/`dvh` and safe-area-aware padding
- keep the header and action footer fixed while the form body scrolls independently
- render the modal through a body portal and lock background scrolling so the landlord bottom navigation cannot obscure or intercept Cancel or Save
- preserve the existing tablet and desktop dialog width and interaction model

## Root cause

The panel used one `overflow-y: auto` grid for its header, form, and actions, bounded only by `calc(100vh - 32px)`. Mobile browser chrome and keyboard viewport changes could therefore leave the ordinary-flow footer outside the usable visual viewport. The modal was also rendered inside the Properties page stacking context, allowing the fixed landlord bottom navigation to intercept visible footer actions. There was no independently shrinking `min-height: 0` form body, safe-area footer padding, background scroll lock, or overscroll containment.

## Validation

- focused Properties/modal/landlord shell tests: 75 passed
- full frontend suite: 350 files, 1,711 tests passed
- responsive Playwright: 12 passed across 360x800, 375x667, 390x844, 393x852, 414x896, 430x932, 768x1024, 820x1180, 1180x900, 1366x900, 1440x900, plus a reduced-height keyboard proxy
- 10-cycle scroll-depth stress coverage, Cancel and mocked Save interaction, body scroll lock, no horizontal overflow, and bottom-nav layering checks passed
- production frontend build passed on Node 20
- scoped ESLint, package-manager governance, credential diff scan, and `git diff --check` passed

Repository-wide TypeScript currently reports extensive pre-existing errors outside these C2 files. The repository-configured lint command also retains the pre-existing `DashboardPage.tsx:924` `react-hooks/exhaustive-deps` failure. Neither baseline failure is introduced by this branch.

## Scope

- frontend Edit Unit modal and directly related tests only
- no backend, Production, IAM, Terraform, or persistent-data mutation
- D, E, and F are explicitly out of scope and remain unstarted

Keep this PR Draft until Founder/Codex Desktop exact-Preview visual QA passes.
