### PR TITLE
Add Communications to mobile bottom navigation

### DIFF
--- a/rentchain-frontend/src/components/layout/LandlordNav.css
+++ b/rentchain-frontend/src/components/layout/LandlordNav.css
@@ -430,7 +430,7 @@
   background: var(--rc-landlord-panel);
   box-shadow: 0 -10px 28px rgba(59, 44, 28, 0.12);
   padding: 8px 10px calc(8px + env(safe-area-inset-bottom, 0px));
-  grid-template-columns: repeat(6, 1fr);
+  grid-template-columns: repeat(5, minmax(0, 1fr));
   z-index: var(--rc-landlord-z-nav);
   box-sizing: border-box;
   max-width: 100%;
@@ -612,7 +612,7 @@
 
   .rc-landlord-mobile-tabbar {
     display: grid;
-    grid-template-columns: repeat(6, minmax(0, 1fr));
+    grid-template-columns: repeat(5, minmax(0, 1fr));
     z-index: var(--rc-landlord-z-nav);
     width: 100%;
     max-width: 100%;

--- a/rentchain-frontend/src/components/layout/LandlordNav.css
+++ b/rentchain-frontend/src/components/layout/LandlordNav.css
@@ -395,6 +395,18 @@
   padding: 8px 4px;
 }
 
+.rc-landlord-communications-drawer-links button {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-height: 52px;
+}
+
+.rc-landlord-communications-drawer-links button svg {
+  flex: 0 0 auto;
+  color: var(--rc-landlord-pine);
+}
+
 .rc-landlord-drawer-group {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));

--- a/rentchain-frontend/src/components/layout/LandlordNav.test.tsx
+++ b/rentchain-frontend/src/components/layout/LandlordNav.test.tsx
@@ -277,25 +277,33 @@ describe("LandlordNav mobile drawer", () => {
     expect(screen.getByTestId("current-path")).toHaveTextContent("/payments");
   });
 
-  it("uses the free-tier landlord mobile app tabs in setup order", () => {
+  it("uses the five-slot landlord mobile IA with Communications primary and Operations in More", () => {
     renderLandlordNav();
 
     const tabbar = screen.getByRole("navigation", { name: "Bottom navigation" });
     expect(within(tabbar).getByText("Dashboard")).toBeInTheDocument();
     expect(within(tabbar).getByText("Properties")).toBeInTheDocument();
     expect(within(tabbar).getByText("Applicants")).toBeInTheDocument();
-    expect(within(tabbar).getByText("Operations")).toBeInTheDocument();
+    expect(within(tabbar).getByText("Communications")).toBeInTheDocument();
     expect(within(tabbar).getByText("More")).toBeInTheDocument();
     expect(within(tabbar).getAllByRole("button").map((button) => button.textContent)).toEqual([
       "Dashboard",
       "Properties",
       "Applicants",
-      "Operations",
+      "Communications",
       "More",
     ]);
     expect(within(tabbar).queryByText("Tenants")).not.toBeInTheDocument();
     expect(within(tabbar).queryByText("Leases")).not.toBeInTheDocument();
     expect(within(tabbar).queryByText("Messages")).not.toBeInTheDocument();
+    expect(within(tabbar).queryByText("Operations")).not.toBeInTheDocument();
+
+    fireEvent.click(within(tabbar).getByRole("button", { name: "Open workspace pages" }));
+    expect(
+      within(screen.getByRole("dialog", { name: "Navigation menu" })).getByRole("button", {
+        name: "Operations",
+      })
+    ).toBeInTheDocument();
   });
 
   it("keeps the shared nav tab configuration aligned with the landlord mobile app tabs", async () => {
@@ -337,25 +345,35 @@ describe("LandlordNav mobile drawer", () => {
     fireEvent.click(within(tabbar).getByRole("button", { name: "Applicants" }));
     expect(screen.getByTestId("current-path")).toHaveTextContent("/applications");
 
-    fireEvent.click(within(tabbar).getByRole("button", { name: "Operations" }));
-    expect(screen.getByTestId("current-path")).toHaveTextContent("/operations");
+    fireEvent.click(within(tabbar).getByRole("button", { name: "Communications" }));
+    expect(screen.getByTestId("current-path")).toHaveTextContent("/landlord/unified-inbox");
   });
 
-  it("marks the Operations tab active on the operations route", () => {
+  it("keeps Operations reachable and active from More", () => {
     renderLandlordNav("/operations");
 
     const tabbar = screen.getByRole("navigation", { name: "Bottom navigation" });
-    expect(within(tabbar).getByRole("button", { name: "Operations" })).toHaveClass("active");
+    expect(within(tabbar).queryByRole("button", { name: "Operations" })).not.toBeInTheDocument();
+    fireEvent.click(within(tabbar).getByRole("button", { name: "Open workspace pages" }));
+    expect(
+      within(screen.getByRole("dialog", { name: "Navigation menu" })).getByRole("button", {
+        name: "Operations",
+      })
+    ).toHaveClass("active");
   });
 
-  it("keeps communication destinations out of the mobile tab bar", () => {
-    renderLandlordNav("/landlord/unified-inbox");
+  it.each(["/landlord/unified-inbox", "/landlord/inbox", "/messages", "/notices"])(
+    "marks Communications active while keeping child routes out of the mobile tab bar at %s",
+    (path) => {
+      renderLandlordNav(path);
 
-    const tabbar = screen.getByRole("navigation", { name: "Bottom navigation" });
-    expect(within(tabbar).queryByRole("button", { name: "Unified Inbox" })).not.toBeInTheDocument();
-    expect(within(tabbar).queryByRole("button", { name: "Messages" })).not.toBeInTheDocument();
-    expect(within(tabbar).queryByRole("button", { name: "Notices" })).not.toBeInTheDocument();
-  });
+      const tabbar = screen.getByRole("navigation", { name: "Bottom navigation" });
+      expect(within(tabbar).getByRole("button", { name: "Communications" })).toHaveClass("active");
+      expect(within(tabbar).queryByRole("button", { name: "Unified Inbox" })).not.toBeInTheDocument();
+      expect(within(tabbar).queryByRole("button", { name: "Messages" })).not.toBeInTheDocument();
+      expect(within(tabbar).queryByRole("button", { name: "Notices" })).not.toBeInTheDocument();
+    }
+  );
 
   it.each([
     ["/landlord/unified-inbox", "Unified Inbox"],
@@ -366,7 +384,11 @@ describe("LandlordNav mobile drawer", () => {
 
     const context = screen.getByLabelText("Workspace context");
     const workspaceNav = screen.getByRole("navigation", { name: "Workspace navigation" });
-    fireEvent.click(screen.getByRole("button", { name: "Communications" }));
+    fireEvent.click(
+      within(document.querySelector(".rc-landlord-mobile-topbar") as HTMLElement).getByRole("button", {
+        name: "Communications",
+      })
+    );
     const communications = screen.getByRole("menu", { name: "Communications destinations" });
     const activeChild = within(communications).getByRole("menuitem", { name: label });
 
@@ -393,7 +415,11 @@ describe("LandlordNav mobile drawer", () => {
     renderLandlordNav(path);
 
     const context = screen.getByLabelText("Workspace context");
-    fireEvent.click(screen.getByRole("button", { name: "Communications" }));
+    fireEvent.click(
+      within(document.querySelector(".rc-landlord-mobile-topbar") as HTMLElement).getByRole("button", {
+        name: "Communications",
+      })
+    );
     const communications = screen.getByRole("menu", { name: "Communications destinations" });
 
     expect(within(communications).getAllByRole("menuitem").map((link) => link.textContent?.replace("✓", ""))).toEqual([

--- a/rentchain-frontend/src/components/layout/LandlordNav.test.tsx
+++ b/rentchain-frontend/src/components/layout/LandlordNav.test.tsx
@@ -335,7 +335,7 @@ describe("LandlordNav mobile drawer", () => {
     expect(within(drawer).queryByRole("button", { name: "Notices" })).not.toBeInTheDocument();
   });
 
-  it("navigates landlord mobile tabs to canonical routes", () => {
+  it("navigates direct landlord tabs while Communications opens its drawer without changing route", () => {
     renderLandlordNav();
 
     const tabbar = screen.getByRole("navigation", { name: "Bottom navigation" });
@@ -346,7 +346,69 @@ describe("LandlordNav mobile drawer", () => {
     expect(screen.getByTestId("current-path")).toHaveTextContent("/applications");
 
     fireEvent.click(within(tabbar).getByRole("button", { name: "Communications" }));
-    expect(screen.getByTestId("current-path")).toHaveTextContent("/landlord/unified-inbox");
+    expect(screen.getByTestId("current-path")).toHaveTextContent("/applications");
+    const communicationsDrawer = screen.getByRole("dialog", { name: "Communications navigation" });
+    expect(within(communicationsDrawer).getAllByRole("button").map((button) => button.textContent)).toEqual([
+      "Close",
+      "Unified Inbox",
+      "Messages",
+      "Notices",
+    ]);
+  });
+
+  it.each([
+    ["Unified Inbox", "/landlord/unified-inbox"],
+    ["Messages", "/messages"],
+    ["Notices", "/notices"],
+  ])("navigates to %s from the Communications drawer and closes it", async (label, path) => {
+    renderLandlordNav("/dashboard");
+
+    const tabbar = screen.getByRole("navigation", { name: "Bottom navigation" });
+    fireEvent.click(within(tabbar).getByRole("button", { name: "Communications" }));
+    fireEvent.click(
+      within(screen.getByRole("dialog", { name: "Communications navigation" })).getByRole("button", { name: label })
+    );
+
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "Communications navigation" })).not.toBeInTheDocument());
+    expect(screen.getByTestId("current-path")).toHaveTextContent(path);
+    expect(within(tabbar).getByRole("button", { name: "Communications" })).toHaveClass("active");
+  });
+
+  it("reopens Communications from child routes and never redirects until a destination is selected", () => {
+    renderLandlordNav("/messages");
+
+    const communications = within(screen.getByRole("navigation", { name: "Bottom navigation" })).getByRole("button", {
+      name: "Communications",
+    });
+    fireEvent.click(communications);
+    expect(screen.getByTestId("current-path")).toHaveTextContent("/messages");
+    expect(
+      within(screen.getByRole("dialog", { name: "Communications navigation" })).getByRole("button", { name: "Messages" })
+    ).toHaveAttribute("aria-current", "page");
+    fireEvent.click(within(screen.getByRole("dialog", { name: "Communications navigation" })).getByRole("button", { name: "Notices" }));
+    expect(screen.getByTestId("current-path")).toHaveTextContent("/notices");
+
+    fireEvent.click(communications);
+    expect(screen.getByTestId("current-path")).toHaveTextContent("/notices");
+    expect(screen.getByRole("dialog", { name: "Communications navigation" })).toBeInTheDocument();
+  });
+
+  it("dismisses the Communications drawer by backdrop and Escape while restoring trigger focus", async () => {
+    renderLandlordNav("/messages");
+
+    const communications = within(screen.getByRole("navigation", { name: "Bottom navigation" })).getByRole("button", {
+      name: "Communications",
+    });
+    fireEvent.click(communications);
+    fireEvent.click(document.querySelector(".rc-landlord-backdrop") as HTMLElement);
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "Communications navigation" })).not.toBeInTheDocument());
+    expect(communications).toHaveFocus();
+
+    fireEvent.click(communications);
+    fireEvent.keyDown(document, { key: "Escape" });
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "Communications navigation" })).not.toBeInTheDocument());
+    expect(communications).toHaveFocus();
+    expect(screen.getByTestId("current-path")).toHaveTextContent("/messages");
   });
 
   it("keeps Operations reachable and active from More", () => {

--- a/rentchain-frontend/src/components/layout/LandlordNav.tsx
+++ b/rentchain-frontend/src/components/layout/LandlordNav.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
-import { Building2, ClipboardList, LayoutDashboard, Menu, ScrollText, X } from "lucide-react";
+import { Building2, LayoutDashboard, Menu, MessagesSquare, ScrollText, X } from "lucide-react";
 import { Link, Navigate, useLocation, useNavigate } from "react-router-dom";
 import TopNav from "./TopNav";
 import { useAuth } from "../../context/useAuth";
@@ -28,7 +28,6 @@ const landlordMobileTabs = [
   { to: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
   { to: "/properties", label: "Properties", icon: Building2 },
   { to: "/applications", label: "Applicants", icon: ScrollText },
-  { to: "/operations", label: "Operations", icon: ClipboardList },
 ];
 
 const stickyWorkspaceIds = new Set([
@@ -129,9 +128,19 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
       }),
     [primaryDrawerItems]
   );
+  const communicationsTab = (() => {
+    const landing = communicationsItems.find((item) => item.id === "unified-inbox");
+    if (!landing) return null;
+    return {
+      to: landing.to,
+      label: "Communications",
+      icon: MessagesSquare,
+      matchPaths: communicationsItems.flatMap((item) => [item.to, ...(item.matchPaths || [])]),
+    };
+  })();
   const tabItems =
     effectiveRole === "landlord" && !isAdminLikeContext
-      ? landlordMobileTabs.filter((item) => !item.requiresMessaging || features?.messaging !== false)
+      ? [...landlordMobileTabs, ...(communicationsTab ? [communicationsTab] : [])]
       : [];
   const showMobileBottomNav = effectiveRole === "landlord" && !isAdminLikeContext;
   const workspaceLabel = resolveWorkspaceLabel(loc.pathname, visibleItems);
@@ -384,9 +393,10 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
 
       {showMobileBottomNav ? (
         <nav className="rc-landlord-mobile-tabbar" aria-label="Bottom navigation">
-          {(navLoading ? [] : tabItems).map(({ to, label, icon: Icon }) => {
+          {(navLoading ? [] : tabItems).map((item) => {
+            const { to, label, icon: Icon } = item;
             if (!Icon) return null;
-            const active = loc.pathname === to || loc.pathname.startsWith(`${to}/`);
+            const active = isNavItemActive(loc.pathname, item);
             return (
               <button
                 key={to}
@@ -398,7 +408,7 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
                 <Icon size={20} strokeWidth={2.2} />
                 <span className="rc-landlord-mobile-tabbar-label">
                   {label}
-                  {label === "Messages" && unreadFlag ? (
+                  {label === "Communications" && unreadFlag ? (
                     <span className="rc-landlord-mobile-tabbar-dot" />
                   ) : null}
                 </span>

--- a/rentchain-frontend/src/components/layout/LandlordNav.tsx
+++ b/rentchain-frontend/src/components/layout/LandlordNav.tsx
@@ -24,6 +24,8 @@ type Props = {
   unreadMessages?: boolean;
 };
 
+type DrawerMode = "workspace" | "communications" | null;
+
 const landlordMobileTabs = [
   { to: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
   { to: "/properties", label: "Properties", icon: Building2 },
@@ -91,9 +93,11 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
   const { features, loading: capsLoading } = useCapabilities();
   const [hasUnread, setHasUnread] = useState<boolean>(false);
   const unreadFlag = typeof unreadMessages === "boolean" ? unreadMessages : hasUnread;
-  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [drawerMode, setDrawerMode] = useState<DrawerMode>(null);
+  const drawerOpen = drawerMode !== null;
   const shellRef = useRef<HTMLDivElement | null>(null);
   const stickyShellRef = useRef<HTMLDivElement | null>(null);
+  const drawerRef = useRef<HTMLElement | null>(null);
   const lastFocusedRef = useRef<HTMLElement | null>(null);
   const navLoading = !ready || isLoading || authStatus === "restoring" || !user || capsLoading;
   const isAdminLikeContext = React.useMemo(() => isAdminContext(user), [user]);
@@ -155,11 +159,11 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
   ].filter(Boolean).join(" ");
 
   const handleDrawerNavigation = (path: string) => {
-    setDrawerOpen(false);
+    setDrawerMode(null);
     nav(path);
   };
   const closeDrawer = () => {
-    setDrawerOpen(false);
+    setDrawerMode(null);
   };
 
   useEffect(() => {
@@ -192,14 +196,14 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
   }, [features?.messaging, isLandlordWorkspace, navLoading]);
 
   useEffect(() => {
-    setDrawerOpen(false);
+    setDrawerMode(null);
   }, [loc.pathname]);
 
   useEffect(() => {
     if (!drawerOpen) return;
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
-        setDrawerOpen(false);
+        setDrawerMode(null);
       }
     };
     document.addEventListener("keydown", onKeyDown);
@@ -218,6 +222,14 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
       document.body.style.overflow = "";
     };
   }, [drawerOpen]);
+
+  useEffect(() => {
+    if (!drawerOpen) return;
+    const target = drawerRef.current?.querySelector<HTMLElement>(
+      drawerMode === "communications" ? '[aria-current="page"], .rc-landlord-communications-drawer-links button' : "button"
+    );
+    target?.focus();
+  }, [drawerMode, drawerOpen]);
 
   React.useLayoutEffect(() => {
     const shell = shellRef.current;
@@ -293,11 +305,11 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
           type="button"
           className="rc-landlord-mobile-menu"
           aria-label="Open menu"
-          aria-expanded={drawerOpen}
+          aria-expanded={drawerMode === "workspace"}
           aria-controls="rc-landlord-drawer"
           onClick={(event) => {
             lastFocusedRef.current = event.currentTarget;
-            setDrawerOpen(true);
+            setDrawerMode("workspace");
           }}
         >
           <Menu size={20} strokeWidth={2.2} />
@@ -317,6 +329,7 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
           />
 
           <aside
+            ref={drawerRef}
             id="rc-landlord-drawer"
             className={[
               "rc-landlord-drawer",
@@ -325,10 +338,10 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
             ].filter(Boolean).join(" ")}
             role="dialog"
             aria-modal="true"
-            aria-label="Navigation menu"
+            aria-label={drawerMode === "communications" ? "Communications navigation" : "Navigation menu"}
           >
             <div className="rc-landlord-drawer-header">
-              <span>Workspace</span>
+              <span>{drawerMode === "communications" ? "Communications" : "Workspace"}</span>
               <button
                 type="button"
                 onClick={(event) => {
@@ -340,8 +353,31 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
                 Close
               </button>
             </div>
-            <div className="rc-landlord-drawer-scroll" tabIndex={0} aria-label="Workspace destinations">
-              {navLoading ? (
+            <div
+              className="rc-landlord-drawer-scroll"
+              tabIndex={0}
+              aria-label={drawerMode === "communications" ? "Communications destinations" : "Workspace destinations"}
+            >
+              {drawerMode === "communications" ? (
+                <div className="rc-landlord-drawer-links rc-landlord-communications-drawer-links">
+                  {communicationsItems.map((item) => {
+                    const Icon = item.icon;
+                    const active = isNavItemActive(loc.pathname, item);
+                    return (
+                      <button
+                        key={item.id}
+                        type="button"
+                        onClick={() => handleDrawerNavigation(item.to)}
+                        className={active ? "active" : ""}
+                        aria-current={active ? "page" : undefined}
+                      >
+                        {Icon ? <Icon size={20} strokeWidth={2.2} /> : null}
+                        <span>{item.label}</span>
+                      </button>
+                    );
+                  })}
+                </div>
+              ) : navLoading ? (
                 <div className="rc-landlord-drawer-links">
                   <button type="button" disabled className="active">
                     Loading menu...
@@ -362,26 +398,28 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
                   ))}
                 </div>
               )}
-              <div className="rc-landlord-drawer-divider" />
-              <button type="button" className="rc-landlord-drawer-signout" onClick={logout}>
-                Sign out
-              </button>
-              {adminDrawerItems.length ? (
-                <div className="rc-landlord-drawer-divider" />
-              ) : null}
-              {adminDrawerItems.length ? (
-                <div className="rc-landlord-drawer-links">
-                  {adminDrawerItems.map(({ id, to, label }) => (
-                    <button
-                      key={id}
-                      type="button"
-                      onClick={() => handleDrawerNavigation(to)}
-                      className={loc.pathname.startsWith(to) ? "active" : ""}
-                    >
-                      {label}
-                    </button>
-                  ))}
-                </div>
+              {drawerMode === "workspace" ? (
+                <>
+                  <div className="rc-landlord-drawer-divider" />
+                  <button type="button" className="rc-landlord-drawer-signout" onClick={logout}>
+                    Sign out
+                  </button>
+                  {adminDrawerItems.length ? <div className="rc-landlord-drawer-divider" /> : null}
+                  {adminDrawerItems.length ? (
+                    <div className="rc-landlord-drawer-links">
+                      {adminDrawerItems.map(({ id, to, label }) => (
+                        <button
+                          key={id}
+                          type="button"
+                          onClick={() => handleDrawerNavigation(to)}
+                          className={loc.pathname.startsWith(to) ? "active" : ""}
+                        >
+                          {label}
+                        </button>
+                      ))}
+                    </div>
+                  ) : null}
+                </>
               ) : null}
             </div>
           </aside>
@@ -401,9 +439,20 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
               <button
                 key={to}
                 type="button"
-                onClick={() => nav(to)}
+                onClick={(event) => {
+                  if (label === "Communications") {
+                    lastFocusedRef.current = event.currentTarget;
+                    setDrawerMode("communications");
+                    return;
+                  }
+                  closeDrawer();
+                  nav(to);
+                }}
                 className={active ? "active" : ""}
                 aria-current={active ? "page" : undefined}
+                aria-haspopup={label === "Communications" ? "dialog" : undefined}
+                aria-expanded={label === "Communications" ? drawerMode === "communications" : undefined}
+                aria-controls={label === "Communications" && drawerMode === "communications" ? "rc-landlord-drawer" : undefined}
               >
                 <Icon size={20} strokeWidth={2.2} />
                 <span className="rc-landlord-mobile-tabbar-label">
@@ -419,14 +468,14 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
             type="button"
             onClick={(event) => {
               lastFocusedRef.current = event.currentTarget;
-              setDrawerOpen((open) => !open);
+              setDrawerMode((current) => current === "workspace" ? null : "workspace");
             }}
-            className={drawerOpen ? "active" : ""}
+            className={drawerMode === "workspace" ? "active" : ""}
             aria-label="Open workspace pages"
-            aria-expanded={drawerOpen}
+            aria-expanded={drawerMode === "workspace"}
             aria-controls="rc-landlord-drawer"
           >
-            {drawerOpen ? <X size={20} strokeWidth={2.2} /> : <Menu size={20} strokeWidth={2.2} />}
+            {drawerMode === "workspace" ? <X size={20} strokeWidth={2.2} /> : <Menu size={20} strokeWidth={2.2} />}
             <span className="rc-landlord-mobile-tabbar-label">More</span>
           </button>
         </nav>

--- a/rentchain-frontend/tests/playwright/workspace-communications-layout.spec.ts
+++ b/rentchain-frontend/tests/playwright/workspace-communications-layout.spec.ts
@@ -30,6 +30,12 @@ const communicationsRoutes = [
   { path: "/notices", title: "Notices" },
 ];
 
+function visibleCommunicationsMenuTrigger(page: Page) {
+  return page
+    .locator(".rc-landlord-topnav:visible, .rc-landlord-mobile-topbar:visible")
+    .getByRole("button", { name: "Communications" });
+}
+
 for (const route of communicationsRoutes) {
   for (const width of desktopViewports) {
     test(`keeps ${route.title} Communications state visible without Workspace scrolling at ${width}px`, async ({ page }) => {
@@ -40,7 +46,7 @@ for (const route of communicationsRoutes) {
       const workspaceNav = page.getByRole("navigation", { name: "Workspace navigation" });
       await expect(workspaceNav.getByRole("group", { name: "Communications" })).toHaveCount(0);
       await expect(workspaceNav.getByText("COMMUNICATIONS")).toHaveCount(0);
-      const trigger = page.getByRole("button", { name: "Communications" });
+      const trigger = visibleCommunicationsMenuTrigger(page);
       await trigger.click();
       const communications = page.getByRole("menu", { name: "Communications destinations" });
       await expect(communications.getByRole("menuitem")).toHaveCount(3);
@@ -91,7 +97,7 @@ for (const route of communicationsRoutes) {
   }
 }
 
-test("keeps communication destinations out of the mobile Workspace drawer and tab bar", async ({ page }) => {
+test("keeps Communications children out of the mobile Workspace drawer and tab bar", async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 });
   await installWorkspaceHarness(page);
   await page.goto("/messages");
@@ -104,6 +110,7 @@ test("keeps communication destinations out of the mobile Workspace drawer and ta
   await expect(drawer.getByRole("button", { name: "Messages" })).toHaveCount(0);
   await expect(drawer.getByRole("button", { name: "Notices" })).toHaveCount(0);
   const tabbar = page.getByRole("navigation", { name: "Bottom navigation" });
+  await expect(tabbar.getByRole("button", { name: "Communications" })).toBeVisible();
   await expect(tabbar.getByRole("button", { name: "Unified Inbox" })).toHaveCount(0);
   await expect(tabbar.getByRole("button", { name: "Messages" })).toHaveCount(0);
   await expect(tabbar.getByRole("button", { name: "Notices" })).toHaveCount(0);
@@ -115,23 +122,26 @@ for (const destination of communicationsRoutes) {
     await installWorkspaceHarness(page);
     await page.goto("/messages");
 
-    await page.getByRole("button", { name: "Communications" }).click();
+    await visibleCommunicationsMenuTrigger(page).click();
     const target = page.getByRole("menu", { name: "Communications destinations" }).getByRole("menuitem", { name: destination.title });
     await target.click();
 
     await expect(page).toHaveURL(new RegExp(`${destination.path.replaceAll("/", "\\/")}$`));
     await expect(page.locator(".rc-landlord-mobile-role")).toHaveText(destination.title);
-    await page.getByRole("button", { name: "Communications" }).click();
+    await visibleCommunicationsMenuTrigger(page).click();
     await expect(page.getByRole("menuitem", { name: destination.title })).toHaveAttribute("aria-current", "page");
   });
 }
 
 for (const viewport of [
-  { width: 375, height: 812 },
-  { width: 360, height: 800 },
+  { width: 390, height: 844 },
+  { width: 393, height: 852 },
+  { width: 414, height: 896 },
   { width: 430, height: 932 },
+  { width: 768, height: 1024 },
+  { width: 820, height: 1180 },
 ]) {
-  test(`keeps Communications exclusive to the header at ${viewport.width}x${viewport.height}`, async ({ page }) => {
+  test(`keeps Communications primary in bottom nav without Workspace duplication at ${viewport.width}x${viewport.height}`, async ({ page }) => {
     await page.setViewportSize(viewport);
     await installWorkspaceHarness(page);
     await page.goto("/notices");
@@ -140,12 +150,26 @@ for (const viewport of [
     const drawer = page.getByRole("dialog", { name: "Navigation menu" });
     await expect(drawer.getByRole("group", { name: "Communications" })).toHaveCount(0);
     await drawer.getByRole("button", { name: "Close menu" }).click();
-    await page.getByRole("button", { name: "Communications" }).click();
+    const tabbar = page.getByRole("navigation", { name: "Bottom navigation" });
+    await expect(tabbar.getByRole("button")).toHaveCount(5);
+    await expect(tabbar.getByText("Dashboard")).toBeVisible();
+    await expect(tabbar.getByText("Properties")).toBeVisible();
+    await expect(tabbar.getByText("Applicants")).toBeVisible();
+    await expect(tabbar.getByText("Communications")).toBeVisible();
+    await expect(tabbar.getByText("More")).toBeVisible();
+    await expect(tabbar.getByText("Operations")).toHaveCount(0);
+    await expect(tabbar.getByRole("button", { name: "Communications" })).toHaveAttribute("aria-current", "page");
+    await visibleCommunicationsMenuTrigger(page).click();
     const communications = page.getByRole("menu", { name: "Communications destinations" });
     await expect(communications.getByRole("menuitem")).toHaveCount(3);
     expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(
       await page.evaluate(() => document.documentElement.clientWidth + 1),
     );
+
+    await tabbar.getByRole("button", { name: "Open workspace pages" }).click();
+    await expect(
+      page.getByRole("dialog", { name: "Navigation menu" }).getByRole("button", { name: "Operations" })
+    ).toBeVisible();
   });
 }
 
@@ -157,7 +181,7 @@ test("redirects the legacy landlord inbox into the canonical Communications shel
   await expect(page).toHaveURL(/\/landlord\/unified-inbox\?status=unread#updates$/);
   const workspaceNav = page.getByRole("navigation", { name: "Workspace navigation" });
   await expect(workspaceNav.getByRole("group", { name: "Communications" })).toHaveCount(0);
-  await page.getByRole("button", { name: "Communications" }).click();
+  await visibleCommunicationsMenuTrigger(page).click();
   const communications = page.getByRole("menu", { name: "Communications destinations" });
   await expect(communications.getByRole("menuitem")).toHaveCount(3);
   await expect(communications.getByRole("menuitem", { name: "Unified Inbox" })).toHaveAttribute("aria-current", "page");
@@ -175,7 +199,10 @@ for (const route of communicationsRoutes) {
       await page.goto(route.path);
 
       await expect(page.locator(".rc-landlord-mobile-role")).toHaveText(route.title);
-      await page.getByRole("button", { name: "Communications" }).click();
+      await expect(
+        page.getByRole("navigation", { name: "Bottom navigation" }).getByRole("button", { name: "Communications" })
+      ).toHaveAttribute("aria-current", "page");
+      await visibleCommunicationsMenuTrigger(page).click();
       const headerMenu = page.getByRole("menu", { name: "Communications destinations" });
       await expect(headerMenu.getByRole("menuitem", { name: "Unified Inbox" })).toBeVisible();
       await expect(headerMenu.getByRole("menuitem", { name: "Messages" })).toBeVisible();

--- a/rentchain-frontend/tests/playwright/workspace-communications-layout.spec.ts
+++ b/rentchain-frontend/tests/playwright/workspace-communications-layout.spec.ts
@@ -116,6 +116,51 @@ test("keeps Communications children out of the mobile Workspace drawer and tab b
   await expect(tabbar.getByRole("button", { name: "Notices" })).toHaveCount(0);
 });
 
+test("uses the bottom Communications control as a dismissible child drawer without implicit navigation", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await installWorkspaceHarness(page);
+  await page.goto("/messages");
+
+  const tabbar = page.getByRole("navigation", { name: "Bottom navigation" });
+  const trigger = tabbar.getByRole("button", { name: "Communications" });
+  await trigger.click();
+  await expect(page).toHaveURL(/\/messages$/);
+  const drawer = page.getByRole("dialog", { name: "Communications navigation" });
+  await expect(drawer.getByRole("button")).toHaveCount(4);
+  await expect(drawer.getByRole("button", { name: "Unified Inbox" })).toBeVisible();
+  await expect(drawer.getByRole("button", { name: "Messages" })).toHaveAttribute("aria-current", "page");
+  await expect(drawer.getByRole("button", { name: "Notices" })).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(drawer).not.toBeAttached();
+  await expect(trigger).toBeFocused();
+  await expect(page).toHaveURL(/\/messages$/);
+
+  await trigger.click();
+  await page.locator(".rc-landlord-backdrop").click({ position: { x: 4, y: 4 } });
+  await expect(drawer).not.toBeAttached();
+  await expect(page).toHaveURL(/\/messages$/);
+});
+
+test("reopens the bottom Communications drawer across child navigation", async ({ page }) => {
+  await page.setViewportSize({ width: 430, height: 932 });
+  await installWorkspaceHarness(page);
+  await page.goto("/messages");
+
+  const trigger = page.getByRole("navigation", { name: "Bottom navigation" }).getByRole("button", { name: "Communications" });
+  await trigger.click();
+  await page.getByRole("dialog", { name: "Communications navigation" }).getByRole("button", { name: "Notices" }).click();
+  await expect(page).toHaveURL(/\/notices$/);
+  await expect(trigger).toHaveAttribute("aria-current", "page");
+
+  await trigger.click();
+  await expect(page).toHaveURL(/\/notices$/);
+  const drawer = page.getByRole("dialog", { name: "Communications navigation" });
+  await expect(drawer.getByRole("button", { name: "Notices" })).toHaveAttribute("aria-current", "page");
+  await drawer.getByRole("button", { name: "Unified Inbox" }).click();
+  await expect(page).toHaveURL(/\/landlord\/unified-inbox$/);
+  await expect(drawer).not.toBeAttached();
+});
+
 for (const destination of communicationsRoutes) {
   test(`navigates to ${destination.title} from the mobile Communications menu`, async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 });
@@ -159,6 +204,13 @@ for (const viewport of [
     await expect(tabbar.getByText("More")).toBeVisible();
     await expect(tabbar.getByText("Operations")).toHaveCount(0);
     await expect(tabbar.getByRole("button", { name: "Communications" })).toHaveAttribute("aria-current", "page");
+    await tabbar.getByRole("button", { name: "Communications" }).click();
+    const communicationsDrawer = page.getByRole("dialog", { name: "Communications navigation" });
+    await expect(communicationsDrawer.getByRole("button", { name: "Unified Inbox" })).toBeVisible();
+    await expect(communicationsDrawer.getByRole("button", { name: "Messages" })).toBeVisible();
+    await expect(communicationsDrawer.getByRole("button", { name: "Notices" })).toHaveAttribute("aria-current", "page");
+    await expect(page).toHaveURL(/\/notices$/);
+    await communicationsDrawer.getByRole("button", { name: "Close menu" }).click();
     await visibleCommunicationsMenuTrigger(page).click();
     const communications = page.getByRole("menu", { name: "Communications destinations" });
     await expect(communications.getByRole("menuitem")).toHaveCount(3);


### PR DESCRIPTION
## Summary

- add Communications as the fourth responsive bottom-navigation destination
- keep exactly five primary slots: Dashboard, Properties, Applicants, Communications, More
- route the Communications parent to canonical Unified Inbox and keep it active for Unified Inbox, Messages, Notices, and the legacy inbox alias
- keep Operations reachable and active in More without changing its route ownership
- preserve the responsive and desktop Communications child selector while keeping all three child destinations out of Workspace, More, and the bottom row

## Founder context and root cause

Communications was not represented in the primary responsive navigation even though Unified Inbox, Messages, and Notices already shared canonical Communications ownership. Operations occupied the fourth slot, while the CSS grid reserved six columns for only five rendered items. This made the primary mobile IA inconsistent with the established Communications grouping.

The correction derives one grouped Communications tab from the canonical navigation configuration, uses the existing grouped route matcher for active state, moves Operations to its existing More path, and makes the bottom grid explicitly five equal min-width columns.

## Validation

- Landlord navigation focused tests: 35 passed
- Top navigation focused tests: 6 passed
- full frontend: 350 files, 1,714 tests passed
- responsive Communications Playwright: 35 passed
- preserved C/C2 Properties Playwright: 23 passed
- TypeScript: passed
- production build: passed on Node 20
- package-manager governance: passed
- Preview PR-head governance: 36/36 passed
- Production governance: 32 boundaries passed
- changed-diff credential scan: clean
- `git diff --check`: passed

Scoped ESLint reports the six existing `LandlordNav.tsx` baseline findings (three `no-explicit-any`, one manual-memoization compiler finding, and two set-state-in-effect findings). D introduces no new scoped lint finding; addressing the established component baseline is outside this navigation-only change.

## Scope and safety

- frontend navigation only
- no backend, auth, billing, Firestore, infrastructure, or deployment changes
- E notification clarity is not started
- F tenant attachment support is not started
- Draft only; Founder visual QA is required before merge
