### PR TITLE
Clarify Communications unread notifications

### DIFF
--- a/rentchain-frontend/src/components/layout/CommunicationsMenu.css
+++ b/rentchain-frontend/src/components/layout/CommunicationsMenu.css
@@ -85,6 +85,22 @@
   color: #245842;
 }
 
+.rc-communications-menu__item-state {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  min-width: 16px;
+}
+
+.rc-communications-menu__child-unread {
+  width: 8px;
+  height: 8px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: #a33a2f;
+}
+
 @media (max-width: 820px) {
   .rc-communications-menu--mobile .rc-communications-menu__trigger {
     min-height: 38px;

--- a/rentchain-frontend/src/components/layout/CommunicationsMenu.tsx
+++ b/rentchain-frontend/src/components/layout/CommunicationsMenu.tsx
@@ -13,11 +13,23 @@ const COMMUNICATION_LINKS = [
 
 type Props = {
   className?: string;
-  hasUnread?: boolean;
+  messagesUnread?: boolean;
+  inboxUnread?: boolean;
 };
 
-export function CommunicationsMenu({ className = "", hasUnread = false }: Props) {
+function destinationUnread(label: string, messagesUnread: boolean, inboxUnread: boolean) {
+  if (label === "Messages") return messagesUnread;
+  if (label === "Unified Inbox") return inboxUnread;
+  return false;
+}
+
+export function CommunicationsMenu({
+  className = "",
+  messagesUnread = false,
+  inboxUnread = false,
+}: Props) {
   const location = useLocation();
+  const hasUnread = messagesUnread || inboxUnread;
   const [open, setOpen] = React.useState(false);
   const rootRef = React.useRef<HTMLDivElement | null>(null);
   const panelRef = React.useRef<HTMLDivElement | null>(null);
@@ -114,6 +126,7 @@ export function CommunicationsMenu({ className = "", hasUnread = false }: Props)
         >
           {COMMUNICATION_LINKS.map((item) => {
             const active = isActive(item);
+            const unread = destinationUnread(item.label, messagesUnread, inboxUnread);
             return (
               <Link
                 key={item.to}
@@ -121,10 +134,14 @@ export function CommunicationsMenu({ className = "", hasUnread = false }: Props)
                 role="menuitem"
                 className={active ? "is-active" : ""}
                 aria-current={active ? "page" : undefined}
+                aria-label={unread ? `${item.label}, unread activity` : item.label}
                 onClick={() => setOpen(false)}
               >
                 <span>{item.label}</span>
-                {active ? <Check size={16} aria-hidden="true" /> : null}
+                <span className="rc-communications-menu__item-state">
+                  {unread ? <span className="rc-communications-menu__child-unread" aria-hidden="true" /> : null}
+                  {active ? <Check size={16} aria-hidden="true" /> : null}
+                </span>
               </Link>
             );
           })}

--- a/rentchain-frontend/src/components/layout/LandlordNav.css
+++ b/rentchain-frontend/src/components/layout/LandlordNav.css
@@ -407,6 +407,15 @@
   color: var(--rc-landlord-pine);
 }
 
+.rc-landlord-communications-child-unread {
+  width: 8px;
+  height: 8px;
+  flex: 0 0 auto;
+  margin-left: auto;
+  border-radius: 50%;
+  background: var(--rc-landlord-danger);
+}
+
 .rc-landlord-drawer-group {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));

--- a/rentchain-frontend/src/components/layout/LandlordNav.test.tsx
+++ b/rentchain-frontend/src/components/layout/LandlordNav.test.tsx
@@ -6,6 +6,7 @@ import { LandlordNav } from "./LandlordNav";
 const mocks = vi.hoisted(() => ({
   logout: vi.fn(),
   fetchLandlordConversations: vi.fn(),
+  fetchUnifiedInbox: vi.fn(),
   useCapabilities: vi.fn(),
   user: { id: "landlord-1", role: "landlord", actorRole: "landlord", email: "owner@example.com" } as {
     id: string;
@@ -34,6 +35,10 @@ vi.mock("../../api/messagesApi", () => ({
   fetchLandlordConversations: mocks.fetchLandlordConversations,
 }));
 
+vi.mock("../../api/unifiedInboxApi", () => ({
+  fetchUnifiedInbox: mocks.fetchUnifiedInbox,
+}));
+
 vi.mock("./TopNav", () => ({
   default: () => <div>Top nav</div>,
 }));
@@ -47,14 +52,17 @@ function CurrentPath() {
   return <div data-testid="current-path">{location.pathname}</div>;
 }
 
-function renderLandlordNav(initialPath = "/dashboard") {
+function renderLandlordNav(
+  initialPath = "/dashboard",
+  unread?: { messages?: boolean; inbox?: boolean }
+) {
   return render(
     <MemoryRouter initialEntries={[initialPath]}>
       <Routes>
         <Route
           path="*"
           element={
-            <LandlordNav>
+            <LandlordNav unreadMessages={unread?.messages} unreadInbox={unread?.inbox}>
               <div data-testid="page-content">Page content</div>
               <CurrentPath />
             </LandlordNav>
@@ -75,6 +83,7 @@ describe("LandlordNav mobile drawer", () => {
     mocks.user = { id: "landlord-1", role: "landlord", actorRole: "landlord", email: "owner@example.com" };
     mocks.logout.mockReset();
     mocks.fetchLandlordConversations.mockResolvedValue([]);
+    mocks.fetchUnifiedInbox.mockResolvedValue({ items: [], records: [] });
     mocks.useCapabilities.mockReturnValue({
       features: {
         messaging: true,
@@ -354,6 +363,45 @@ describe("LandlordNav mobile drawer", () => {
       "Messages",
       "Notices",
     ]);
+  });
+
+  it("shows matching Messages and Inbox indicators in the responsive drawer without a Notices indicator", () => {
+    renderLandlordNav("/dashboard", { messages: true, inbox: true });
+
+    const tabbar = screen.getByRole("navigation", { name: "Bottom navigation" });
+    const communications = within(tabbar).getByRole("button", { name: "Communications" });
+    expect(communications.querySelector(".rc-landlord-mobile-tabbar-dot")).toBeInTheDocument();
+
+    fireEvent.click(communications);
+    const drawer = screen.getByRole("dialog", { name: "Communications navigation" });
+    expect(within(drawer).getByRole("button", { name: "Unified Inbox, unread activity" })).toBeInTheDocument();
+    expect(within(drawer).getByRole("button", { name: "Messages, unread activity" })).toBeInTheDocument();
+    expect(within(drawer).getByRole("button", { name: "Notices" })).toBeInTheDocument();
+  });
+
+  it("keeps each unread child independent across navigation and clears the parent only when neither is unread", async () => {
+    const { rerender } = renderLandlordNav("/dashboard", { messages: false, inbox: true });
+    const tabbar = screen.getByRole("navigation", { name: "Bottom navigation" });
+    const communications = within(tabbar).getByRole("button", { name: "Communications" });
+
+    fireEvent.click(communications);
+    const drawer = screen.getByRole("dialog", { name: "Communications navigation" });
+    expect(within(drawer).getByRole("button", { name: "Unified Inbox, unread activity" })).toBeInTheDocument();
+    expect(within(drawer).getByRole("button", { name: "Messages" })).toBeInTheDocument();
+    fireEvent.click(within(drawer).getByRole("button", { name: "Messages" }));
+    await waitFor(() => expect(screen.getByTestId("current-path")).toHaveTextContent("/messages"));
+    expect(communications.querySelector(".rc-landlord-mobile-tabbar-dot")).toBeInTheDocument();
+
+    rerender(
+      <MemoryRouter initialEntries={["/dashboard"]}>
+        <LandlordNav unreadMessages={false} unreadInbox={false}>
+          <div>Page content</div>
+        </LandlordNav>
+      </MemoryRouter>
+    );
+    expect(
+      screen.getByRole("navigation", { name: "Bottom navigation" }).querySelector(".rc-landlord-mobile-tabbar-dot")
+    ).not.toBeInTheDocument();
   });
 
   it.each([

--- a/rentchain-frontend/src/components/layout/LandlordNav.tsx
+++ b/rentchain-frontend/src/components/layout/LandlordNav.tsx
@@ -3,7 +3,6 @@ import { Building2, LayoutDashboard, Menu, MessagesSquare, ScrollText, X } from 
 import { Link, Navigate, useLocation, useNavigate } from "react-router-dom";
 import TopNav from "./TopNav";
 import { useAuth } from "../../context/useAuth";
-import { fetchLandlordConversations } from "../../api/messagesApi";
 import {
   COMMUNICATIONS_GROUP_ID,
   getVisibleNavItems,
@@ -18,10 +17,16 @@ import { getRoleDefaultDestination } from "@/lib/authDestination";
 import { RentChainLogo } from "../brand/RentChainLogo";
 import "./LandlordNav.css";
 import { CommunicationsMenu } from "./CommunicationsMenu";
+import {
+  EMPTY_COMMUNICATIONS_UNREAD,
+  loadCommunicationsUnreadState,
+  type CommunicationsUnreadState,
+} from "./communicationsUnread";
 
 type Props = {
   children: React.ReactNode;
   unreadMessages?: boolean;
+  unreadInbox?: boolean;
 };
 
 type DrawerMode = "workspace" | "communications" | null;
@@ -86,13 +91,17 @@ function isAdminContext(user: unknown): boolean {
   );
 }
 
-export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
+export const LandlordNav: React.FC<Props> = ({ children, unreadMessages, unreadInbox }) => {
   const nav = useNavigate();
   const loc = useLocation();
   const { logout, user, ready, isLoading, authStatus } = useAuth();
   const { features, loading: capsLoading } = useCapabilities();
-  const [hasUnread, setHasUnread] = useState<boolean>(false);
-  const unreadFlag = typeof unreadMessages === "boolean" ? unreadMessages : hasUnread;
+  const [loadedUnread, setLoadedUnread] = useState<CommunicationsUnreadState>(EMPTY_COMMUNICATIONS_UNREAD);
+  const unreadState = {
+    messages: typeof unreadMessages === "boolean" ? unreadMessages : loadedUnread.messages,
+    inbox: typeof unreadInbox === "boolean" ? unreadInbox : loadedUnread.inbox,
+  };
+  const unreadFlag = unreadState.messages || unreadState.inbox;
   const [drawerMode, setDrawerMode] = useState<DrawerMode>(null);
   const drawerOpen = drawerMode !== null;
   const shellRef = useRef<HTMLDivElement | null>(null);
@@ -168,23 +177,19 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
 
   useEffect(() => {
     let mounted = true;
-    if (navLoading || !isLandlordWorkspace || features?.messaging === false) {
-      setHasUnread(false);
+    if (navLoading || !isLandlordWorkspace) {
       return () => {
         mounted = false;
       };
     }
     const load = async () => {
       try {
-        const list = await fetchLandlordConversations();
+        const next = await loadCommunicationsUnreadState(features?.messaging !== false);
         if (!mounted) return;
-        const unread = (list || []).some(
-          (c: any) => c?.hasUnread === true || (c?.unreadCount ?? 0) > 0
-        );
-        setHasUnread(unread);
+        setLoadedUnread(next);
       } catch {
         if (!mounted) return;
-        setHasUnread(false);
+        setLoadedUnread(EMPTY_COMMUNICATIONS_UNREAD);
       }
     };
     void load();
@@ -276,7 +281,7 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
   return (
     <div className={shellClassName} ref={shellRef}>
       <div className="rc-landlord-topnav" ref={stickyShellRef}>
-        <TopNav />
+        <TopNav communicationsUnread={unreadState} />
         <div className="rc-landlord-workspace-bar" aria-label="Workspace context">
           <div className="rc-landlord-workspace-context">
             <span>Current workspace</span>
@@ -300,7 +305,13 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
       <div className="rc-landlord-mobile-topbar">
         <RentChainLogo href="/dashboard" size="sm" />
         <span className="rc-landlord-mobile-role">{workspaceLabel}</span>
-        {communicationsItems.length ? <CommunicationsMenu className="rc-communications-menu--mobile" hasUnread={unreadFlag} /> : null}
+        {communicationsItems.length ? (
+          <CommunicationsMenu
+            className="rc-communications-menu--mobile"
+            messagesUnread={unreadState.messages}
+            inboxUnread={unreadState.inbox}
+          />
+        ) : null}
         <button
           type="button"
           className="rc-landlord-mobile-menu"
@@ -363,6 +374,12 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
                   {communicationsItems.map((item) => {
                     const Icon = item.icon;
                     const active = isNavItemActive(loc.pathname, item);
+                    const unread =
+                      item.id === "messages"
+                        ? unreadState.messages
+                        : item.id === "unified-inbox"
+                          ? unreadState.inbox
+                          : false;
                     return (
                       <button
                         key={item.id}
@@ -370,9 +387,11 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
                         onClick={() => handleDrawerNavigation(item.to)}
                         className={active ? "active" : ""}
                         aria-current={active ? "page" : undefined}
+                        aria-label={unread ? `${item.label}, unread activity` : item.label}
                       >
                         {Icon ? <Icon size={20} strokeWidth={2.2} /> : null}
                         <span>{item.label}</span>
+                        {unread ? <span className="rc-landlord-communications-child-unread" aria-hidden="true" /> : null}
                       </button>
                     );
                   })}

--- a/rentchain-frontend/src/components/layout/TopNav.test.tsx
+++ b/rentchain-frontend/src/components/layout/TopNav.test.tsx
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   useAuthMock: vi.fn(),
   useCapabilitiesMock: vi.fn(),
   fetchLandlordConversationsMock: vi.fn(),
+  fetchUnifiedInboxMock: vi.fn(),
 }));
 
 vi.mock("react-router-dom", async () => {
@@ -29,6 +30,10 @@ vi.mock("@/hooks/useCapabilities", () => ({
 
 vi.mock("../../api/messagesApi", () => ({
   fetchLandlordConversations: mocks.fetchLandlordConversationsMock,
+}));
+
+vi.mock("../../api/unifiedInboxApi", () => ({
+  fetchUnifiedInbox: mocks.fetchUnifiedInboxMock,
 }));
 
 vi.mock("./WorkspaceDrawer", () => ({
@@ -62,7 +67,10 @@ describe("TopNav", () => {
   beforeEach(() => {
     mocks.navigateMock.mockReset();
     mocks.logoutMock.mockReset();
+    mocks.fetchLandlordConversationsMock.mockReset();
+    mocks.fetchUnifiedInboxMock.mockReset();
     mocks.fetchLandlordConversationsMock.mockResolvedValue([]);
+    mocks.fetchUnifiedInboxMock.mockResolvedValue({ items: [], records: [] });
     mocks.useAuthMock.mockReturnValue({
       user: { id: "landlord-1", role: "landlord", actorRole: "landlord", email: "l@example.com" },
       logout: mocks.logoutMock,
@@ -156,6 +164,57 @@ describe("TopNav", () => {
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "Communications (unread)" })).toBeInTheDocument();
     });
+
+    fireEvent.click(screen.getByRole("button", { name: "Communications (unread)" }));
+    expect(screen.getByRole("menuitem", { name: "Messages, unread activity" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Unified Inbox" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Notices" })).toBeInTheDocument();
+  });
+
+  it("shows an Inbox-specific indicator without inventing Messages or Notices state", async () => {
+    mocks.fetchUnifiedInboxMock.mockResolvedValue({
+      items: [{ id: "maintenance-1", status: "unread", sourceKind: "landlord.maintenance" }],
+      records: [],
+    });
+
+    renderTopNav();
+
+    const trigger = await screen.findByRole("button", { name: "Communications (unread)" });
+    fireEvent.click(trigger);
+
+    expect(screen.getByRole("menuitem", { name: "Unified Inbox, unread activity" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Messages" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Notices" })).toBeInTheDocument();
+  });
+
+  it("shows both child indicators while leaving menu navigation non-acknowledging", async () => {
+    mocks.fetchLandlordConversationsMock.mockResolvedValue([{ id: "conv-1", hasUnread: true }]);
+    mocks.fetchUnifiedInboxMock.mockResolvedValue({
+      items: [{ id: "lease-1", status: "unread", sourceKind: "landlord.lease" }],
+      records: [],
+    });
+
+    renderTopNav();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Communications (unread)" }));
+    expect(screen.getByRole("menuitem", { name: "Unified Inbox, unread activity" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Messages, unread activity" })).toBeInTheDocument();
+    expect(mocks.fetchLandlordConversationsMock).toHaveBeenCalledTimes(1);
+    expect(mocks.fetchUnifiedInboxMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not duplicate a shared unread message as Inbox-specific activity", async () => {
+    mocks.fetchLandlordConversationsMock.mockResolvedValue([{ id: "conv-1", hasUnread: true }]);
+    mocks.fetchUnifiedInboxMock.mockResolvedValue({
+      items: [{ id: "conv-1", status: "unread", sourceKind: "landlord.message" }],
+      records: [],
+    });
+
+    renderTopNav();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Communications (unread)" }));
+    expect(screen.getByRole("menuitem", { name: "Messages, unread activity" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Unified Inbox" })).toBeInTheDocument();
   });
 
   it("closes the Communications menu on Escape and restores trigger focus", async () => {

--- a/rentchain-frontend/src/components/layout/TopNav.tsx
+++ b/rentchain-frontend/src/components/layout/TopNav.tsx
@@ -7,9 +7,13 @@ import { WorkspaceDrawer } from "./WorkspaceDrawer";
 import { Button } from "../ui/Ui";
 import { colors, radius, shadows, spacing, text, layout, blur } from "../../styles/tokens";
 import { RentChainLogo } from "../brand/RentChainLogo";
-import { fetchLandlordConversations } from "../../api/messagesApi";
 import { useCapabilities } from "@/hooks/useCapabilities";
 import { CommunicationsMenu } from "./CommunicationsMenu";
+import {
+  EMPTY_COMMUNICATIONS_UNREAD,
+  loadCommunicationsUnreadState,
+  type CommunicationsUnreadState,
+} from "./communicationsUnread";
 import "./TopNav.css";
 
 function roleLabel(raw: string): string {
@@ -53,12 +57,16 @@ function userInitials(user: ReturnType<typeof useAuth>["user"]): string {
   return initialsFromName(name) || initialsFromEmail(user?.email || "") || "U";
 }
 
-const TopNav: React.FC = () => {
+type Props = {
+  communicationsUnread?: CommunicationsUnreadState;
+};
+
+const TopNav: React.FC<Props> = ({ communicationsUnread }) => {
   const navigate = useNavigate();
   const { user, logout, ready, isLoading, authStatus } = useAuth();
   const { features } = useCapabilities();
   const [drawerOpen, setDrawerOpen] = useState(false);
-  const [hasUnreadMessages, setHasUnreadMessages] = useState(false);
+  const [loadedUnread, setLoadedUnread] = useState<CommunicationsUnreadState>(EMPTY_COMMUNICATIONS_UNREAD);
   const authResolved = ready && !isLoading && authStatus !== "restoring" && !!user;
   const effectiveRole = React.useMemo(() => {
     if (!authResolved) return "";
@@ -75,22 +83,22 @@ const TopNav: React.FC = () => {
   const canShowCommunications =
     authResolved &&
     (effectiveRole === "landlord" || effectiveRole === "admin");
-  const canLoadUnreadMessages = canShowCommunications && features?.messaging !== false;
+  const canLoadUnread = canShowCommunications && communicationsUnread === undefined;
+  const effectiveUnread = communicationsUnread || loadedUnread;
 
   React.useEffect(() => {
-    if (!canLoadUnreadMessages) {
-      setHasUnreadMessages(false);
+    if (!canLoadUnread) {
       return;
     }
     let mounted = true;
     const loadUnreadState = async () => {
       try {
-        const conversations = await fetchLandlordConversations();
+        const next = await loadCommunicationsUnreadState(features?.messaging !== false);
         if (!mounted) return;
-        setHasUnreadMessages((conversations || []).some((conversation: any) => conversation?.hasUnread === true));
+        setLoadedUnread(next);
       } catch {
         if (!mounted) return;
-        setHasUnreadMessages(false);
+        setLoadedUnread(EMPTY_COMMUNICATIONS_UNREAD);
       }
     };
     void loadUnreadState();
@@ -99,7 +107,7 @@ const TopNav: React.FC = () => {
       mounted = false;
       window.clearInterval(interval);
     };
-  }, [canLoadUnreadMessages]);
+  }, [canLoadUnread, features?.messaging]);
 
   return (
     <>
@@ -145,7 +153,12 @@ const TopNav: React.FC = () => {
             >
               Role: {roleBadge}
             </span>
-            {canShowCommunications ? <CommunicationsMenu hasUnread={hasUnreadMessages} /> : null}
+            {canShowCommunications ? (
+              <CommunicationsMenu
+                messagesUnread={effectiveUnread.messages}
+                inboxUnread={effectiveUnread.inbox}
+              />
+            ) : null}
             {canShowSchedulingShortcut ? (
               <Button
                 className="rc-top-nav-optional-action"

--- a/rentchain-frontend/src/components/layout/communicationsUnread.test.ts
+++ b/rentchain-frontend/src/components/layout/communicationsUnread.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest";
+import { deriveCommunicationsUnreadState } from "./communicationsUnread";
+
+vi.mock("../../api/messagesApi", () => ({
+  fetchLandlordConversations: vi.fn(),
+}));
+
+vi.mock("../../api/unifiedInboxApi", () => ({
+  fetchUnifiedInbox: vi.fn(),
+}));
+
+describe("deriveCommunicationsUnreadState", () => {
+  it("returns neither when all real sources are read", () => {
+    expect(
+      deriveCommunicationsUnreadState(
+        [{ id: "conversation-1", hasUnread: false }],
+        [{
+          id: "inbox-1",
+          sourceKind: "landlord.maintenance",
+          audienceRole: "landlord",
+          title: "Maintenance update",
+          body: "Update",
+          priority: "normal",
+          status: "read",
+          occurredAt: "2026-08-12T00:00:00.000Z",
+          readAt: "2026-08-12T01:00:00.000Z",
+        }]
+      )
+    ).toEqual({ messages: false, inbox: false });
+  });
+
+  it("derives both independent sources while assigning shared message events only to Messages", () => {
+    expect(
+      deriveCommunicationsUnreadState(
+        [{ id: "conversation-1", hasUnread: true }],
+        [
+          {
+            id: "conversation-1",
+            sourceKind: "landlord.message",
+            audienceRole: "landlord",
+            title: "Message",
+            body: "Message",
+            priority: "normal",
+            status: "unread",
+            occurredAt: "2026-08-12T00:00:00.000Z",
+            readAt: null,
+          },
+          {
+            id: "inbox-1",
+            sourceKind: "landlord.lease",
+            audienceRole: "landlord",
+            title: "Lease update",
+            body: "Update",
+            priority: "normal",
+            status: "unread",
+            occurredAt: "2026-08-12T00:00:00.000Z",
+            readAt: null,
+          },
+        ]
+      )
+    ).toEqual({ messages: true, inbox: true });
+  });
+
+  it("never derives Notices state from navigation symmetry", () => {
+    expect(
+      deriveCommunicationsUnreadState([], [{
+        id: "notice-1",
+        sourceKind: "landlord.notice",
+        audienceRole: "landlord",
+        title: "Notice",
+        body: "Notice",
+        priority: "normal",
+        status: "read",
+        occurredAt: "2026-08-12T00:00:00.000Z",
+        readAt: "2026-08-12T01:00:00.000Z",
+      }])
+    ).toEqual({ messages: false, inbox: false });
+  });
+});

--- a/rentchain-frontend/src/components/layout/communicationsUnread.ts
+++ b/rentchain-frontend/src/components/layout/communicationsUnread.ts
@@ -1,0 +1,46 @@
+import { fetchLandlordConversations, type Conversation } from "../../api/messagesApi";
+import {
+  fetchUnifiedInbox,
+  type UnifiedInboxRecord,
+} from "../../api/unifiedInboxApi";
+
+export type CommunicationsUnreadState = {
+  messages: boolean;
+  inbox: boolean;
+};
+
+export const EMPTY_COMMUNICATIONS_UNREAD: CommunicationsUnreadState = {
+  messages: false,
+  inbox: false,
+};
+
+export function deriveCommunicationsUnreadState(
+  conversations: Conversation[],
+  inboxRecords: UnifiedInboxRecord[]
+): CommunicationsUnreadState {
+  return {
+    messages: conversations.some(
+      (conversation) =>
+        conversation.hasUnread === true ||
+        Number((conversation as Conversation & { unreadCount?: number }).unreadCount || 0) > 0
+    ),
+    inbox: inboxRecords.some(
+      (record) => record.status === "unread" && record.sourceKind !== "landlord.message"
+    ),
+  };
+}
+
+export async function loadCommunicationsUnreadState(
+  includeMessages: boolean
+): Promise<CommunicationsUnreadState> {
+  const [conversationsResult, inboxResult] = await Promise.allSettled([
+    includeMessages ? fetchLandlordConversations() : Promise.resolve([]),
+    fetchUnifiedInbox("landlord"),
+  ]);
+
+  const conversations = conversationsResult.status === "fulfilled" ? conversationsResult.value : [];
+  const response = inboxResult.status === "fulfilled" ? inboxResult.value : null;
+  const inboxRecords = response?.records?.length ? response.records : response?.items || [];
+
+  return deriveCommunicationsUnreadState(conversations, inboxRecords);
+}

--- a/rentchain-frontend/tests/playwright/workspace-communications-layout.spec.ts
+++ b/rentchain-frontend/tests/playwright/workspace-communications-layout.spec.ts
@@ -5,7 +5,12 @@ test.use({ serviceWorkers: "block" });
 
 const desktopViewports = [1440, 1366, 1309, 1280, 1180, 1024];
 
-async function installWorkspaceHarness(page: Page) {
+type UnreadHarnessState = {
+  messages?: boolean;
+  inbox?: boolean;
+};
+
+async function installWorkspaceHarness(page: Page, unread: UnreadHarnessState = {}) {
   await page.route("**/src/api/baseUrl.ts", async (route) => {
     const response = await route.fetch();
     const body = (await response.text())
@@ -19,7 +24,41 @@ async function installWorkspaceHarness(page: Page) {
     await route.fulfill({
       status: 200,
       contentType: "application/json",
-      body: JSON.stringify({ ok: true, plan: "free", features: { messaging: false } }),
+      body: JSON.stringify({ ok: true, plan: "free", features: { messaging: unread.messages === true } }),
+    });
+  });
+  await page.route("**/api/landlord/messages/conversations", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        conversations: unread.messages ? [{ id: "conversation-1", hasUnread: true }] : [],
+      }),
+    });
+  });
+  await page.route("**/api/landlord/inbox", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ok: true,
+        items: unread.inbox
+          ? [{
+              id: "maintenance-1",
+              sourceKind: "landlord.maintenance",
+              audienceRole: "landlord",
+              title: "Maintenance update",
+              body: "Synthetic update",
+              priority: "normal",
+              status: "unread",
+              occurredAt: "2026-08-12T00:00:00.000Z",
+              readAt: null,
+            }]
+          : [],
+        total: unread.inbox ? 1 : 0,
+        limit: 100,
+        offset: 0,
+      }),
     });
   });
 }
@@ -34,6 +73,49 @@ function visibleCommunicationsMenuTrigger(page: Page) {
   return page
     .locator(".rc-landlord-topnav:visible, .rc-landlord-mobile-topbar:visible")
     .getByRole("button", { name: "Communications" });
+}
+
+for (const width of [1180, 1440]) {
+  test(`shows truthful child unread indicators in the desktop menu at ${width}px`, async ({ page }) => {
+    await page.setViewportSize({ width, height: 900 });
+    await installWorkspaceHarness(page, { messages: true, inbox: true });
+    await page.goto("/messages");
+
+    const trigger = page.getByRole("button", { name: "Communications (unread)" });
+    await trigger.click();
+    const menu = page.getByRole("menu", { name: "Communications destinations" });
+    await expect(menu.getByRole("menuitem", { name: "Unified Inbox, unread activity" })).toBeVisible();
+    await expect(menu.getByRole("menuitem", { name: "Messages, unread activity" })).toBeVisible();
+    await expect(menu.getByRole("menuitem", { name: "Notices" })).toBeVisible();
+    await expect(menu.locator(".rc-communications-menu__child-unread")).toHaveCount(2);
+  });
+}
+
+for (const viewport of [
+  { width: 390, height: 844 },
+  { width: 393, height: 852 },
+  { width: 414, height: 896 },
+  { width: 430, height: 932 },
+  { width: 820, height: 1180 },
+]) {
+  test(`keeps child unread truth readable in the responsive drawer at ${viewport.width}x${viewport.height}`, async ({ page }) => {
+    await page.setViewportSize(viewport);
+    await installWorkspaceHarness(page, { messages: true, inbox: true });
+    await page.goto("/messages");
+
+    const tabbar = page.getByRole("navigation", { name: "Bottom navigation" });
+    const trigger = tabbar.getByRole("button", { name: "Communications" });
+    await expect(trigger.locator(".rc-landlord-mobile-tabbar-dot")).toBeVisible();
+    await trigger.click();
+    const drawer = page.getByRole("dialog", { name: "Communications navigation" });
+    await expect(drawer.getByRole("button", { name: "Unified Inbox, unread activity" })).toBeVisible();
+    await expect(drawer.getByRole("button", { name: "Messages, unread activity" })).toBeVisible();
+    await expect(drawer.getByRole("button", { name: "Notices" })).toBeVisible();
+    await expect(drawer.locator(".rc-landlord-communications-child-unread")).toHaveCount(2);
+    expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(
+      await page.evaluate(() => document.documentElement.clientWidth + 1),
+    );
+  });
 }
 
 for (const route of communicationsRoutes) {


### PR DESCRIPTION
## Summary

- derive Messages and Unified Inbox unread indicators from existing landlord-authorized state
- keep Communications as an aggregate unread signal without double-counting shared message events
- show accessible child indicators in the desktop menu and responsive sheet
- intentionally leave Notices without an indicator because no Notices unread model exists

## Architecture

- Messages uses conversation `hasUnread` state backed by `lastReadAtLandlord`
- Unified Inbox uses unread non-message records backed by record-level read state
- bridged `landlord.message` inbox records remain assigned to Messages so one tenant message is not represented as two destinations
- opening Communications or navigating to a destination does not acknowledge state
- no backend, Firestore, infrastructure, provider, or acknowledgement change

## Validation

- focused notification/navigation tests: 54 passed
- full frontend: 1,727 passed
- TypeScript: passed
- production build: passed
- Communications Playwright: 44 passed across desktop, tablet, and mobile
- package, Preview, and Production governance: passed
- credential scan and diff check: clean
- scoped lint: no new finding; five existing baseline findings remain in previously touched navigation/test code

## Scope

- E only: Communications notification clarity
- F tenant maintenance attachments remains unstarted

## QA

Draft for exact-head Preview visual verification of Messages-only, Inbox-only, both, neither, parent aggregation, and responsive child indicators.
