### PR TITLE
Bootstrap HCP Preview Storage control-plane permissions

### DIFF
--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -345,6 +345,47 @@ check "b6_preview_artifact_reader_boundary" {
   }
 }
 
+check "f1_hcp_storage_control_plane_boundary" {
+  assert {
+    condition = (
+      google_project_iam_custom_role.hcp_terraform_preview_storage_reader.project == "rentchain-preview" &&
+      google_project_iam_custom_role.hcp_terraform_preview_storage_reader.role_id == "hcpTerraformPreviewStorageReader" &&
+      local.hcp_terraform_preview_storage_reader_permissions == toset([
+        "storage.buckets.get",
+        "storage.buckets.getIamPolicy",
+      ]) &&
+      google_project_iam_member.hcp_terraform_preview_storage_reader.member == local.hcp_terraform_plan_member
+    )
+    error_message = "The HCP plan identity must retain exactly the two approved Preview bucket read permissions."
+  }
+
+  assert {
+    condition = (
+      google_project_iam_custom_role.terraform_preview_storage_manager.project == "rentchain-preview" &&
+      google_project_iam_custom_role.terraform_preview_storage_manager.role_id == "terraformPreviewStorageManager" &&
+      local.terraform_preview_storage_manager_permissions == toset([
+        "storage.buckets.create",
+        "storage.buckets.get",
+        "storage.buckets.getIamPolicy",
+        "storage.buckets.setIamPolicy",
+        "storage.buckets.update",
+      ]) &&
+      google_project_iam_member.terraform_preview_storage_manager.member == local.hcp_terraform_apply_member
+    )
+    error_message = "The HCP apply identity must retain exactly the five approved Preview bucket control-plane permissions."
+  }
+
+  assert {
+    condition = (
+      !contains(local.hcp_terraform_preview_storage_reader_permissions, "storage.buckets.delete") &&
+      !contains(local.terraform_preview_storage_manager_permissions, "storage.buckets.delete") &&
+      length([for permission in local.hcp_terraform_preview_storage_reader_permissions : permission if startswith(permission, "storage.objects.")]) == 0 &&
+      length([for permission in local.terraform_preview_storage_manager_permissions : permission if startswith(permission, "storage.objects.")]) == 0
+    )
+    error_message = "The HCP Storage bootstrap must exclude bucket delete and all object-data permissions."
+  }
+}
+
 check "b5_image_delivery_boundary" {
   assert {
     condition = local.github_preview_image_publisher_permissions == toset([

--- a/infra/environments/preview-foundation/iam.tf
+++ b/infra/environments/preview-foundation/iam.tf
@@ -61,6 +61,19 @@ locals {
   terraform_preview_custom_role_updater_permissions = toset([
     "iam.roles.update",
   ])
+
+  hcp_terraform_preview_storage_reader_permissions = toset([
+    "storage.buckets.get",
+    "storage.buckets.getIamPolicy",
+  ])
+
+  terraform_preview_storage_manager_permissions = toset([
+    "storage.buckets.create",
+    "storage.buckets.get",
+    "storage.buckets.getIamPolicy",
+    "storage.buckets.setIamPolicy",
+    "storage.buckets.update",
+  ])
 }
 
 resource "google_project_iam_custom_role" "hcp_terraform_preview_b7_reader" {
@@ -125,6 +138,52 @@ resource "google_project_iam_custom_role" "terraform_preview_custom_role_updater
 resource "google_project_iam_member" "terraform_preview_custom_role_updater" {
   project = var.project_id
   role    = google_project_iam_custom_role.terraform_preview_custom_role_updater.name
+  member  = local.hcp_terraform_apply_member
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_project_iam_custom_role" "hcp_terraform_preview_storage_reader" {
+  project     = var.project_id
+  role_id     = "hcpTerraformPreviewStorageReader"
+  title       = "HCP Terraform Preview Storage Reader"
+  description = "Plan-phase read access for governed Preview bucket metadata and IAM policy."
+  permissions = local.hcp_terraform_preview_storage_reader_permissions
+  stage       = "GA"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_project_iam_member" "hcp_terraform_preview_storage_reader" {
+  project = var.project_id
+  role    = google_project_iam_custom_role.hcp_terraform_preview_storage_reader.name
+  member  = local.hcp_terraform_plan_member
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_project_iam_custom_role" "terraform_preview_storage_manager" {
+  project     = var.project_id
+  role_id     = "terraformPreviewStorageManager"
+  title       = "Terraform Preview Storage Manager"
+  description = "Apply-phase control-plane access for governed Preview buckets without delete or object permissions."
+  permissions = local.terraform_preview_storage_manager_permissions
+  stage       = "GA"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_project_iam_member" "terraform_preview_storage_manager" {
+  project = var.project_id
+  role    = google_project_iam_custom_role.terraform_preview_storage_manager.name
   member  = local.hcp_terraform_apply_member
 
   lifecycle {

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -35,7 +35,7 @@ EOF
 actual_resources="$(rg -No 'resource "[^"]+"' "$root_dir" --glob '*.tf' | sed -E 's/.*resource "([^"]+)"/\1/' | sort -u)"
 test "$actual_resources" = "$expected_resources"
 
-test "$(rg -No '^resource "[^"]+"' "$root_dir" --glob '*.tf' | wc -l | tr -d ' ')" = "42"
+test "$(rg -No '^resource "[^"]+"' "$root_dir" --glob '*.tf' | wc -l | tr -d ' ')" = "46"
 
 test "$(rg -No 'service\s*=\s*"[^"]+\.googleapis\.com"' "$root_dir/services.tf" | wc -l | tr -d ' ')" = "0"
 test "$(rg -No '"(apikeys|artifactregistry|cloudresourcemanager|firestore|iam|identitytoolkit|run|secretmanager|serviceusage)\.googleapis\.com"' "$root_dir/services.tf" | sort -u | wc -l | tr -d ' ')" = "9"
@@ -78,6 +78,53 @@ fi
 
 if rg -n 'allUsers|allAuthenticatedUsers|google_storage_bucket|google_firestore_(document|field|index)|google_compute|google_container|google_cloudbuild' "$root_dir" --glob '*.tf'; then
   echo "Public IAM or workload resource found" >&2
+  exit 1
+fi
+
+expected_storage_plan_permissions="$(cat <<'EOF'
+storage.buckets.get
+storage.buckets.getIamPolicy
+EOF
+)"
+actual_storage_plan_permissions="$(
+  sed -n '/hcp_terraform_preview_storage_reader_permissions = toset(/,/])/p' "$root_dir/iam.tf" \
+    | rg -No '"[^"]+"' \
+    | tr -d '"'
+)"
+test "$actual_storage_plan_permissions" = "$expected_storage_plan_permissions"
+
+expected_storage_apply_permissions="$(cat <<'EOF'
+storage.buckets.create
+storage.buckets.get
+storage.buckets.getIamPolicy
+storage.buckets.setIamPolicy
+storage.buckets.update
+EOF
+)"
+actual_storage_apply_permissions="$(
+  sed -n '/terraform_preview_storage_manager_permissions = toset(/,/])/p' "$root_dir/iam.tf" \
+    | rg -No '"[^"]+"' \
+    | tr -d '"'
+)"
+test "$actual_storage_apply_permissions" = "$expected_storage_apply_permissions"
+
+rg -q 'role_id     = "hcpTerraformPreviewStorageReader"' "$root_dir/iam.tf"
+rg -q 'role_id     = "terraformPreviewStorageManager"' "$root_dir/iam.tf"
+rg -q 'resource "google_project_iam_member" "hcp_terraform_preview_storage_reader"' "$root_dir/iam.tf"
+rg -q 'resource "google_project_iam_member" "terraform_preview_storage_manager"' "$root_dir/iam.tf"
+rg -q 'member  = local\.hcp_terraform_plan_member' "$root_dir/iam.tf"
+rg -q 'member  = local\.hcp_terraform_apply_member' "$root_dir/iam.tf"
+grep -Fq 'local.hcp_terraform_preview_storage_reader_permissions == toset([' "$root_dir/checks.tf"
+grep -Fq 'local.terraform_preview_storage_manager_permissions == toset([' "$root_dir/checks.tf"
+
+if printf '%s\n%s\n' "$actual_storage_plan_permissions" "$actual_storage_apply_permissions" \
+  | rg -n 'storage\.buckets\.delete|storage\.objects\.'; then
+  echo "Bucket delete or object-data permission found in HCP Storage bootstrap" >&2
+  exit 1
+fi
+
+if rg -n 'roles/storage\.|google_storage_bucket|google_storage_bucket_iam|allUsers|allAuthenticatedUsers' "$root_dir" --glob '*.tf'; then
+  echo "Predefined Storage role, bucket resource, bucket IAM, or public principal found in bootstrap" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Purpose

PR #1525 F1 QA needs a separately governed private Preview attachment bucket, but the HCP Terraform plan and apply identities currently have no Storage control-plane permissions. This bootstrap adds only the capability needed for a later, separate bucket-foundation change.

## Exact identities and permissions

Plan identity: `hcp-terraform-preview@rentchain-preview.iam.gserviceaccount.com`

- `storage.buckets.get`
- `storage.buckets.getIamPolicy`

Apply identity: `hcp-terraform-preview-apply@rentchain-preview.iam.gserviceaccount.com`

- `storage.buckets.create`
- `storage.buckets.get`
- `storage.buckets.getIamPolicy`
- `storage.buckets.setIamPolicy`
- `storage.buckets.update`

`storage.buckets.update` is required for the later PAP, UBLA, and bucket-IAM lifecycle. The roles are dedicated custom roles with exact project bindings to preserve plan/apply separation.

## Containment

- no `storage.buckets.delete`
- no `storage.objects.*`
- no predefined or project-wide Storage role
- no bucket or bucket IAM resource
- no runtime, Vercel, or GitHub deploy identity change
- no public or cross-project principal
- no Production change
- PR #1525 remains untouched at `d4fe051bcac7b47a5161b4b2c0c49ca8621acef3`

The separate Preview storage foundation may resume only after this bootstrap is merged, applied through the governed HCP run, verified effective, and followed by a zero-drift plan.

## Validation

- `terraform fmt -check -recursive`
- `terraform init -backend=false`
- `terraform validate`
- `bash tests/validate_scope.sh`
- `git diff --check`

The existing mock `.tftest.hcl` harness has an unrelated baseline failure involving the Google Beta imported Firebase resource and known-after-apply assertions; the unchanged deployment-foundation test reproduces it. No test framework or unrelated foundation resource was changed here.
