### PR TITLE
Add Preview attachment storage foundation

### DIFF
--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -391,7 +391,7 @@ check "f1_preview_attachment_storage_boundary" {
     condition = (
       google_storage_bucket.preview_attachments.project == "rentchain-preview" &&
       google_storage_bucket.preview_attachments.name == "rentchain-preview-attachments" &&
-      google_storage_bucket.preview_attachments.location == "northamerica-northeast1" &&
+      lower(google_storage_bucket.preview_attachments.location) == "northamerica-northeast1" &&
       google_storage_bucket.preview_attachments.public_access_prevention == "enforced" &&
       google_storage_bucket.preview_attachments.uniform_bucket_level_access &&
       !google_storage_bucket.preview_attachments.force_destroy

--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -386,6 +386,44 @@ check "f1_hcp_storage_control_plane_boundary" {
   }
 }
 
+check "f1_preview_attachment_storage_boundary" {
+  assert {
+    condition = (
+      google_storage_bucket.preview_attachments.project == "rentchain-preview" &&
+      google_storage_bucket.preview_attachments.name == "rentchain-preview-attachments" &&
+      google_storage_bucket.preview_attachments.location == "northamerica-northeast1" &&
+      google_storage_bucket.preview_attachments.public_access_prevention == "enforced" &&
+      google_storage_bucket.preview_attachments.uniform_bucket_level_access &&
+      !google_storage_bucket.preview_attachments.force_destroy
+    )
+    error_message = "The F1 attachment bucket must remain private, non-destructive, and isolated in the Montreal Preview project."
+  }
+
+  assert {
+    condition = (
+      google_project_iam_custom_role.preview_attachment_object_runtime.project == "rentchain-preview" &&
+      google_project_iam_custom_role.preview_attachment_object_runtime.role_id == "previewAttachmentObjectRuntime" &&
+      local.preview_attachment_object_permissions == toset([
+        "storage.objects.create",
+        "storage.objects.delete",
+        "storage.objects.get",
+      ]) &&
+      google_storage_bucket_iam_member.preview_attachment_runtime.bucket == google_storage_bucket.preview_attachments.name &&
+      google_storage_bucket_iam_member.preview_attachment_runtime.member == google_service_account.preview_backend_runtime.member
+    )
+    error_message = "Preview attachment object access must remain exact, bucket-scoped, and limited to the Preview runtime identity."
+  }
+
+  assert {
+    condition = (
+      google_service_account_iam_member.preview_runtime_self_token_creator.service_account_id == google_service_account.preview_backend_runtime.name &&
+      google_service_account_iam_member.preview_runtime_self_token_creator.role == "roles/iam.serviceAccountTokenCreator" &&
+      google_service_account_iam_member.preview_runtime_self_token_creator.member == google_service_account.preview_backend_runtime.member
+    )
+    error_message = "Preview keyless signing must remain a self-member-only binding on the exact runtime service account."
+  }
+}
+
 check "b5_image_delivery_boundary" {
   assert {
     condition = local.github_preview_image_publisher_permissions == toset([

--- a/infra/environments/preview-foundation/outputs.tf
+++ b/infra/environments/preview-foundation/outputs.tf
@@ -76,3 +76,13 @@ output "vercel_preview_proxy_identity" {
   }
   sensitive = false
 }
+
+output "preview_attachment_storage" {
+  description = "Non-sensitive identifiers for the private Preview attachment storage foundation."
+  value = {
+    bucket_name             = google_storage_bucket.preview_attachments.name
+    location                = google_storage_bucket.preview_attachments.location
+    runtime_service_account = google_service_account.preview_backend_runtime.email
+  }
+  sensitive = false
+}

--- a/infra/environments/preview-foundation/storage.tf
+++ b/infra/environments/preview-foundation/storage.tf
@@ -1,0 +1,60 @@
+locals {
+  preview_attachment_bucket_name = "rentchain-preview-attachments"
+  preview_attachment_object_permissions = toset([
+    "storage.objects.create",
+    "storage.objects.delete",
+    "storage.objects.get",
+  ])
+}
+
+resource "google_storage_bucket" "preview_attachments" {
+  project                     = var.project_id
+  name                        = local.preview_attachment_bucket_name
+  location                    = local.preview_deployment_region
+  public_access_prevention    = "enforced"
+  uniform_bucket_level_access = true
+  force_destroy               = false
+
+  labels = {
+    environment = "preview"
+    managed-by  = "terraform"
+    purpose     = "maintenance-attachment-qa"
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_project_iam_custom_role" "preview_attachment_object_runtime" {
+  project     = var.project_id
+  role_id     = "previewAttachmentObjectRuntime"
+  title       = "Preview Attachment Object Runtime"
+  description = "Exact object create, get, and delete access for the governed Preview attachment bucket."
+  permissions = local.preview_attachment_object_permissions
+  stage       = "GA"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_storage_bucket_iam_member" "preview_attachment_runtime" {
+  bucket = google_storage_bucket.preview_attachments.name
+  role   = google_project_iam_custom_role.preview_attachment_object_runtime.name
+  member = google_service_account.preview_backend_runtime.member
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_service_account_iam_member" "preview_runtime_self_token_creator" {
+  service_account_id = google_service_account.preview_backend_runtime.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = google_service_account.preview_backend_runtime.member
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -30,12 +30,14 @@ google_secret_manager_secret_iam_member
 google_secret_manager_secret_version
 google_service_account
 google_service_account_iam_member
+google_storage_bucket
+google_storage_bucket_iam_member
 EOF
 )"
 actual_resources="$(rg -No 'resource "[^"]+"' "$root_dir" --glob '*.tf' | sed -E 's/.*resource "([^"]+)"/\1/' | sort -u)"
 test "$actual_resources" = "$expected_resources"
 
-test "$(rg -No '^resource "[^"]+"' "$root_dir" --glob '*.tf' | wc -l | tr -d ' ')" = "46"
+test "$(rg -No '^resource "[^"]+"' "$root_dir" --glob '*.tf' | wc -l | tr -d ' ')" = "50"
 
 test "$(rg -No 'service\s*=\s*"[^"]+\.googleapis\.com"' "$root_dir/services.tf" | wc -l | tr -d ' ')" = "0"
 test "$(rg -No '"(apikeys|artifactregistry|cloudresourcemanager|firestore|iam|identitytoolkit|run|secretmanager|serviceusage)\.googleapis\.com"' "$root_dir/services.tf" | sort -u | wc -l | tr -d ' ')" = "9"
@@ -76,7 +78,7 @@ if rg -n 'credentials\s*=|credentials_file|GOOGLE_APPLICATION_CREDENTIALS|servic
   exit 1
 fi
 
-if rg -n 'allUsers|allAuthenticatedUsers|google_storage_bucket|google_firestore_(document|field|index)|google_compute|google_container|google_cloudbuild' "$root_dir" --glob '*.tf'; then
+if rg -n 'allUsers|allAuthenticatedUsers|google_firestore_(document|field|index)|google_compute|google_container|google_cloudbuild' "$root_dir" --glob '*.tf'; then
   echo "Public IAM or workload resource found" >&2
   exit 1
 fi
@@ -123,8 +125,48 @@ if printf '%s\n%s\n' "$actual_storage_plan_permissions" "$actual_storage_apply_p
   exit 1
 fi
 
-if rg -n 'roles/storage\.|google_storage_bucket|google_storage_bucket_iam|allUsers|allAuthenticatedUsers' "$root_dir" --glob '*.tf'; then
-  echo "Predefined Storage role, bucket resource, bucket IAM, or public principal found in bootstrap" >&2
+if rg -n 'roles/storage\.|allUsers|allAuthenticatedUsers' "$root_dir" --glob '*.tf'; then
+  echo "Predefined Storage role or public principal found in Preview foundation" >&2
+  exit 1
+fi
+
+storage_file="$root_dir/storage.tf"
+test "$(rg -No '^resource "google_storage_bucket" "preview_attachments"' "$storage_file" | wc -l | tr -d ' ')" = "1"
+test "$(rg -No '^resource "google_storage_bucket_iam_member" "preview_attachment_runtime"' "$storage_file" | wc -l | tr -d ' ')" = "1"
+test "$(rg -No '^resource "google_project_iam_custom_role" "preview_attachment_object_runtime"' "$storage_file" | wc -l | tr -d ' ')" = "1"
+test "$(rg -No '^resource "google_service_account_iam_member" "preview_runtime_self_token_creator"' "$storage_file" | wc -l | tr -d ' ')" = "1"
+rg -q 'preview_attachment_bucket_name = "rentchain-preview-attachments"' "$storage_file"
+rg -q 'location[[:space:]]*= local\.preview_deployment_region' "$storage_file"
+rg -q 'public_access_prevention[[:space:]]*= "enforced"' "$storage_file"
+rg -q 'uniform_bucket_level_access[[:space:]]*= true' "$storage_file"
+rg -q 'force_destroy[[:space:]]*= false' "$storage_file"
+rg -U -q '(?s)resource "google_storage_bucket" "preview_attachments" \{.*lifecycle \{\n    prevent_destroy = true\n  \}' "$storage_file"
+
+expected_attachment_object_permissions="$(cat <<'EOF'
+storage.objects.create
+storage.objects.delete
+storage.objects.get
+EOF
+)"
+actual_attachment_object_permissions="$(
+  sed -n '/preview_attachment_object_permissions = toset(/,/])/p' "$storage_file" \
+    | rg -No '"[^"]+"' \
+    | tr -d '"'
+)"
+test "$actual_attachment_object_permissions" = "$expected_attachment_object_permissions"
+rg -q 'role_id     = "previewAttachmentObjectRuntime"' "$storage_file"
+rg -q 'bucket = google_storage_bucket\.preview_attachments\.name' "$storage_file"
+rg -q 'role   = google_project_iam_custom_role\.preview_attachment_object_runtime\.name' "$storage_file"
+rg -q 'member = google_service_account\.preview_backend_runtime\.member' "$storage_file"
+rg -U -q 'service_account_id = google_service_account\.preview_backend_runtime\.name\n  role[[:space:]]*= "roles/iam\.serviceAccountTokenCreator"\n  member[[:space:]]*= google_service_account\.preview_backend_runtime\.member' "$storage_file"
+
+test "$(rg -No 'roles/iam\.serviceAccountTokenCreator' "$root_dir" --glob '*.tf' | wc -l | tr -d ' ')" = "2"
+if rg -n 'storage\.objects\.(list|update|setIamPolicy|getIamPolicy)|storage\.buckets\.(delete|create|update|setIamPolicy|getIamPolicy|get)' "$storage_file"; then
+  echo "Forbidden object or bucket control-plane permission found in the attachment runtime foundation" >&2
+  exit 1
+fi
+if rg -n 'vercel-preview-proxy|github-preview-deploy|hcp-terraform-preview|project-0d9658de-af29-4dc0-a99|rentchain-documents-prod' "$storage_file"; then
+  echo "Non-runtime, HCP, Production, or Production-bucket identity found in attachment storage" >&2
   exit 1
 fi
 
@@ -538,7 +580,7 @@ if rg -n 'project-0d9658de-af29-4dc0-a99|production' "$apply_permissions_file"; 
   exit 1
 fi
 
-if rg -n 'roles/(owner|editor|run\.admin|artifactregistry\.writer|cloudbuild\.builds\.editor|iam\.serviceAccountTokenCreator|storage\.admin)|google_service_account_key|principalSet://.*/workloadIdentityPools/github-preview-deploy/\*' "$root_dir" --glob '*.tf'; then
+if rg -n 'roles/(owner|editor|run\.admin|artifactregistry\.writer|cloudbuild\.builds\.editor|storage\.admin)|google_service_account_key|principalSet://.*/workloadIdentityPools/github-preview-deploy/\*' "$root_dir" --glob '*.tf'; then
   echo "Broad deployment permission, static key, or wildcard federation found" >&2
   exit 1
 fi

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -137,6 +137,7 @@ test "$(rg -No '^resource "google_project_iam_custom_role" "preview_attachment_o
 test "$(rg -No '^resource "google_service_account_iam_member" "preview_runtime_self_token_creator"' "$storage_file" | wc -l | tr -d ' ')" = "1"
 rg -q 'preview_attachment_bucket_name = "rentchain-preview-attachments"' "$storage_file"
 rg -q 'location[[:space:]]*= local\.preview_deployment_region' "$storage_file"
+grep -Fq 'lower(google_storage_bucket.preview_attachments.location) == "northamerica-northeast1"' "$root_dir/checks.tf"
 rg -q 'public_access_prevention[[:space:]]*= "enforced"' "$storage_file"
 rg -q 'uniform_bucket_level_access[[:space:]]*= true' "$storage_file"
 rg -q 'force_destroy[[:space:]]*= false' "$storage_file"


### PR DESCRIPTION
## Purpose

PR #1525 F1 end-to-end QA requires private non-production object storage. This change adds the separately governed Preview-only storage foundation after the HCP control-plane bootstrap was applied and verified at zero drift.

## Storage contract

- bucket: `rentchain-preview-attachments`
- project: `rentchain-preview`
- location: `northamerica-northeast1`
- Public Access Prevention: enforced
- Uniform Bucket-Level Access: enabled
- versioning: disabled
- automatic deletion lifecycle: none
- force destroy: false

## Runtime access

The custom role `previewAttachmentObjectRuntime` contains exactly:

- `storage.objects.create`
- `storage.objects.get`
- `storage.objects.delete`

It is bound only on the exact Preview attachment bucket to `preview-backend-runtime@rentchain-preview.iam.gserviceaccount.com`. No object list or bucket control-plane permission is granted.

The same runtime service account receives self-member-only, service-account-scoped `roles/iam.serviceAccountTokenCreator` for keyless short-lived signed URLs. It is not project-scoped and is not granted to Vercel, GitHub, HCP, or Production principals.

## Containment

- no public principal or ACL
- no predefined/project-wide Storage role
- no Production project or `rentchain-documents-prod` access
- no permanent Preview Cloud Run mutation
- no PR #1525 application change; it remains frozen at `d4fe051bcac7b47a5161b4b2c0c49ca8621acef3`
- no QA fixture, object, image, or backend deployment before Founder confirms the later main HCP run

Post-QA retention is an explicit future decision: retain as governed reusable Preview storage or remove through a separate exact-manifest Terraform/HCP cleanup PR.

## Validation

- post-bootstrap run `run-Dh1g3YgbnoXSTraK`: `0 add, 0 change, 0 destroy`
- `terraform fmt -check -recursive`
- `terraform init -backend=false`
- `terraform validate`
- `bash tests/validate_scope.sh`
- `git diff --check`
