### PR TITLE
Fix Preview attachment storage Terraform check

### DIFF
--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -408,7 +408,7 @@ check "f1_preview_attachment_storage_boundary" {
         "storage.objects.delete",
         "storage.objects.get",
       ]) &&
-      google_storage_bucket_iam_member.preview_attachment_runtime.bucket == google_storage_bucket.preview_attachments.name &&
+      trimprefix(google_storage_bucket_iam_member.preview_attachment_runtime.bucket, "b/") == google_storage_bucket.preview_attachments.name &&
       google_storage_bucket_iam_member.preview_attachment_runtime.member == google_service_account.preview_backend_runtime.member
     )
     error_message = "Preview attachment object access must remain exact, bucket-scoped, and limited to the Preview runtime identity."

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 repo_dir="$(cd "$root_dir/../../.." && pwd)"
+checks_file="$root_dir/checks.tf"
 workflow_file="$repo_dir/.github/workflows/preview-deployment-identity-validation.yml"
 dockerfile="$repo_dir/rentchain-api/Dockerfile"
 dockerignore_file="$repo_dir/rentchain-api/.dockerignore"
@@ -160,6 +161,11 @@ rg -q 'bucket = google_storage_bucket\.preview_attachments\.name' "$storage_file
 rg -q 'role   = google_project_iam_custom_role\.preview_attachment_object_runtime\.name' "$storage_file"
 rg -q 'member = google_service_account\.preview_backend_runtime\.member' "$storage_file"
 rg -U -q 'service_account_id = google_service_account\.preview_backend_runtime\.name\n  role[[:space:]]*= "roles/iam\.serviceAccountTokenCreator"\n  member[[:space:]]*= google_service_account\.preview_backend_runtime\.member' "$storage_file"
+rg -q 'trimprefix(google_storage_bucket_iam_member\.preview_attachment_runtime\.bucket, "b/") == google_storage_bucket\.preview_attachments\.name' "$checks_file"
+if rg -n 'preview_attachment_runtime\.bucket == google_storage_bucket\.preview_attachments\.name' "$checks_file"; then
+  echo "Preview attachment IAM bucket checks must normalize the provider canonical b/ prefix" >&2
+  exit 1
+fi
 
 test "$(rg -No 'roles/iam\.serviceAccountTokenCreator' "$root_dir" --glob '*.tf' | wc -l | tr -d ' ')" = "2"
 if rg -n 'storage\.objects\.(list|update|setIamPolicy|getIamPolicy)|storage\.buckets\.(delete|create|update|setIamPolicy|getIamPolicy|get)' "$storage_file"; then


### PR DESCRIPTION
## Summary

- normalize the Google provider's canonical `b/` prefix before comparing the attachment bucket IAM resource to the governed bucket name
- pin the normalized assertion in the Preview foundation source-governance test
- retain all existing exact bucket, role, permission, runtime-principal, and self-signing safeguards

## Root cause

After the approved storage foundation apply, Terraform state stored the bucket IAM member's `bucket` attribute as `b/rentchain-preview-attachments`, while the bucket resource's `name` remained `rentchain-preview-attachments`. The previous raw equality check therefore warned even though the live resource and IAM binding were correct.

## Scope and containment

- assertion/test only; no managed resource configuration changed
- no IAM, bucket, Production, Cloud Run, Firestore, Vercel, application, or PR #1525 changes
- live bucket independently verified private, PAP-enforced, UBLA-enabled, correctly scoped, and empty

## Validation

- `terraform fmt -check`
- `terraform init -backend=false -upgrade=false`
- `terraform validate`
- `bash ./tests/validate_scope.sh`
- `git diff --check`

The PR remains Draft pending an authoritative speculative HCP plan proving `0 add, 0 change, 0 destroy` with the warning removed.
