### PR TITLE
Allow Preview runtime to delete F1 attachment metadata

### DIFF
--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -43,6 +43,7 @@ check "b7_preview_datastore_boundary" {
     condition = local.preview_runtime_firestore_permissions == toset([
       "datastore.databases.get",
       "datastore.entities.create",
+      "datastore.entities.delete",
       "datastore.entities.get",
       "datastore.entities.list",
       "datastore.entities.update",

--- a/infra/environments/preview-foundation/datastore_auth.tf
+++ b/infra/environments/preview-foundation/datastore_auth.tf
@@ -7,6 +7,7 @@ locals {
   preview_runtime_firestore_permissions = toset([
     "datastore.databases.get",
     "datastore.entities.create",
+    "datastore.entities.delete",
     "datastore.entities.get",
     "datastore.entities.list",
     "datastore.entities.update",

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -239,6 +239,7 @@ grep -Fq "resource.name == 'projects/\${var.project_id}/databases/\${local.previ
 expected_runtime_firestore_permissions="$(cat <<'EOF'
 datastore.databases.get
 datastore.entities.create
+datastore.entities.delete
 datastore.entities.get
 datastore.entities.list
 datastore.entities.update


### PR DESCRIPTION
## Summary

- add only `datastore.entities.delete` to the existing Preview backend Firestore runtime custom role
- update the exact-set Terraform check and static governance assertion
- preserve the existing `(default)` Preview database condition and exact runtime identity binding

## Proven requirement

PR #1525 controlled attachment QA proved that GCS deletion succeeds but Firestore attachment metadata deletion fails because `previewBackendFirestoreRuntime` currently lacks `datastore.entities.delete`. Existing get/list/create/update and storage permissions already cover every other operation in the path.

Classification: `MINIMUM_FIRESTORE_DELETE_DELTA`

## Containment

- project remains `rentchain-preview`
- identity remains `preview-backend-runtime@rentchain-preview.iam.gserviceaccount.com`
- no Production principal or resource
- no predefined datastore admin/user role
- no storage permission or bucket change
- no Invoker, Vercel proxy, HCP identity, public IAM, backend, frontend, or PR #1525 application change

## Validation

- `terraform fmt -check -recursive` — passed
- `terraform init -backend=false -input=false` — passed
- `terraform validate` — passed
- `bash tests/validate_scope.sh` — passed
- `git diff --check` — passed
- repository-wide mocked `terraform test` retains unrelated provider-normalization / known-after-apply baseline failures; no failure identifies this exact permission-set assertion

Do not apply locally. HCP plan semantics must show only an in-place custom-role permission change with no destroy or unrelated action.
