### PR TITLE
Add Preview identity document storage foundation

### DIFF
--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -425,6 +425,35 @@ check "f1_preview_attachment_storage_boundary" {
   }
 }
 
+check "g1b_preview_identity_document_storage_boundary" {
+  assert {
+    condition = (
+      google_storage_bucket.preview_identity_documents.project == "rentchain-preview" &&
+      google_storage_bucket.preview_identity_documents.name == "rentchain-preview-identity-documents" &&
+      lower(google_storage_bucket.preview_identity_documents.location) == "northamerica-northeast1" &&
+      google_storage_bucket.preview_identity_documents.public_access_prevention == "enforced" &&
+      google_storage_bucket.preview_identity_documents.uniform_bucket_level_access &&
+      !google_storage_bucket.preview_identity_documents.force_destroy
+    )
+    error_message = "The G1B identity-document bucket must remain private, non-destructive, and isolated in the Montreal Preview project."
+  }
+
+  assert {
+    condition = (
+      google_project_iam_custom_role.preview_identity_document_object_runtime.project == "rentchain-preview" &&
+      google_project_iam_custom_role.preview_identity_document_object_runtime.role_id == "previewIdentityDocumentObjectRuntime" &&
+      local.preview_identity_document_object_permissions == toset([
+        "storage.objects.create",
+        "storage.objects.delete",
+        "storage.objects.get",
+      ]) &&
+      trimprefix(google_storage_bucket_iam_member.preview_identity_document_runtime.bucket, "b/") == google_storage_bucket.preview_identity_documents.name &&
+      google_storage_bucket_iam_member.preview_identity_document_runtime.member == google_service_account.preview_backend_runtime.member
+    )
+    error_message = "Preview identity-document object access must remain exact, bucket-scoped, and limited to the Preview runtime identity."
+  }
+}
+
 check "b5_image_delivery_boundary" {
   assert {
     condition = local.github_preview_image_publisher_permissions == toset([

--- a/infra/environments/preview-foundation/outputs.tf
+++ b/infra/environments/preview-foundation/outputs.tf
@@ -86,3 +86,13 @@ output "preview_attachment_storage" {
   }
   sensitive = false
 }
+
+output "preview_identity_document_storage" {
+  description = "Non-sensitive identifiers for the private Preview identity-document storage foundation."
+  value = {
+    bucket_name             = google_storage_bucket.preview_identity_documents.name
+    location                = google_storage_bucket.preview_identity_documents.location
+    runtime_service_account = google_service_account.preview_backend_runtime.email
+  }
+  sensitive = false
+}

--- a/infra/environments/preview-foundation/storage.tf
+++ b/infra/environments/preview-foundation/storage.tf
@@ -5,6 +5,12 @@ locals {
     "storage.objects.delete",
     "storage.objects.get",
   ])
+  preview_identity_document_bucket_name = "rentchain-preview-identity-documents"
+  preview_identity_document_object_permissions = toset([
+    "storage.objects.create",
+    "storage.objects.delete",
+    "storage.objects.get",
+  ])
 }
 
 resource "google_storage_bucket" "preview_attachments" {
@@ -42,6 +48,48 @@ resource "google_project_iam_custom_role" "preview_attachment_object_runtime" {
 resource "google_storage_bucket_iam_member" "preview_attachment_runtime" {
   bucket = google_storage_bucket.preview_attachments.name
   role   = google_project_iam_custom_role.preview_attachment_object_runtime.name
+  member = google_service_account.preview_backend_runtime.member
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_storage_bucket" "preview_identity_documents" {
+  project                     = var.project_id
+  name                        = local.preview_identity_document_bucket_name
+  location                    = local.preview_deployment_region
+  public_access_prevention    = "enforced"
+  uniform_bucket_level_access = true
+  force_destroy               = false
+
+  labels = {
+    environment = "preview"
+    managed-by  = "terraform"
+    purpose     = "tenant-identity-document-qa"
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_project_iam_custom_role" "preview_identity_document_object_runtime" {
+  project     = var.project_id
+  role_id     = "previewIdentityDocumentObjectRuntime"
+  title       = "Preview Identity Document Object Runtime"
+  description = "Exact object create, get, and delete access for the governed Preview identity-document bucket."
+  permissions = local.preview_identity_document_object_permissions
+  stage       = "GA"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_storage_bucket_iam_member" "preview_identity_document_runtime" {
+  bucket = google_storage_bucket.preview_identity_documents.name
+  role   = google_project_iam_custom_role.preview_identity_document_object_runtime.name
   member = google_service_account.preview_backend_runtime.member
 
   lifecycle {

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -38,7 +38,7 @@ EOF
 actual_resources="$(rg -No 'resource "[^"]+"' "$root_dir" --glob '*.tf' | sed -E 's/.*resource "([^"]+)"/\1/' | sort -u)"
 test "$actual_resources" = "$expected_resources"
 
-test "$(rg -No '^resource "[^"]+"' "$root_dir" --glob '*.tf' | wc -l | tr -d ' ')" = "50"
+test "$(rg -No '^resource "[^"]+"' "$root_dir" --glob '*.tf' | wc -l | tr -d ' ')" = "53"
 
 test "$(rg -No 'service\s*=\s*"[^"]+\.googleapis\.com"' "$root_dir/services.tf" | wc -l | tr -d ' ')" = "0"
 test "$(rg -No '"(apikeys|artifactregistry|cloudresourcemanager|firestore|iam|identitytoolkit|run|secretmanager|serviceusage)\.googleapis\.com"' "$root_dir/services.tf" | sort -u | wc -l | tr -d ' ')" = "9"
@@ -174,6 +174,35 @@ if rg -n 'storage\.objects\.(list|update|setIamPolicy|getIamPolicy)|storage\.buc
 fi
 if rg -n 'vercel-preview-proxy|github-preview-deploy|hcp-terraform-preview|project-0d9658de-af29-4dc0-a99|rentchain-documents-prod' "$storage_file"; then
   echo "Non-runtime, HCP, Production, or Production-bucket identity found in attachment storage" >&2
+  exit 1
+fi
+
+test "$(rg -No '^resource "google_storage_bucket" "preview_identity_documents"' "$storage_file" | wc -l | tr -d ' ')" = "1"
+test "$(rg -No '^resource "google_storage_bucket_iam_member" "preview_identity_document_runtime"' "$storage_file" | wc -l | tr -d ' ')" = "1"
+test "$(rg -No '^resource "google_project_iam_custom_role" "preview_identity_document_object_runtime"' "$storage_file" | wc -l | tr -d ' ')" = "1"
+rg -q 'preview_identity_document_bucket_name = "rentchain-preview-identity-documents"' "$storage_file"
+grep -Fq 'lower(google_storage_bucket.preview_identity_documents.location) == "northamerica-northeast1"' "$checks_file"
+rg -U -q '(?s)resource "google_storage_bucket" "preview_identity_documents" \{.*public_access_prevention[[:space:]]*= "enforced".*uniform_bucket_level_access[[:space:]]*= true.*force_destroy[[:space:]]*= false.*lifecycle \{\n    prevent_destroy = true\n  \}' "$storage_file"
+
+expected_identity_document_object_permissions="$(cat <<'EOF'
+storage.objects.create
+storage.objects.delete
+storage.objects.get
+EOF
+)"
+actual_identity_document_object_permissions="$(
+  sed -n '/preview_identity_document_object_permissions = toset(/,/])/p' "$storage_file" \
+    | rg -No '"[^"]+"' \
+    | tr -d '"'
+)"
+test "$actual_identity_document_object_permissions" = "$expected_identity_document_object_permissions"
+rg -q 'role_id     = "previewIdentityDocumentObjectRuntime"' "$storage_file"
+rg -q 'bucket = google_storage_bucket\.preview_identity_documents\.name' "$storage_file"
+rg -q 'role   = google_project_iam_custom_role\.preview_identity_document_object_runtime\.name' "$storage_file"
+rg -q 'member = google_service_account\.preview_backend_runtime\.member' "$storage_file"
+grep -Fq 'trimprefix(google_storage_bucket_iam_member.preview_identity_document_runtime.bucket, "b/") == google_storage_bucket.preview_identity_documents.name' "$checks_file"
+if printf '%s\n' "$actual_identity_document_object_permissions" | rg -n 'storage\.objects\.(list|update|setIamPolicy|getIamPolicy)|storage\.buckets\.'; then
+  echo "Forbidden list, update, IAM, or bucket control-plane permission found in the identity-document runtime foundation" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- add the dedicated private `rentchain-preview-identity-documents` bucket in `rentchain-preview`
- enforce Public Access Prevention, uniform bucket-level access, Montreal region placement, and non-destructive lifecycle safeguards
- add an identity-specific custom role with exactly object create/get/delete and bind it only on the dedicated bucket to the existing Preview backend runtime service account
- reuse the existing runtime self-signing binding without widening project IAM

## Security boundary

- Preview only; no Production resource or target
- no public member, predefined Storage role, object listing, bucket deletion permission, browser credential, or maintenance-bucket reuse
- no application runtime, frontend, provider, biometric, OCR, PDF, or user-data change

## Validation

- `terraform fmt -check -recursive infra/environments/preview-foundation` — passed
- `terraform -chdir=infra/environments/preview-foundation init -backend=false -input=false` — passed
- `terraform -chdir=infra/environments/preview-foundation validate` — passed
- `bash infra/environments/preview-foundation/tests/validate_scope.sh` — passed
- `git diff --check` — passed
- existing mock baseline-label Terraform test remains unable to plan because multiple pre-existing provider-computed check assertions are unknown under the mock provider; this change does not alter those checks

## Governance

Draft only. Do not merge or apply until the exact HCP speculative plan proves only the three intended Preview additions and no change or destroy.
