### PR TITLE
Remove temporary G1B Preview QA auth scaffolding

### DIFF
--- a/rentchain-api/src/middleware/__tests__/previewQaAuth.test.ts
+++ b/rentchain-api/src/middleware/__tests__/previewQaAuth.test.ts
@@ -7,9 +7,6 @@ import {
   PR1512_PREVIEW_QA_IDENTITY_ALIAS,
   PR1512_PREVIEW_QA_LANDLORD_ID,
   PR1512_PREVIEW_QA_SCOPE,
-  G1B_PREVIEW_QA_FOREIGN_TENANT_ALIAS,
-  G1B_PREVIEW_QA_SCOPE,
-  G1B_PREVIEW_QA_TENANT_ALIAS,
   decidePreviewQaAuth,
   isPreviewQaAuthenticatedRequest,
   previewQaAuth,
@@ -38,13 +35,6 @@ const pr1512EnabledEnv = {
   PREVIEW_QA_AUTH_SCOPE: PR1512_PREVIEW_QA_SCOPE,
   K_SERVICE: "rentchain-pr1512-notices-qa-590e0ecb",
   PREVIEW_QA_EXPECTED_SERVICE: "rentchain-pr1512-notices-qa-590e0ecb",
-} as NodeJS.ProcessEnv;
-
-const g1bEnabledEnv = {
-  ...enabledEnv,
-  PREVIEW_QA_AUTH_SCOPE: G1B_PREVIEW_QA_SCOPE,
-  K_SERVICE: "rentchain-g1b-identity-qa-7b79594d",
-  PREVIEW_QA_EXPECTED_SERVICE: "rentchain-g1b-identity-qa-7b79594d",
 } as NodeJS.ProcessEnv;
 
 function decide(overrides: Partial<Parameters<typeof decidePreviewQaAuth>[0]> = {}) {
@@ -183,41 +173,6 @@ describe("previewQaAuth", () => {
       landlordId: PR1512_PREVIEW_QA_LANDLORD_ID,
       role: "landlord",
     });
-  });
-
-  it.each([G1B_PREVIEW_QA_TENANT_ALIAS, G1B_PREVIEW_QA_FOREIGN_TENANT_ALIAS])(
-    "injects only fixed G1B synthetic tenant identity %s",
-    (selector) => {
-      process.env = { ...g1bEnabledEnv };
-      const headers = { "x-rentchain-preview-qa-identity": selector, "x-tenant-id": "arbitrary" };
-      const req: any = { method: "GET", headers, header: (name: string) => headers[name.toLowerCase() as keyof typeof headers] };
-      const res: any = { status: () => res, json: () => res };
-      let nextCalled = false;
-      previewQaAuth("tenant-identity-list")(req, res, () => { nextCalled = true; });
-      expect(nextCalled).toBe(true);
-      expect(req.user).toMatchObject({ id: selector, tenantId: selector, role: "tenant" });
-      expect(req.user.tenantId).not.toBe("arbitrary");
-    },
-  );
-
-  it.each([
-    ["POST", "tenant-identity-consent"],
-    ["POST", "tenant-identity-upload"],
-    ["GET", "tenant-identity-list"],
-    ["POST", "tenant-identity-access"],
-    ["DELETE", "tenant-identity-delete"],
-  ] as const)("allows only G1B operation %s %s on its isolated service", (method, route) => {
-    expect(decide({ env: g1bEnabledEnv, method, route, selector: G1B_PREVIEW_QA_TENANT_ALIAS })).toEqual({ kind: "allow" });
-  });
-
-  it.each([
-    ["Production", { ...g1bEnabledEnv, GOOGLE_CLOUD_PROJECT: "project-0d9658de-af29-4dc0-a99" }],
-    ["permanent Preview", { ...g1bEnabledEnv, K_SERVICE: "rentchain-preview-backend", PREVIEW_QA_EXPECTED_SERVICE: "rentchain-preview-backend" }],
-    ["wrong service", { ...g1bEnabledEnv, K_SERVICE: "rentchain-g1b-identity-qa-deadbeef" }],
-    ["wrong scope", { ...g1bEnabledEnv, PREVIEW_QA_AUTH_SCOPE: PR1512_PREVIEW_QA_SCOPE }],
-    ["disabled", { ...g1bEnabledEnv, PREVIEW_QA_AUTH_ENABLED: "false" }],
-  ])("rejects G1B under %s", (_label, env) => {
-    expect(decide({ env, method: "GET", route: "tenant-identity-list", selector: G1B_PREVIEW_QA_TENANT_ALIAS })).toEqual({ kind: "reject" });
   });
 
   it.each([

--- a/rentchain-api/src/middleware/previewQaAuth.ts
+++ b/rentchain-api/src/middleware/previewQaAuth.ts
@@ -10,12 +10,6 @@ export const PR1512_PREVIEW_QA_SCOPE = "pr1512-property-notices";
 export const PR1512_PREVIEW_QA_IDENTITY_ALIAS = "pr1512-landlord";
 export const PR1512_PREVIEW_QA_LANDLORD_ID = "qa-pr1512-landlord";
 export const PR1512_PREVIEW_QA_SERVICE_PATTERN = /^rentchain-pr1512-notices-qa-[a-f0-9]{8}$/;
-export const G1B_PREVIEW_QA_SCOPE = "g1b-synthetic-identity-qa-v1";
-export const G1B_PREVIEW_QA_TENANT_ALIAS = "qa-g1b-tenant";
-export const G1B_PREVIEW_QA_FOREIGN_TENANT_ALIAS = "qa-g1b-foreign-tenant";
-export const G1B_PREVIEW_QA_TENANT_ID = "qa-g1b-tenant";
-export const G1B_PREVIEW_QA_FOREIGN_TENANT_ID = "qa-g1b-foreign-tenant";
-export const G1B_PREVIEW_QA_SERVICE_PATTERN = /^rentchain-g1b-identity-qa-[a-f0-9]{8}$/;
 
 const PREVIEW_PROJECT_ID = "rentchain-preview";
 const PRODUCTION_PROJECT_ID = "project-0d9658de-af29-4dc0-a99";
@@ -40,12 +34,7 @@ export type PreviewQaRoute =
   | "tenant-maintenance-attachment-upload"
   | "tenant-maintenance-attachment-delete"
   | "landlord-maintenance-attachment-list"
-  | "landlord-maintenance-attachment-access"
-  | "tenant-identity-consent"
-  | "tenant-identity-upload"
-  | "tenant-identity-list"
-  | "tenant-identity-access"
-  | "tenant-identity-delete";
+  | "landlord-maintenance-attachment-access";
 
 type PreviewQaContract = {
   scope: string;
@@ -53,8 +42,6 @@ type PreviewQaContract = {
   selector: string;
   landlordId: string;
   email: string;
-  role?: "landlord" | "tenant";
-  tenantId?: string;
   allowedOperations: ReadonlySet<string>;
 };
 
@@ -97,25 +84,6 @@ const previewQaContracts: readonly PreviewQaContract[] = [
       "POST:landlord-notice-create",
     ]),
   },
-  ...[
-    { selector: G1B_PREVIEW_QA_TENANT_ALIAS, tenantId: G1B_PREVIEW_QA_TENANT_ID },
-    { selector: G1B_PREVIEW_QA_FOREIGN_TENANT_ALIAS, tenantId: G1B_PREVIEW_QA_FOREIGN_TENANT_ID },
-  ].map(({ selector, tenantId }): PreviewQaContract => ({
-    scope: G1B_PREVIEW_QA_SCOPE,
-    servicePattern: G1B_PREVIEW_QA_SERVICE_PATTERN,
-    selector,
-    landlordId: "",
-    tenantId,
-    role: "tenant",
-    email: `${tenantId}@example.invalid`,
-    allowedOperations: new Set([
-      "POST:tenant-identity-consent",
-      "POST:tenant-identity-upload",
-      "GET:tenant-identity-list",
-      "POST:tenant-identity-access",
-      "DELETE:tenant-identity-delete",
-    ]),
-  })),
 ];
 
 type PreviewQaDecision =
@@ -143,7 +111,7 @@ export function decidePreviewQaAuth(input: PreviewQaDecisionInput): PreviewQaDec
   const expectedService = String(input.env.PREVIEW_QA_EXPECTED_SERVICE || "").trim();
   const firestoreEnabled = String(input.env.FIRESTORE_ENABLED || "").trim().toLowerCase();
   const firestoreDatabaseId = String(input.env.FIRESTORE_DATABASE_ID || "").trim();
-  const contract = previewQaContracts.find((candidate) => candidate.scope === scope && candidate.selector === input.selector);
+  const contract = previewQaContracts.find((candidate) => candidate.scope === scope);
 
   const isolatedPreviewQa =
     enabled === "true" &&
@@ -159,6 +127,7 @@ export function decidePreviewQaAuth(input: PreviewQaDecisionInput): PreviewQaDec
     firestoreDatabaseId === "(default)";
 
   if (!isolatedPreviewQa || !contract) return { kind: "reject" };
+  if (input.selector !== contract?.selector) return { kind: "reject" };
   if (!contract.allowedOperations.has(`${input.method.toUpperCase()}:${input.route}`)) return { kind: "reject" };
   return { kind: "allow" };
 }
@@ -215,18 +184,8 @@ export function previewQaAuth(route: PreviewQaRoute): RequestHandler {
     }
 
     const scope = String(process.env.PREVIEW_QA_AUTH_SCOPE || "").trim();
-    const contract = previewQaContracts.find((candidate) => candidate.scope === scope && candidate.selector === selector);
+    const contract = previewQaContracts.find((candidate) => candidate.scope === scope);
     if (!contract) return res.status(401).json({ ok: false, error: "unauthenticated" });
-    if (contract.role === "tenant" && contract.tenantId) {
-      (req as any).user = {
-        id: contract.tenantId,
-        email: contract.email,
-        role: "tenant",
-        tenantId: contract.tenantId,
-      };
-      (req as any)[previewQaAuthenticated] = true;
-      return next();
-    }
     const entitlements = syntheticLandlordEntitlements(contract.landlordId);
     (req as any).user = {
       id: contract.landlordId,

--- a/rentchain-api/src/routes/tenantIdentityDocumentRoutes.ts
+++ b/rentchain-api/src/routes/tenantIdentityDocumentRoutes.ts
@@ -14,7 +14,6 @@ import {
   type IdentityDocumentRuntimePolicy,
 } from "../lib/identityDocuments";
 import { authenticateJwt } from "../middleware/authMiddleware";
-import { previewQaAuth } from "../middleware/previewQaAuth";
 import { resolveTenancyContext } from "../services/tenantPortal/tenancyContextService";
 
 const router = Router();
@@ -125,7 +124,7 @@ function respondError(res: any, error: unknown) {
   return res.status(500).json({ ok: false, error: "IDENTITY_DOCUMENT_OPERATION_FAILED" });
 }
 
-router.post("/identity-documents/consent", previewQaAuth("tenant-identity-consent"), async (req: any, res) => {
+router.post("/identity-documents/consent", async (req: any, res) => {
   try {
     if (forbiddenAuthorityOverride(req.body)) return res.status(400).json({ ok: false, error: "IDENTITY_OVERRIDE_NOT_ALLOWED" });
     const parsed = consentSchema.safeParse(req.body);
@@ -139,7 +138,7 @@ router.post("/identity-documents/consent", previewQaAuth("tenant-identity-consen
   }
 });
 
-router.get("/identity-documents", previewQaAuth("tenant-identity-list"), async (req: any, res) => {
+router.get("/identity-documents", async (req: any, res) => {
   try {
     const context = await resolveCanonicalSubject(req);
     if (!context) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
@@ -149,7 +148,7 @@ router.get("/identity-documents", previewQaAuth("tenant-identity-list"), async (
   }
 });
 
-router.post("/identity-documents", previewQaAuth("tenant-identity-upload"), async (req: any, res) => {
+router.post("/identity-documents", async (req: any, res) => {
   upload.single("file")(req, res, async (uploadError: any) => {
     try {
       if (uploadError) {
@@ -174,7 +173,7 @@ router.post("/identity-documents", previewQaAuth("tenant-identity-upload"), asyn
   });
 });
 
-router.post("/identity-documents/:documentId/access", previewQaAuth("tenant-identity-access"), async (req: any, res) => {
+router.post("/identity-documents/:documentId/access", async (req: any, res) => {
   try {
     const context = await resolveCanonicalSubject(req);
     if (!context) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
@@ -185,7 +184,7 @@ router.post("/identity-documents/:documentId/access", previewQaAuth("tenant-iden
   }
 });
 
-router.delete("/identity-documents/:documentId", previewQaAuth("tenant-identity-delete"), async (req: any, res) => {
+router.delete("/identity-documents/:documentId", async (req: any, res) => {
   try {
     const context = await resolveCanonicalSubject(req);
     if (!context) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });


### PR DESCRIPTION
## Scope

Removes only the temporary G1B synthetic Preview authentication scaffolding after PR #1535 merged and its isolated QA lifecycle completed.

## Classification

- Category B temporary bootstrap/auth scaffolding: G1B-specific Preview QA scope, fixed synthetic tenant selectors, operation allowlist, and identity-route hooks.
- Permanent G1B identity custody, consent, canonical authorization, storage, projection, sanitization, lifecycle, and audit implementation remains unchanged.
- Existing shared Preview QA contracts for other features remain unchanged.
- G1C is not included and has not started.

## Cleanup evidence

- Exact synthetic Firestore fixtures, consent, identity metadata, and ten metadata-only QA audit events removed.
- Four retained synthetic PNG/WebP objects removed; lifecycle-deleted JPEG pair remained absent.
- Temporary service `rentchain-g1b-identity-qa-ac6fe37b` removed.
- Permanent bucket `rentchain-preview-identity-documents` and its bucket-scoped runtime IAM retained.
- Immutable QA image retained under the established artifact retention boundary.

## Validation

- Identity foundation/application/image runtime plus shared Preview QA auth: 114 passed.
- Backend TypeScript production build: passed.
- Supply-chain governance: passed.
- Credential scan: passed.
- `git diff --check`: passed.

Draft only. Do not merge without separate Founder authorization.
