### PR TITLE
G1C Mandatory Tenant Portal Government ID Workflow

### DIFF
--- a/rentchain-api/src/lib/identityDocuments/__tests__/tenantIdentityRequirementStatus.test.ts
+++ b/rentchain-api/src/lib/identityDocuments/__tests__/tenantIdentityRequirementStatus.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { buildTenantIdentityRequirementStatus } from "../tenantIdentityRequirementStatus";
+
+const context = {
+  actorUserId: "tenant-user",
+  subjectId: "canonical-subject",
+  organizationId: "organization",
+  tenantId: "tenant",
+  applicantParticipantId: "applicant-participant",
+  applicationIds: ["application"],
+  activeWorkflow: true as const,
+};
+
+const policy = {
+  requirementPolicyId: "tenant_government_photo_id_required",
+  requirementPolicyVersion: "v1",
+  policyTextVersion: "v1",
+  privacyNoticeVersion: "v1",
+  retentionPolicyId: "identity-retention",
+  retentionPolicyVersion: "v1",
+};
+
+describe("buildTenantIdentityRequirementStatus", () => {
+  it("requires an upload without implying verification", () => {
+    expect(buildTenantIdentityRequirementStatus({ context, policy, documents: [] })).toMatchObject({
+      required: true,
+      requirementStatus: "action_required",
+      collectionStatus: "not_uploaded",
+      verificationStatus: "not_started",
+      activeDocumentCount: 0,
+      applicationContinuity: true,
+      tenantContinuity: true,
+      biometricProcessing: false,
+      pdfSupported: false,
+    });
+  });
+
+  it("marks a ready image received while preserving not-started verification", () => {
+    const result = buildTenantIdentityRequirementStatus({
+      context,
+      policy,
+      documents: [{ status: "ready", verificationStatus: "not_started" }],
+    });
+    expect(result.requirementStatus).toBe("satisfied");
+    expect(result.collectionStatus).toBe("received");
+    expect(result.verificationStatus).toBe("not_started");
+    expect(result.acceptedMimeTypes).not.toContain("application/pdf");
+  });
+
+  it("does not count replaced or deletion-scheduled records as active", () => {
+    const result = buildTenantIdentityRequirementStatus({
+      context,
+      policy,
+      documents: [
+        { status: "replaced", verificationStatus: "not_started" },
+        { status: "deletion_scheduled", verificationStatus: "not_started" },
+      ],
+    });
+    expect(result.activeDocumentCount).toBe(0);
+    expect(result.requirementStatus).toBe("action_required");
+  });
+});

--- a/rentchain-api/src/lib/identityDocuments/index.ts
+++ b/rentchain-api/src/lib/identityDocuments/index.ts
@@ -7,5 +7,6 @@ export * from "./identityDocumentStorage";
 export * from "./identityDocumentTypes";
 export * from "./identityVerificationProvider";
 export * from "./tenantIdentityRequirement";
+export * from "./tenantIdentityRequirementStatus";
 export * from "./gcsIdentityDocumentStorage";
 export * from "./firestoreIdentityDocumentRepository";

--- a/rentchain-api/src/lib/identityDocuments/tenantIdentityRequirementStatus.ts
+++ b/rentchain-api/src/lib/identityDocuments/tenantIdentityRequirementStatus.ts
@@ -1,0 +1,43 @@
+import type {
+  CanonicalIdentitySubjectContext,
+  IdentityDocumentRuntimePolicy,
+} from "./identityDocumentApplicationService";
+import { IDENTITY_DOCUMENT_MIME_TYPES, MAX_IDENTITY_DOCUMENT_FILE_BYTES } from "./identityDocumentTypes";
+
+type IdentityDocumentSummary = {
+  status: "pending_upload" | "processing" | "ready" | "rejected" | "replaced" | "deletion_scheduled" | "deleted";
+  verificationStatus: "not_started" | "pending" | "verified" | "review_required" | "failed" | "expired" | "cancelled";
+};
+
+export function buildTenantIdentityRequirementStatus(input: {
+  context: CanonicalIdentitySubjectContext;
+  policy: IdentityDocumentRuntimePolicy;
+  documents: readonly IdentityDocumentSummary[];
+}) {
+  const activeDocuments = input.documents.filter(
+    (document) => document.status !== "replaced" && document.status !== "deletion_scheduled",
+  );
+  const receivedDocument = activeDocuments.find((document) => document.status === "ready");
+
+  return {
+    required: true as const,
+    requirementStatus: receivedDocument ? ("satisfied" as const) : ("action_required" as const),
+    collectionStatus: receivedDocument ? ("received" as const) : ("not_uploaded" as const),
+    verificationStatus: receivedDocument?.verificationStatus ?? ("not_started" as const),
+    activeDocumentCount: activeDocuments.length,
+    consent: {
+      purpose: "identity_document_collection" as const,
+      requirementPolicyId: input.policy.requirementPolicyId,
+      requirementPolicyVersion: input.policy.requirementPolicyVersion,
+      policyTextVersion: input.policy.policyTextVersion,
+      privacyNoticeVersion: input.policy.privacyNoticeVersion,
+      retentionPolicyVersion: input.policy.retentionPolicyVersion,
+    },
+    acceptedMimeTypes: IDENTITY_DOCUMENT_MIME_TYPES,
+    maxFileBytes: MAX_IDENTITY_DOCUMENT_FILE_BYTES,
+    applicationContinuity: Boolean(input.context.applicationIds.length || input.context.applicantParticipantId),
+    tenantContinuity: Boolean(input.context.tenantId),
+    biometricProcessing: false as const,
+    pdfSupported: false as const,
+  };
+}

--- a/rentchain-api/src/middleware/__tests__/previewQaAuth.test.ts
+++ b/rentchain-api/src/middleware/__tests__/previewQaAuth.test.ts
@@ -7,6 +7,8 @@ import {
   PR1512_PREVIEW_QA_IDENTITY_ALIAS,
   PR1512_PREVIEW_QA_LANDLORD_ID,
   PR1512_PREVIEW_QA_SCOPE,
+  G1C_PREVIEW_QA_SCOPE,
+  G1C_PREVIEW_QA_TENANT_ALIAS,
   decidePreviewQaAuth,
   isPreviewQaAuthenticatedRequest,
   previewQaAuth,
@@ -35,6 +37,13 @@ const pr1512EnabledEnv = {
   PREVIEW_QA_AUTH_SCOPE: PR1512_PREVIEW_QA_SCOPE,
   K_SERVICE: "rentchain-pr1512-notices-qa-590e0ecb",
   PREVIEW_QA_EXPECTED_SERVICE: "rentchain-pr1512-notices-qa-590e0ecb",
+} as NodeJS.ProcessEnv;
+
+const g1cEnabledEnv = {
+  ...enabledEnv,
+  PREVIEW_QA_AUTH_SCOPE: G1C_PREVIEW_QA_SCOPE,
+  K_SERVICE: "rentchain-g1c-identity-qa-v1",
+  PREVIEW_QA_EXPECTED_SERVICE: "rentchain-g1c-identity-qa-v1",
 } as NodeJS.ProcessEnv;
 
 function decide(overrides: Partial<Parameters<typeof decidePreviewQaAuth>[0]> = {}) {
@@ -85,6 +94,38 @@ function invoke(options: {
 }
 
 describe("previewQaAuth", () => {
+  it("injects only the fixed G1C synthetic tenant identity", () => {
+    process.env = { ...g1cEnabledEnv };
+    const headers = { "x-rentchain-preview-qa-identity": G1C_PREVIEW_QA_TENANT_ALIAS, "x-tenant-id": "arbitrary" };
+    const req: any = { method: "GET", headers, header: (name: string) => headers[name.toLowerCase() as keyof typeof headers] };
+    const res: any = { status: () => res, json: () => res };
+    let nextCalled = false;
+    previewQaAuth("tenant-identity-status")(req, res, () => { nextCalled = true; });
+    expect(nextCalled).toBe(true);
+    expect(req.user).toMatchObject({ id: "qa-g1c-tenant", tenantId: "qa-g1c-tenant", role: "tenant" });
+    expect(req.user.tenantId).not.toBe("arbitrary");
+  });
+
+  it.each([
+    ["GET", "tenant-identity-status"],
+    ["POST", "tenant-identity-consent"],
+    ["POST", "tenant-identity-upload"],
+    ["GET", "tenant-identity-list"],
+    ["POST", "tenant-identity-access"],
+    ["DELETE", "tenant-identity-delete"],
+  ] as const)("allows only G1C operation %s %s", (method, route) => {
+    expect(decide({ env: g1cEnabledEnv, method, route, selector: G1C_PREVIEW_QA_TENANT_ALIAS })).toEqual({ kind: "allow" });
+  });
+
+  it.each([
+    ["Production", { ...g1cEnabledEnv, GOOGLE_CLOUD_PROJECT: "project-0d9658de-af29-4dc0-a99" }],
+    ["permanent Preview", { ...g1cEnabledEnv, K_SERVICE: "rentchain-preview-backend", PREVIEW_QA_EXPECTED_SERVICE: "rentchain-preview-backend" }],
+    ["wrong service", { ...g1cEnabledEnv, K_SERVICE: "rentchain-g1c-identity-qa-v2" }],
+    ["wrong scope", { ...g1cEnabledEnv, PREVIEW_QA_AUTH_SCOPE: PR1512_PREVIEW_QA_SCOPE }],
+    ["disabled", { ...g1cEnabledEnv, PREVIEW_QA_AUTH_ENABLED: "false" }],
+  ])("rejects G1C under %s", (_label, env) => {
+    expect(decide({ env, method: "GET", route: "tenant-identity-status", selector: G1C_PREVIEW_QA_TENANT_ALIAS })).toEqual({ kind: "reject" });
+  });
   const originalEnv = process.env;
 
   beforeEach(() => {

--- a/rentchain-api/src/middleware/previewQaAuth.ts
+++ b/rentchain-api/src/middleware/previewQaAuth.ts
@@ -10,6 +10,10 @@ export const PR1512_PREVIEW_QA_SCOPE = "pr1512-property-notices";
 export const PR1512_PREVIEW_QA_IDENTITY_ALIAS = "pr1512-landlord";
 export const PR1512_PREVIEW_QA_LANDLORD_ID = "qa-pr1512-landlord";
 export const PR1512_PREVIEW_QA_SERVICE_PATTERN = /^rentchain-pr1512-notices-qa-[a-f0-9]{8}$/;
+export const G1C_PREVIEW_QA_SCOPE = "g1c-synthetic-identity-qa-v1";
+export const G1C_PREVIEW_QA_TENANT_ALIAS = "qa-g1c-tenant";
+export const G1C_PREVIEW_QA_TENANT_ID = "qa-g1c-tenant";
+export const G1C_PREVIEW_QA_SERVICE_PATTERN = /^rentchain-g1c-identity-qa-v1$/;
 
 const PREVIEW_PROJECT_ID = "rentchain-preview";
 const PRODUCTION_PROJECT_ID = "project-0d9658de-af29-4dc0-a99";
@@ -34,7 +38,13 @@ export type PreviewQaRoute =
   | "tenant-maintenance-attachment-upload"
   | "tenant-maintenance-attachment-delete"
   | "landlord-maintenance-attachment-list"
-  | "landlord-maintenance-attachment-access";
+  | "landlord-maintenance-attachment-access"
+  | "tenant-identity-status"
+  | "tenant-identity-consent"
+  | "tenant-identity-upload"
+  | "tenant-identity-list"
+  | "tenant-identity-access"
+  | "tenant-identity-delete";
 
 type PreviewQaContract = {
   scope: string;
@@ -42,6 +52,8 @@ type PreviewQaContract = {
   selector: string;
   landlordId: string;
   email: string;
+  role?: "landlord" | "tenant";
+  tenantId?: string;
   allowedOperations: ReadonlySet<string>;
 };
 
@@ -82,6 +94,23 @@ const previewQaContracts: readonly PreviewQaContract[] = [
       "GET:landlord-notice-list",
       "GET:landlord-notice-detail",
       "POST:landlord-notice-create",
+    ]),
+  },
+  {
+    scope: G1C_PREVIEW_QA_SCOPE,
+    servicePattern: G1C_PREVIEW_QA_SERVICE_PATTERN,
+    selector: G1C_PREVIEW_QA_TENANT_ALIAS,
+    landlordId: "",
+    tenantId: G1C_PREVIEW_QA_TENANT_ID,
+    role: "tenant",
+    email: "qa-g1c-tenant@example.invalid",
+    allowedOperations: new Set([
+      "GET:tenant-identity-status",
+      "POST:tenant-identity-consent",
+      "POST:tenant-identity-upload",
+      "GET:tenant-identity-list",
+      "POST:tenant-identity-access",
+      "DELETE:tenant-identity-delete",
     ]),
   },
 ];
@@ -186,6 +215,16 @@ export function previewQaAuth(route: PreviewQaRoute): RequestHandler {
     const scope = String(process.env.PREVIEW_QA_AUTH_SCOPE || "").trim();
     const contract = previewQaContracts.find((candidate) => candidate.scope === scope);
     if (!contract) return res.status(401).json({ ok: false, error: "unauthenticated" });
+    if (contract.role === "tenant" && contract.tenantId) {
+      (req as any).user = {
+        id: contract.tenantId,
+        email: contract.email,
+        role: "tenant",
+        tenantId: contract.tenantId,
+      };
+      (req as any)[previewQaAuthenticated] = true;
+      return next();
+    }
     const entitlements = syntheticLandlordEntitlements(contract.landlordId);
     (req as any).user = {
       id: contract.landlordId,

--- a/rentchain-api/src/routes/tenantIdentityDocumentRoutes.ts
+++ b/rentchain-api/src/routes/tenantIdentityDocumentRoutes.ts
@@ -15,6 +15,7 @@ import {
   type IdentityDocumentRuntimePolicy,
 } from "../lib/identityDocuments";
 import { authenticateJwt } from "../middleware/authMiddleware";
+import { previewQaAuth } from "../middleware/previewQaAuth";
 import { resolveTenancyContext } from "../services/tenantPortal/tenancyContextService";
 
 const router = Router();
@@ -125,7 +126,7 @@ function respondError(res: any, error: unknown) {
   return res.status(500).json({ ok: false, error: "IDENTITY_DOCUMENT_OPERATION_FAILED" });
 }
 
-router.post("/identity-documents/consent", async (req: any, res) => {
+router.post("/identity-documents/consent", previewQaAuth("tenant-identity-consent"), async (req: any, res) => {
   try {
     if (forbiddenAuthorityOverride(req.body)) return res.status(400).json({ ok: false, error: "IDENTITY_OVERRIDE_NOT_ALLOWED" });
     const parsed = consentSchema.safeParse(req.body);
@@ -139,7 +140,7 @@ router.post("/identity-documents/consent", async (req: any, res) => {
   }
 });
 
-router.get("/identity-documents", async (req: any, res) => {
+router.get("/identity-documents", previewQaAuth("tenant-identity-list"), async (req: any, res) => {
   try {
     const context = await resolveCanonicalSubject(req);
     if (!context) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
@@ -149,7 +150,7 @@ router.get("/identity-documents", async (req: any, res) => {
   }
 });
 
-router.get("/identity-documents/status", async (req: any, res) => {
+router.get("/identity-documents/status", previewQaAuth("tenant-identity-status"), async (req: any, res) => {
   try {
     const context = await resolveCanonicalSubject(req);
     if (!context) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
@@ -164,7 +165,7 @@ router.get("/identity-documents/status", async (req: any, res) => {
   }
 });
 
-router.post("/identity-documents", async (req: any, res) => {
+router.post("/identity-documents", previewQaAuth("tenant-identity-upload"), async (req: any, res) => {
   upload.single("file")(req, res, async (uploadError: any) => {
     try {
       if (uploadError) {
@@ -189,7 +190,7 @@ router.post("/identity-documents", async (req: any, res) => {
   });
 });
 
-router.post("/identity-documents/:documentId/access", async (req: any, res) => {
+router.post("/identity-documents/:documentId/access", previewQaAuth("tenant-identity-access"), async (req: any, res) => {
   try {
     const context = await resolveCanonicalSubject(req);
     if (!context) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
@@ -200,7 +201,7 @@ router.post("/identity-documents/:documentId/access", async (req: any, res) => {
   }
 });
 
-router.delete("/identity-documents/:documentId", async (req: any, res) => {
+router.delete("/identity-documents/:documentId", previewQaAuth("tenant-identity-delete"), async (req: any, res) => {
   try {
     const context = await resolveCanonicalSubject(req);
     if (!context) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });

--- a/rentchain-api/src/routes/tenantIdentityDocumentRoutes.ts
+++ b/rentchain-api/src/routes/tenantIdentityDocumentRoutes.ts
@@ -10,6 +10,7 @@ import {
   IdentityDocumentApplicationService,
   IdentityDocumentImageError,
   MAX_IDENTITY_DOCUMENT_FILE_BYTES,
+  buildTenantIdentityRequirementStatus,
   type CanonicalIdentitySubjectContext,
   type IdentityDocumentRuntimePolicy,
 } from "../lib/identityDocuments";
@@ -143,6 +144,21 @@ router.get("/identity-documents", async (req: any, res) => {
     const context = await resolveCanonicalSubject(req);
     if (!context) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
     return res.json({ ok: true, data: await service().list(context) });
+  } catch (error) {
+    return respondError(res, error);
+  }
+});
+
+router.get("/identity-documents/status", async (req: any, res) => {
+  try {
+    const context = await resolveCanonicalSubject(req);
+    if (!context) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    const runtimePolicy = identityDocumentRuntimePolicyFromEnvironment();
+    const documents = await service().list(context);
+    return res.json({
+      ok: true,
+      data: buildTenantIdentityRequirementStatus({ context, policy: runtimePolicy, documents }),
+    });
   } catch (error) {
     return respondError(res, error);
   }

--- a/rentchain-frontend/api/g1c-bootstrap.ts
+++ b/rentchain-frontend/api/g1c-bootstrap.ts
@@ -1,0 +1,5 @@
+import { handleG1cBrowserBootstrap } from "../server/g1cBrowserBootstrap.js";
+
+export default function handler(req: any, res: any) {
+  return handleG1cBrowserBootstrap(req, res);
+}

--- a/rentchain-frontend/api/g1c-identity/[...path].ts
+++ b/rentchain-frontend/api/g1c-identity/[...path].ts
@@ -1,0 +1,7 @@
+import { handleG1cIdentityQaProxy } from "../../server/g1cIdentityQaProxy.js";
+
+export const config = { api: { bodyParser: false } };
+
+export default async function handler(req: any, res: any) {
+  return handleG1cIdentityQaProxy(req, res);
+}

--- a/rentchain-frontend/server/g1cBrowserBootstrap.ts
+++ b/rentchain-frontend/server/g1cBrowserBootstrap.ts
@@ -1,0 +1,33 @@
+export const G1C_BOOTSTRAP = {
+  branch: "feat/g1c-mandatory-tenant-government-id-workflow-v1",
+  scope: "g1c-synthetic-identity-qa-v1",
+  principalId: "qa-g1c-tenant",
+} as const;
+
+function fail(res: any, status: number, error: string) {
+  res.setHeader("cache-control", "no-store");
+  return res.status(status).json({ ok: false, error });
+}
+
+export function classifyG1cBootstrap(req: any) {
+  const sha = String(process.env.VERCEL_GIT_COMMIT_SHA || "").trim();
+  const allowed =
+    String(req?.method || "GET").toUpperCase() === "GET" &&
+    process.env.VERCEL_ENV === "preview" &&
+    process.env.VERCEL_GIT_COMMIT_REF === G1C_BOOTSTRAP.branch &&
+    /^[0-9a-f]{40}$/.test(sha);
+  return allowed ? { allowed: true as const, sha } : { allowed: false as const };
+}
+
+export function handleG1cBrowserBootstrap(req: any, res: any) {
+  const decision = classifyG1cBootstrap(req);
+  if (!decision.allowed) return fail(res, 404, "G1C_BOOTSTRAP_NOT_AVAILABLE");
+  res.setHeader("cache-control", "no-store");
+  res.setHeader("x-rentchain-qa-bootstrap", "g1c-fixed-session");
+  return res.status(200).json({
+    ok: true,
+    scope: G1C_BOOTSTRAP.scope,
+    deploymentSha: decision.sha,
+    session: { role: "tenant", principalId: G1C_BOOTSTRAP.principalId },
+  });
+}

--- a/rentchain-frontend/server/g1cIdentityQaProxy.ts
+++ b/rentchain-frontend/server/g1cIdentityQaProxy.ts
@@ -1,0 +1,104 @@
+import {
+  acquireVercelOidcToken,
+  exchangeVercelToken,
+  generateCloudRunIdToken,
+  PreviewAuthBridgeError,
+  type PreviewAuthConfig,
+} from "./previewAuthBridge.js";
+
+export const G1C_IDENTITY_QA = {
+  branch: "feat/g1c-mandatory-tenant-government-id-workflow-v1",
+  projectNumber: "501298948635",
+  poolId: "vercel-preview-proxy",
+  providerId: "vercel-preview",
+  serviceAccount: "vercel-preview-proxy@rentchain-preview.iam.gserviceaccount.com",
+  serviceUrl: "https://rentchain-g1c-identity-qa-v1-glistw4pya-nn.a.run.app",
+  selector: "qa-g1c-tenant",
+} as const;
+
+const providerPath = `projects/${G1C_IDENTITY_QA.projectNumber}/locations/global/workloadIdentityPools/${G1C_IDENTITY_QA.poolId}/providers/${G1C_IDENTITY_QA.providerId}`;
+const auth: PreviewAuthConfig = {
+  vercelOidcTokenAudience: `https://iam.googleapis.com/${providerPath}`,
+  googleStsAudience: `//iam.googleapis.com/${providerPath}`,
+  cloudRunIdTokenAudience: G1C_IDENTITY_QA.serviceUrl,
+  serviceAccountEmail: G1C_IDENTITY_QA.serviceAccount,
+  cloudRunServiceUrl: G1C_IDENTITY_QA.serviceUrl,
+  expectedSpikeCommit: "",
+};
+
+const DOCUMENT_ID = "[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}";
+const LIST_OR_UPLOAD = /^\/api\/tenant\/identity-documents$/;
+const STATUS = /^\/api\/tenant\/identity-documents\/status$/;
+const CONSENT = /^\/api\/tenant\/identity-documents\/consent$/;
+const ACCESS = new RegExp(`^/api/tenant/identity-documents/${DOCUMENT_ID}/access$`, "i");
+const DELETE = new RegExp(`^/api/tenant/identity-documents/${DOCUMENT_ID}$`, "i");
+const SAFE_RESPONSE_HEADERS = new Set(["cache-control", "content-type", "x-request-id", "x-route-source"]);
+
+function fail(res: any, status: number, error: string) {
+  res.setHeader("cache-control", "no-store");
+  return res.status(status).json({ ok: false, error });
+}
+
+export function classifyG1cIdentityRequest(req: any) {
+  const raw = String(req?.url || "").split("?", 1)[0];
+  const prefix = "/api/g1c-identity/";
+  if (!raw.startsWith(prefix) || /%2f|%5c|\\|\0/i.test(raw)) return { allowed: false as const, status: 404 };
+  const backendPath = `/${raw.slice(prefix.length)}`;
+  const method = String(req?.method || "GET").toUpperCase();
+  const allowed =
+    (method === "GET" && (LIST_OR_UPLOAD.test(backendPath) || STATUS.test(backendPath))) ||
+    (method === "POST" && (LIST_OR_UPLOAD.test(backendPath) || CONSENT.test(backendPath) || ACCESS.test(backendPath))) ||
+    (method === "DELETE" && DELETE.test(backendPath));
+  return allowed ? { allowed: true as const, backendPath, method } : { allowed: false as const, status: 404 };
+}
+
+async function requestBody(req: any): Promise<Buffer | undefined> {
+  if (["GET", "HEAD"].includes(String(req?.method || "GET").toUpperCase())) return undefined;
+  if (Buffer.isBuffer(req.body)) return req.body;
+  const chunks: Buffer[] = [];
+  if (req && typeof req[Symbol.asyncIterator] === "function") {
+    for await (const chunk of req) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return chunks.length ? Buffer.concat(chunks) : undefined;
+}
+
+export async function handleG1cIdentityQaProxy(req: any, res: any, dependencies: any = {}) {
+  if (process.env.VERCEL_ENV !== "preview" || process.env.VERCEL_GIT_COMMIT_REF !== G1C_IDENTITY_QA.branch) {
+    return fail(res, 403, "G1C_QA_CONTEXT_REJECTED");
+  }
+  const decision = classifyG1cIdentityRequest(req);
+  if (!decision.allowed) return fail(res, decision.status, "G1C_QA_ROUTE_NOT_ALLOWED");
+  const fetchImpl = dependencies.fetchImpl ?? fetch;
+  try {
+    const oidc = await acquireVercelOidcToken(auth, dependencies.getVercelOidcToken);
+    const access = await exchangeVercelToken(oidc, auth, fetchImpl);
+    const identity = await generateCloudRunIdToken(access, auth, G1C_IDENTITY_QA.serviceUrl, fetchImpl);
+    const body = await requestBody(req);
+    const headers: Record<string, string> = {
+      accept: "application/json",
+      "X-Serverless-Authorization": `Bearer ${identity}`,
+      "x-rentchain-preview-qa-identity": G1C_IDENTITY_QA.selector,
+    };
+    const contentType = String(req?.headers?.["content-type"] || "");
+    if (body && contentType) headers["content-type"] = contentType;
+    const upstream = await fetchImpl(`${G1C_IDENTITY_QA.serviceUrl}${decision.backendPath}`, {
+      method: decision.method,
+      redirect: "manual",
+      headers,
+      body,
+    });
+    const payload = Buffer.from(await upstream.arrayBuffer());
+    for (const [name, value] of upstream.headers.entries()) if (SAFE_RESPONSE_HEADERS.has(name.toLowerCase())) res.setHeader(name, value);
+    res.setHeader("cache-control", "no-store");
+    res.setHeader("x-rentchain-api-proxy", "g1c-identity-qa");
+    return res.status(upstream.status).send(payload);
+  } catch (error) {
+    const code = error instanceof PreviewAuthBridgeError && error.code.startsWith("STS_")
+      ? "G1C_QA_STS_FAILED"
+      : error instanceof PreviewAuthBridgeError && error.code.startsWith("IAM_")
+        ? "G1C_QA_IDENTITY_FAILED"
+        : "G1C_QA_BACKEND_UNAVAILABLE";
+    console.error("[g1c-identity-qa] request failed", { code });
+    return fail(res, 502, code);
+  }
+}

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -229,6 +229,7 @@ const TenantActivityPage = lazy(() => import("./pages/tenant/TenantActivityPage"
 const TenantParticipationPage = lazy(() => import("./pages/TenantParticipationPage"));
 const TenantAttachmentsPage = lazy(() => import("./pages/tenant/TenantAttachmentsPage"));
 const TenantIdentityPage = lazy(() => import("./pages/tenant/TenantIdentityPage"));
+const G1cPreviewIdentityGate = lazy(() => import("./pages/tenant/G1cPreviewIdentityGate"));
 const TenantNoticesCenterPage = lazy(() => import("./pages/tenant/TenantNoticesCenterPage"));
 const TenantProfilePage = lazy(() => import("./pages/tenant/TenantProfilePage"));
 const TenantAccessPage = lazy(() => import("./pages/tenant/TenantAccessPage"));
@@ -1914,7 +1915,12 @@ function App() {
         />
         <Route
           path="/tenant/identity"
-          element={renderTenantShell(suspensePage(<TenantIdentityPage />))}
+          element={suspensePage(
+            <G1cPreviewIdentityGate
+              normal={renderTenantShell(suspensePage(<TenantIdentityPage />))}
+              qa={<TenantLayout><TenantIdentityPage /></TenantLayout>}
+            />
+          )}
         />
         <Route
           path="/tenant/notices"

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -228,6 +228,7 @@ const TenantLedgerPage = lazy(() => import("./pages/tenant/TenantLedgerPage"));
 const TenantActivityPage = lazy(() => import("./pages/tenant/TenantActivityPage"));
 const TenantParticipationPage = lazy(() => import("./pages/TenantParticipationPage"));
 const TenantAttachmentsPage = lazy(() => import("./pages/tenant/TenantAttachmentsPage"));
+const TenantIdentityPage = lazy(() => import("./pages/tenant/TenantIdentityPage"));
 const TenantNoticesCenterPage = lazy(() => import("./pages/tenant/TenantNoticesCenterPage"));
 const TenantProfilePage = lazy(() => import("./pages/tenant/TenantProfilePage"));
 const TenantAccessPage = lazy(() => import("./pages/tenant/TenantAccessPage"));
@@ -1910,6 +1911,10 @@ function App() {
         <Route
           path="/tenant/documents"
           element={renderTenantShell(suspensePage(<TenantAttachmentsPage />))}
+        />
+        <Route
+          path="/tenant/identity"
+          element={renderTenantShell(suspensePage(<TenantIdentityPage />))}
         />
         <Route
           path="/tenant/notices"

--- a/rentchain-frontend/src/api/tenantApiFetch.test.ts
+++ b/rentchain-frontend/src/api/tenantApiFetch.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { G1C_QA_PRINCIPAL, G1C_QA_SCOPE, G1C_QA_SESSION_KEY } from "../platform/g1cQaSession";
+
+const mocks = vi.hoisted(() => ({
+  apiBaseUrl: "https://rentchain-landlord-api-cyaabkl54a-uc.a.run.app",
+  getTenantToken: vi.fn(() => "tenant-token"),
+}));
+
+vi.mock("./config", () => ({ get API_BASE_URL() { return mocks.apiBaseUrl; } }));
+vi.mock("../lib/tenantAuth", () => ({ getTenantToken: mocks.getTenantToken }));
+
+import { G1cQaTenantApiSuppressedError, tenantApiFetch } from "./tenantApiFetch";
+
+function setSession(scope = G1C_QA_SCOPE, principalId = G1C_QA_PRINCIPAL) {
+  window.sessionStorage.setItem(G1C_QA_SESSION_KEY, JSON.stringify({ scope, session: { principalId } }));
+}
+
+describe("tenant API browser routing", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    window.sessionStorage.clear();
+    mocks.apiBaseUrl = "https://rentchain-landlord-api-cyaabkl54a-uc.a.run.app";
+  });
+
+  it.each([
+    "/tenant/workspace",
+    "/tenant/communication/summary",
+    "/tenant/me",
+    "/tenant/messages",
+    "https://arbitrary-backend.example/api/tenant/workspace",
+  ])("suppresses %s before any browser request in the exact G1C session", async (path) => {
+    setSession();
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    await expect(tenantApiFetch(path)).rejects.toBeInstanceOf(G1cQaTenantApiSuppressedError);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("preserves normal Production tenant API resolution", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } }),
+    );
+
+    await tenantApiFetch("/tenant/workspace");
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://rentchain-landlord-api-cyaabkl54a-uc.a.run.app/api/tenant/workspace",
+      expect.objectContaining({ headers: expect.objectContaining({ Authorization: "Bearer tenant-token" }) }),
+    );
+  });
+
+  it.each([
+    ["other-preview-scope", G1C_QA_PRINCIPAL],
+    [G1C_QA_SCOPE, "qa-g1c-foreign-tenant"],
+  ])("does not suppress unrelated Preview session %s / %s", async (scope, principalId) => {
+    setSession(scope, principalId);
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } }),
+    );
+
+    await tenantApiFetch("/tenant/workspace");
+    expect(fetchSpy).toHaveBeenCalledOnce();
+  });
+
+  it("provides a global zero-direct-run.app guard for fixed G1C browser traffic", async () => {
+    setSession();
+    const applicationRequests: string[] = [];
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      applicationRequests.push(String(input));
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    });
+
+    await Promise.allSettled([
+      tenantApiFetch("/tenant/workspace"),
+      tenantApiFetch("/tenant/communication/summary"),
+      tenantApiFetch("/tenant/maintenance-requests"),
+      tenantApiFetch("/tenant/notices"),
+      tenantApiFetch("/tenant/profile"),
+    ]);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(applicationRequests.filter((url) => new URL(url).hostname.endsWith(".run.app"))).toEqual([]);
+  });
+});

--- a/rentchain-frontend/src/api/tenantApiFetch.ts
+++ b/rentchain-frontend/src/api/tenantApiFetch.ts
@@ -1,10 +1,24 @@
 import { API_BASE_URL } from "./config";
 import { getTenantToken } from "../lib/tenantAuth";
+import { hasG1cQaSession } from "../platform/g1cQaSession";
 
 type Jsonish = Record<string, any>;
 type TenantApiInit = Omit<RequestInit, "body"> & { body?: BodyInit | Jsonish };
 
+export class G1cQaTenantApiSuppressedError extends Error {
+  readonly code = "G1C_QA_TENANT_API_SUPPRESSED";
+
+  constructor(readonly path: string) {
+    super("This Tenant Portal request is unavailable in the fixed G1C synthetic QA session.");
+    this.name = "G1cQaTenantApiSuppressedError";
+  }
+}
+
 export async function tenantApiFetch<T = any>(path: string, init: TenantApiInit = {}): Promise<T> {
+  // G1C has one deliberately narrow same-origin proxy for identity-document QA.
+  // Fail closed before resolving the legacy absolute API base so unrelated shell
+  // and navigation requests cannot reach Production or any direct run.app host.
+  if (hasG1cQaSession()) throw new G1cQaTenantApiSuppressedError(path);
   if (!API_BASE_URL) throw new Error("API_BASE_URL is not configured");
   const base = API_BASE_URL.replace(/\/$/, "").replace(/\/api$/i, "");
 

--- a/rentchain-frontend/src/api/tenantCommunicationsApi.test.ts
+++ b/rentchain-frontend/src/api/tenantCommunicationsApi.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { G1C_QA_PRINCIPAL, G1C_QA_SCOPE, G1C_QA_SESSION_KEY } from "../platform/g1cQaSession";
+
+const mocks = vi.hoisted(() => ({ tenantApiFetch: vi.fn() }));
+vi.mock("./tenantApiFetch", () => ({ tenantApiFetch: mocks.tenantApiFetch }));
+
+import { getTenantCommunicationSummary, getTenantMessages } from "./tenantCommunicationsApi";
+
+describe("tenant communication routing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.sessionStorage.clear();
+  });
+
+  it("suppresses only the background summary request in the exact G1C QA session", async () => {
+    window.sessionStorage.setItem(G1C_QA_SESSION_KEY, JSON.stringify({
+      scope: G1C_QA_SCOPE,
+      session: { principalId: G1C_QA_PRINCIPAL },
+    }));
+
+    await expect(getTenantCommunicationSummary()).resolves.toMatchObject({
+      ok: true,
+      unreadMessages: 0,
+      unreadNotices: 0,
+      unreadTotal: 0,
+    });
+    expect(mocks.tenantApiFetch).not.toHaveBeenCalled();
+  });
+
+  it("preserves normal Production summary routing outside G1C QA", async () => {
+    mocks.tenantApiFetch.mockResolvedValue({ ok: true, unreadTotal: 2 });
+    await getTenantCommunicationSummary();
+    expect(mocks.tenantApiFetch).toHaveBeenCalledWith("/tenant/communication/summary");
+  });
+
+  it("does not suppress unrelated tenant communication routes in G1C QA", async () => {
+    window.sessionStorage.setItem(G1C_QA_SESSION_KEY, JSON.stringify({
+      scope: G1C_QA_SCOPE,
+      session: { principalId: G1C_QA_PRINCIPAL },
+    }));
+    mocks.tenantApiFetch.mockResolvedValue({ ok: true, items: [], unreadCount: 0 });
+    await getTenantMessages();
+    expect(mocks.tenantApiFetch).toHaveBeenCalledWith("/tenant/messages");
+  });
+
+  it("cannot suppress the summary for a foreign synthetic principal", async () => {
+    window.sessionStorage.setItem(G1C_QA_SESSION_KEY, JSON.stringify({
+      scope: G1C_QA_SCOPE,
+      session: { principalId: "qa-g1c-foreign-tenant" },
+    }));
+    mocks.tenantApiFetch.mockResolvedValue({ ok: true, unreadTotal: 0 });
+    await getTenantCommunicationSummary();
+    expect(mocks.tenantApiFetch).toHaveBeenCalledWith("/tenant/communication/summary");
+  });
+});

--- a/rentchain-frontend/src/api/tenantCommunicationsApi.ts
+++ b/rentchain-frontend/src/api/tenantCommunicationsApi.ts
@@ -1,5 +1,6 @@
 import { tenantApiFetch } from "./tenantApiFetch";
 import type { TenantSafeProjectionMetadata } from "./tenantPortal";
+import { hasG1cQaSession } from "../platform/g1cQaSession";
 
 export type TenantCommunicationType = "notice" | "message" | "maintenance_update" | "screening_update" | "system";
 export type TenantCommunicationPriority = "low" | "normal" | "high";
@@ -93,6 +94,18 @@ export async function markTenantScreeningUpdateRead(requestId: string) {
 }
 
 export async function getTenantCommunicationSummary() {
+  if (hasG1cQaSession()) {
+    return {
+      ok: true,
+      unreadMessages: 0,
+      unreadNotices: 0,
+      unreadMaintenanceUpdates: 0,
+      unreadScreeningUpdates: 0,
+      unreadTotal: 0,
+      latestMessagePreview: null,
+      latestMessageAt: null,
+    } satisfies TenantCommunicationSummary;
+  }
   return tenantApiFetch<TenantCommunicationSummary>("/tenant/communication/summary");
 }
 

--- a/rentchain-frontend/src/api/tenantIdentityDocumentsApi.test.ts
+++ b/rentchain-frontend/src/api/tenantIdentityDocumentsApi.test.ts
@@ -13,7 +13,7 @@ describe("tenant identity documents API", () => {
 
   it("loads the canonical tenant requirement without a client-selected subject", async () => {
     await getTenantIdentityRequirement();
-    expect(mocks.tenantApiFetch).toHaveBeenCalledWith("/tenant/identity-documents/status");
+    expect(mocks.tenantApiFetch).toHaveBeenCalledWith("/tenant/identity-documents/status", {});
     expect(JSON.stringify(mocks.tenantApiFetch.mock.calls)).not.toContain("subjectId");
   });
 

--- a/rentchain-frontend/src/api/tenantIdentityDocumentsApi.test.ts
+++ b/rentchain-frontend/src/api/tenantIdentityDocumentsApi.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getTenantIdentityRequirement, recordTenantIdentityConsent, uploadTenantIdentityDocument } from "./tenantIdentityDocumentsApi";
+
+const mocks = vi.hoisted(() => ({ tenantApiFetch: vi.fn() }));
+vi.mock("./tenantApiFetch", () => mocks);
+
+describe("tenant identity documents API", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.tenantApiFetch.mockResolvedValue({ ok: true, data: {} });
+  });
+
+  it("loads the canonical tenant requirement without a client-selected subject", async () => {
+    await getTenantIdentityRequirement();
+    expect(mocks.tenantApiFetch).toHaveBeenCalledWith("/tenant/identity-documents/status");
+    expect(JSON.stringify(mocks.tenantApiFetch.mock.calls)).not.toContain("subjectId");
+  });
+
+  it("records explicit collection consent", async () => {
+    await recordTenantIdentityConsent("en-CA");
+    expect(mocks.tenantApiFetch).toHaveBeenCalledWith("/tenant/identity-documents/consent", {
+      method: "POST",
+      body: { acknowledged: true, displayedLocale: "en-CA" },
+    });
+  });
+
+  it("uploads image metadata as multipart without authority overrides", async () => {
+    const file = new File(["image"], "id.png", { type: "image/png" });
+    await uploadTenantIdentityDocument({ file, documentType: "passport", side: "photo_page", issuingCountry: "CA" });
+    const [, init] = mocks.tenantApiFetch.mock.calls[0];
+    expect(init.method).toBe("POST");
+    expect(init.body).toBeInstanceOf(FormData);
+    expect(init.body.get("file")).toBe(file);
+    expect(init.body.get("subjectId")).toBeNull();
+    expect(init.body.get("tenantId")).toBeNull();
+  });
+});

--- a/rentchain-frontend/src/api/tenantIdentityDocumentsApi.ts
+++ b/rentchain-frontend/src/api/tenantIdentityDocumentsApi.ts
@@ -1,16 +1,7 @@
 import { tenantApiFetch } from "./tenantApiFetch";
+import { G1C_QA_SESSION_KEY, hasG1cQaSession } from "../platform/g1cQaSession";
 
-export const G1C_QA_SESSION_KEY = "rentchain.qa.g1c.fixed-session";
-
-function hasG1cQaSession() {
-  if (typeof window === "undefined") return false;
-  try {
-    const value = JSON.parse(window.sessionStorage.getItem(G1C_QA_SESSION_KEY) || "null");
-    return value?.scope === "g1c-synthetic-identity-qa-v1" && value?.session?.principalId === "qa-g1c-tenant";
-  } catch {
-    return false;
-  }
-}
+export { G1C_QA_SESSION_KEY } from "../platform/g1cQaSession";
 
 async function tenantIdentityFetch<T = any>(path: string, init: { method?: string; body?: any } = {}): Promise<T> {
   if (!hasG1cQaSession()) return tenantApiFetch<T>(path, init);

--- a/rentchain-frontend/src/api/tenantIdentityDocumentsApi.ts
+++ b/rentchain-frontend/src/api/tenantIdentityDocumentsApi.ts
@@ -1,0 +1,109 @@
+import { tenantApiFetch } from "./tenantApiFetch";
+
+export const TENANT_IDENTITY_ACCEPTED_MIME_TYPES = ["image/jpeg", "image/png", "image/webp"] as const;
+export const TENANT_IDENTITY_MAX_FILE_BYTES = 10 * 1024 * 1024;
+
+export type TenantIdentityDocumentType =
+  | "drivers_license"
+  | "passport"
+  | "provincial_id"
+  | "other_government_photo_id";
+
+export type TenantIdentityDocumentSide = "front" | "back" | "photo_page" | "single";
+
+export type TenantIdentityDocument = {
+  documentId: string;
+  documentType: TenantIdentityDocumentType;
+  side: TenantIdentityDocumentSide;
+  status: "pending_upload" | "processing" | "ready" | "rejected" | "replaced" | "deletion_scheduled";
+  verificationStatus: "not_started" | "pending" | "verified" | "review_required" | "failed" | "expired" | "cancelled";
+  mimeType: (typeof TENANT_IDENTITY_ACCEPTED_MIME_TYPES)[number];
+  byteSize: number;
+  width: number;
+  height: number;
+  uploadedAt: string;
+  sanitizedAccessAvailable: boolean;
+};
+
+export type TenantIdentityRequirementStatus = {
+  required: true;
+  requirementStatus: "action_required" | "satisfied";
+  collectionStatus: "not_uploaded" | "received";
+  verificationStatus: TenantIdentityDocument["verificationStatus"];
+  activeDocumentCount: number;
+  consent: {
+    purpose: "identity_document_collection";
+    requirementPolicyId: string;
+    requirementPolicyVersion: string;
+    policyTextVersion: string;
+    privacyNoticeVersion: string;
+    retentionPolicyVersion: string;
+  };
+  acceptedMimeTypes: readonly string[];
+  maxFileBytes: number;
+  applicationContinuity: boolean;
+  tenantContinuity: boolean;
+  biometricProcessing: false;
+  pdfSupported: false;
+};
+
+export type TenantIdentityAccess = {
+  accessReference: string;
+  expiresAt: string;
+  expiresInSeconds: 300;
+  representation: "sanitized";
+  cachePolicy: "private, no-store";
+};
+
+export async function getTenantIdentityRequirement(): Promise<TenantIdentityRequirementStatus> {
+  const response = await tenantApiFetch<{ ok: true; data: TenantIdentityRequirementStatus }>(
+    "/tenant/identity-documents/status",
+  );
+  return response.data;
+}
+
+export async function listTenantIdentityDocuments(): Promise<TenantIdentityDocument[]> {
+  const response = await tenantApiFetch<{ ok: true; data: TenantIdentityDocument[] }>("/tenant/identity-documents");
+  return Array.isArray(response.data) ? response.data : [];
+}
+
+export async function recordTenantIdentityConsent(displayedLocale: string): Promise<void> {
+  await tenantApiFetch("/tenant/identity-documents/consent", {
+    method: "POST",
+    body: { acknowledged: true, displayedLocale },
+  });
+}
+
+export async function uploadTenantIdentityDocument(input: {
+  file: File;
+  documentType: TenantIdentityDocumentType;
+  side: TenantIdentityDocumentSide;
+  issuingCountry: string;
+  issuingRegion?: string;
+  replaceDocumentId?: string;
+}): Promise<TenantIdentityDocument> {
+  const form = new FormData();
+  form.append("file", input.file);
+  form.append("documentType", input.documentType);
+  form.append("side", input.side);
+  form.append("issuingCountry", input.issuingCountry);
+  if (input.issuingRegion) form.append("issuingRegion", input.issuingRegion);
+  if (input.replaceDocumentId) form.append("replaceDocumentId", input.replaceDocumentId);
+  const response = await tenantApiFetch<{ ok: true; data: TenantIdentityDocument }>("/tenant/identity-documents", {
+    method: "POST",
+    body: form,
+  });
+  return response.data;
+}
+
+export async function getTenantIdentityDocumentAccess(documentId: string): Promise<TenantIdentityAccess> {
+  const response = await tenantApiFetch<{ ok: true; data: TenantIdentityAccess }>(
+    `/tenant/identity-documents/${encodeURIComponent(documentId)}/access`,
+    { method: "POST", body: {} },
+  );
+  return response.data;
+}
+
+export async function deleteTenantIdentityDocument(documentId: string): Promise<void> {
+  await tenantApiFetch(`/tenant/identity-documents/${encodeURIComponent(documentId)}`, { method: "DELETE" });
+}

--- a/rentchain-frontend/src/api/tenantIdentityDocumentsApi.ts
+++ b/rentchain-frontend/src/api/tenantIdentityDocumentsApi.ts
@@ -1,5 +1,37 @@
 import { tenantApiFetch } from "./tenantApiFetch";
 
+export const G1C_QA_SESSION_KEY = "rentchain.qa.g1c.fixed-session";
+
+function hasG1cQaSession() {
+  if (typeof window === "undefined") return false;
+  try {
+    const value = JSON.parse(window.sessionStorage.getItem(G1C_QA_SESSION_KEY) || "null");
+    return value?.scope === "g1c-synthetic-identity-qa-v1" && value?.session?.principalId === "qa-g1c-tenant";
+  } catch {
+    return false;
+  }
+}
+
+async function tenantIdentityFetch<T = any>(path: string, init: { method?: string; body?: any } = {}): Promise<T> {
+  if (!hasG1cQaSession()) return tenantApiFetch<T>(path, init);
+  const backendPath = path.startsWith("/api/") ? path : `/api${path.startsWith("/") ? path : `/${path}`}`;
+  const headers: Record<string, string> = { accept: "application/json" };
+  let body = init.body;
+  if (body && !(body instanceof FormData)) {
+    headers["content-type"] = "application/json";
+    body = JSON.stringify(body);
+  }
+  const response = await fetch(`/api/g1c-identity${backendPath}`, { method: init.method || "GET", headers, body });
+  const payload = await response.json().catch(() => null);
+  if (!response.ok) {
+    const error: any = new Error(payload?.error || `Identity request failed (${response.status})`);
+    error.payload = payload;
+    error.status = response.status;
+    throw error;
+  }
+  return payload as T;
+}
+
 export const TENANT_IDENTITY_ACCEPTED_MIME_TYPES = ["image/jpeg", "image/png", "image/webp"] as const;
 export const TENANT_IDENTITY_MAX_FILE_BYTES = 10 * 1024 * 1024;
 
@@ -56,19 +88,19 @@ export type TenantIdentityAccess = {
 };
 
 export async function getTenantIdentityRequirement(): Promise<TenantIdentityRequirementStatus> {
-  const response = await tenantApiFetch<{ ok: true; data: TenantIdentityRequirementStatus }>(
+  const response = await tenantIdentityFetch<{ ok: true; data: TenantIdentityRequirementStatus }>(
     "/tenant/identity-documents/status",
   );
   return response.data;
 }
 
 export async function listTenantIdentityDocuments(): Promise<TenantIdentityDocument[]> {
-  const response = await tenantApiFetch<{ ok: true; data: TenantIdentityDocument[] }>("/tenant/identity-documents");
+  const response = await tenantIdentityFetch<{ ok: true; data: TenantIdentityDocument[] }>("/tenant/identity-documents");
   return Array.isArray(response.data) ? response.data : [];
 }
 
 export async function recordTenantIdentityConsent(displayedLocale: string): Promise<void> {
-  await tenantApiFetch("/tenant/identity-documents/consent", {
+  await tenantIdentityFetch("/tenant/identity-documents/consent", {
     method: "POST",
     body: { acknowledged: true, displayedLocale },
   });
@@ -89,7 +121,7 @@ export async function uploadTenantIdentityDocument(input: {
   form.append("issuingCountry", input.issuingCountry);
   if (input.issuingRegion) form.append("issuingRegion", input.issuingRegion);
   if (input.replaceDocumentId) form.append("replaceDocumentId", input.replaceDocumentId);
-  const response = await tenantApiFetch<{ ok: true; data: TenantIdentityDocument }>("/tenant/identity-documents", {
+  const response = await tenantIdentityFetch<{ ok: true; data: TenantIdentityDocument }>("/tenant/identity-documents", {
     method: "POST",
     body: form,
   });
@@ -97,7 +129,7 @@ export async function uploadTenantIdentityDocument(input: {
 }
 
 export async function getTenantIdentityDocumentAccess(documentId: string): Promise<TenantIdentityAccess> {
-  const response = await tenantApiFetch<{ ok: true; data: TenantIdentityAccess }>(
+  const response = await tenantIdentityFetch<{ ok: true; data: TenantIdentityAccess }>(
     `/tenant/identity-documents/${encodeURIComponent(documentId)}/access`,
     { method: "POST", body: {} },
   );
@@ -105,5 +137,5 @@ export async function getTenantIdentityDocumentAccess(documentId: string): Promi
 }
 
 export async function deleteTenantIdentityDocument(documentId: string): Promise<void> {
-  await tenantApiFetch(`/tenant/identity-documents/${encodeURIComponent(documentId)}`, { method: "DELETE" });
+  await tenantIdentityFetch(`/tenant/identity-documents/${encodeURIComponent(documentId)}`, { method: "DELETE" });
 }

--- a/rentchain-frontend/src/components/layout/TenantNav.test.tsx
+++ b/rentchain-frontend/src/components/layout/TenantNav.test.tsx
@@ -110,6 +110,7 @@ describe("TenantNav mobile bottom navigation", () => {
     const menu = screen.getByRole("dialog", { name: "Tenant menu" });
     expect(menu).toHaveClass("is-open");
     expect(within(menu).getByRole("button", { name: "Profile" })).toBeInTheDocument();
+    expect(within(menu).getByRole("button", { name: "Identity" })).toBeInTheDocument();
     expect(within(menu).getByRole("button", { name: "Maintenance" })).toBeInTheDocument();
     expect(within(menu).queryByRole("button", { name: "Properties" })).not.toBeInTheDocument();
     expect(within(menu).queryByRole("button", { name: "Admin" })).not.toBeInTheDocument();

--- a/rentchain-frontend/src/components/layout/TenantNav.tsx
+++ b/rentchain-frontend/src/components/layout/TenantNav.tsx
@@ -20,6 +20,7 @@ const navItems = [
   { label: "Access", to: "/tenant/access" },
   { label: "Application", to: "/tenant/application" },
   { label: "Documents", to: "/tenant/documents" },
+  { label: "Identity", to: "/tenant/identity" },
   { label: "Payments", to: "/tenant/payments" },
   { label: "History", to: "/tenant/activity" },
   { label: "Lease", to: "/tenant/lease" },

--- a/rentchain-frontend/src/pages/tenant/G1cPreviewIdentityGate.tsx
+++ b/rentchain-frontend/src/pages/tenant/G1cPreviewIdentityGate.tsx
@@ -1,0 +1,33 @@
+import React, { useEffect, useState } from "react";
+import { useLocation } from "react-router-dom";
+
+import { G1C_QA_SESSION_KEY } from "../../api/tenantIdentityDocumentsApi";
+
+export default function G1cPreviewIdentityGate(props: { qa: React.ReactNode; normal: React.ReactNode }) {
+  const location = useLocation();
+  const requested = new URLSearchParams(location.search).get("g1cQa") === "1";
+  const [state, setState] = useState<"loading" | "ready" | "unavailable">("loading");
+
+  useEffect(() => {
+    if (!requested) return setState("unavailable");
+    let cancelled = false;
+    void fetch("/api/g1c-bootstrap", { headers: { accept: "application/json" } })
+      .then(async (response) => {
+        const payload = await response.json().catch(() => null);
+        if (!response.ok || payload?.scope !== "g1c-synthetic-identity-qa-v1" || payload?.session?.principalId !== "qa-g1c-tenant") {
+          throw new Error("bootstrap unavailable");
+        }
+        window.sessionStorage.setItem(G1C_QA_SESSION_KEY, JSON.stringify(payload));
+        if (!cancelled) setState("ready");
+      })
+      .catch(() => {
+        window.sessionStorage.removeItem(G1C_QA_SESSION_KEY);
+        if (!cancelled) setState("unavailable");
+      });
+    return () => { cancelled = true; };
+  }, [requested]);
+
+  if (!requested || state === "unavailable") return <>{props.normal}</>;
+  if (state === "loading") return <main style={{ padding: 24 }}>Initializing fixed synthetic Preview tenant…</main>;
+  return <>{props.qa}</>;
+}

--- a/rentchain-frontend/src/pages/tenant/TenantIdentityPage.css
+++ b/rentchain-frontend/src/pages/tenant/TenantIdentityPage.css
@@ -1,0 +1,42 @@
+.tenant-identity-summary,
+.tenant-identity-panel { background: #fff; border: 1px solid rgba(15,23,42,.1); border-radius: 16px; padding: 20px; box-shadow: 0 8px 24px rgba(15,23,42,.04); }
+.tenant-identity-summary { display: flex; justify-content: space-between; gap: 20px; align-items: flex-start; border-left: 5px solid #7c3aed; }
+.tenant-identity-summary h2,.tenant-identity-panel h2 { margin: 0 0 8px; color: #0f172a; }
+.tenant-identity-summary p,.tenant-identity-panel p { margin: 0; color: #475569; line-height: 1.55; }
+.tenant-identity-continuity { margin-top: 8px !important; font-size: 14px; }
+.tenant-identity-eyebrow { color: #6d28d9 !important; text-transform: uppercase; font-size: 12px; font-weight: 800; letter-spacing: .08em; }
+.tenant-identity-statuses { display: grid; gap: 8px; min-width: 190px; }
+.tenant-identity-statuses span { padding: 8px 10px; border-radius: 999px; background: #f3e8ff; color: #5b21b6; font-size: 13px; font-weight: 800; text-align: center; }
+.tenant-identity-document-grid { display: grid; gap: 16px; margin-top: 16px; grid-template-columns: repeat(auto-fit,minmax(260px,1fr)); }
+.tenant-identity-document { border: 1px solid #e2e8f0; border-radius: 14px; overflow: hidden; display: grid; background: #f8fafc; }
+.tenant-identity-document img,.tenant-identity-placeholder,.tenant-identity-local-preview { width: 100%; aspect-ratio: 4/3; object-fit: contain; background: #e2e8f0; }
+.tenant-identity-placeholder { display: grid; place-items: center; color: #475569; font-weight: 700; }
+.tenant-identity-document-copy { display: grid; gap: 5px; padding: 14px; color: #475569; font-size: 14px; }
+.tenant-identity-document-copy strong { color: #0f172a; font-size: 16px; }
+.tenant-identity-actions,.tenant-identity-submit-row,.tenant-identity-file-fields { display: flex; flex-wrap: wrap; gap: 10px; }
+.tenant-identity-actions { padding: 0 14px 14px; }
+.tenant-identity-actions button,.tenant-identity-submit-row button,.tenant-identity-file-button { border: 1px solid #cbd5e1; border-radius: 10px; padding: 10px 13px; background: #fff; color: #1e293b; font-weight: 750; cursor: pointer; }
+.tenant-identity-actions .danger { color: #b91c1c; }
+.tenant-identity-form { display: grid; grid-template-columns: repeat(2,minmax(0,1fr)); gap: 16px; margin-top: 20px; }
+.tenant-identity-form > label:not(.tenant-identity-consent):not(.tenant-identity-file-button) { display: grid; gap: 7px; font-weight: 750; color: #334155; }
+.tenant-identity-form select,.tenant-identity-form input:not([type=file]):not([type=checkbox]) { min-height: 44px; border: 1px solid #cbd5e1; border-radius: 10px; padding: 9px 11px; font: inherit; }
+.tenant-identity-file-fields,.tenant-identity-consent,.tenant-identity-message,.tenant-identity-progress,.tenant-identity-submit-row,.tenant-identity-local-preview,.tenant-identity-selected-file { grid-column: 1/-1; }
+.tenant-identity-selected-file { display:flex; justify-content:space-between; align-items:center; gap:12px; flex-wrap:wrap; }
+.tenant-identity-selected-file button { border:1px solid #cbd5e1; border-radius:10px; background:#fff; padding:9px 12px; font-weight:750; }
+.tenant-identity-file-button input { position: absolute; width: 1px; height: 1px; opacity: 0; }
+.tenant-identity-consent { display: flex; gap: 12px; align-items: flex-start; color: #334155; line-height: 1.5; }
+.tenant-identity-consent input { width: 20px; height: 20px; flex: 0 0 auto; }
+.tenant-identity-message { border-radius: 10px; padding: 11px 13px; color: #334155; background: #eef2ff; }
+.tenant-identity-progress { height: 6px; overflow: hidden; background: #ddd6fe; border-radius: 99px; }
+.tenant-identity-progress::after { content:""; display:block; width:40%; height:100%; background:#7c3aed; animation:tenant-identity-progress 1s infinite ease-in-out; }
+.tenant-identity-submit-row { justify-content: flex-end; }
+.tenant-identity-submit-row .primary { background: #6d28d9; border-color: #6d28d9; color: #fff; }
+@keyframes tenant-identity-progress { from { transform:translateX(-100%); } to { transform:translateX(350%); } }
+@media (prefers-reduced-motion: reduce) { .tenant-identity-progress::after { animation:none; width:100%; } }
+@media (max-width: 640px) {
+  .tenant-identity-summary { display:grid; padding:16px; }
+  .tenant-identity-statuses { min-width:0; }
+  .tenant-identity-panel { padding:16px; }
+  .tenant-identity-form { grid-template-columns:1fr; }
+  .tenant-identity-actions button,.tenant-identity-submit-row button,.tenant-identity-file-button { width:100%; text-align:center; }
+}

--- a/rentchain-frontend/src/pages/tenant/TenantIdentityPage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantIdentityPage.test.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+
+import TenantIdentityPage from "./TenantIdentityPage";
+
+const api = vi.hoisted(() => ({
+  getTenantIdentityRequirement: vi.fn(),
+  listTenantIdentityDocuments: vi.fn(),
+  recordTenantIdentityConsent: vi.fn(),
+  uploadTenantIdentityDocument: vi.fn(),
+  getTenantIdentityDocumentAccess: vi.fn(),
+  deleteTenantIdentityDocument: vi.fn(),
+}));
+vi.mock("../../api/tenantIdentityDocumentsApi", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../api/tenantIdentityDocumentsApi")>()),
+  ...api,
+}));
+
+const requirement = {
+  required: true,
+  requirementStatus: "action_required",
+  collectionStatus: "not_uploaded",
+  verificationStatus: "not_started",
+  activeDocumentCount: 0,
+  consent: { purpose: "identity_document_collection", requirementPolicyId: "required-id", requirementPolicyVersion: "v1", policyTextVersion: "v1", privacyNoticeVersion: "v1", retentionPolicyVersion: "v1" },
+  acceptedMimeTypes: ["image/jpeg", "image/png", "image/webp"],
+  maxFileBytes: 10 * 1024 * 1024,
+  applicationContinuity: true,
+  tenantContinuity: true,
+  biometricProcessing: false,
+  pdfSupported: false,
+} as const;
+
+describe("TenantIdentityPage", () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    api.getTenantIdentityRequirement.mockResolvedValue(requirement);
+    api.listTenantIdentityDocuments.mockResolvedValue([]);
+    api.recordTenantIdentityConsent.mockResolvedValue(undefined);
+    api.uploadTenantIdentityDocument.mockResolvedValue({});
+    Object.defineProperty(URL, "createObjectURL", { configurable: true, value: vi.fn(() => "blob:preview") });
+    Object.defineProperty(URL, "revokeObjectURL", { configurable: true, value: vi.fn() });
+  });
+
+  it("renders a mandatory image-only workflow without false verification", async () => {
+    render(<MemoryRouter><TenantIdentityPage /></MemoryRouter>);
+    expect(await screen.findByText("Government ID required")).toBeInTheDocument();
+    expect(screen.getAllByText("Verification not started").length).toBeGreaterThan(0);
+    expect(screen.getByText(/PDF is not supported/)).toBeInTheDocument();
+    expect(screen.getByText(/No facial recognition/)).toBeInTheDocument();
+    expect(screen.queryByText(/^Verified$/)).not.toBeInTheDocument();
+  });
+
+  it("blocks upload until explicit consent is checked", async () => {
+    render(<MemoryRouter><TenantIdentityPage /></MemoryRouter>);
+    await screen.findByText("Government ID required");
+    const fileInput = screen.getByLabelText("Choose an existing image");
+    fireEvent.change(fileInput, { target: { files: [new File(["image"], "id.png", { type: "image/png" })] } });
+    fireEvent.click(screen.getByRole("button", { name: "Upload government ID" }));
+    expect(await screen.findByText(/Review and accept/)).toBeInTheDocument();
+    expect(api.recordTenantIdentityConsent).not.toHaveBeenCalled();
+  });
+
+  it("records consent before uploading an accepted image", async () => {
+    render(<MemoryRouter><TenantIdentityPage /></MemoryRouter>);
+    await screen.findByText("Government ID required");
+    fireEvent.change(screen.getByLabelText("Choose an existing image"), { target: { files: [new File(["image"], "id.png", { type: "image/png" })] } });
+    fireEvent.click(screen.getByRole("checkbox"));
+    fireEvent.click(screen.getByRole("button", { name: "Upload government ID" }));
+    await waitFor(() => expect(api.uploadTenantIdentityDocument).toHaveBeenCalled());
+    expect(api.recordTenantIdentityConsent.mock.invocationCallOrder[0]).toBeLessThan(api.uploadTenantIdentityDocument.mock.invocationCallOrder[0]);
+  });
+});

--- a/rentchain-frontend/src/pages/tenant/TenantIdentityPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantIdentityPage.tsx
@@ -1,0 +1,276 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+
+import {
+  deleteTenantIdentityDocument,
+  getTenantIdentityDocumentAccess,
+  getTenantIdentityRequirement,
+  listTenantIdentityDocuments,
+  recordTenantIdentityConsent,
+  uploadTenantIdentityDocument,
+  type TenantIdentityDocument,
+  type TenantIdentityDocumentSide,
+  type TenantIdentityDocumentType,
+  type TenantIdentityRequirementStatus,
+} from "../../api/tenantIdentityDocumentsApi";
+import { TenantErrorState, TenantLoadingState, TenantSurfaceShell, formatDate } from "./TenantWorkspaceShared";
+import {
+  TENANT_IDENTITY_DOCUMENT_TYPES,
+  activeTenantIdentityDocuments,
+  sidesForDocumentType,
+  tenantIdentityErrorMessage,
+  tenantIdentityStatusLabel,
+  validateIdentityImage,
+} from "./tenantIdentityWorkflow";
+import "./TenantIdentityPage.css";
+
+const verificationLabel = (status: TenantIdentityDocument["verificationStatus"]) =>
+  status === "not_started" ? "Verification not started" : `Verification ${status.replace(/_/g, " ")}`;
+
+export default function TenantIdentityPage() {
+  const [requirement, setRequirement] = useState<TenantIdentityRequirementStatus | null>(null);
+  const [documents, setDocuments] = useState<TenantIdentityDocument[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [consented, setConsented] = useState(false);
+  const [documentType, setDocumentType] = useState<TenantIdentityDocumentType>("drivers_license");
+  const [side, setSide] = useState<TenantIdentityDocumentSide>("front");
+  const [issuingCountry, setIssuingCountry] = useState("CA");
+  const [issuingRegion, setIssuingRegion] = useState("");
+  const [file, setFile] = useState<File | null>(null);
+  const [filePreview, setFilePreview] = useState<string | null>(null);
+  const [accessByDocument, setAccessByDocument] = useState<Record<string, string>>({});
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [replaceDocumentId, setReplaceDocumentId] = useState<string | undefined>();
+  const uploadHeadingRef = useRef<HTMLHeadingElement>(null);
+  const messageRef = useRef<HTMLDivElement>(null);
+
+  const refresh = async () => {
+    const [nextRequirement, nextDocuments] = await Promise.all([
+      getTenantIdentityRequirement(),
+      listTenantIdentityDocuments(),
+    ]);
+    setRequirement(nextRequirement);
+    setDocuments(nextDocuments);
+  };
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const [nextRequirement, nextDocuments] = await Promise.all([
+          getTenantIdentityRequirement(),
+          listTenantIdentityDocuments(),
+        ]);
+        if (!cancelled) {
+          setRequirement(nextRequirement);
+          setDocuments(nextDocuments);
+        }
+      } catch (cause) {
+        if (!cancelled) setError(tenantIdentityErrorMessage(cause));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!file) {
+      setFilePreview(null);
+      return;
+    }
+    const url = URL.createObjectURL(file);
+    setFilePreview(url);
+    return () => URL.revokeObjectURL(url);
+  }, [file]);
+
+  const sides = useMemo(() => sidesForDocumentType(documentType), [documentType]);
+  const activeDocuments = useMemo(() => activeTenantIdentityDocuments(documents), [documents]);
+
+  const selectFile = (selected?: File) => {
+    setMessage(null);
+    if (!selected) return;
+    const validationError = validateIdentityImage(selected);
+    if (validationError) {
+      setFile(null);
+      setMessage(validationError);
+      return;
+    }
+    setFile(selected);
+  };
+
+  useEffect(() => {
+    if (message) messageRef.current?.focus();
+  }, [message]);
+
+  const submit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setMessage(null);
+    if (!consented) return setMessage("Review and accept the collection consent before upload.");
+    if (!file) return setMessage("Choose or take a government ID image before upload.");
+    setBusy(true);
+    try {
+      await recordTenantIdentityConsent(navigator.language || "en-CA");
+      await uploadTenantIdentityDocument({
+        file,
+        documentType,
+        side,
+        issuingCountry: issuingCountry.trim().toUpperCase(),
+        issuingRegion: issuingRegion.trim() || undefined,
+        replaceDocumentId,
+      });
+      await refresh();
+      setFile(null);
+      setConsented(false);
+      setReplaceDocumentId(undefined);
+      setMessage("Government ID received. Verification has not started.");
+    } catch (cause) {
+      setMessage(tenantIdentityErrorMessage(cause));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const openSanitizedPreview = async (document: TenantIdentityDocument) => {
+    setMessage(null);
+    try {
+      const access = await getTenantIdentityDocumentAccess(document.documentId);
+      setAccessByDocument((current) => ({ ...current, [document.documentId]: access.accessReference }));
+    } catch (cause) {
+      setMessage(tenantIdentityErrorMessage(cause));
+    }
+  };
+
+  const removeDocument = async (document: TenantIdentityDocument) => {
+    if (!window.confirm("Delete this government ID image? You will need to upload another image to satisfy the requirement.")) return;
+    setBusy(true);
+    setMessage(null);
+    try {
+      await deleteTenantIdentityDocument(document.documentId);
+      setAccessByDocument((current) => {
+        const next = { ...current };
+        delete next[document.documentId];
+        return next;
+      });
+      await refresh();
+      setMessage("Government ID image deleted. A new upload is required.");
+    } catch (cause) {
+      setMessage(tenantIdentityErrorMessage(cause));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const beginReplacement = (document: TenantIdentityDocument) => {
+    setReplaceDocumentId(document.documentId);
+    setDocumentType(document.documentType);
+    const nextSides = sidesForDocumentType(document.documentType);
+    setSide(nextSides.some((option) => option.value === document.side) ? document.side : nextSides[0].value);
+    setMessage("Choose a replacement image. The current image remains available until replacement succeeds.");
+    requestAnimationFrame(() => uploadHeadingRef.current?.focus());
+  };
+
+  if (loading) return <TenantSurfaceShell title="Government ID"><TenantLoadingState label="Loading government ID requirement..." /></TenantSurfaceShell>;
+  if (error || !requirement) return <TenantSurfaceShell title="Government ID"><TenantErrorState message={error || "Unable to load government ID requirement."} /></TenantSurfaceShell>;
+
+  return (
+    <TenantSurfaceShell
+      title="Government ID"
+      subtitle="Upload one approved government-issued photo ID. Your private image is available only through time-limited, sanitized access."
+    >
+      <section className="tenant-identity-summary" aria-labelledby="identity-requirement-heading">
+        <div>
+          <p className="tenant-identity-eyebrow">Mandatory requirement</p>
+          <h2 id="identity-requirement-heading">{tenantIdentityStatusLabel(documents)}</h2>
+          <p>{requirement.collectionStatus === "received" ? "Your government ID image has been received." : "Upload a government ID image to complete this requirement."}</p>
+          {requirement.applicationContinuity ? <p className="tenant-identity-continuity">This requirement follows your canonical application record into your tenant workspace; no duplicate upload is needed when an accepted image already exists.</p> : null}
+          <p className="tenant-identity-continuity">This is a display-only readiness status. It does not block lease signing or move-in and does not mean identity verification or face matching is complete.</p>
+        </div>
+        <div className="tenant-identity-statuses">
+          <span>{requirement.requirementStatus === "satisfied" ? "Requirement satisfied" : "Action required"}</span>
+          <span>{verificationLabel(requirement.verificationStatus)}</span>
+        </div>
+      </section>
+
+      <section className="tenant-identity-panel" aria-labelledby="existing-id-heading">
+        <h2 id="existing-id-heading">Your government ID images</h2>
+        {activeDocuments.length === 0 ? <p>No government ID image has been uploaded.</p> : (
+          <div className="tenant-identity-document-grid">
+            {activeDocuments.map((document) => (
+              <article className="tenant-identity-document" key={document.documentId}>
+                {accessByDocument[document.documentId] ? (
+                  <img src={accessByDocument[document.documentId]} alt={`Sanitized ${document.documentType.replace(/_/g, " ")} preview`} />
+                ) : <div className="tenant-identity-placeholder">Private image preview</div>}
+                <div className="tenant-identity-document-copy">
+                  <strong>{TENANT_IDENTITY_DOCUMENT_TYPES.find((option) => option.value === document.documentType)?.label}</strong>
+                  <span>{document.side.replace(/_/g, " ")} · {formatDate(document.uploadedAt)}</span>
+                  <span>Government ID received · {verificationLabel(document.verificationStatus)}</span>
+                </div>
+                <div className="tenant-identity-actions">
+                  <button type="button" onClick={() => void openSanitizedPreview(document)} disabled={busy || !document.sanitizedAccessAvailable}>View private preview</button>
+                  <button type="button" onClick={() => beginReplacement(document)} disabled={busy}>Replace</button>
+                  <button className="danger" type="button" onClick={() => void removeDocument(document)} disabled={busy}>Delete</button>
+                </div>
+              </article>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section className="tenant-identity-panel" aria-labelledby="upload-id-heading">
+        <h2 id="upload-id-heading" ref={uploadHeadingRef} tabIndex={-1}>{replaceDocumentId ? "Replace government ID image" : "Upload government ID image"}</h2>
+        <p>Accepted ID types: driver’s licence, passport, provincial identification, or another approved government-issued photo ID. Accepted files: JPEG, PNG, or WebP, up to 10 MB. PDF is not supported. No facial recognition, biometric matching, OCR, or provider verification is performed.</p>
+        <form className="tenant-identity-form" onSubmit={submit}>
+          <label>Document type
+            <select value={documentType} onChange={(event) => {
+              const next = event.target.value as TenantIdentityDocumentType;
+              setDocumentType(next);
+              setSide(sidesForDocumentType(next)[0].value);
+            }}>
+              {TENANT_IDENTITY_DOCUMENT_TYPES.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
+            </select>
+          </label>
+          <label>Image side
+            <select value={side} onChange={(event) => setSide(event.target.value as TenantIdentityDocumentSide)}>
+              {sides.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
+            </select>
+          </label>
+          <label>Issuing country
+            <input value={issuingCountry} maxLength={2} onChange={(event) => setIssuingCountry(event.target.value)} required />
+          </label>
+          <label>Province / region <span>(optional)</span>
+            <input value={issuingRegion} onChange={(event) => setIssuingRegion(event.target.value)} />
+          </label>
+          <div className="tenant-identity-file-fields">
+            <label className="tenant-identity-file-button">Choose an existing image
+              <input type="file" accept="image/jpeg,image/png,image/webp" onChange={(event) => selectFile(event.target.files?.[0])} />
+            </label>
+            <label className="tenant-identity-file-button">Take a photo
+              <input type="file" accept="image/jpeg,image/png,image/webp" capture="environment" onChange={(event) => selectFile(event.target.files?.[0])} />
+            </label>
+          </div>
+          {filePreview ? <img className="tenant-identity-local-preview" src={filePreview} alt="Selected government ID image preview" /> : null}
+          {file ? (
+            <div className="tenant-identity-selected-file">
+              <p><strong>Selected:</strong> {file.name} · {(file.size / 1024).toFixed(1)} KB · {file.type} · {documentType.replace(/_/g, " ")} · {side.replace(/_/g, " ")}</p>
+              <button type="button" onClick={() => setFile(null)} disabled={busy}>Remove selected image</button>
+            </div>
+          ) : null}
+          <label className="tenant-identity-consent">
+            <input type="checkbox" checked={consented} onChange={(event) => setConsented(event.target.checked)} />
+            <span>I consent to RentChain collecting and privately storing this government ID image for the identity-document requirement under policy {requirement.consent.requirementPolicyVersion}, privacy notice {requirement.consent.privacyNoticeVersion}, and retention policy {requirement.consent.retentionPolicyVersion}.</span>
+          </label>
+          {message ? <div className="tenant-identity-message" role="status" ref={messageRef} tabIndex={-1}>{message}</div> : null}
+          {busy ? <div className="tenant-identity-progress" role="progressbar" aria-label="Government ID operation in progress" aria-valuetext="In progress" /> : null}
+          <div className="tenant-identity-submit-row">
+            {replaceDocumentId ? <button type="button" onClick={() => { setReplaceDocumentId(undefined); setFile(null); }} disabled={busy}>Cancel replacement</button> : null}
+            <button className="primary" type="submit" disabled={busy}>{busy ? "Uploading..." : replaceDocumentId ? "Upload replacement" : "Upload government ID"}</button>
+          </div>
+        </form>
+      </section>
+    </TenantSurfaceShell>
+  );
+}

--- a/rentchain-frontend/src/pages/tenant/TenantIdentityRequirementCard.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantIdentityRequirementCard.tsx
@@ -1,0 +1,37 @@
+import React, { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+
+import { getTenantIdentityRequirement, type TenantIdentityRequirementStatus } from "../../api/tenantIdentityDocumentsApi";
+
+export default function TenantIdentityRequirementCard() {
+  const [status, setStatus] = useState<TenantIdentityRequirementStatus | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void getTenantIdentityRequirement()
+      .then((next) => { if (!cancelled) setStatus(next); })
+      .catch(() => undefined);
+    return () => { cancelled = true; };
+  }, []);
+
+  const received = status?.collectionStatus === "received";
+  return (
+    <section aria-labelledby="tenant-identity-reminder-heading" style={{
+      display: "flex", justifyContent: "space-between", alignItems: "center", flexWrap: "wrap", gap: 14,
+      padding: "16px 18px", border: `1px solid ${received ? "#bbf7d0" : "#fed7aa"}`,
+      borderRadius: 14, background: received ? "#f0fdf4" : "#fff7ed",
+    }}>
+      <div style={{ display: "grid", gap: 4 }}>
+        <strong id="tenant-identity-reminder-heading" style={{ color: "#0f172a" }}>
+          {received ? "Government ID received" : "Government ID required"}
+        </strong>
+        <span style={{ color: "#475569" }}>
+          {received ? "Your private image is stored. Verification has not started." : "Upload one approved government-issued photo ID to complete this mandatory requirement."}
+        </span>
+      </div>
+      <Link to="/tenant/identity" style={{ fontWeight: 800, color: "#6d28d9" }}>
+        {received ? "Manage government ID" : "Upload government ID"}
+      </Link>
+    </section>
+  );
+}

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
@@ -74,6 +74,7 @@ import { buildTenantWorkspaceModeView } from "./tenantWorkspaceMode";
 import { buildActiveTenancyWorkspaceState } from "./activeTenancyWorkspaceState";
 import { buildTenantCommunicationsWorkspaceState } from "./tenantCommunicationsWorkspaceState";
 import TenantWorkspaceModeBanner from "./TenantWorkspaceModeBanner";
+import TenantIdentityRequirementCard from "./TenantIdentityRequirementCard";
 import StructuredNotificationList from "../StructuredNotificationList";
 import { buildTenantStructuredNotificationTriggers } from "../structuredNotificationTriggers";
 import { filterStructuredNotificationsByPreferences } from "../notificationChannelRouting";
@@ -1023,6 +1024,7 @@ export default function TenantWorkspacePage() {
       }
     >
       <TenantWorkspaceModeBanner view={modeView} />
+      <TenantIdentityRequirementCard />
 
       <TenantInfoCard heading="Active tenancy" accent="#7c3aed">
         <div style={{ display: "grid", gap: spacing.sm }}>

--- a/rentchain-frontend/src/pages/tenant/tenantIdentityWorkflow.test.ts
+++ b/rentchain-frontend/src/pages/tenant/tenantIdentityWorkflow.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { sidesForDocumentType, tenantIdentityStatusLabel, validateIdentityImage } from "./tenantIdentityWorkflow";
+
+describe("tenant identity workflow", () => {
+  it("uses document-appropriate image sides", () => {
+    expect(sidesForDocumentType("passport")).toEqual([{ value: "photo_page", label: "Photo page" }]);
+    expect(sidesForDocumentType("drivers_license").map((side) => side.value)).toEqual(["front", "back"]);
+  });
+
+  it("rejects PDF and oversized uploads before network access", () => {
+    expect(validateIdentityImage(new File(["pdf"], "id.pdf", { type: "application/pdf" }))).toMatch(/Unsupported/);
+    const oversized = new File([new Uint8Array(10 * 1024 * 1024 + 1)], "id.png", { type: "image/png" });
+    expect(validateIdentityImage(oversized)).toMatch(/too large/i);
+  });
+
+  it("describes custody without claiming verification", () => {
+    expect(tenantIdentityStatusLabel([{ status: "ready" } as any])).toBe("Government ID received");
+  });
+});

--- a/rentchain-frontend/src/pages/tenant/tenantIdentityWorkflow.ts
+++ b/rentchain-frontend/src/pages/tenant/tenantIdentityWorkflow.ts
@@ -1,0 +1,55 @@
+import {
+  TENANT_IDENTITY_ACCEPTED_MIME_TYPES,
+  TENANT_IDENTITY_MAX_FILE_BYTES,
+  type TenantIdentityDocument,
+  type TenantIdentityDocumentSide,
+  type TenantIdentityDocumentType,
+} from "../../api/tenantIdentityDocumentsApi";
+
+export const TENANT_IDENTITY_DOCUMENT_TYPES: Array<{ value: TenantIdentityDocumentType; label: string }> = [
+  { value: "drivers_license", label: "Driver’s licence" },
+  { value: "passport", label: "Passport" },
+  { value: "provincial_id", label: "Provincial identification" },
+  { value: "other_government_photo_id", label: "Other approved government-issued photo ID" },
+];
+
+export function sidesForDocumentType(type: TenantIdentityDocumentType): Array<{ value: TenantIdentityDocumentSide; label: string }> {
+  if (type === "passport") return [{ value: "photo_page", label: "Photo page" }];
+  if (type === "drivers_license" || type === "provincial_id") {
+    return [
+      { value: "front", label: "Front" },
+      { value: "back", label: "Back" },
+    ];
+  }
+  return [{ value: "single", label: "Single image" }];
+}
+
+export function validateIdentityImage(file: File): string | null {
+  if (!TENANT_IDENTITY_ACCEPTED_MIME_TYPES.includes(file.type as any)) {
+    return "Unsupported image format. Choose a JPEG, PNG, or WebP image.";
+  }
+  if (file.size > TENANT_IDENTITY_MAX_FILE_BYTES) return "File too large. Choose an image smaller than 10 MB.";
+  return null;
+}
+
+export function activeTenantIdentityDocuments(documents: TenantIdentityDocument[]) {
+  return documents.filter((document) => !["replaced", "deletion_scheduled"].includes(document.status));
+}
+
+export function tenantIdentityStatusLabel(documents: TenantIdentityDocument[]) {
+  const active = activeTenantIdentityDocuments(documents);
+  if (active.some((document) => document.status === "ready")) return "Government ID received";
+  if (active.some((document) => document.status === "processing" || document.status === "pending_upload")) return "Upload in progress";
+  if (active.some((document) => document.status === "rejected")) return "Action required";
+  return "Government ID required";
+}
+
+export function tenantIdentityErrorMessage(error: any) {
+  const code = String(error?.payload?.error || error?.message || "").trim();
+  if (code.includes("FILE_TOO_LARGE")) return "File too large. Choose an image smaller than 10 MB.";
+  if (code.includes("UNSUPPORTED") || code.includes("MIME") || code.includes("INPUT_INVALID")) return "Unsupported image format or document details.";
+  if (code.includes("IMAGE_DIMENSIONS") || code.includes("PIXEL")) return "Image dimensions are unsupported. Choose a smaller image.";
+  if (code.includes("CONSENT_REQUIRED")) return "Government ID collection consent is required before upload.";
+  if (code.includes("UNAUTHORIZED") || code.includes("NOT_FOUND")) return "This document is not available in your tenant workspace.";
+  return "Upload failed — try again.";
+}

--- a/rentchain-frontend/src/platform/g1cBrowserBootstrap.test.ts
+++ b/rentchain-frontend/src/platform/g1cBrowserBootstrap.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { classifyG1cBootstrap, handleG1cBrowserBootstrap } from "../../server/g1cBrowserBootstrap";
+
+function response() {
+  return { statusCode: 200, body: undefined as any, headers: new Map<string, string>(), setHeader(name: string, value: string) { this.headers.set(name.toLowerCase(), value); }, status(code: number) { this.statusCode = code; return this; }, json(value: any) { this.body = value; return this; } };
+}
+
+const exactEnv = { VERCEL_ENV: "preview", VERCEL_GIT_COMMIT_REF: "feat/g1c-mandatory-tenant-government-id-workflow-v1", VERCEL_GIT_COMMIT_SHA: "a".repeat(40) };
+
+describe("G1C browser bootstrap", () => {
+  afterEach(() => vi.unstubAllEnvs());
+  it("returns only the fixed synthetic tenant session", () => {
+    Object.entries(exactEnv).forEach(([key, value]) => vi.stubEnv(key, value));
+    const res = response();
+    handleG1cBrowserBootstrap({ method: "GET", query: { subjectId: "arbitrary" } }, res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({ scope: "g1c-synthetic-identity-qa-v1", session: { role: "tenant", principalId: "qa-g1c-tenant" } });
+    expect(JSON.stringify(res.body)).not.toContain("arbitrary");
+    expect(res.headers.get("cache-control")).toBe("no-store");
+  });
+  it.each([
+    ["Production", { ...exactEnv, VERCEL_ENV: "production" }],
+    ["main", { ...exactEnv, VERCEL_GIT_COMMIT_REF: "main" }],
+    ["missing SHA", { ...exactEnv, VERCEL_GIT_COMMIT_SHA: "" }],
+  ])("fails closed for %s", (_label, env) => {
+    Object.entries(env).forEach(([key, value]) => vi.stubEnv(key, value));
+    expect(classifyG1cBootstrap({ method: "GET" })).toEqual({ allowed: false });
+  });
+});

--- a/rentchain-frontend/src/platform/g1cIdentityQaProxy.test.ts
+++ b/rentchain-frontend/src/platform/g1cIdentityQaProxy.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { classifyG1cIdentityRequest, G1C_IDENTITY_QA, handleG1cIdentityQaProxy } from "../../server/g1cIdentityQaProxy";
+
+function response() {
+  return { statusCode: 200, body: undefined as any, headers: new Map<string, string>(), setHeader(name: string, value: string) { this.headers.set(name.toLowerCase(), value); }, status(code: number) { this.statusCode = code; return this; }, json(value: any) { this.body = value; return this; }, send(value: any) { this.body = value; return this; } };
+}
+const request = (url: string, method = "GET", body?: Buffer) => ({ url, method, body, headers: { "content-type": "application/json", authorization: "Bearer browser-value", "x-backend-url": "https://production.invalid" } });
+
+describe("G1C identity QA proxy", () => {
+  afterEach(() => vi.unstubAllEnvs());
+  it.each([
+    ["GET", "/api/g1c-identity/api/tenant/identity-documents/status"],
+    ["GET", "/api/g1c-identity/api/tenant/identity-documents"],
+    ["POST", "/api/g1c-identity/api/tenant/identity-documents/consent"],
+    ["POST", "/api/g1c-identity/api/tenant/identity-documents"],
+    ["POST", "/api/g1c-identity/api/tenant/identity-documents/123e4567-e89b-42d3-a456-426614174000/access"],
+    ["DELETE", "/api/g1c-identity/api/tenant/identity-documents/123e4567-e89b-42d3-a456-426614174000"],
+  ])("allows only %s %s", (method, url) => expect(classifyG1cIdentityRequest(request(url, method)).allowed).toBe(true));
+
+  it.each([
+    ["POST", "/api/g1c-identity/api/tenant/identity-documents/status"],
+    ["GET", "/api/g1c-identity/api/tenant/identity-documents/arbitrary/access"],
+    ["GET", "/api/g1c-identity/api/admin/users"],
+    ["GET", "/api/g1c-identity/https://production.invalid"],
+  ])("rejects %s %s", (method, url) => expect(classifyG1cIdentityRequest(request(url, method)).allowed).toBe(false));
+
+  it("injects fixed server-owned identity and target", async () => {
+    vi.stubEnv("VERCEL_ENV", "preview");
+    vi.stubEnv("VERCEL_GIT_COMMIT_REF", G1C_IDENTITY_QA.branch);
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: "access", expires_in: 300, token_type: "Bearer" }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ token: "header.identity.signature" }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true, data: [] }), { status: 200, headers: { "content-type": "application/json" } }));
+    const res = response();
+    await handleG1cIdentityQaProxy(request("/api/g1c-identity/api/tenant/identity-documents"), res, { fetchImpl, getVercelOidcToken: async () => "oidc" });
+    const [target, init] = fetchImpl.mock.calls[2];
+    expect(target).toBe(`${G1C_IDENTITY_QA.serviceUrl}/api/tenant/identity-documents`);
+    expect(init.headers["x-rentchain-preview-qa-identity"]).toBe("qa-g1c-tenant");
+    expect(init.headers.authorization).toBeUndefined();
+    expect(JSON.stringify(init.headers)).not.toContain("browser-value");
+    expect(JSON.stringify(target)).not.toContain("production.invalid");
+  });
+});

--- a/rentchain-frontend/src/platform/g1cQaSession.test.ts
+++ b/rentchain-frontend/src/platform/g1cQaSession.test.ts
@@ -1,0 +1,25 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { G1C_QA_PRINCIPAL, G1C_QA_SCOPE, G1C_QA_SESSION_KEY, hasG1cQaSession } from "./g1cQaSession";
+
+describe("G1C fixed QA session", () => {
+  beforeEach(() => window.sessionStorage.clear());
+
+  it("accepts only the exact G1C scope and principal", () => {
+    window.sessionStorage.setItem(G1C_QA_SESSION_KEY, JSON.stringify({
+      scope: G1C_QA_SCOPE,
+      session: { principalId: G1C_QA_PRINCIPAL },
+    }));
+    expect(hasG1cQaSession()).toBe(true);
+  });
+
+  it.each([
+    null,
+    "not-json",
+    JSON.stringify({ scope: G1C_QA_SCOPE, session: { principalId: "qa-g1c-foreign-tenant" } }),
+    JSON.stringify({ scope: "other-preview-scope", session: { principalId: G1C_QA_PRINCIPAL } }),
+  ])("rejects missing, malformed, foreign, or unrelated sessions", (value) => {
+    if (value !== null) window.sessionStorage.setItem(G1C_QA_SESSION_KEY, value);
+    expect(hasG1cQaSession()).toBe(false);
+  });
+});

--- a/rentchain-frontend/src/platform/g1cQaSession.ts
+++ b/rentchain-frontend/src/platform/g1cQaSession.ts
@@ -1,0 +1,13 @@
+export const G1C_QA_SESSION_KEY = "rentchain.qa.g1c.fixed-session";
+export const G1C_QA_SCOPE = "g1c-synthetic-identity-qa-v1";
+export const G1C_QA_PRINCIPAL = "qa-g1c-tenant";
+
+export function hasG1cQaSession(storage: Pick<Storage, "getItem"> | null = typeof window === "undefined" ? null : window.sessionStorage) {
+  if (!storage) return false;
+  try {
+    const value = JSON.parse(storage.getItem(G1C_QA_SESSION_KEY) || "null");
+    return value?.scope === G1C_QA_SCOPE && value?.session?.principalId === G1C_QA_PRINCIPAL;
+  } catch {
+    return false;
+  }
+}

--- a/rentchain-frontend/src/platform/vercelRoutePrecedence.test.ts
+++ b/rentchain-frontend/src/platform/vercelRoutePrecedence.test.ts
@@ -32,6 +32,14 @@ describe("Vercel Preview backend route precedence", () => {
   it("routes the complete Preview suffix to the existing Function before filesystem misses", () => {
     expect(config.routes).toEqual([
       {
+        src: "^/api/g1c-bootstrap$",
+        dest: "/api/g1c-bootstrap",
+      },
+      {
+        src: "^/api/g1c-identity/(.*)$",
+        dest: "/api/g1c-identity/[...path]?path=$1",
+      },
+      {
         src: "^/api/pr1516-(?:bootstrap|notices(?:/.*)?)$",
         status: 404,
       },
@@ -54,19 +62,19 @@ describe("Vercel Preview backend route precedence", () => {
     "/api/preview-backend/api/me",
     "/api/preview-backend/api/auth/login",
   ])("reserves %s for the dedicated filesystem Function", (requestPath) => {
-    const functionRoute = config.routes[2];
+    const functionRoute = config.routes[4];
     const match = new RegExp(functionRoute.src as string).exec(requestPath);
 
     expect(match?.[1]).toBe(requestPath.slice("/api/preview-backend/".length));
     expect(functionRoute.dest?.replace("$1", match?.[1] ?? "")).toBe(
       `/api/preview-backend/[...path]?path=${match?.[1]}`,
     );
-    expect(config.routes[3]).toEqual({ handle: "filesystem" });
+    expect(config.routes[5]).toEqual({ handle: "filesystem" });
   });
 
   it("reserves the PR #1512 read-only QA suffix before filesystem misses", () => {
     const requestPath = "/api/pr1512-notices/api/landlord/notices";
-    const functionRoute = config.routes[1];
+    const functionRoute = config.routes[3];
     const match = new RegExp(functionRoute.src as string).exec(requestPath);
     expect(match?.[1]).toBe("api/landlord/notices");
     expect(functionRoute.dest?.replace("$1", match?.[1] ?? "")).toBe(
@@ -79,10 +87,17 @@ describe("Vercel Preview backend route precedence", () => {
     "/api/pr1516-bootstrap",
     "/api/pr1516-notices/api/landlord/notices/recipients",
   ])("fails the retired PR #1516 QA path closed before Production rewrites: %s", (requestPath) => {
-    const retiredRoute = config.routes[0];
+    const retiredRoute = config.routes[2];
     expect(new RegExp(retiredRoute.src as string).test(requestPath)).toBe(true);
     expect(retiredRoute).toMatchObject({ status: 404 });
     expect(retiredRoute.dest).toBeUndefined();
+  });
+
+  it("reserves strict G1C bootstrap and identity proxy functions before Production rewrites", () => {
+    expect(config.routes[0]).toEqual({ src: "^/api/g1c-bootstrap$", dest: "/api/g1c-bootstrap" });
+    expect(config.routes[1]).toEqual({ src: "^/api/g1c-identity/(.*)$", dest: "/api/g1c-identity/[...path]?path=$1" });
+    expect(existsSync(join(frontendRoot, "api/g1c-bootstrap.ts"))).toBe(true);
+    expect(existsSync(join(frontendRoot, "api/g1c-identity/[...path].ts"))).toBe(true);
   });
 
   it.each(["/api/properties", "/api/tenants"])(

--- a/rentchain-frontend/vercel.json
+++ b/rentchain-frontend/vercel.json
@@ -83,6 +83,14 @@
   ],
   "routes": [
     {
+      "src": "^/api/g1c-bootstrap$",
+      "dest": "/api/g1c-bootstrap"
+    },
+    {
+      "src": "^/api/g1c-identity/(.*)$",
+      "dest": "/api/g1c-identity/[...path]?path=$1"
+    },
+    {
       "src": "^/api/pr1516-(?:bootstrap|notices(?:/.*)?)$",
       "status": 404
     },


### PR DESCRIPTION
## Summary

Implements the mandatory Tenant Portal government-ID workflow on the merged G1B private identity-document foundation.

Included:

- mandatory tenant-facing identity requirement and dashboard reminder
- versioned government-ID collection consent/disclosure
- JPEG, PNG, and WebP upload UI with mobile camera and existing-image paths
- useful contained pending preview and accessible progress/errors
- canonical application-to-tenant continuity display
- received/status language kept separate from verification status
- short-lived sanitized private preview
- server-confirmed replacement and explicit deletion
- first-class Tenant Portal Identity navigation and responsive layout
- narrow canonical read-only requirement-status endpoint
- same-origin Preview QA scope (runtime verification pending exact-head deployment)

Not included:

- facial recognition, face matching, selfies, or biometrics
- external/provider verification
- OCR or extracted government-ID numbers
- PDF ingestion
- landlord raw-ID review
- lease-signing or move-in biometric enforcement
- Production identity uploads or infrastructure mutation

## Validation

- focused frontend: 17 passed
- G1A/G1B identity backend: 46 passed
- full frontend: 354 files / 1,742 tests passed
- frontend production build: passed
- backend TypeScript build on Node 20.11.1: passed
- Preview image governance: 43/43 passed
- scoped credential scan: passed
- `git diff --check`: passed
- full backend comparison: 3,245 passed; 32 unrelated baseline failures in 14 files (date-sensitive/timeout assertions outside G1C); identity suites remain green

## Governance

- Draft only; do not merge before controlled exact-head Preview runtime QA and Founder/Codex Desktop visual QA.
- No Production, IAM, Terraform, storage foundation, provider, or real-user mutation was performed.
