### PR TITLE
Add temporary G1C Preview Invoker

### DIFF
--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -527,3 +527,16 @@ check "b7_vercel_preview_proxy_identity_boundary" {
     error_message = "Run Invoker must remain service-scoped to the private Preview backend and dedicated Vercel proxy identity."
   }
 }
+
+check "g1c_vercel_preview_proxy_invoker_boundary" {
+  assert {
+    condition = (
+      google_cloud_run_v2_service_iam_member.g1c_vercel_proxy_invoker.project == "rentchain-preview" &&
+      google_cloud_run_v2_service_iam_member.g1c_vercel_proxy_invoker.location == "northamerica-northeast1" &&
+      basename(google_cloud_run_v2_service_iam_member.g1c_vercel_proxy_invoker.name) == "rentchain-g1c-identity-qa-v1" &&
+      google_cloud_run_v2_service_iam_member.g1c_vercel_proxy_invoker.role == "roles/run.invoker" &&
+      google_cloud_run_v2_service_iam_member.g1c_vercel_proxy_invoker.member == "serviceAccount:vercel-preview-proxy@rentchain-preview.iam.gserviceaccount.com"
+    )
+    error_message = "G1C Vercel Invoker must remain service-scoped to the exact isolated identity QA service and existing proxy identity."
+  }
+}

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -38,7 +38,7 @@ EOF
 actual_resources="$(rg -No 'resource "[^"]+"' "$root_dir" --glob '*.tf' | sed -E 's/.*resource "([^"]+)"/\1/' | sort -u)"
 test "$actual_resources" = "$expected_resources"
 
-test "$(rg -No '^resource "[^"]+"' "$root_dir" --glob '*.tf' | wc -l | tr -d ' ')" = "53"
+test "$(rg -No '^resource "[^"]+"' "$root_dir" --glob '*.tf' | wc -l | tr -d ' ')" = "54"
 
 test "$(rg -No 'service\s*=\s*"[^"]+\.googleapis\.com"' "$root_dir/services.tf" | wc -l | tr -d ' ')" = "0"
 test "$(rg -No '"(apikeys|artifactregistry|cloudresourcemanager|firestore|iam|identitytoolkit|run|secretmanager|serviceusage)\.googleapis\.com"' "$root_dir/services.tf" | sort -u | wc -l | tr -d ' ')" = "9"
@@ -207,12 +207,13 @@ if printf '%s\n' "$actual_identity_document_object_permissions" | rg -n 'storage
 fi
 
 vercel_identity_file="$root_dir/vercel_preview_identity.tf"
-test "$(rg -No '^resource "' "$vercel_identity_file" | wc -l | tr -d ' ')" = "6"
+test "$(rg -No '^resource "' "$vercel_identity_file" | wc -l | tr -d ' ')" = "7"
 test "$(rg -No '^resource "google_iam_workload_identity_pool" "vercel_preview_proxy"' "$vercel_identity_file" | wc -l | tr -d ' ')" = "1"
 test "$(rg -No '^resource "google_iam_workload_identity_pool_provider" "vercel_preview"' "$vercel_identity_file" | wc -l | tr -d ' ')" = "1"
 test "$(rg -No '^resource "google_service_account" "vercel_preview_proxy"' "$vercel_identity_file" | wc -l | tr -d ' ')" = "1"
 test "$(rg -No '^resource "google_service_account_iam_member" "vercel_preview_proxy_(workload_identity_user|openid_token_creator)"' "$vercel_identity_file" | wc -l | tr -d ' ')" = "2"
 test "$(rg -No '^resource "google_cloud_run_v2_service_iam_member" "vercel_preview_proxy_invoker"' "$vercel_identity_file" | wc -l | tr -d ' ')" = "1"
+test "$(rg -No '^resource "google_cloud_run_v2_service_iam_member" "g1c_vercel_proxy_invoker"' "$vercel_identity_file" | wc -l | tr -d ' ')" = "1"
 
 rg -q 'workload_identity_pool_id = "vercel-preview-proxy"' "$vercel_identity_file"
 rg -q 'workload_identity_pool_provider_id = "vercel-preview"' "$vercel_identity_file"
@@ -220,7 +221,13 @@ rg -q 'vercel_preview_issuer[[:space:]]*=[[:space:]]*"https://oidc\.vercel\.com/
 test "$(rg -No 'allowed_audiences' "$vercel_identity_file" | wc -l | tr -d ' ')" = "0"
 test "$(rg -No 'google_service_account_iam_member\.vercel_preview_proxy_(workload_identity_user|openid_token_creator)\.service_account_id' "$root_dir/checks.tf" | wc -l | tr -d ' ')" = "0"
 rg -U -q 'basename\(\n        google_cloud_run_v2_service_iam_member\.vercel_preview_proxy_invoker\.name\n      \) == "rentchain-preview-backend"' "$root_dir/checks.tf"
-test "$(rg -No 'role     = "roles/run\.invoker"' "$vercel_identity_file" | wc -l | tr -d ' ')" = "1"
+rg -q 'name     = "rentchain-g1c-identity-qa-v1"' "$vercel_identity_file"
+rg -q 'google_cloud_run_v2_service_iam_member\.g1c_vercel_proxy_invoker\.project == "rentchain-preview"' "$root_dir/checks.tf"
+rg -q 'google_cloud_run_v2_service_iam_member\.g1c_vercel_proxy_invoker\.location == "northamerica-northeast1"' "$root_dir/checks.tf"
+rg -q 'basename\(google_cloud_run_v2_service_iam_member\.g1c_vercel_proxy_invoker\.name\) == "rentchain-g1c-identity-qa-v1"' "$root_dir/checks.tf"
+rg -q 'google_cloud_run_v2_service_iam_member\.g1c_vercel_proxy_invoker\.role == "roles/run.invoker"' "$root_dir/checks.tf"
+rg -q 'google_cloud_run_v2_service_iam_member\.g1c_vercel_proxy_invoker\.member == "serviceAccount:vercel-preview-proxy@rentchain-preview.iam.gserviceaccount.com"' "$root_dir/checks.tf"
+test "$(rg -No 'role     = "roles/run\.invoker"' "$vercel_identity_file" | wc -l | tr -d ' ')" = "2"
 grep -Fq 'length(google_iam_workload_identity_pool_provider.vercel_preview.attribute_mapping) == 4' "$root_dir/checks.tf"
 grep -Fq 'attribute_mapping["google.subject"] == "assertion.sub"' "$root_dir/checks.tf"
 grep -Fq 'attribute_mapping["attribute.owner_id"] == "assertion.owner_id"' "$root_dir/checks.tf"

--- a/infra/environments/preview-foundation/vercel_preview_identity.tf
+++ b/infra/environments/preview-foundation/vercel_preview_identity.tf
@@ -92,3 +92,13 @@ resource "google_cloud_run_v2_service_iam_member" "vercel_preview_proxy_invoker"
   role     = "roles/run.invoker"
   member   = google_service_account.vercel_preview_proxy.member
 }
+
+# Temporary service-level access for G1C mandatory Tenant Portal government-ID
+# browser QA. Remove through Terraform/HCP after the PR QA/release lifecycle.
+resource "google_cloud_run_v2_service_iam_member" "g1c_vercel_proxy_invoker" {
+  project  = var.project_id
+  location = local.preview_deployment_region
+  name     = "rentchain-g1c-identity-qa-v1"
+  role     = "roles/run.invoker"
+  member   = google_service_account.vercel_preview_proxy.member
+}


### PR DESCRIPTION
## Scope

Separately governed temporary Preview IAM for G1C automated browser QA.

- Adds exactly one service-level `roles/run.invoker` member for `rentchain-g1c-identity-qa-v1`.
- Uses only the existing `vercel-preview-proxy@rentchain-preview.iam.gserviceaccount.com` identity.
- Adds an exact service/project/region/member boundary check and source-scope validation.
- Does not add project-level IAM, public access, Production access, a new identity, or a permanent Preview service change.

## Why

The exact-head PR #1537 Vercel same-origin proxy must invoke the private isolated G1C backend for synthetic Tenant Portal government-ID QA. Live audit confirmed the isolated service has no Invoker member and the Preview project has no project-level Invoker for this identity.

## Validation

- `terraform fmt -check infra/environments/preview-foundation`
- `terraform -chdir=infra/environments/preview-foundation validate`
- `bash infra/environments/preview-foundation/tests/validate_scope.sh`
- `git diff --check`

Expected HCP plan: `1 add, 0 change, 0 destroy` for only `google_cloud_run_v2_service_iam_member.g1c_vercel_proxy_invoker`.

No apply is authorized from Codex. Founder HCP Confirm & Apply is required before G1C live browser QA resumes.

## Cleanup obligation

Remove this exact Terraform resource through a separately governed cleanup PR after the G1C QA/release lifecycle, then delete the isolated service and exact synthetic QA records/objects by manifest.
