### PR TITLE
Enable permanent Preview backend runtime storage configuration

### DIFF
--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -140,9 +140,25 @@ check "b7_preview_backend_auth_secret_injection_boundary" {
       one([
         for env in google_cloud_run_v2_service.preview_backend[0].template[0].containers[0].env : env
         if env.name == "FIRESTORE_ENABLED"
-      ]).value == "false"
+      ]).value == "true" &&
+      length([
+        for env in google_cloud_run_v2_service.preview_backend[0].template[0].containers[0].env : env
+        if env.name == "GCS_UPLOAD_BUCKET"
+      ]) == 1 &&
+      one([
+        for env in google_cloud_run_v2_service.preview_backend[0].template[0].containers[0].env : env
+        if env.name == "GCS_UPLOAD_BUCKET"
+      ]).value == google_storage_bucket.preview_attachments.name &&
+      length([
+        for env in google_cloud_run_v2_service.preview_backend[0].template[0].containers[0].env : env
+        if env.name == "GCS_IDENTITY_DOCUMENT_BUCKET"
+      ]) == 1 &&
+      one([
+        for env in google_cloud_run_v2_service.preview_backend[0].template[0].containers[0].env : env
+        if env.name == "GCS_IDENTITY_DOCUMENT_BUCKET"
+      ]).value == google_storage_bucket.preview_identity_documents.name
     ) : true
-    error_message = "The Preview backend must receive only explicit version 1 of the governed Identity Toolkit secret while Firestore remains disabled."
+    error_message = "The Preview backend must receive explicit Identity Toolkit secret version 1, enabled Firestore, and only the governed Preview storage buckets."
   }
 }
 

--- a/infra/environments/preview-foundation/cloud_run.tf
+++ b/infra/environments/preview-foundation/cloud_run.tf
@@ -55,7 +55,17 @@ resource "google_cloud_run_v2_service" "preview_backend" {
 
       env {
         name  = "FIRESTORE_ENABLED"
-        value = "false"
+        value = "true"
+      }
+
+      env {
+        name  = "GCS_UPLOAD_BUCKET"
+        value = google_storage_bucket.preview_attachments.name
+      }
+
+      env {
+        name  = "GCS_IDENTITY_DOCUMENT_BUCKET"
+        value = google_storage_bucket.preview_identity_documents.name
       }
 
       env {

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -297,7 +297,10 @@ if rg -n 'firebaseauth\.users\.(create|delete|update|sendEmail)|datastore\.(data
   exit 1
 fi
 
-rg -U -q 'name  = "FIRESTORE_ENABLED"\n        value = "false"' "$root_dir/cloud_run.tf"
+rg -U -q 'name  = "FIRESTORE_ENABLED"\n        value = "true"' "$root_dir/cloud_run.tf"
+rg -U -q 'name  = "GCS_UPLOAD_BUCKET"\n        value = google_storage_bucket\.preview_attachments\.name' "$root_dir/cloud_run.tf"
+rg -U -q 'name  = "GCS_IDENTITY_DOCUMENT_BUCKET"\n        value = google_storage_bucket\.preview_identity_documents\.name' "$root_dir/cloud_run.tf"
+test "$(rg -No 'name  = "(FIRESTORE_ENABLED|GCS_UPLOAD_BUCKET|GCS_IDENTITY_DOCUMENT_BUCKET)"' "$root_dir/cloud_run.tf" | wc -l | tr -d ' ')" = "3"
 test "$(rg -No 'name = "FIREBASE_API_KEY"' "$root_dir/cloud_run.tf" | wc -l | tr -d ' ')" = "1"
 rg -U -q 'env \{\n        name = "FIREBASE_API_KEY"\n\n        value_source \{\n          secret_key_ref \{\n            secret  = google_secret_manager_secret\.preview_backend_identity_toolkit\[0\]\.secret_id\n            version = "1"\n          \}\n        \}\n      \}' "$root_dir/cloud_run.tf"
 grep -Fq 'google_secret_manager_secret_iam_member.preview_backend_identity_toolkit_accessor,' "$root_dir/cloud_run.tf"


### PR DESCRIPTION
## Purpose

Enable the already-merged F1 Maintenance attachment and G1 Identity runtimes in the permanent Preview backend by supplying their required existing-resource environment configuration.

## Exact semantic delta

- `FIRESTORE_ENABLED=false` to `true`
- add `GCS_UPLOAD_BUCKET=rentchain-preview-attachments`
- add `GCS_IDENTITY_DOCUMENT_BUCKET=rentchain-preview-identity-documents`

The bucket values reference the existing Terraform-managed bucket resources rather than duplicating their names.

## Explicitly unchanged

- Cloud Run image and source metadata
- service name, project, and region
- runtime service account
- IAM and WIF/OIDC
- buckets and Firestore database resources
- secrets and secret versions
- ingress, CPU, memory, timeout, concurrency, scaling, and port
- Production resources

## Validation

- `terraform fmt -check`
- `terraform init -backend=false`
- `terraform validate`
- `bash infra/environments/preview-foundation/tests/validate_scope.sh`
- `git diff --check`
- changed-diff credential pattern scan
- live Cloud Run and HCP state contract verification

This PR must remain Draft until its speculative HCP plan proves the sole resource action is the existing permanent Preview Cloud Run service environment update with no image, IAM, bucket, secret, Firestore-resource, Production, replacement, or destroy action.
