### PR TITLE
Configure permanent Preview Firestore database ID

### DIFF
--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -143,6 +143,14 @@ check "b7_preview_backend_auth_secret_injection_boundary" {
       ]).value == "true" &&
       length([
         for env in google_cloud_run_v2_service.preview_backend[0].template[0].containers[0].env : env
+        if env.name == "FIRESTORE_DATABASE_ID"
+      ]) == 1 &&
+      one([
+        for env in google_cloud_run_v2_service.preview_backend[0].template[0].containers[0].env : env
+        if env.name == "FIRESTORE_DATABASE_ID"
+      ]).value == "(default)" &&
+      length([
+        for env in google_cloud_run_v2_service.preview_backend[0].template[0].containers[0].env : env
         if env.name == "GCS_UPLOAD_BUCKET"
       ]) == 1 &&
       one([
@@ -158,7 +166,7 @@ check "b7_preview_backend_auth_secret_injection_boundary" {
         if env.name == "GCS_IDENTITY_DOCUMENT_BUCKET"
       ]).value == google_storage_bucket.preview_identity_documents.name
     ) : true
-    error_message = "The Preview backend must receive explicit Identity Toolkit secret version 1, enabled Firestore, and only the governed Preview storage buckets."
+    error_message = "The Preview backend must receive explicit Identity Toolkit secret version 1, enabled default Firestore database, and only the governed Preview storage buckets."
   }
 }
 

--- a/infra/environments/preview-foundation/cloud_run.tf
+++ b/infra/environments/preview-foundation/cloud_run.tf
@@ -59,6 +59,11 @@ resource "google_cloud_run_v2_service" "preview_backend" {
       }
 
       env {
+        name  = "FIRESTORE_DATABASE_ID"
+        value = "(default)"
+      }
+
+      env {
         name  = "GCS_UPLOAD_BUCKET"
         value = google_storage_bucket.preview_attachments.name
       }

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -298,13 +298,14 @@ if rg -n 'firebaseauth\.users\.(create|delete|update|sendEmail)|datastore\.(data
 fi
 
 rg -U -q 'name  = "FIRESTORE_ENABLED"\n        value = "true"' "$root_dir/cloud_run.tf"
+rg -U -q 'name  = "FIRESTORE_DATABASE_ID"\n        value = "\(default\)"' "$root_dir/cloud_run.tf"
 rg -U -q 'name  = "GCS_UPLOAD_BUCKET"\n        value = google_storage_bucket\.preview_attachments\.name' "$root_dir/cloud_run.tf"
 rg -U -q 'name  = "GCS_IDENTITY_DOCUMENT_BUCKET"\n        value = google_storage_bucket\.preview_identity_documents\.name' "$root_dir/cloud_run.tf"
-test "$(rg -No 'name  = "(FIRESTORE_ENABLED|GCS_UPLOAD_BUCKET|GCS_IDENTITY_DOCUMENT_BUCKET)"' "$root_dir/cloud_run.tf" | wc -l | tr -d ' ')" = "3"
+test "$(rg -No 'name  = "(FIRESTORE_ENABLED|FIRESTORE_DATABASE_ID|GCS_UPLOAD_BUCKET|GCS_IDENTITY_DOCUMENT_BUCKET)"' "$root_dir/cloud_run.tf" | wc -l | tr -d ' ')" = "4"
 test "$(rg -No 'name = "FIREBASE_API_KEY"' "$root_dir/cloud_run.tf" | wc -l | tr -d ' ')" = "1"
 rg -U -q 'env \{\n        name = "FIREBASE_API_KEY"\n\n        value_source \{\n          secret_key_ref \{\n            secret  = google_secret_manager_secret\.preview_backend_identity_toolkit\[0\]\.secret_id\n            version = "1"\n          \}\n        \}\n      \}' "$root_dir/cloud_run.tf"
 grep -Fq 'google_secret_manager_secret_iam_member.preview_backend_identity_toolkit_accessor,' "$root_dir/cloud_run.tf"
-if rg -n 'FIRESTORE_DATABASE_ID|PREVIEW_AUTH_ENABLED|FIREBASE_PROJECT_ID|google_apikeys_key|key_string|version\s*=\s*"latest"' "$root_dir/cloud_run.tf"; then
+if rg -n 'PREVIEW_AUTH_ENABLED|FIREBASE_PROJECT_ID|google_apikeys_key|key_string|version\s*=\s*"latest"' "$root_dir/cloud_run.tf"; then
   echo "B7 Cloud Run secret injection contains a prohibited activation field, direct key reference, or mutable secret version" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary

- add only `FIRESTORE_DATABASE_ID=(default)` to the existing permanent Preview backend Cloud Run service
- retain `FIRESTORE_ENABLED=true` and both governed Preview bucket environment values
- extend the existing Terraform contract check and focused static assertion

## Scope and containment

- environment-only one-variable runtime delta
- no image change
- no IAM change
- no bucket change
- no Firestore resource change
- no secret change
- no Production change
- no frontend or backend application change
- no apply or deployment performed by this PR

## Validation

- `terraform fmt -check`: passed
- `terraform validate`: passed
- focused `FIRESTORE_DATABASE_ID=(default)` and four-variable contract assertions: passed
- `git diff --check`: passed
- credential diff inspection: passed

The repository-wide `tests/validate_scope.sh` currently stops on an unrelated baseline assertion inherited from `main`: it expects 54 Terraform resource blocks while the current tree has 53. This change adds no resource and does not alter that count.

## Governed next steps

1. Obtain an authoritative HCP speculative plan proving `0 add, 1 change, 0 destroy` on only `google_cloud_run_v2_service.preview_backend[0]` and only the new environment value.
2. Merge only if all substantive checks pass and `REVIEW_REQUIRED` is the sole governance blocker.
3. Verify the exact main-triggered HCP plan matches.
4. Stop for Founder Confirm & Apply. No apply, artifact build, manual Cloud Run deployment, or UI routing work is authorized here.
