### PR TITLE
Update permanent Preview backend to current main runtime

### DIFF
--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -294,7 +294,7 @@ check "b6_preview_backend_boundary" {
   assert {
     condition = (
       local.preview_backend_service_name == "rentchain-preview-backend" &&
-      local.preview_backend_image_digest == "northamerica-northeast1-docker.pkg.dev/rentchain-preview/rentchain-preview/backend@sha256:3a7de2792511786d9f984de5f99ee19b5466ad8336d9ec4e307702c9dedd8cfd" &&
+      local.preview_backend_image_digest == "northamerica-northeast1-docker.pkg.dev/rentchain-preview/rentchain-preview/backend@sha256:bfd6f231432abdce497bceac81c4c8e1b32b230e1cf46a225b2ce7d116df583c" &&
       local.preview_backend_source_sha == "d28c61991131e9a76874d5eb92adceac048f9417" &&
       !var.enable_preview_backend_service || (
         google_cloud_run_v2_service.preview_backend[0].project == "rentchain-preview" &&

--- a/infra/environments/preview-foundation/cloud_run.tf
+++ b/infra/environments/preview-foundation/cloud_run.tf
@@ -1,6 +1,6 @@
 locals {
   preview_backend_service_name = "rentchain-preview-backend"
-  preview_backend_image_digest = "northamerica-northeast1-docker.pkg.dev/rentchain-preview/rentchain-preview/backend@sha256:270adb21de2b271eb468b28b1a591a3f27544aae162f1f028ad74c7bfd30960f"
+  preview_backend_image_digest = "northamerica-northeast1-docker.pkg.dev/rentchain-preview/rentchain-preview/backend@sha256:bfd6f231432abdce497bceac81c4c8e1b32b230e1cf46a225b2ce7d116df583c"
   preview_backend_source_sha   = "d28c61991131e9a76874d5eb92adceac048f9417"
 }
 


### PR DESCRIPTION
## Trusted artifact

- source: exact protected `main` at `a92a6f88d7788949135c2026af1601f85f7aeaab`
- workflow: Preview backend image delivery run `31970722000`
- immutable digest: `sha256:bfd6f231432abdce497bceac81c4c8e1b32b230e1cf46a225b2ce7d116df583c`
- Node.js `24.19.0`
- `linux/amd64`
- non-root runtime user `node`
- Sharp `0.35.3`; libvips `8.18.3`
- F1 Maintenance and G1 Identity route families present in the compiled artifact
- complete Preview environment startup and `/health` passed
- 89 focused backend tests passed

## Exact service delta

Image only: update the existing permanent Preview backend's immutable digest and its narrow boundary assertion.

## Preserved environment

- `FIRESTORE_ENABLED=true`
- `FIRESTORE_DATABASE_ID=(default)`
- `GCS_UPLOAD_BUCKET=rentchain-preview-attachments`
- `GCS_IDENTITY_DOCUMENT_BUCKET=rentchain-preview-identity-documents`

## Explicitly unchanged

- IAM and runtime service account
- buckets
- Firestore resource
- secrets
- ingress, compute, scaling, timeout, concurrency, and traffic configuration
- Production
- frontend/backend application source
- workflows

## Validation

- `terraform fmt -check`: passed
- `terraform validate`: passed
- `git diff --check`: passed
- exact repository diff: two one-line substitutions in two Terraform files
- credential diff inspection: no credential introduced

The repository scope script retains the unrelated `main` baseline mismatch expecting 54 Terraform resource blocks while 53 exist. This image-only branch does not change resource cardinality or that assertion.

Keep Draft until the authoritative speculative HCP plan proves `0 add, 1 change, 0 destroy` with only the image changing. No Terraform apply or manual Cloud Run deployment is part of this PR.
