### PR TITLE
Route Preview UI traffic through the permanent backend

### DIFF
--- a/rentchain-frontend/api/preview-backend/[...path].ts
+++ b/rentchain-frontend/api/preview-backend/[...path].ts
@@ -1,5 +1,7 @@
 import { handlePreviewBackendProxy } from "../../server/previewBackendProxy.js";
 
+export const config = { api: { bodyParser: false } };
+
 export default async function handler(req: any, res: any) {
   return handlePreviewBackendProxy(req, res);
 }

--- a/rentchain-frontend/scripts/build.mjs
+++ b/rentchain-frontend/scripts/build.mjs
@@ -15,13 +15,14 @@ const env = {
   VITE_BUILD_ID: buildId,
 };
 
-if (
-  process.env.VERCEL_ENV === "preview" &&
-  process.env.VERCEL_GIT_COMMIT_REF === "feat/property-notices-v1"
-) {
-  env.VITE_API_BASE_URL = "/api/pr1512-notices";
+if (process.env.VERCEL_ENV === "preview") {
   env.VITE_DEPLOY_ENV = "preview";
-  env.VITE_PR1512_NOTICES_QA = "true";
+  if (process.env.VERCEL_GIT_COMMIT_REF === "feat/property-notices-v1") {
+    env.VITE_API_BASE_URL = "/api/pr1512-notices";
+    env.VITE_PR1512_NOTICES_QA = "true";
+  } else {
+    env.VITE_API_BASE_URL = "/api/preview-backend";
+  }
 }
 
 function run(cmd, args) {

--- a/rentchain-frontend/server/previewBackendProxy.ts
+++ b/rentchain-frontend/server/previewBackendProxy.ts
@@ -30,16 +30,11 @@ export const PREVIEW_PROXY_AUTH_CONFIG: PreviewAuthConfig = {
   expectedSpikeCommit: "",
 };
 
-export const PREVIEW_PROXY_BODY_LIMIT_BYTES = 16 * 1024;
+export const PREVIEW_PROXY_BODY_LIMIT_BYTES = 10 * 1024 * 1024;
 export const PREVIEW_PROXY_TOKEN_TIMEOUT_MS = 5_000;
 export const PREVIEW_PROXY_UPSTREAM_TIMEOUT_MS = 10_000;
 
-const ROUTE_METHODS = new Map<string, ReadonlySet<string>>([
-  ["/api/auth/login", new Set(["POST"])],
-  ["/api/auth/logout", new Set(["POST"])],
-  ["/api/me", new Set(["GET"])],
-  ["/api/auth/me", new Set(["GET"])],
-]);
+const ALLOWED_METHODS = new Set(["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE"]);
 
 const RESPONSE_HEADERS = new Set([
   "cache-control",
@@ -122,7 +117,7 @@ export function resolvePreviewBackendPath(req: any): {
   }
 
   const backendPath = `/${decodedSuffix}`;
-  if (!ROUTE_METHODS.has(backendPath)) {
+  if (!backendPath.startsWith("/api/")) {
     throw new PreviewBackendProxyError("PREVIEW_PROXY_ROUTE_NOT_ALLOWED", 404);
   }
 
@@ -130,13 +125,13 @@ export function resolvePreviewBackendPath(req: any): {
 }
 
 function assertMethod(backendPath: string, method: string) {
-  if (!ROUTE_METHODS.get(backendPath)?.has(method)) {
+  if (!backendPath.startsWith("/api/") || !ALLOWED_METHODS.has(method)) {
     throw new PreviewBackendProxyError("PREVIEW_PROXY_METHOD_NOT_ALLOWED", 405);
   }
 }
 
-function requestBody(req: any, method: string): BodyInit | undefined {
-  if (method === "GET") return undefined;
+async function requestBody(req: any, method: string): Promise<BodyInit | undefined> {
+  if (method === "GET" || method === "HEAD") return undefined;
 
   const declaredLength = Number(req?.headers?.["content-length"] || 0);
   if (
@@ -147,6 +142,19 @@ function requestBody(req: any, method: string): BodyInit | undefined {
   }
 
   const input = req?.body;
+  if (input == null && req && typeof req[Symbol.asyncIterator] === "function") {
+    const chunks: Buffer[] = [];
+    let byteLength = 0;
+    for await (const chunk of req) {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      byteLength += buffer.byteLength;
+      if (byteLength > PREVIEW_PROXY_BODY_LIMIT_BYTES) {
+        throw new PreviewBackendProxyError("PREVIEW_PROXY_BODY_TOO_LARGE", 413);
+      }
+      chunks.push(buffer);
+    }
+    return chunks.length ? Buffer.concat(chunks) : undefined;
+  }
   if (input == null) return undefined;
 
   let body: string | ArrayBuffer;
@@ -166,6 +174,8 @@ function requestBody(req: any, method: string): BodyInit | undefined {
     ).buffer;
   } else if (input instanceof ArrayBuffer) {
     body = input.slice(0);
+  } else if (Buffer.isBuffer(input)) {
+    body = Uint8Array.from(input).buffer;
   } else {
     try {
       body = JSON.stringify(input);
@@ -249,10 +259,12 @@ export async function handlePreviewBackendProxy(
     route = resolvePreviewBackendPath(req);
     method = String(req?.method || "GET").toUpperCase();
     assertMethod(route.backendPath, method);
-    body = requestBody(req, method);
+    body = await requestBody(req, method);
   } catch (error) {
     if (error instanceof PreviewBackendProxyError) {
-      if (error.status === 405) res.setHeader("allow", "GET, POST");
+      if (error.status === 405) {
+        res.setHeader("allow", Array.from(ALLOWED_METHODS).join(", "));
+      }
       return jsonError(res, error.status, error.code);
     }
     return jsonError(res, 400, "PREVIEW_PROXY_BODY_INVALID");

--- a/rentchain-frontend/src/api/apiFetch.test.ts
+++ b/rentchain-frontend/src/api/apiFetch.test.ts
@@ -61,7 +61,6 @@ describe("legacy apiFetch URL parity", () => {
   it.each([
     "/api/api/auth/login",
     "api/api/auth/login",
-    "/api/properties",
   ])("rejects malformed or unsupported Preview input %s before credentials", async (input) => {
     vi.stubEnv("VITE_DEPLOY_ENV", "preview");
     vi.stubEnv("VITE_API_BASE_URL", "/api/preview-backend");
@@ -74,6 +73,25 @@ describe("legacy apiFetch URL parity", () => {
     expect(fetchMock).not.toHaveBeenCalled();
     expect(mocks.getFirebaseIdToken).not.toHaveBeenCalled();
     expect(mocks.getAuthToken).not.toHaveBeenCalled();
+  });
+
+  it("routes ordinary Preview application requests through the same-origin proxy", async () => {
+    vi.stubEnv("VITE_DEPLOY_ENV", "preview");
+    vi.stubEnv("VITE_API_BASE_URL", "/api/preview-backend");
+    const fetchMock = vi.fn(async () =>
+      new Response("{}", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    );
+    global.fetch = fetchMock as typeof fetch;
+
+    await apiFetch("/api/properties", { method: "POST" });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/preview-backend/api/properties",
+      expect.any(Object)
+    );
   });
 
   it("does not duplicate the Preview proxy prefix", async () => {

--- a/rentchain-frontend/src/api/baseUrl.ts
+++ b/rentchain-frontend/src/api/baseUrl.ts
@@ -151,8 +151,7 @@ export function getApiBaseUrlForRequest(input: string, method = "GET"): string {
     throw new PreviewApiRouteUnavailableError(input, method);
   }
   if (configuredBase !== PREVIEW_API_BASE_URL) return configuredBase;
-  if (isPreviewAuthRequest(input, method)) return PREVIEW_API_BASE_URL;
-  throw new PreviewApiRouteUnavailableError(input, method);
+  return PREVIEW_API_BASE_URL;
 }
 
 export function getApiBaseUrlForPath(input: string): string {
@@ -189,7 +188,7 @@ export function assertPreviewBrowserRequestAvailable(inputUrl: string, method = 
   if (parsed.origin === origin && parsed.pathname.startsWith(prefix)) {
     const backendPath = parsed.pathname.slice(configuredBase.length);
     if (configuredBase === PR1512_NOTICES_QA_API_BASE_URL && isPr1512QaReadRequest(backendPath, method)) return;
-    if (configuredBase === PREVIEW_API_BASE_URL && isPreviewAuthRequest(backendPath, method)) return;
+    if (configuredBase === PREVIEW_API_BASE_URL && normalizeBackendPath(backendPath).startsWith("/api/")) return;
     throw new PreviewApiRouteUnavailableError(backendPath, method);
   }
 

--- a/rentchain-frontend/src/context/__tests__/AuthContext.previewDashboardIsolation.test.tsx
+++ b/rentchain-frontend/src/context/__tests__/AuthContext.previewDashboardIsolation.test.tsx
@@ -44,7 +44,7 @@ describe("Preview login-to-dashboard isolation", () => {
     vi.restoreAllMocks();
   });
 
-  it("mounts the dashboard while rejecting every unsupported loader before fetch", async () => {
+  it("mounts the dashboard with every application loader on the same-origin proxy", async () => {
     const [{ default: DashboardPage }, { LoginPage }] = await Promise.all([
       import("../../pages/DashboardPage"),
       import("../../pages/LoginPage"),
@@ -66,7 +66,10 @@ describe("Preview login-to-dashboard isolation", () => {
           headers: { "content-type": "application/json" },
         });
       }
-      throw new Error(`Dashboard request reached fetch: ${url}`);
+      return new Response(JSON.stringify({ error: "synthetic-unavailable" }), {
+        status: 503,
+        headers: { "content-type": "application/json" },
+      });
     });
     global.fetch = fetchMock as typeof fetch;
 
@@ -92,26 +95,18 @@ describe("Preview login-to-dashboard isolation", () => {
     fireEvent.click(screen.getByRole("button", { name: "Sign in" }));
 
     expect(await screen.findByTestId("dashboard-operational-grid")).toBeInTheDocument();
-    await waitFor(() =>
-      expect(
-        screen.getAllByText(
-          "This operation is not available in the current Preview environment."
-        ).length
-      ).toBeGreaterThan(0)
+    await waitFor(() => expect(captured.length).toBeGreaterThan(2));
+    expect(captured).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ url: `${PREVIEW_PROXY}/api/auth/login` }),
+        expect.objectContaining({ url: `${PREVIEW_PROXY}/api/me` }),
+      ])
     );
 
-    expect(
-      captured.map(({ url, init }) => [String(init.method || "GET").toUpperCase(), url])
-    ).toEqual([
-      ["POST", `${PREVIEW_PROXY}/api/auth/login`],
-      ["GET", `${PREVIEW_PROXY}/api/me`],
-    ]);
-
     for (const { url } of captured) {
+      expect(url.startsWith(PREVIEW_PROXY)).toBe(true);
       expect(url.startsWith(PRODUCTION_API)).toBe(false);
-      expect(url).not.toMatch(
-        /\/api\/(?:landlord\/(?:portfolio-status-financial|decision-queue|maintenance|inbox)|applications|tenants|work-orders)/
-      );
+      expect(url).not.toContain(".run.app");
     }
   });
 });

--- a/rentchain-frontend/src/lib/apiClient.test.ts
+++ b/rentchain-frontend/src/lib/apiClient.test.ts
@@ -1,10 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  PREVIEW_API_BASE_URL,
-  PREVIEW_API_ROUTE_NOT_AVAILABLE,
-  PRODUCTION_API_BASE_URL,
-  PreviewApiRouteUnavailableError,
-} from "../api/baseUrl";
+import { PREVIEW_API_BASE_URL, PRODUCTION_API_BASE_URL } from "../api/baseUrl";
 import * as authToken from "./authToken";
 import * as firebaseAuthToken from "./firebaseAuthToken";
 import {
@@ -39,9 +34,9 @@ describe("resolveApiUrl", () => {
     ["/api/auth/logout", "GET"],
     ["/api/me", "POST"],
     ["/api/auth/me", "POST"],
-  ])("fails closed for unauthorized Preview auth operation %s %s", (path, method) => {
+  ])("routes application methods through Preview for backend authorization: %s %s", (path, method) => {
     usePreviewEnvironment();
-    expect(() => resolveApiUrl(path, method)).toThrow(PreviewApiRouteUnavailableError);
+    expect(resolveApiUrl(path, method)).toBe(`${PREVIEW_API_BASE_URL}${path}`);
   });
 
   it("preserves query strings without duplicating the proxy prefix", () => {
@@ -58,13 +53,6 @@ describe("resolveApiUrl", () => {
     );
   });
 
-  it("fails closed for unrelated Preview calls", () => {
-    usePreviewEnvironment();
-    expect(() => resolveApiUrl("/api/properties")).toThrow(
-      "not available in the current Preview environment"
-    );
-  });
-
   it.each([
     "/api/properties",
     "/api/tenants",
@@ -73,22 +61,9 @@ describe("resolveApiUrl", () => {
     "/api/landlord/portfolio-status-financial",
     "/api/landlord/decision-queue",
     "/api/landlord/inbox",
-  ])("rejects unsupported Preview request %s before credentials or fetch", async (path) => {
+  ])("routes supported Preview application request %s through the same-origin proxy", (path) => {
     usePreviewEnvironment();
-    const fetchSpy = vi.spyOn(globalThis, "fetch");
-    const firebaseSpy = vi.spyOn(firebaseAuthToken, "getFirebaseIdToken");
-    const bearerSpy = vi.spyOn(authToken, "getAuthToken");
-
-    await expect(apiFetch(path, { method: "GET" })).rejects.toMatchObject({
-      code: PREVIEW_API_ROUTE_NOT_AVAILABLE,
-      path,
-      method: "GET",
-      message: "This operation is not available in the current Preview environment.",
-    });
-
-    expect(fetchSpy).not.toHaveBeenCalled();
-    expect(firebaseSpy).not.toHaveBeenCalled();
-    expect(bearerSpy).not.toHaveBeenCalled();
+    expect(resolveApiUrl(path, "GET")).toBe(`${PREVIEW_API_BASE_URL}${path}`);
   });
 
   it("preserves normal Production URL construction", () => {

--- a/rentchain-frontend/src/platform/previewBackendProxy.test.ts
+++ b/rentchain-frontend/src/platform/previewBackendProxy.test.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { Readable } from "node:stream";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -142,9 +143,6 @@ describe("Preview backend proxy", () => {
   });
 
   it.each([
-    "/api/preview-backend/api/admin/users",
-    "/api/preview-backend/api/auth/signup",
-    "/api/preview-backend/api/auth/login/extra",
     "/api/preview-backend/api/preview-backend/api/auth/login",
     "/api/preview-backend//api/auth/login",
     "/api/preview-backend/https://example.invalid",
@@ -154,6 +152,15 @@ describe("Preview backend proxy", () => {
     expect(() => resolvePreviewBackendPath(request(url, "GET"))).toThrow(
       "PREVIEW_PROXY_ROUTE_NOT_ALLOWED",
     );
+  });
+
+  it.each([
+    ["/api/preview-backend/api/properties", "/api/properties"],
+    ["/api/preview-backend/api/tenant/identity-documents/status", "/api/tenant/identity-documents/status"],
+    ["/api/preview-backend/api/landlord/maintenance/request-1/attachments", "/api/landlord/maintenance/request-1/attachments"],
+    ["/api/preview-backend/api/admin/users", "/api/admin/users"],
+  ])("forwards normalized fixed-backend application path %s", (url, backendPath) => {
+    expect(resolvePreviewBackendPath(request(url, "GET"))).toEqual({ backendPath, query: "" });
   });
 
   it.each([
@@ -171,7 +178,7 @@ describe("Preview backend proxy", () => {
   it("rejects unsupported methods", async () => {
     const res = responseRecorder();
     await handlePreviewBackendProxy(
-      request("/api/preview-backend/api/auth/login", "GET"),
+      request("/api/preview-backend/api/auth/login", "CONNECT"),
       res,
       successfulDependencies().dependencies,
     );
@@ -180,6 +187,35 @@ describe("Preview backend proxy", () => {
       ok: false,
       error: "PREVIEW_PROXY_METHOD_NOT_ALLOWED",
     });
+    expect(res.headers.get("allow")).toBe("GET, HEAD, POST, PUT, PATCH, DELETE");
+  });
+
+  it("streams an unparsed multipart upload without exposing Google credentials", async () => {
+    const boundary = "rentchain-preview-upload";
+    const uploadBody = Buffer.from(
+      `--${boundary}\r\nContent-Disposition: form-data; name="file"; filename="id.png"\r\nContent-Type: image/png\r\n\r\nsynthetic-image\r\n--${boundary}--\r\n`,
+    );
+    const req = Readable.from([uploadBody]) as any;
+    Object.assign(req, request("/api/preview-backend/api/tenant/identity-documents", "POST", {
+      headers: {
+        authorization: "Bearer synthetic-tenant-session",
+        "content-type": `multipart/form-data; boundary=${boundary}`,
+        "content-length": String(uploadBody.byteLength),
+      },
+      body: undefined,
+    }));
+    const { requests, dependencies } = successfulDependencies();
+    const res = responseRecorder();
+
+    await handlePreviewBackendProxy(req, res, dependencies);
+
+    expect(res.statusCode).toBe(200);
+    expect(requests[2].init?.body).toEqual(uploadBody);
+    expect(requests[2].init?.headers).toMatchObject({
+      authorization: "Bearer synthetic-tenant-session",
+      "content-type": `multipart/form-data; boundary=${boundary}`,
+    });
+    expect(JSON.stringify(requests[2].init?.headers)).not.toContain("vercel-oidc");
   });
 
   it("uses exact identity constants and preserves application authorization separately", async () => {
@@ -345,6 +381,22 @@ describe("Preview backend proxy", () => {
     expect(
       fs.existsSync(path.join(frontendRoot, "api/preview-backend/[...path].ts")),
     ).toBe(true);
+  });
+
+  it("forces ordinary Vercel Preview builds through the same-origin backend proxy", () => {
+    const buildScript = fs.readFileSync(path.resolve(process.cwd(), "scripts/build.mjs"), "utf8");
+    expect(buildScript).toContain('process.env.VERCEL_ENV === "preview"');
+    expect(buildScript).toContain('env.VITE_DEPLOY_ENV = "preview"');
+    expect(buildScript).toContain('env.VITE_API_BASE_URL = "/api/preview-backend"');
+    expect(buildScript).toContain('env.VITE_API_BASE_URL = "/api/pr1512-notices"');
+  });
+
+  it("disables Vercel body parsing so binary uploads reach the proxy unchanged", () => {
+    const entrypoint = fs.readFileSync(
+      path.resolve(process.cwd(), "api/preview-backend/[...path].ts"),
+      "utf8",
+    );
+    expect(entrypoint).toContain("bodyParser: false");
   });
 
   it("does not introduce the Preview Cloud Run URL into browser source", () => {

--- a/rentchain-frontend/src/runtime/previewFetchGuard.test.ts
+++ b/rentchain-frontend/src/runtime/previewFetchGuard.test.ts
@@ -45,19 +45,17 @@ describe("Preview governed fetch", () => {
     expect(originalFetch.mock.calls[1][1]?.method).toBe("POST");
   });
 
-  it("rejects Request paths and init method overrides before credentials", async () => {
+  it("rejects raw same-origin API paths but permits method overrides inside the proxy", async () => {
     const { originalFetch, getAuthToken, governedFetch } = setup();
     expect(() =>
       governedFetch(new Request(`${ORIGIN}/api/auth/login`, { method: "POST" }))
     ).toThrow(expect.objectContaining({ code: "PREVIEW_API_ROUTE_NOT_AVAILABLE" }));
-    expect(() =>
-      governedFetch(
-        new Request(`${PROXY}/api/auth/login`, { method: "POST" }),
-        { method: "GET" }
-      )
-    ).toThrow(expect.objectContaining({ code: "PREVIEW_API_ROUTE_NOT_AVAILABLE" }));
-    expect(getAuthToken).not.toHaveBeenCalled();
-    expect(originalFetch).not.toHaveBeenCalled();
+    await governedFetch(
+      new Request(`${PROXY}/api/auth/login`, { method: "POST" }),
+      { method: "GET" }
+    );
+    expect(getAuthToken).toHaveBeenCalledOnce();
+    expect(originalFetch).toHaveBeenCalledOnce();
   });
 
   it.each([
@@ -95,17 +93,13 @@ describe("Preview governed fetch", () => {
     expect(originalFetch).not.toHaveBeenCalled();
   });
 
-  it("passes authorized login and me and rejects their wrong methods", async () => {
+  it("passes application API paths and lets the backend authorize each method", async () => {
     const { originalFetch, governedFetch } = setup();
     await governedFetch("/api/preview-backend/api/auth/login", { method: "POST" });
     await governedFetch("/api/preview-backend/api/me", { method: "GET" });
-    expect(() =>
-      governedFetch("/api/preview-backend/api/auth/login", { method: "GET" })
-    ).toThrow(expect.objectContaining({ code: "PREVIEW_API_ROUTE_NOT_AVAILABLE" }));
-    expect(() =>
-      governedFetch("/api/preview-backend/api/me", { method: "POST" })
-    ).toThrow(expect.objectContaining({ code: "PREVIEW_API_ROUTE_NOT_AVAILABLE" }));
-    expect(originalFetch).toHaveBeenCalledTimes(2);
+    await governedFetch("/api/preview-backend/api/auth/login", { method: "GET" });
+    await governedFetch("/api/preview-backend/api/me", { method: "POST" });
+    expect(originalFetch).toHaveBeenCalledTimes(4);
   });
 
   it("attaches the token only to relative or exact same-origin Preview proxy URLs", async () => {
@@ -137,13 +131,11 @@ describe("Preview governed fetch", () => {
     expect(originalFetch.mock.calls[0][1]).toBeUndefined();
   });
 
-  it("rejects same-origin unsupported proxy paths before token access", () => {
+  it("allows same-origin product API paths and attaches application credentials", async () => {
     const { originalFetch, getAuthToken, governedFetch } = setup();
-    expect(() =>
-      governedFetch("/api/preview-backend/api/properties", { method: "GET" })
-    ).toThrow(expect.objectContaining({ code: "PREVIEW_API_ROUTE_NOT_AVAILABLE" }));
-    expect(getAuthToken).not.toHaveBeenCalled();
-    expect(originalFetch).not.toHaveBeenCalled();
+    await governedFetch("/api/preview-backend/api/properties", { method: "GET" });
+    expect(getAuthToken).toHaveBeenCalledOnce();
+    expect(originalFetch).toHaveBeenCalledOnce();
   });
 
   it.each(["production", "development"])("does not apply Preview blocking in %s", async (env) => {


### PR DESCRIPTION
## Summary
- force ordinary Vercel Preview builds to use the same-origin `/api/preview-backend` bridge
- extend the fixed-target Preview bridge from auth-only traffic to normalized application `/api/*` routes
- preserve application authorization separately from server-side Vercel OIDC/WIF Cloud Run credentials
- support raw multipart upload bodies for F1/G1 image routes while retaining bounded request size and fixed backend targeting
- preserve Production routing and the isolated PR #1512 Notices Preview exception

## Security and containment
- browser receives no Google credential
- proxy target remains fixed to `rentchain-preview-backend`
- malformed paths, traversal, unsupported methods, direct Production, and direct `run.app` requests fail closed
- no Production, IAM, Terraform, provider, or data mutation

## Validation
- focused same-origin/proxy suite: 143 passed
- updated routing integration suite: 43 passed
- full frontend suite: 1,779 passed across 359 files (with required `VITE_API_BASE_URL` test baseline)
- Node 24.19.0 production build: passed
- TypeScript `tsc --noEmit`: passed
- `git diff --check`: passed
- credential review: only explicit synthetic test tokens; no credential material

## Runtime QA still required
Keep this PR Draft until its exact-head Vercel Preview proves actual OIDC/WIF invocation, zero direct browser `run.app`/Production API requests, authenticated landlord and tenant routing, F1/G1 paths, responsive behavior, and Founder visual acceptance.