### PR TITLE
Configure permanent Preview JWT signing secret

### DIFF
--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -170,6 +170,42 @@ check "b7_preview_backend_auth_secret_injection_boundary" {
   }
 }
 
+check "preview_backend_jwt_secret_boundary" {
+  assert {
+    condition = (
+      google_secret_manager_secret.preview_backend_jwt.project == "rentchain-preview" &&
+      google_secret_manager_secret.preview_backend_jwt.secret_id == "preview-backend-jwt-secret" &&
+      google_secret_manager_secret.preview_backend_jwt.deletion_protection &&
+      google_secret_manager_secret_version.preview_backend_jwt.secret_data_wo_version == 1 &&
+      google_secret_manager_secret_version.preview_backend_jwt.deletion_policy == "DISABLE" &&
+      google_secret_manager_secret_iam_member.preview_backend_jwt_accessor.secret_id == google_secret_manager_secret.preview_backend_jwt.id &&
+      google_secret_manager_secret_iam_member.preview_backend_jwt_accessor.role == "roles/secretmanager.secretAccessor" &&
+      google_secret_manager_secret_iam_member.preview_backend_jwt_accessor.member == google_service_account.preview_backend_runtime.member
+    )
+    error_message = "The Preview JWT signing secret must remain Preview-only, write-only provisioned, deletion-protected, and accessible only through the exact runtime secret-level binding."
+  }
+}
+
+check "preview_backend_jwt_secret_injection_boundary" {
+  assert {
+    condition = var.enable_preview_backend_service ? (
+      length([
+        for env in google_cloud_run_v2_service.preview_backend[0].template[0].containers[0].env : env
+        if env.name == "JWT_SECRET"
+      ]) == 1 &&
+      one([
+        for env in google_cloud_run_v2_service.preview_backend[0].template[0].containers[0].env : env
+        if env.name == "JWT_SECRET"
+      ]).value_source[0].secret_key_ref[0].secret == google_secret_manager_secret.preview_backend_jwt.secret_id &&
+      one([
+        for env in google_cloud_run_v2_service.preview_backend[0].template[0].containers[0].env : env
+        if env.name == "JWT_SECRET"
+      ]).value_source[0].secret_key_ref[0].version == "1"
+    ) : true
+    error_message = "The permanent Preview backend must receive exactly one JWT_SECRET from version 1 of the dedicated Preview JWT secret."
+  }
+}
+
 check "b7_hcp_bootstrap_iam_boundary" {
   assert {
     condition = (

--- a/infra/environments/preview-foundation/cloud_run.tf
+++ b/infra/environments/preview-foundation/cloud_run.tf
@@ -85,6 +85,17 @@ resource "google_cloud_run_v2_service" "preview_backend" {
       }
 
       env {
+        name = "JWT_SECRET"
+
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.preview_backend_jwt.secret_id
+            version = "1"
+          }
+        }
+      }
+
+      env {
         name  = "APP_GIT_SHA"
         value = local.preview_backend_source_sha
       }
@@ -106,5 +117,6 @@ resource "google_cloud_run_v2_service" "preview_backend" {
   depends_on = [
     google_project_service.approved_management["run.googleapis.com"],
     google_secret_manager_secret_iam_member.preview_backend_identity_toolkit_accessor,
+    google_secret_manager_secret_iam_member.preview_backend_jwt_accessor,
   ]
 }

--- a/infra/environments/preview-foundation/secret_manager.tf
+++ b/infra/environments/preview-foundation/secret_manager.tf
@@ -40,3 +40,40 @@ resource "google_secret_manager_secret_iam_member" "preview_backend_identity_too
   role      = "roles/secretmanager.secretAccessor"
   member    = google_service_account.preview_backend_runtime.member
 }
+
+resource "google_secret_manager_secret" "preview_backend_jwt" {
+  project   = var.project_id
+  secret_id = "preview-backend-jwt-secret"
+
+  replication {
+    auto {}
+  }
+
+  deletion_protection = true
+
+  depends_on = [
+    google_project_service.approved_management["secretmanager.googleapis.com"],
+  ]
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_secret_manager_secret_version" "preview_backend_jwt" {
+  secret                 = google_secret_manager_secret.preview_backend_jwt.id
+  secret_data_wo         = var.preview_backend_jwt_secret
+  secret_data_wo_version = 1
+  deletion_policy        = "DISABLE"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "google_secret_manager_secret_iam_member" "preview_backend_jwt_accessor" {
+  project   = var.project_id
+  secret_id = google_secret_manager_secret.preview_backend_jwt.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = google_service_account.preview_backend_runtime.member
+}

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -303,8 +303,20 @@ rg -U -q 'name  = "GCS_UPLOAD_BUCKET"\n        value = google_storage_bucket\.pr
 rg -U -q 'name  = "GCS_IDENTITY_DOCUMENT_BUCKET"\n        value = google_storage_bucket\.preview_identity_documents\.name' "$root_dir/cloud_run.tf"
 test "$(rg -No 'name  = "(FIRESTORE_ENABLED|FIRESTORE_DATABASE_ID|GCS_UPLOAD_BUCKET|GCS_IDENTITY_DOCUMENT_BUCKET)"' "$root_dir/cloud_run.tf" | wc -l | tr -d ' ')" = "4"
 test "$(rg -No 'name = "FIREBASE_API_KEY"' "$root_dir/cloud_run.tf" | wc -l | tr -d ' ')" = "1"
+test "$(rg -No 'name = "JWT_SECRET"' "$root_dir/cloud_run.tf" | wc -l | tr -d ' ')" = "1"
 rg -U -q 'env \{\n        name = "FIREBASE_API_KEY"\n\n        value_source \{\n          secret_key_ref \{\n            secret  = google_secret_manager_secret\.preview_backend_identity_toolkit\[0\]\.secret_id\n            version = "1"\n          \}\n        \}\n      \}' "$root_dir/cloud_run.tf"
 grep -Fq 'google_secret_manager_secret_iam_member.preview_backend_identity_toolkit_accessor,' "$root_dir/cloud_run.tf"
+rg -U -q 'env \{
+        name = "JWT_SECRET"
+
+        value_source \{
+          secret_key_ref \{
+            secret  = google_secret_manager_secret\.preview_backend_jwt\.secret_id
+            version = "1"
+          \}
+        \}
+      \}' "$root_dir/cloud_run.tf"
+grep -Fq 'google_secret_manager_secret_iam_member.preview_backend_jwt_accessor,' "$root_dir/cloud_run.tf"
 if rg -n 'PREVIEW_AUTH_ENABLED|FIREBASE_PROJECT_ID|google_apikeys_key|key_string|version\s*=\s*"latest"' "$root_dir/cloud_run.tf"; then
   echo "B7 Cloud Run secret injection contains a prohibited activation field, direct key reference, or mutable secret version" >&2
   exit 1
@@ -423,15 +435,15 @@ if printf '%s\n%s\n%s\n' "$actual_b7_reader_permissions" "$actual_b7_manager_bas
   exit 1
 fi
 
-test "$(rg -No 'roles/secretmanager\.[A-Za-z]+' "$root_dir" --glob '*.tf' | wc -l | tr -d ' ')" = "2"
+test "$(rg -No 'roles/secretmanager\.[A-Za-z]+' "$root_dir" --glob '*.tf' | wc -l | tr -d ' ')" = "4"
 if rg -n 'roles/secretmanager\.' "$root_dir" --glob '*.tf' | rg -v '(secret_manager|checks)\.tf:.*roles/secretmanager\.secretAccessor'; then
   echo "Secret Manager predefined role found outside the exact secret-level runtime accessor" >&2
   exit 1
 fi
 
-test "$(rg -No '^resource "google_secret_manager_secret"' "$root_dir/secret_manager.tf" | wc -l | tr -d ' ')" = "1"
-test "$(rg -No '^resource "google_secret_manager_secret_iam_member"' "$root_dir/secret_manager.tf" | wc -l | tr -d ' ')" = "1"
-test "$(rg -No '^resource "google_secret_manager_secret_version"' "$root_dir/secret_manager.tf" | wc -l | tr -d ' ')" = "1"
+test "$(rg -No '^resource "google_secret_manager_secret"' "$root_dir/secret_manager.tf" | wc -l | tr -d ' ')" = "2"
+test "$(rg -No '^resource "google_secret_manager_secret_iam_member"' "$root_dir/secret_manager.tf" | wc -l | tr -d ' ')" = "2"
+test "$(rg -No '^resource "google_secret_manager_secret_version"' "$root_dir/secret_manager.tf" | wc -l | tr -d ' ')" = "2"
 rg -q 'secret_id = "preview-backend-identity-toolkit-api-key"' "$root_dir/secret_manager.tf"
 rg -U -q 'replication \{\n    auto \{\}\n  \}' "$root_dir/secret_manager.tf"
 rg -q 'deletion_protection = true' "$root_dir/secret_manager.tf"
@@ -442,7 +454,25 @@ rg -q 'deletion_policy        = "DISABLE"' "$root_dir/secret_manager.tf"
 rg -U -q '(?s)resource "google_secret_manager_secret_version" "preview_backend_identity_toolkit" \{.*lifecycle \{\n    create_before_destroy = true\n  \}' "$root_dir/secret_manager.tf"
 rg -U -q 'resource "google_secret_manager_secret_iam_member" "preview_backend_identity_toolkit_accessor" \{\n  count = var\.b7_foundation_phase >= 2 && var\.b7_phase2_recovery_stage >= 2 && var\.b7_restricted_api_key_activation \? 1 : 0\n\n  project   = var\.project_id\n  secret_id = google_secret_manager_secret\.preview_backend_identity_toolkit\[0\]\.secret_id\n  role      = "roles/secretmanager\.secretAccessor"\n  member    = google_service_account\.preview_backend_runtime\.member\n\}' "$root_dir/secret_manager.tf"
 grep -Fq 'google_secret_manager_secret_iam_member.preview_backend_identity_toolkit_accessor[0].secret_id == google_secret_manager_secret.preview_backend_identity_toolkit[0].id' "$root_dir/checks.tf"
-test "$(rg -No 'secret_data_wo\s*=' "$root_dir/secret_manager.tf" | wc -l | tr -d ' ')" = "1"
+rg -q 'secret_id = "preview-backend-jwt-secret"' "$root_dir/secret_manager.tf"
+grep -Fq 'secret_data_wo         = var.preview_backend_jwt_secret' "$root_dir/secret_manager.tf"
+rg -U -q 'variable "preview_backend_jwt_secret" \{
+  description = "Dedicated high-entropy Preview-only JWT signing secret supplied as a sensitive HCP Terraform workspace variable\."
+  type        = string
+  sensitive   = true
+  nullable    = false' "$root_dir/variables.tf"
+if rg -n 'preview_backend_jwt_secret' "$root_dir/terraform.tfvars.example"; then
+  echo "Preview JWT secret must not be placed in the example tfvars file" >&2
+  exit 1
+fi
+rg -U -q 'resource "google_secret_manager_secret_iam_member" "preview_backend_jwt_accessor" \{
+  project   = var\.project_id
+  secret_id = google_secret_manager_secret\.preview_backend_jwt\.secret_id
+  role      = "roles/secretmanager\.secretAccessor"
+  member    = google_service_account\.preview_backend_runtime\.member
+\}' "$root_dir/secret_manager.tf"
+grep -Fq 'google_secret_manager_secret_iam_member.preview_backend_jwt_accessor.secret_id == google_secret_manager_secret.preview_backend_jwt.id' "$root_dir/checks.tf"
+test "$(rg -No 'secret_data_wo\s*=' "$root_dir/secret_manager.tf" | wc -l | tr -d ' ')" = "2"
 if rg -n '(^|[[:space:]])secret_data[[:space:]]*=' "$root_dir" --glob '*.tf'; then
   echo "Ordinary Secret Manager secret_data found; write-only delivery is required" >&2
   exit 1

--- a/infra/environments/preview-foundation/variables.tf
+++ b/infra/environments/preview-foundation/variables.tf
@@ -104,3 +104,15 @@ variable "b7_restricted_api_key_activation" {
   type        = bool
   default     = true
 }
+
+variable "preview_backend_jwt_secret" {
+  description = "Dedicated high-entropy Preview-only JWT signing secret supplied as a sensitive HCP Terraform workspace variable."
+  type        = string
+  sensitive   = true
+  nullable    = false
+
+  validation {
+    condition     = length(var.preview_backend_jwt_secret) >= 64
+    error_message = "preview_backend_jwt_secret must contain at least 64 characters of high-entropy secret material."
+  }
+}


### PR DESCRIPTION
## Proven blocker

`PREVIEW_AUTH_RUNTIME_CONFIG_BLOCKER = JWT_SECRET_NOT_CONFIGURED`

Exact same-origin login reaches permanent Preview backend revision `rentchain-preview-backend-00006-62w`, completes Firebase authentication and account-context loading, then fails at `jwt_sign`.

## Exact desired change

- create dedicated Preview-only Secret Manager metadata `preview-backend-jwt-secret`;
- provision version `1` through Terraform write-only `secret_data_wo` from required sensitive HCP variable `preview_backend_jwt_secret`;
- grant only `preview-backend-runtime@rentchain-preview.iam.gserviceaccount.com` secret-level `roles/secretmanager.secretAccessor`;
- bind only `JWT_SECRET` on `rentchain-preview-backend` through Cloud Run secret-backed environment configuration.

The required HCP sensitive variable is not yet present. Keep this PR Draft and do not merge until the Founder supplies it and the speculative HCP plan is exact.

## Validation

- `terraform fmt -check`: pass
- `terraform init -backend=false -upgrade=false`: pass
- `terraform validate`: pass
- focused `tests/validate_scope.sh`: pass
- `git diff --check`: pass
- credential/static scan: pass
- legacy `terraform test`: pre-existing activated-root harness failures (`known after apply` checks and artifact-reader normalization); no JWT-specific failure isolated

## Explicitly unchanged

- Production JWT secret and Production backend
- permanent Preview backend image
- Firestore/GCS environment values
- buckets and Firestore resources
- runtime service account
- frontend/backend product code
- WIF/OIDC and Invoker IAM
- Draft PR #1546
- active synthetic authentication fixtures

No secret value is present in this PR. No Apply is authorized.
