### PR TITLE
Make Preview JWT boundary check plan-time deterministic

### DIFF
--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -178,7 +178,7 @@ check "preview_backend_jwt_secret_boundary" {
       google_secret_manager_secret.preview_backend_jwt.deletion_protection &&
       google_secret_manager_secret_version.preview_backend_jwt.secret_data_wo_version == 1 &&
       google_secret_manager_secret_version.preview_backend_jwt.deletion_policy == "DISABLE" &&
-      google_secret_manager_secret_iam_member.preview_backend_jwt_accessor.secret_id == google_secret_manager_secret.preview_backend_jwt.id &&
+      google_secret_manager_secret_iam_member.preview_backend_jwt_accessor.secret_id == google_secret_manager_secret.preview_backend_jwt.secret_id &&
       google_secret_manager_secret_iam_member.preview_backend_jwt_accessor.role == "roles/secretmanager.secretAccessor" &&
       google_secret_manager_secret_iam_member.preview_backend_jwt_accessor.member == google_service_account.preview_backend_runtime.member
     )

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -38,7 +38,7 @@ EOF
 actual_resources="$(rg -No 'resource "[^"]+"' "$root_dir" --glob '*.tf' | sed -E 's/.*resource "([^"]+)"/\1/' | sort -u)"
 test "$actual_resources" = "$expected_resources"
 
-test "$(rg -No '^resource "[^"]+"' "$root_dir" --glob '*.tf' | wc -l | tr -d ' ')" = "54"
+test "$(rg -No '^resource "[^"]+"' "$root_dir" --glob '*.tf' | wc -l | tr -d ' ')" = "56"
 
 test "$(rg -No 'service\s*=\s*"[^"]+\.googleapis\.com"' "$root_dir/services.tf" | wc -l | tr -d ' ')" = "0"
 test "$(rg -No '"(apikeys|artifactregistry|cloudresourcemanager|firestore|iam|identitytoolkit|run|secretmanager|serviceusage)\.googleapis\.com"' "$root_dir/services.tf" | sort -u | wc -l | tr -d ' ')" = "9"
@@ -317,8 +317,13 @@ rg -U -q 'env \{
         \}
       \}' "$root_dir/cloud_run.tf"
 grep -Fq 'google_secret_manager_secret_iam_member.preview_backend_jwt_accessor,' "$root_dir/cloud_run.tf"
+grep -Fq 'preview_backend_service_name = "rentchain-preview-backend"' "$root_dir/cloud_run.tf"
 if rg -n 'PREVIEW_AUTH_ENABLED|FIREBASE_PROJECT_ID|google_apikeys_key|key_string|version\s*=\s*"latest"' "$root_dir/cloud_run.tf"; then
   echo "B7 Cloud Run secret injection contains a prohibited activation field, direct key reference, or mutable secret version" >&2
+  exit 1
+fi
+if rg -U -n 'name = "JWT_SECRET"\n[[:space:]]+value[[:space:]]*=' "$root_dir/cloud_run.tf"; then
+  echo "Preview JWT_SECRET must use a secret-backed value source, not a literal value" >&2
   exit 1
 fi
 if rg -U -n 'name = "FIREBASE_API_KEY"\n[[:space:]]+value[[:space:]]*=' "$root_dir/cloud_run.tf"; then
@@ -471,7 +476,15 @@ rg -U -q 'resource "google_secret_manager_secret_iam_member" "preview_backend_jw
   role      = "roles/secretmanager\.secretAccessor"
   member    = google_service_account\.preview_backend_runtime\.member
 \}' "$root_dir/secret_manager.tf"
-grep -Fq 'google_secret_manager_secret_iam_member.preview_backend_jwt_accessor.secret_id == google_secret_manager_secret.preview_backend_jwt.id' "$root_dir/checks.tf"
+grep -Fq 'google_secret_manager_secret_iam_member.preview_backend_jwt_accessor.secret_id == google_secret_manager_secret.preview_backend_jwt.secret_id' "$root_dir/checks.tf"
+if rg -n 'preview_backend_jwt_accessor\.secret_id == google_secret_manager_secret\.preview_backend_jwt\.(id|name)' "$root_dir/checks.tf"; then
+  echo "Preview JWT boundary check must use the plan-time-known configured secret_id" >&2
+  exit 1
+fi
+if rg -n 'project-0d9658de-af29-4dc0-a99|rentchain-landlord-api|JWT_SECRET.*value[[:space:]]*=' "$root_dir/secret_manager.tf" "$root_dir/cloud_run.tf" "$root_dir/checks.tf"; then
+  echo "Production reference or plaintext JWT configuration found in the Preview JWT boundary" >&2
+  exit 1
+fi
 test "$(rg -No 'secret_data_wo\s*=' "$root_dir/secret_manager.tf" | wc -l | tr -d ' ')" = "2"
 if rg -n '(^|[[:space:]])secret_data[[:space:]]*=' "$root_dir" --glob '*.tf'; then
   echo "Ordinary Secret Manager secret_data found; write-only delivery is required" >&2


### PR DESCRIPTION
## Summary

- makes `preview_backend_jwt_secret_boundary` plan-time deterministic
- replaces the new-secret provider-computed `.id` operand with the same resource's configured `.secret_id`
- strengthens focused static policy coverage without changing runtime resources

## Root cause

The current main plan marks `google_secret_manager_secret.preview_backend_jwt.id` unknown until the secret is created. That operand caused the entire check assertion to be known only after apply even though the IAM resource's configured `secret_id`, the secret's configured `secret_id`, role, member, project, and version policy are all known during planning.

The repaired equality remains materially tied to the exact `google_secret_manager_secret.preview_backend_jwt` resource and retains the secret-level `google_secret_manager_secret_iam_member` boundary.

## Scope

Validation only. No changes to the JWT secret, secret version, IAM resource, Cloud Run service, image, Firestore/GCS configuration, Production, application code, or Draft PR #1546.

## Validation

- Terraform format: passed
- Terraform init without backend: passed
- Terraform validate: passed
- Preview foundation scope validation: passed
- package-manager governance: passed
- credential diff scan: passed
- diff check: passed

The speculative HCP plan must prove no incremental runtime delta and show the boundary check passing at plan time before this PR can move Ready.
