### PR TITLE
Enable permanent Preview authentication runtime

### DIFF
--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -137,6 +137,22 @@ check "b7_preview_backend_auth_secret_injection_boundary" {
         for env in google_cloud_run_v2_service.preview_backend[0].template[0].containers[0].env : env
         if env.name == "FIREBASE_API_KEY"
       ]).value_source[0].secret_key_ref[0].version == "1" &&
+      length([
+        for env in google_cloud_run_v2_service.preview_backend[0].template[0].containers[0].env : env
+        if env.name == "PREVIEW_AUTH_ENABLED"
+      ]) == 1 &&
+      one([
+        for env in google_cloud_run_v2_service.preview_backend[0].template[0].containers[0].env : env
+        if env.name == "PREVIEW_AUTH_ENABLED"
+      ]).value == "true" &&
+      length([
+        for env in google_cloud_run_v2_service.preview_backend[0].template[0].containers[0].env : env
+        if env.name == "FIREBASE_PROJECT_ID"
+      ]) == 1 &&
+      one([
+        for env in google_cloud_run_v2_service.preview_backend[0].template[0].containers[0].env : env
+        if env.name == "FIREBASE_PROJECT_ID"
+      ]).value == "rentchain-preview" &&
       one([
         for env in google_cloud_run_v2_service.preview_backend[0].template[0].containers[0].env : env
         if env.name == "FIRESTORE_ENABLED"
@@ -166,7 +182,7 @@ check "b7_preview_backend_auth_secret_injection_boundary" {
         if env.name == "GCS_IDENTITY_DOCUMENT_BUCKET"
       ]).value == google_storage_bucket.preview_identity_documents.name
     ) : true
-    error_message = "The Preview backend must receive explicit Identity Toolkit secret version 1, enabled default Firestore database, and only the governed Preview storage buckets."
+    error_message = "The Preview backend must receive exact Preview authentication activation, Identity Toolkit secret version 1, enabled default Firestore database, and only the governed Preview storage buckets."
   }
 }
 

--- a/infra/environments/preview-foundation/cloud_run.tf
+++ b/infra/environments/preview-foundation/cloud_run.tf
@@ -54,6 +54,16 @@ resource "google_cloud_run_v2_service" "preview_backend" {
       }
 
       env {
+        name  = "PREVIEW_AUTH_ENABLED"
+        value = "true"
+      }
+
+      env {
+        name  = "FIREBASE_PROJECT_ID"
+        value = var.project_id
+      }
+
+      env {
         name  = "FIRESTORE_ENABLED"
         value = "true"
       }

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -299,6 +299,14 @@ fi
 
 rg -U -q 'name  = "FIRESTORE_ENABLED"\n        value = "true"' "$root_dir/cloud_run.tf"
 rg -U -q 'name  = "FIRESTORE_DATABASE_ID"\n        value = "\(default\)"' "$root_dir/cloud_run.tf"
+rg -U -q 'name  = "PREVIEW_AUTH_ENABLED"\n        value = "true"' "$root_dir/cloud_run.tf"
+rg -U -q 'name  = "FIREBASE_PROJECT_ID"\n        value = var\.project_id' "$root_dir/cloud_run.tf"
+test "$(rg -No 'name  = "PREVIEW_AUTH_ENABLED"' "$root_dir/cloud_run.tf" | wc -l | tr -d ' ')" = "1"
+test "$(rg -No 'name  = "FIREBASE_PROJECT_ID"' "$root_dir/cloud_run.tf" | wc -l | tr -d ' ')" = "1"
+grep -Fq 'if env.name == "PREVIEW_AUTH_ENABLED"' "$root_dir/checks.tf"
+grep -Fq ']).value == "true"' "$root_dir/checks.tf"
+grep -Fq 'if env.name == "FIREBASE_PROJECT_ID"' "$root_dir/checks.tf"
+grep -Fq ']).value == "rentchain-preview"' "$root_dir/checks.tf"
 rg -U -q 'name  = "GCS_UPLOAD_BUCKET"\n        value = google_storage_bucket\.preview_attachments\.name' "$root_dir/cloud_run.tf"
 rg -U -q 'name  = "GCS_IDENTITY_DOCUMENT_BUCKET"\n        value = google_storage_bucket\.preview_identity_documents\.name' "$root_dir/cloud_run.tf"
 test "$(rg -No 'name  = "(FIRESTORE_ENABLED|FIRESTORE_DATABASE_ID|GCS_UPLOAD_BUCKET|GCS_IDENTITY_DOCUMENT_BUCKET)"' "$root_dir/cloud_run.tf" | wc -l | tr -d ' ')" = "4"
@@ -318,10 +326,29 @@ rg -U -q 'env \{
       \}' "$root_dir/cloud_run.tf"
 grep -Fq 'google_secret_manager_secret_iam_member.preview_backend_jwt_accessor,' "$root_dir/cloud_run.tf"
 grep -Fq 'preview_backend_service_name = "rentchain-preview-backend"' "$root_dir/cloud_run.tf"
-if rg -n 'PREVIEW_AUTH_ENABLED|FIREBASE_PROJECT_ID|google_apikeys_key|key_string|version\s*=\s*"latest"' "$root_dir/cloud_run.tf"; then
-  echo "B7 Cloud Run secret injection contains a prohibited activation field, direct key reference, or mutable secret version" >&2
+if rg -n 'google_apikeys_key|key_string|version\s*=\s*"latest"' "$root_dir/cloud_run.tf"; then
+  echo "B7 Cloud Run secret injection contains a direct key reference or mutable secret version" >&2
   exit 1
 fi
+
+preview_auth_env_is_exact() {
+  local enabled_value="${1:-}"
+  local project_value="${2:-}"
+  test "$enabled_value" = "true" && test "$project_value" = "rentchain-preview"
+}
+
+preview_auth_env_is_exact "true" "rentchain-preview"
+for rejected_auth_env in \
+  "false|rentchain-preview" \
+  "|rentchain-preview" \
+  "true|other-preview" \
+  "true|project-0d9658de-af29-4dc0-a99"; do
+  IFS='|' read -r rejected_enabled rejected_project <<< "$rejected_auth_env"
+  if preview_auth_env_is_exact "$rejected_enabled" "$rejected_project"; then
+    echo "Preview authentication environment accepted a prohibited value pair: $rejected_auth_env" >&2
+    exit 1
+  fi
+done
 if rg -U -n 'name = "JWT_SECRET"\n[[:space:]]+value[[:space:]]*=' "$root_dir/cloud_run.tf"; then
   echo "Preview JWT_SECRET must use a secret-backed value source, not a literal value" >&2
   exit 1


### PR DESCRIPTION
## Proven blocker

`AUTHENTICATION_READY_DEFERRED_ROOT_CAUSE = ADDITIONAL_AUTH_ENV_MISSING`

The permanent Preview backend has working secret-backed Firebase API key and JWT
configuration, but its Terraform-managed Cloud Run template omits the two exact
activation fields required by the current application guard.

## Exact changes

- add `PREVIEW_AUTH_ENABLED=true`
- add `FIREBASE_PROJECT_ID=rentchain-preview`
- replace the former activation-field prohibition with exact positive and
  negative Preview boundary validation

## Already healthy and unchanged

- JWT secret binding and secret-level runtime access
- JWT secret version `1`
- trusted backend image
- Firestore and GCS configuration/resources
- runtime service account
- IAM and custom roles
- buckets
- Production
- Draft PR #1546
- synthetic Preview authentication fixtures

## Validation

- Terraform format and format check: pass
- Terraform init with backend disabled: pass
- Terraform validate: pass
- Preview scope and focused negative tests: pass
- governance and credential scan: pass
- diff check: pass

Keep Draft until the exact speculative HCP plan proves a single in-place Preview
Cloud Run service update with only these two environment values.
