### PR TITLE
Fix tenant monthly payments empty-state query

### DIFF
--- a/rentchain-api/src/routes/__tests__/paymentsRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/paymentsRoutes.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const collections = new Map<string, Map<string, any>>();
+const orderedQueries: Array<{ collection: string; filters: Array<{ field: string; value: any }>; field?: string }> = [];
 const authState = vi.hoisted(() => ({
   user: { id: "landlord-1", landlordId: "landlord-1", role: "landlord" } as any,
 }));
@@ -16,6 +17,13 @@ function buildQuery(name: string, filters: Array<{ field: string; value: any }> 
       filters.every((filter) => data?.[filter.field] === filter.value)
     );
   return {
+    get: async () => {
+      const docs = applyFilters().map(([docId, data]) => ({
+        id: docId,
+        data: () => data,
+      }));
+      return { docs };
+    },
     where: (field: string, _op: string, value: any) =>
       buildQuery(name, [...filters, { field, value }]),
     limit: (_count?: number) => ({
@@ -27,19 +35,22 @@ function buildQuery(name: string, filters: Array<{ field: string; value: any }> 
         return { docs };
       },
     }),
-    orderBy: (_orderField?: string, _direction?: string) => ({
-      limit: (_count?: number) => ({
-        get: async () => {
-          const docs = applyFilters()
-            .sort((a, b) => String(b[1]?.paidAt || "").localeCompare(String(a[1]?.paidAt || "")))
-            .map(([docId, data]) => ({
-              id: docId,
-              data: () => data,
-            }));
-          return { docs };
-        },
-      }),
-    }),
+    orderBy: (_orderField?: string, _direction?: string) => {
+      orderedQueries.push({ collection: name, filters, field: _orderField });
+      return {
+        limit: (_count?: number) => ({
+          get: async () => {
+            const docs = applyFilters()
+              .sort((a, b) => String(b[1]?.paidAt || "").localeCompare(String(a[1]?.paidAt || "")))
+              .map(([docId, data]) => ({
+                id: docId,
+                data: () => data,
+              }));
+            return { docs };
+          },
+        }),
+      };
+    },
   };
 }
 
@@ -105,6 +116,7 @@ vi.mock("../../services/leaseService", () => ({
 describe("paymentsRoutes exports", () => {
   beforeEach(async () => {
     collections.clear();
+    orderedQueries.length = 0;
     authState.user = { id: "landlord-1", landlordId: "landlord-1", role: "landlord" };
     ensureCollection("tenants").set("tenant-1", {
       id: "tenant-1",
@@ -1112,6 +1124,29 @@ describe("paymentsRoutes exports", () => {
         }),
       ],
       total: 1800,
+    });
+    expect(orderedQueries).not.toContainEqual({
+      collection: "payments",
+      filters: [{ field: "tenantId", value: "tenant-1" }],
+      field: "paidAt",
+    });
+  });
+
+  it("returns an empty monthly result without an index-dependent ordered query", async () => {
+    ensureCollection("payments").clear();
+
+    const router = (await import("../paymentsRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/payments/tenant/tenant-empty/monthly?year=2026&month=8",
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ payments: [], total: 0 });
+    expect(orderedQueries).not.toContainEqual({
+      collection: "payments",
+      filters: [{ field: "tenantId", value: "tenant-empty" }],
+      field: "paidAt",
     });
   });
 });

--- a/rentchain-api/src/routes/__tests__/paymentsRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/paymentsRoutes.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const collections = new Map<string, Map<string, any>>();
 const orderedQueries: Array<{ collection: string; filters: Array<{ field: string; value: any }>; field?: string }> = [];
+let queryGetError: Error | null = null;
 const authState = vi.hoisted(() => ({
   user: { id: "landlord-1", landlordId: "landlord-1", role: "landlord" } as any,
 }));
@@ -18,6 +19,7 @@ function buildQuery(name: string, filters: Array<{ field: string; value: any }> 
     );
   return {
     get: async () => {
+      if (queryGetError) throw queryGetError;
       const docs = applyFilters().map(([docId, data]) => ({
         id: docId,
         data: () => data,
@@ -117,6 +119,7 @@ describe("paymentsRoutes exports", () => {
   beforeEach(async () => {
     collections.clear();
     orderedQueries.length = 0;
+    queryGetError = null;
     authState.user = { id: "landlord-1", landlordId: "landlord-1", role: "landlord" };
     ensureCollection("tenants").set("tenant-1", {
       id: "tenant-1",
@@ -1148,5 +1151,52 @@ describe("paymentsRoutes exports", () => {
       filters: [{ field: "tenantId", value: "tenant-empty" }],
       field: "paidAt",
     });
+  });
+
+  it("keeps monthly payments tenant-scoped and ordered newest first", async () => {
+    ensureCollection("payments").set("payment-2", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      amount: 900,
+      paidAt: "2026-04-20",
+      method: "e-transfer",
+      status: "Recorded",
+    });
+    ensureCollection("payments").set("foreign-payment", {
+      landlordId: "landlord-2",
+      tenantId: "tenant-2",
+      propertyId: "prop-2",
+      amount: 5000,
+      paidAt: "2026-04-30",
+      method: "e-transfer",
+      status: "Recorded",
+    });
+
+    const router = (await import("../paymentsRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/payments/tenant/tenant-1/monthly?year=2026&month=4",
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.payments.map((payment: any) => payment.id)).toEqual(["payment-2", "payment-1"]);
+    expect(res.body.total).toBe(2700);
+    expect(res.body.payments).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ tenantId: "tenant-2" })])
+    );
+  });
+
+  it("preserves the monthly backend error contract for query failures", async () => {
+    queryGetError = new Error("query unavailable");
+
+    const router = (await import("../paymentsRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/payments/tenant/tenant-1/monthly?year=2026&month=4",
+    });
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ ok: false, error: "PAYMENTS_MONTHLY_FAILED" });
   });
 });

--- a/rentchain-api/src/routes/paymentsRoutes.ts
+++ b/rentchain-api/src/routes/paymentsRoutes.ts
@@ -278,10 +278,15 @@ async function listPersistedPayments(
       .sort((a, b) => paymentDateMillis(b) - paymentDateMillis(a));
   }
 
-  const query = tenantId
-    ? base.where("tenantId", "==", tenantId).orderBy("paidAt", "desc").limit(200)
-    : base.orderBy("paidAt", "desc").limit(500);
-  const snap = await query.get();
+  if (tenantId) {
+    const snap = await base.where("tenantId", "==", tenantId).get();
+    return snap.docs
+      .map((doc: any) => normalizePersistedPayment(doc.id, doc.data() as any))
+      .sort((a, b) => paymentDateMillis(b) - paymentDateMillis(a))
+      .slice(0, 200);
+  }
+
+  const snap = await base.orderBy("paidAt", "desc").limit(500).get();
   return snap.docs.map((doc: any) => normalizePersistedPayment(doc.id, doc.data() as any));
 }
 


### PR DESCRIPTION
## Summary

- remove the undeclared composite-index dependency from tenant-specific monthly payment reads
- preserve deterministic newest-first results and the existing 200-record cap in application code
- return the established empty `{ payments: [], total: 0 }` contract for valid tenants with no payments

## Root cause

Founder-equivalent QA on Draft PR #1546 reached the permanent Preview backend through the same-origin Vercel proxy. `GET /api/payments/tenant/:tenantId/monthly` returned HTTP 500 `PAYMENTS_MONTHLY_FAILED` because Firestore rejected `where("tenantId", "==", ...).orderBy("paidAt", "desc")` with `FAILED_PRECONDITION: The query requires an index`.

The synthetic tenant intentionally has zero payment, rent-payment, and ledger records. Zero payments is a valid API/UI state, so no fixture data or Firestore index should be invented to mask this backend query defect.

## Validation

- focused payments route tests: 29 passed
- backend Node 24 TypeScript build: passed
- `git diff --check`: passed

## Containment

- no fixture or payment data mutation
- no provider interaction
- no Terraform, IAM, Firestore-index, deployment, or Production change
- PR #1546 remains Draft and unchanged

## Follow-up gate

After governed review, merge, and permanent Preview backend publication, targeted Tenant Detail QA must confirm the monthly endpoint returns 200 empty state through the exact same-origin PR #1546 Preview. Complete Founder-equivalent browser QA for #1546 must then restart from the beginning.
