### PR TITLE
Publish Tenant Detail payments fix to permanent Preview

### DIFF
--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -351,7 +351,7 @@ check "b6_preview_backend_boundary" {
   assert {
     condition = (
       local.preview_backend_service_name == "rentchain-preview-backend" &&
-      local.preview_backend_image_digest == "northamerica-northeast1-docker.pkg.dev/rentchain-preview/rentchain-preview/backend@sha256:bfd6f231432abdce497bceac81c4c8e1b32b230e1cf46a225b2ce7d116df583c" &&
+      local.preview_backend_image_digest == "northamerica-northeast1-docker.pkg.dev/rentchain-preview/rentchain-preview/backend@sha256:54700c92b15f0e95ed3c3aea2266d2030a90fcff972006c6a2de8332fa6f8b0c" &&
       local.preview_backend_source_sha == "d28c61991131e9a76874d5eb92adceac048f9417" &&
       !var.enable_preview_backend_service || (
         google_cloud_run_v2_service.preview_backend[0].project == "rentchain-preview" &&

--- a/infra/environments/preview-foundation/cloud_run.tf
+++ b/infra/environments/preview-foundation/cloud_run.tf
@@ -1,6 +1,6 @@
 locals {
   preview_backend_service_name = "rentchain-preview-backend"
-  preview_backend_image_digest = "northamerica-northeast1-docker.pkg.dev/rentchain-preview/rentchain-preview/backend@sha256:bfd6f231432abdce497bceac81c4c8e1b32b230e1cf46a225b2ce7d116df583c"
+  preview_backend_image_digest = "northamerica-northeast1-docker.pkg.dev/rentchain-preview/rentchain-preview/backend@sha256:54700c92b15f0e95ed3c3aea2266d2030a90fcff972006c6a2de8332fa6f8b0c"
   preview_backend_source_sha   = "d28c61991131e9a76874d5eb92adceac048f9417"
 }
 


### PR DESCRIPTION
## Source and artifact

- merged application PR: #1551
- exact main source: `732c15d4cd12a9aa2b965d4e2a27833a246fea00`
- trusted workflow: Preview backend image delivery run `32043412358`
- trusted digest: `sha256:54700c92b15f0e95ed3c3aea2266d2030a90fcff972006c6a2de8332fa6f8b0c`
- runtime: Node 24.19.0, linux/amd64, user node
- workflow health and artifact governance: passed

## Exact scope

This PR changes only the permanent Preview backend immutable image pin and its exact Terraform boundary assertion.

No environment, IAM, secret, bucket, Firestore, traffic, or Production configuration changes are included.

## Validation

- Terraform format check: passed
- Terraform init with backend disabled: passed
- Terraform validate: passed
- Preview foundation focused scope guard: passed
- diff check and credential scan: passed
- exact diff: two replacements across `cloud_run.tf` and `checks.tf`

Keep Draft until the HCP speculative plan proves exactly `0 add, 1 change, 0 destroy` for only `google_cloud_run_v2_service.preview_backend[0]`, with the image digest as the sole semantic delta.
