### PR TITLE
Configure permanent Preview identity policy runtime

### DIFF
--- a/infra/environments/preview-foundation/checks.tf
+++ b/infra/environments/preview-foundation/checks.tf
@@ -186,6 +186,22 @@ check "b7_preview_backend_auth_secret_injection_boundary" {
   }
 }
 
+check "preview_identity_policy_runtime_boundary" {
+  assert {
+    condition = var.enable_preview_backend_service ? (
+      length([
+        for env in google_cloud_run_v2_service.preview_backend[0].template[0].containers[0].env : env
+        if contains(keys(local.preview_identity_policy_environment), env.name)
+      ]) == 6 &&
+      {
+        for env in google_cloud_run_v2_service.preview_backend[0].template[0].containers[0].env : env.name => env.value
+        if contains(keys(local.preview_identity_policy_environment), env.name)
+      } == local.preview_identity_policy_environment
+    ) : true
+    error_message = "The permanent Preview backend must receive the exact six non-secret identity-policy values derived from the merged G1 contracts."
+  }
+}
+
 check "preview_backend_jwt_secret_boundary" {
   assert {
     condition = (

--- a/infra/environments/preview-foundation/cloud_run.tf
+++ b/infra/environments/preview-foundation/cloud_run.tf
@@ -2,6 +2,14 @@ locals {
   preview_backend_service_name = "rentchain-preview-backend"
   preview_backend_image_digest = "northamerica-northeast1-docker.pkg.dev/rentchain-preview/rentchain-preview/backend@sha256:54700c92b15f0e95ed3c3aea2266d2030a90fcff972006c6a2de8332fa6f8b0c"
   preview_backend_source_sha   = "d28c61991131e9a76874d5eb92adceac048f9417"
+  preview_identity_policy_environment = {
+    IDENTITY_DOCUMENT_REQUIREMENT_POLICY_ID      = "tenant_government_photo_id_required"
+    IDENTITY_DOCUMENT_REQUIREMENT_POLICY_VERSION = "v1"
+    IDENTITY_DOCUMENT_POLICY_TEXT_VERSION        = "identity_collection_v1"
+    IDENTITY_DOCUMENT_PRIVACY_NOTICE_VERSION     = "privacy_v1"
+    IDENTITY_DOCUMENT_RETENTION_POLICY_ID        = "identity_retention"
+    IDENTITY_DOCUMENT_RETENTION_POLICY_VERSION   = "v1"
+  }
 }
 
 resource "google_cloud_run_v2_service" "preview_backend" {
@@ -81,6 +89,15 @@ resource "google_cloud_run_v2_service" "preview_backend" {
       env {
         name  = "GCS_IDENTITY_DOCUMENT_BUCKET"
         value = google_storage_bucket.preview_identity_documents.name
+      }
+
+      dynamic "env" {
+        for_each = local.preview_identity_policy_environment
+
+        content {
+          name  = env.key
+          value = env.value
+        }
       }
 
       env {

--- a/infra/environments/preview-foundation/tests/validate_scope.sh
+++ b/infra/environments/preview-foundation/tests/validate_scope.sh
@@ -577,6 +577,31 @@ if rg -n 'FIREBASE_API_KEY' "$root_dir" --glob '*.tf' | rg -v '/(cloud_run|check
   exit 1
 fi
 
+expected_identity_policy_environment="$(cat <<'EOF'
+IDENTITY_DOCUMENT_POLICY_TEXT_VERSION=identity_collection_v1
+IDENTITY_DOCUMENT_PRIVACY_NOTICE_VERSION=privacy_v1
+IDENTITY_DOCUMENT_REQUIREMENT_POLICY_ID=tenant_government_photo_id_required
+IDENTITY_DOCUMENT_REQUIREMENT_POLICY_VERSION=v1
+IDENTITY_DOCUMENT_RETENTION_POLICY_ID=identity_retention
+IDENTITY_DOCUMENT_RETENTION_POLICY_VERSION=v1
+EOF
+)"
+actual_identity_policy_environment="$(
+  sed -n '/preview_identity_policy_environment = {/,/  }/p' "$root_dir/cloud_run.tf" \
+    | rg -No 'IDENTITY_DOCUMENT_[A-Z_]+\s*=\s*"[^"]+"' \
+    | sed -E 's/[[:space:]]*=[[:space:]]*/=/' \
+    | sort
+)"
+test "$actual_identity_policy_environment" = "$expected_identity_policy_environment"
+test "$(printf '%s\n' "$actual_identity_policy_environment" | wc -l | tr -d ' ')" = "6"
+rg -U -q 'dynamic "env" \{\n        for_each = local\.preview_identity_policy_environment' "$root_dir/cloud_run.tf"
+rg -q 'check "preview_identity_policy_runtime_boundary"' "$root_dir/checks.tf"
+grep -Fq '== local.preview_identity_policy_environment' "$root_dir/checks.tf"
+if printf '%s\n' "$actual_identity_policy_environment" | rg -n 'project-0d9658de-af29-4dc0-a99|rentchain-landlord-api|secret|token|password'; then
+  echo "Preview identity policy configuration contains a Production reference or secret-like value" >&2
+  exit 1
+fi
+
 if rg -n 'roles/serviceusage\.serviceUsageConsumer' "$root_dir" --glob '*.tf'; then
   echo "Predefined Service Usage role found in Preview foundation" >&2
   exit 1


### PR DESCRIPTION
## Summary

Configure the permanent Preview backend with the exact six non-secret tenant identity-policy runtime values required by the merged G1 application contract.

## Root cause

Authenticated same-origin Tenant Identity routes reached the permanent Preview backend but returned HTTP 500 because `IDENTITY_DOCUMENT_REQUIREMENT_POLICY_ID` and the related policy contract were not configured at runtime.

Classification: `PREVIEW_BACKEND_IDENTITY_RUNTIME_DEFECT`.

## Exact values

- `IDENTITY_DOCUMENT_REQUIREMENT_POLICY_ID=tenant_government_photo_id_required`
- `IDENTITY_DOCUMENT_REQUIREMENT_POLICY_VERSION=v1`
- `IDENTITY_DOCUMENT_POLICY_TEXT_VERSION=identity_collection_v1`
- `IDENTITY_DOCUMENT_PRIVACY_NOTICE_VERSION=privacy_v1`
- `IDENTITY_DOCUMENT_RETENTION_POLICY_ID=identity_retention`
- `IDENTITY_DOCUMENT_RETENTION_POLICY_VERSION=v1`

The requirement ID/version come from `DEFAULT_TENANT_GOVERNMENT_ID_REQUIREMENT_POLICY`; the consent values come from the exact-current merged identity application-service contract.

## Scope

- Preview Cloud Run Terraform only
- exact-six Terraform policy boundary check
- focused static scope/value validation
- no secrets
- no Production, IAM, bucket, Firestore, JWT, image, provider, or application-code changes
- no Terraform Apply or manual Cloud Run mutation

## Validation

- `terraform fmt -check`
- `terraform init -backend=false -input=false`
- `terraform validate`
- `bash tests/validate_scope.sh`
- `git diff --check`

All passed locally.
