### PR TITLE
Add canonical lease and occupancy state foundation

### DIFF
--- a/rentchain-api/src/lib/leases/__tests__/canonicalLeaseOccupancyState.test.ts
+++ b/rentchain-api/src/lib/leases/__tests__/canonicalLeaseOccupancyState.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveCanonicalLeaseTermState,
+  evaluateCanonicalOccupancy,
+  evaluateCanonicalTenantRelationship,
+  selectCanonicalCurrentLease,
+  type CanonicalLeaseStateInput,
+} from "../canonicalLeaseOccupancyState";
+
+const asOfDate = "2026-05-01T18:00:00-03:00";
+const activeLease: CanonicalLeaseStateInput = {
+  id: "lease-active",
+  landlordId: "landlord-1",
+  propertyId: "property-1",
+  unitId: "unit-1",
+  tenantId: "tenant-1",
+  status: "active",
+  executionState: "executed",
+  startDate: "2026-01-01",
+  endDate: "2026-12-31",
+};
+
+describe("canonical lease and occupancy state", () => {
+  it("keeps an inclusive end date active through that UTC calendar day", () => {
+    const lease = { ...activeLease, endDate: "2026-04-30" };
+    expect(deriveCanonicalLeaseTermState(lease, "2026-04-30T23:59:59Z").state).toBe("active");
+    expect(deriveCanonicalLeaseTermState(lease, "2026-05-01T00:00:00Z").state).toBe("past");
+  });
+
+  it("treats a date-only end consistently across offset instants", () => {
+    const lease = { ...activeLease, endDate: "2026-04-30" };
+    expect(deriveCanonicalLeaseTermState(lease, "2026-05-01T00:30:00+14:00").state).toBe("active");
+    expect(deriveCanonicalLeaseTermState(lease, "2026-05-01T00:30:00Z").state).toBe("past");
+  });
+
+  it("gives explicit terminal state precedence over dates", () => {
+    expect(deriveCanonicalLeaseTermState({ ...activeLease, status: "ended" }, asOfDate).state).toBe("ended");
+    expect(deriveCanonicalLeaseTermState({ ...activeLease, status: "terminated" }, asOfDate).state).toBe("terminated");
+  });
+
+  it("keeps draft execution separate from an overlapping term", () => {
+    const result = deriveCanonicalLeaseTermState({ ...activeLease, executionState: "not_started" }, asOfDate);
+    expect(result).toMatchObject({ state: "draft", supportsCurrentOccupancy: false });
+  });
+
+  it("derives upcoming and rejects invalid date ranges", () => {
+    expect(deriveCanonicalLeaseTermState({ ...activeLease, startDate: "2026-06-01" }, asOfDate).state).toBe("upcoming");
+    expect(deriveCanonicalLeaseTermState({ ...activeLease, startDate: "2027-01-01", endDate: "2026-12-31" }, asOfDate)).toMatchObject({
+      state: "unknown",
+      reasons: ["INVALID_LEASE_DATE_RANGE"],
+    });
+  });
+
+  it("selects only a context-matched current occupancy-supporting lease", () => {
+    const selection = selectCanonicalCurrentLease(
+      [
+        { ...activeLease, id: "past", endDate: "2026-04-30" },
+        { ...activeLease, id: "draft", executionState: "not_started" },
+        activeLease,
+        { ...activeLease, id: "foreign", landlordId: "landlord-2" },
+      ],
+      { landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", asOfDate }
+    );
+    expect(selection.lease?.id).toBe("lease-active");
+  });
+
+  it("fails closed when multiple leases currently support the same context", () => {
+    const selection = selectCanonicalCurrentLease(
+      [activeLease, { ...activeLease, id: "lease-active-2" }],
+      { propertyId: "property-1", unitId: "unit-1", asOfDate }
+    );
+    expect(selection).toMatchObject({ lease: null, reasons: ["MULTIPLE_CURRENT_LEASES"] });
+  });
+
+  it("does not treat an expired lease with stale occupied state as vacant", () => {
+    const selection = selectCanonicalCurrentLease(
+      [{ ...activeLease, endDate: "2026-04-30" }],
+      { propertyId: "property-1", unitId: "unit-1", asOfDate }
+    );
+    const occupancy = evaluateCanonicalOccupancy({
+      persistedUnitOccupancy: "occupied",
+      persistedTenancyStatus: "active",
+      currentLeasePointerId: "lease-active",
+      selection,
+    });
+    expect(occupancy.occupancyState).toBe("review_needed");
+    expect(occupancy.reasons).toEqual(expect.arrayContaining(["STALE_CURRENT_LEASE_POINTER", "OCCUPIED_WITHOUT_CURRENT_LEASE"]));
+  });
+
+  it("reports vacancy only when no current lease conflicts with explicit vacancy", () => {
+    const selection = selectCanonicalCurrentLease([], { propertyId: "property-1", unitId: "unit-1", asOfDate });
+    expect(evaluateCanonicalOccupancy({ persistedUnitOccupancy: "vacant", selection })).toMatchObject({
+      occupancyState: "vacant",
+      supportingLeaseId: null,
+    });
+  });
+
+  it("flags an active lease on an explicitly vacant projection", () => {
+    const selection = selectCanonicalCurrentLease([activeLease], { propertyId: "property-1", unitId: "unit-1", asOfDate });
+    expect(evaluateCanonicalOccupancy({ persistedUnitOccupancy: "vacant", selection })).toMatchObject({
+      occupancyState: "review_needed",
+      reasons: ["VACANT_WITH_CURRENT_LEASE"],
+    });
+  });
+
+  it("derives current, past, and unresolved tenant relationships from canonical occupancy", () => {
+    const currentSelection = selectCanonicalCurrentLease([activeLease], { tenantId: "tenant-1", asOfDate });
+    const occupied = evaluateCanonicalOccupancy({ persistedUnitOccupancy: "occupied", currentLeasePointerId: "lease-active", selection: currentSelection });
+    expect(evaluateCanonicalTenantRelationship({ tenantId: "tenant-1", persistedTenantStatus: "current", currentLeasePointerId: "lease-active", selection: currentSelection, occupancy: occupied }).relationshipState).toBe("current_occupant");
+
+    const noLease = selectCanonicalCurrentLease([], { tenantId: "tenant-1", asOfDate });
+    const vacant = evaluateCanonicalOccupancy({ persistedUnitOccupancy: "vacant", selection: noLease });
+    expect(evaluateCanonicalTenantRelationship({ tenantId: "tenant-1", persistedTenantStatus: "past", selection: noLease, occupancy: vacant }).relationshipState).toBe("past_tenant");
+    expect(evaluateCanonicalTenantRelationship({ tenantId: "tenant-1", persistedTenantStatus: "current", selection: noLease, occupancy: vacant })).toMatchObject({
+      relationshipState: "occupancy_unresolved",
+      reasons: ["TENANT_CURRENT_WITHOUT_CURRENT_LEASE"],
+    });
+  });
+
+  it("keeps a coherent past tenant past when the only lease is expired", () => {
+    const selection = selectCanonicalCurrentLease(
+      [{ ...activeLease, endDate: "2026-04-30" }],
+      { tenantId: "tenant-1", asOfDate }
+    );
+    const occupancy = evaluateCanonicalOccupancy({ persistedUnitOccupancy: "vacant", selection });
+
+    expect(evaluateCanonicalTenantRelationship({
+      tenantId: "tenant-1",
+      persistedTenantStatus: "past",
+      selection,
+      occupancy,
+    })).toMatchObject({
+      relationshipState: "past_tenant",
+      reasons: ["PAST_LEASE_CANNOT_SUPPORT_OCCUPANCY"],
+    });
+  });
+
+  it("does not use renewal linkage to make a past predecessor current", () => {
+    const predecessor = { ...activeLease, id: "old", endDate: "2026-04-30", successorLeaseId: "next" };
+    const successor = { ...activeLease, id: "next", startDate: "2026-05-01", endDate: "2027-04-30" };
+    const selection = selectCanonicalCurrentLease([predecessor, successor], { propertyId: "property-1", unitId: "unit-1", asOfDate });
+    expect(selection.lease?.id).toBe("next");
+  });
+});

--- a/rentchain-api/src/lib/leases/canonicalLeaseOccupancyState.ts
+++ b/rentchain-api/src/lib/leases/canonicalLeaseOccupancyState.ts
@@ -1,0 +1,273 @@
+export type CanonicalLeaseTermState =
+  | "draft"
+  | "upcoming"
+  | "active"
+  | "past"
+  | "ended"
+  | "terminated"
+  | "unknown";
+
+export type CanonicalOccupancyState = "vacant" | "occupied" | "review_needed";
+export type CanonicalTenantRelationshipState = "current_occupant" | "past_tenant" | "occupancy_unresolved";
+
+export type CanonicalLeaseConflictReason =
+  | "MULTIPLE_CURRENT_LEASES"
+  | "INVALID_LEASE_DATE_RANGE"
+  | "CURRENT_LEASE_CONTEXT_MISMATCH"
+  | "DRAFT_LEASE_CANNOT_SUPPORT_OCCUPANCY"
+  | "UPCOMING_LEASE_CANNOT_SUPPORT_OCCUPANCY"
+  | "PAST_LEASE_CANNOT_SUPPORT_OCCUPANCY"
+  | "ENDED_LEASE_CANNOT_SUPPORT_OCCUPANCY"
+  | "LEASE_EXECUTION_INCOMPLETE"
+  | "OCCUPIED_WITHOUT_CURRENT_LEASE"
+  | "VACANT_WITH_CURRENT_LEASE"
+  | "STALE_CURRENT_LEASE_POINTER"
+  | "TENANT_CURRENT_WITHOUT_CURRENT_LEASE";
+
+export type CanonicalLeaseStateInput = {
+  id: string;
+  landlordId?: unknown;
+  propertyId?: unknown;
+  unitId?: unknown;
+  tenantId?: unknown;
+  status?: unknown;
+  startDate?: unknown;
+  leaseStartDate?: unknown;
+  leaseStart?: unknown;
+  endDate?: unknown;
+  leaseEndDate?: unknown;
+  leaseEnd?: unknown;
+  executionState?: unknown;
+  executionStatus?: unknown;
+  endedAt?: unknown;
+  terminatedAt?: unknown;
+  terminationDate?: unknown;
+  successorLeaseId?: unknown;
+  renewedByLeaseId?: unknown;
+  updatedAt?: unknown;
+  createdAt?: unknown;
+};
+
+export type CanonicalLeaseTermResult = {
+  state: CanonicalLeaseTermState;
+  effectiveStartDate: string | null;
+  effectiveEndDate: string | null;
+  supportsCurrentOccupancy: boolean;
+  reasons: CanonicalLeaseConflictReason[];
+};
+
+export type CanonicalLeaseSelectorContext = {
+  landlordId?: unknown;
+  propertyId?: unknown;
+  unitId?: unknown;
+  tenantId?: unknown;
+  asOfDate?: unknown;
+};
+
+export type CanonicalLeaseSelection = {
+  lease: CanonicalLeaseStateInput | null;
+  lifecycle: CanonicalLeaseTermResult | null;
+  candidates: Array<{ lease: CanonicalLeaseStateInput; lifecycle: CanonicalLeaseTermResult }>;
+  reasons: CanonicalLeaseConflictReason[];
+};
+
+const DRAFT_STATUSES = new Set(["draft", "created", "prepared", "pending", "pending_signature", "sent"]);
+const ENDED_STATUSES = new Set(["ended", "expired", "past", "archived", "renewed", "superseded"]);
+const TERMINATED_STATUSES = new Set(["terminated", "ended_early", "cancelled", "canceled", "void", "abandoned"]);
+const INCOMPLETE_EXECUTION = new Set([
+  "draft",
+  "not_started",
+  "in_progress",
+  "ready_for_tenant_signature",
+  "tenant_signed",
+  "ready_for_landlord_signature",
+  "landlord_signed",
+]);
+const OCCUPIED_STATUSES = new Set(["occupied", "active", "current", "leased", "rented"]);
+const VACANT_STATUSES = new Set(["vacant", "available"]);
+const PAST_TENANT_STATUSES = new Set(["past", "former", "inactive", "ended", "vacated"]);
+
+function normalize(value: unknown): string {
+  return String(value || "").trim().toLowerCase().replace(/[\s-]+/g, "_");
+}
+
+function value(value: unknown): string | null {
+  const normalized = String(value || "").trim();
+  return normalized || null;
+}
+
+function firstValue(...values: unknown[]): unknown {
+  return values.find((candidate) => candidate != null && candidate !== "");
+}
+
+// The existing backend lifecycle contract uses UTC calendar days. Date-only
+// values therefore remain active through their named end day and become past
+// on the following UTC day, independent of the server's local timezone.
+function toUtcDay(valueToParse: unknown): number | null {
+  if (valueToParse == null || valueToParse === "") return null;
+  let parsed: Date;
+  if (valueToParse instanceof Date) parsed = valueToParse;
+  else if (typeof valueToParse === "number") parsed = new Date(valueToParse);
+  else if (typeof (valueToParse as any)?.toDate === "function") parsed = (valueToParse as any).toDate();
+  else if (typeof (valueToParse as any)?.toMillis === "function") parsed = new Date((valueToParse as any).toMillis());
+  else if (typeof (valueToParse as any)?.seconds === "number") parsed = new Date((valueToParse as any).seconds * 1000);
+  else parsed = new Date(String(valueToParse));
+  if (!(parsed instanceof Date) || Number.isNaN(parsed.getTime())) return null;
+  return Date.UTC(parsed.getUTCFullYear(), parsed.getUTCMonth(), parsed.getUTCDate());
+}
+
+function isoDay(day: number | null): string | null {
+  return day == null ? null : new Date(day).toISOString().slice(0, 10);
+}
+
+function executionState(input: CanonicalLeaseStateInput): string {
+  return normalize(input.executionState || input.executionStatus);
+}
+
+export function deriveCanonicalLeaseTermState(
+  input: CanonicalLeaseStateInput,
+  asOfDate: unknown = new Date()
+): CanonicalLeaseTermResult {
+  const status = normalize(input.status);
+  const execution = executionState(input);
+  const currentDay = toUtcDay(asOfDate) ?? toUtcDay(new Date())!;
+  const startDay = toUtcDay(firstValue(input.startDate, input.leaseStartDate, input.leaseStart));
+  const endDay = toUtcDay(firstValue(input.endDate, input.leaseEndDate, input.leaseEnd));
+  const terminatedDay = toUtcDay(firstValue(input.terminationDate, input.terminatedAt));
+
+  const base = (state: CanonicalLeaseTermState, reasons: CanonicalLeaseConflictReason[] = []): CanonicalLeaseTermResult => ({
+    state,
+    effectiveStartDate: isoDay(startDay),
+    effectiveEndDate: isoDay(endDay),
+    supportsCurrentOccupancy: state === "active" && !INCOMPLETE_EXECUTION.has(execution),
+    reasons,
+  });
+
+  if (startDay != null && endDay != null && startDay > endDay) {
+    return base("unknown", ["INVALID_LEASE_DATE_RANGE"]);
+  }
+  if (TERMINATED_STATUSES.has(status) || (terminatedDay != null && terminatedDay <= currentDay)) {
+    return base("terminated", ["ENDED_LEASE_CANNOT_SUPPORT_OCCUPANCY"]);
+  }
+  if (ENDED_STATUSES.has(status) || input.endedAt) {
+    return base("ended", ["ENDED_LEASE_CANNOT_SUPPORT_OCCUPANCY"]);
+  }
+  if (DRAFT_STATUSES.has(status) || execution === "draft" || execution === "not_started") {
+    return base("draft", ["DRAFT_LEASE_CANNOT_SUPPORT_OCCUPANCY"]);
+  }
+  if (startDay != null && startDay > currentDay) {
+    return base("upcoming", ["UPCOMING_LEASE_CANNOT_SUPPORT_OCCUPANCY"]);
+  }
+  if (endDay != null && endDay < currentDay) {
+    return base("past", ["PAST_LEASE_CANNOT_SUPPORT_OCCUPANCY"]);
+  }
+  if (startDay == null || endDay == null) return base("unknown");
+  if (INCOMPLETE_EXECUTION.has(execution)) return base("active", ["LEASE_EXECUTION_INCOMPLETE"]);
+  return base("active");
+}
+
+function contextMatches(lease: CanonicalLeaseStateInput, context: CanonicalLeaseSelectorContext): boolean {
+  return (["landlordId", "propertyId", "unitId", "tenantId"] as const).every((key) => {
+    const expected = value(context[key]);
+    return !expected || value(lease[key]) === expected;
+  });
+}
+
+function timeValue(valueToParse: unknown): number {
+  if (valueToParse == null || valueToParse === "") return 0;
+  if (typeof valueToParse === "number" && Number.isFinite(valueToParse)) return valueToParse;
+  if (typeof (valueToParse as any)?.toMillis === "function") return Number((valueToParse as any).toMillis()) || 0;
+  const parsed = Date.parse(String(valueToParse));
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export function selectCanonicalCurrentLease(
+  leases: CanonicalLeaseStateInput[],
+  context: CanonicalLeaseSelectorContext = {}
+): CanonicalLeaseSelection {
+  const scoped = leases.filter((lease) => contextMatches(lease, context));
+  const candidates = scoped
+    .map((lease) => ({ lease, lifecycle: deriveCanonicalLeaseTermState(lease, context.asOfDate) }))
+    .filter(({ lifecycle }) => lifecycle.supportsCurrentOccupancy)
+    .sort((left, right) => {
+      const updated = timeValue(right.lease.updatedAt) - timeValue(left.lease.updatedAt);
+      if (updated !== 0) return updated;
+      const created = timeValue(right.lease.createdAt) - timeValue(left.lease.createdAt);
+      if (created !== 0) return created;
+      return left.lease.id.localeCompare(right.lease.id);
+    });
+
+  if (candidates.length > 1) {
+    return { lease: null, lifecycle: null, candidates, reasons: ["MULTIPLE_CURRENT_LEASES"] };
+  }
+  if (candidates.length === 1) {
+    return { lease: candidates[0].lease, lifecycle: candidates[0].lifecycle, candidates, reasons: [] };
+  }
+
+  const hasContextMismatch = leases.length > 0 && scoped.length === 0;
+  const reasons = hasContextMismatch
+    ? (["CURRENT_LEASE_CONTEXT_MISMATCH"] as CanonicalLeaseConflictReason[])
+    : Array.from(new Set(scoped.flatMap((lease) => deriveCanonicalLeaseTermState(lease, context.asOfDate).reasons)));
+  return { lease: null, lifecycle: null, candidates, reasons };
+}
+
+export function evaluateCanonicalOccupancy(input: {
+  persistedUnitOccupancy?: unknown;
+  persistedTenancyStatus?: unknown;
+  currentLeasePointerId?: unknown;
+  selection: CanonicalLeaseSelection;
+}): { occupancyState: CanonicalOccupancyState; supportingLeaseId: string | null; reasons: CanonicalLeaseConflictReason[] } {
+  const unitOccupancy = normalize(input.persistedUnitOccupancy);
+  const tenancyStatus = normalize(input.persistedTenancyStatus);
+  const persistedOccupied = OCCUPIED_STATUSES.has(unitOccupancy) || OCCUPIED_STATUSES.has(tenancyStatus);
+  const persistedVacant = VACANT_STATUSES.has(unitOccupancy) || VACANT_STATUSES.has(tenancyStatus);
+  const pointer = value(input.currentLeasePointerId);
+  const selectedId = input.selection.lease?.id || null;
+  const reasons = [...input.selection.reasons];
+
+  if (pointer && pointer !== selectedId) reasons.push("STALE_CURRENT_LEASE_POINTER");
+  if (reasons.includes("MULTIPLE_CURRENT_LEASES")) {
+    return { occupancyState: "review_needed", supportingLeaseId: null, reasons: Array.from(new Set(reasons)) };
+  }
+  if (selectedId && persistedVacant) reasons.push("VACANT_WITH_CURRENT_LEASE");
+  if (!selectedId && persistedOccupied) reasons.push("OCCUPIED_WITHOUT_CURRENT_LEASE");
+  if (reasons.includes("STALE_CURRENT_LEASE_POINTER") || reasons.includes("VACANT_WITH_CURRENT_LEASE") || reasons.includes("OCCUPIED_WITHOUT_CURRENT_LEASE")) {
+    return { occupancyState: "review_needed", supportingLeaseId: selectedId, reasons: Array.from(new Set(reasons)) };
+  }
+  if (selectedId) return { occupancyState: "occupied", supportingLeaseId: selectedId, reasons: [] };
+  return { occupancyState: "vacant", supportingLeaseId: null, reasons: Array.from(new Set(reasons)) };
+}
+
+export function evaluateCanonicalTenantRelationship(input: {
+  tenantId?: unknown;
+  persistedTenantStatus?: unknown;
+  currentLeasePointerId?: unknown;
+  selection: CanonicalLeaseSelection;
+  occupancy: ReturnType<typeof evaluateCanonicalOccupancy>;
+}): { relationshipState: CanonicalTenantRelationshipState; supportingLeaseId: string | null; reasons: CanonicalLeaseConflictReason[] } {
+  const reasons = [...input.occupancy.reasons];
+  const tenantId = value(input.tenantId);
+  const selected = input.selection.lease;
+  if (selected && tenantId && value(selected.tenantId) !== tenantId) reasons.push("CURRENT_LEASE_CONTEXT_MISMATCH");
+  if (input.occupancy.occupancyState === "occupied" && selected && !reasons.length) {
+    return { relationshipState: "current_occupant", supportingLeaseId: selected.id, reasons: [] };
+  }
+  const tenantStatus = normalize(input.persistedTenantStatus);
+  if (OCCUPIED_STATUSES.has(tenantStatus) && !selected) reasons.push("TENANT_CURRENT_WITHOUT_CURRENT_LEASE");
+  const unresolvedReasons = new Set<CanonicalLeaseConflictReason>([
+    "MULTIPLE_CURRENT_LEASES",
+    "INVALID_LEASE_DATE_RANGE",
+    "CURRENT_LEASE_CONTEXT_MISMATCH",
+    "OCCUPIED_WITHOUT_CURRENT_LEASE",
+    "VACANT_WITH_CURRENT_LEASE",
+    "STALE_CURRENT_LEASE_POINTER",
+    "TENANT_CURRENT_WITHOUT_CURRENT_LEASE",
+  ]);
+  if (reasons.some((reason) => unresolvedReasons.has(reason)) || input.occupancy.occupancyState === "review_needed") {
+    return { relationshipState: "occupancy_unresolved", supportingLeaseId: selected?.id || null, reasons: Array.from(new Set(reasons)) };
+  }
+  if (PAST_TENANT_STATUSES.has(tenantStatus) || !selected) {
+    return { relationshipState: "past_tenant", supportingLeaseId: null, reasons: Array.from(new Set(reasons)) };
+  }
+  return { relationshipState: "occupancy_unresolved", supportingLeaseId: selected.id, reasons };
+}


### PR DESCRIPTION
## Summary

- add a pure canonical lease-term contract with deterministic UTC calendar-day semantics and inclusive end dates
- add a context-scoped current occupancy-supporting lease selector that rejects stale active, draft, upcoming, past, terminal, and execution-incomplete records
- add fail-closed occupancy and tenant-relationship evaluators with machine-readable conflict reasons
- add a 13-case regression matrix covering expiry, draft execution, ambiguity, stale projections, renewal successor selection, and timezone boundaries

## Root cause addressed

The prior audit found passive lease expiry without canonical reconciliation plus divergent `/properties`, `/leases`, and `/tenants` projections. Persisted status and pointers could remain active after the term expired, while each page derived a different result.

PR A establishes the shared domain foundation only. It does not integrate pages, mutate data, auto-end leases, auto-vacate units, or implement Resolve Occupancy. Those remain PR B and PR C scope.

## Domain boundaries

- lease term, occupancy, tenant relationship, execution, and payment remain separate dimensions
- an expired lease does not imply vacancy; stale occupied state becomes `review_needed`
- multiple current leases return `MULTIPLE_CURRENT_LEASES` with no arbitrary winner
- a stale pointer or persisted `Current` status cannot establish current occupancy

## Validation

- focused canonical/lifecycle/coherence tests: 35 passed
- backend TypeScript production build: passed
- `git diff --check`: passed
- full backend comparison: 3,275 passed, 29 unrelated existing failures across 12 files; the new 13-test suite passed

## Explicitly out of scope

- `/properties`, `/leases`, or `/tenants` presentation integration
- user-facing Resolve Occupancy workflow
- Firestore/data repair or migration
- automatic term-end or vacancy mutation
- Production, Terraform, IAM, Cloud Run, auth, billing, screening, or deployment changes
