### PR TITLE
Integrate canonical lease and occupancy state across Properties, Leases, and Tenants

### DIFF
--- a/rentchain-api/src/lib/leases/__tests__/canonicalLeaseOccupancyProjection.test.ts
+++ b/rentchain-api/src/lib/leases/__tests__/canonicalLeaseOccupancyProjection.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { buildCanonicalLeaseOccupancyProjection } from "../canonicalLeaseOccupancyProjection";
+
+const activeLease = {
+  id: "lease-active",
+  landlordId: "landlord-1",
+  propertyId: "property-1",
+  unitId: "unit-1",
+  tenantId: "tenant-1",
+  startDate: "2026-01-01",
+  endDate: "2026-12-31",
+  executionStatus: "fully_executed",
+};
+
+describe("canonical lease occupancy projection", () => {
+  it("projects one shared active/occupied/current state", () => {
+    expect(buildCanonicalLeaseOccupancyProjection({
+      leases: [activeLease],
+      context: { propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-1", asOfDate: "2026-08-17" },
+      persistedUnitOccupancy: "occupied",
+      tenantId: "tenant-1",
+    })).toMatchObject({
+      leaseTermState: "active",
+      occupancyState: "occupied",
+      tenantRelationshipState: "current_occupant",
+      supportingLeaseId: "lease-active",
+    });
+  });
+
+  it("does not allow an expired lease to preserve occupied/current labels", () => {
+    const result = buildCanonicalLeaseOccupancyProjection({
+      leases: [{ ...activeLease, id: "lease-past", endDate: "2026-04-30", status: "active" }],
+      context: { propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-1", asOfDate: "2026-08-17" },
+      persistedUnitOccupancy: "occupied",
+      persistedTenantStatus: "current",
+      currentLeasePointerId: "lease-past",
+      tenantId: "tenant-1",
+    });
+    expect(result.leaseTermState).toBe("past");
+    expect(result.occupancyState).toBe("review_needed");
+    expect(result.tenantRelationshipState).toBe("occupancy_unresolved");
+    expect(result.reasons).toContain("OCCUPIED_WITHOUT_CURRENT_LEASE");
+  });
+
+  it("fails closed when two current leases support one unit", () => {
+    const result = buildCanonicalLeaseOccupancyProjection({
+      leases: [activeLease, { ...activeLease, id: "lease-active-2", tenantId: "tenant-2" }],
+      context: { propertyId: "property-1", unitId: "unit-1", asOfDate: "2026-08-17" },
+      persistedUnitOccupancy: "occupied",
+    });
+    expect(result.occupancyState).toBe("review_needed");
+    expect(result.reasons).toContain("MULTIPLE_CURRENT_LEASES");
+  });
+});

--- a/rentchain-api/src/lib/leases/__tests__/canonicalLeaseOccupancyProjection.test.ts
+++ b/rentchain-api/src/lib/leases/__tests__/canonicalLeaseOccupancyProjection.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildCanonicalLeaseOccupancyProjection, canonicalLeaseMatchesUnit } from "../canonicalLeaseOccupancyProjection";
+import {
+  buildCanonicalLeaseOccupancyProjection,
+  canonicalLeaseMatchesUnit,
+  resolveCanonicalUnitProjectionInputs,
+} from "../canonicalLeaseOccupancyProjection";
 
 const activeLease = {
   id: "lease-active",
@@ -55,5 +59,79 @@ describe("canonical lease occupancy projection", () => {
     });
     expect(result.occupancyState).toBe("review_needed");
     expect(result.reasons).toContain("MULTIPLE_CURRENT_LEASES");
+  });
+
+  it("uses raw occupied/current linkage only when normalized unit inputs are absent", () => {
+    const unitInputs = resolveCanonicalUnitProjectionInputs({
+      id: "unit-1",
+      raw: {
+        occupancyStatus: "occupied",
+        currentLeaseId: "lease-past",
+        currentTenantId: "tenant-1",
+      },
+    });
+    const result = buildCanonicalLeaseOccupancyProjection({
+      leases: [{ ...activeLease, id: "lease-past", endDate: "2026-04-30", status: "active" }],
+      context: { propertyId: "property-1", unitId: "unit-1", tenantId: unitInputs.tenantId, asOfDate: "2026-08-17" },
+      ...unitInputs,
+    });
+
+    expect(unitInputs).toMatchObject({
+      persistedUnitOccupancy: "occupied",
+      currentLeasePointerId: "lease-past",
+      tenantId: "tenant-1",
+    });
+    expect(result).toMatchObject({
+      leaseTermState: "past",
+      occupancyState: "review_needed",
+      tenantRelationshipState: "occupancy_unresolved",
+      supportingLeaseId: null,
+    });
+  });
+
+  it("keeps explicit normalized vacancy authoritative over stale raw occupied data", () => {
+    const unitInputs = resolveCanonicalUnitProjectionInputs({
+      occupancyStatus: "vacant",
+      currentLeaseId: "lease-active",
+      raw: { occupancyStatus: "occupied", currentLeaseId: "lease-stale" },
+    });
+    const result = buildCanonicalLeaseOccupancyProjection({
+      leases: [activeLease],
+      context: { propertyId: "property-1", unitId: "unit-1", asOfDate: "2026-08-17" },
+      ...unitInputs,
+    });
+
+    expect(unitInputs.persistedUnitOccupancy).toBe("vacant");
+    expect(unitInputs.currentLeasePointerId).toBe("lease-active");
+    expect(result.occupancyState).toBe("review_needed");
+    expect(result.reasons).toContain("VACANT_WITH_CURRENT_LEASE");
+  });
+
+  it("keeps normalized occupied evidence for the active control", () => {
+    const unitInputs = resolveCanonicalUnitProjectionInputs({
+      occupancyStatus: "occupied",
+      currentLeaseId: "lease-active",
+      currentTenantId: "tenant-1",
+      raw: { occupancyStatus: "vacant", currentLeaseId: "lease-stale", currentTenantId: "tenant-stale" },
+    });
+    const result = buildCanonicalLeaseOccupancyProjection({
+      leases: [activeLease],
+      context: { propertyId: "property-1", unitId: "unit-1", tenantId: unitInputs.tenantId, asOfDate: "2026-08-17" },
+      ...unitInputs,
+    });
+
+    expect(result).toMatchObject({
+      leaseTermState: "active",
+      occupancyState: "occupied",
+      tenantRelationshipState: "current_occupant",
+      supportingLeaseId: "lease-active",
+    });
+  });
+
+  it("normalizes boolean occupancy evidence without treating false as absent", () => {
+    expect(resolveCanonicalUnitProjectionInputs({ isOccupied: false, raw: { status: "occupied" } }))
+      .toMatchObject({ persistedUnitOccupancy: "vacant" });
+    expect(resolveCanonicalUnitProjectionInputs({ raw: { occupied: true } }))
+      .toMatchObject({ persistedUnitOccupancy: "occupied" });
   });
 });

--- a/rentchain-api/src/lib/leases/__tests__/canonicalLeaseOccupancyProjection.test.ts
+++ b/rentchain-api/src/lib/leases/__tests__/canonicalLeaseOccupancyProjection.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildCanonicalLeaseOccupancyProjection } from "../canonicalLeaseOccupancyProjection";
+import { buildCanonicalLeaseOccupancyProjection, canonicalLeaseMatchesUnit } from "../canonicalLeaseOccupancyProjection";
 
 const activeLease = {
   id: "lease-active",
@@ -13,6 +13,11 @@ const activeLease = {
 };
 
 describe("canonical lease occupancy projection", () => {
+  it("matches property units through the canonical resolved unit id", () => {
+    expect(canonicalLeaseMatchesUnit({ unitId: "legacy-label", resolvedUnitId: "unit-1" }, "unit-1")).toBe(true);
+    expect(canonicalLeaseMatchesUnit({ unitId: "legacy-label", resolvedUnitId: "unit-1" }, "legacy-label")).toBe(false);
+  });
+
   it("projects one shared active/occupied/current state", () => {
     expect(buildCanonicalLeaseOccupancyProjection({
       leases: [activeLease],

--- a/rentchain-api/src/lib/leases/canonicalLeaseOccupancyProjection.ts
+++ b/rentchain-api/src/lib/leases/canonicalLeaseOccupancyProjection.ts
@@ -19,6 +19,12 @@ export type CanonicalLeaseOccupancyProjection = {
   reasons: CanonicalLeaseConflictReason[];
 };
 
+export function canonicalLeaseMatchesUnit(raw: Record<string, any>, unitId: unknown): boolean {
+  const expectedUnitId = String(unitId || "").trim();
+  if (!expectedUnitId) return false;
+  return String(raw?.resolvedUnitId || raw?.unitId || "").trim() === expectedUnitId;
+}
+
 export function toCanonicalLeaseStateInput(raw: Record<string, any>): CanonicalLeaseStateInput {
   return {
     id: String(raw?.id || "").trim(),

--- a/rentchain-api/src/lib/leases/canonicalLeaseOccupancyProjection.ts
+++ b/rentchain-api/src/lib/leases/canonicalLeaseOccupancyProjection.ts
@@ -1,0 +1,111 @@
+import {
+  deriveCanonicalLeaseTermState,
+  evaluateCanonicalOccupancy,
+  evaluateCanonicalTenantRelationship,
+  selectCanonicalCurrentLease,
+  type CanonicalLeaseConflictReason,
+  type CanonicalLeaseSelectorContext,
+  type CanonicalLeaseStateInput,
+  type CanonicalLeaseTermState,
+  type CanonicalOccupancyState,
+  type CanonicalTenantRelationshipState,
+} from "./canonicalLeaseOccupancyState";
+
+export type CanonicalLeaseOccupancyProjection = {
+  leaseTermState: CanonicalLeaseTermState | null;
+  occupancyState: CanonicalOccupancyState;
+  tenantRelationshipState: CanonicalTenantRelationshipState;
+  supportingLeaseId: string | null;
+  reasons: CanonicalLeaseConflictReason[];
+};
+
+export function toCanonicalLeaseStateInput(raw: Record<string, any>): CanonicalLeaseStateInput {
+  return {
+    id: String(raw?.id || "").trim(),
+    landlordId: raw?.landlordId,
+    propertyId: raw?.propertyId,
+    unitId: raw?.resolvedUnitId || raw?.unitId || raw?.unitNumber || raw?.unitLabel,
+    tenantId: raw?.primaryTenantId || raw?.tenantId || raw?.tenantIds?.[0],
+    status: raw?.status,
+    startDate: raw?.startDate,
+    leaseStartDate: raw?.leaseStartDate,
+    leaseStart: raw?.leaseStart,
+    endDate: raw?.endDate,
+    leaseEndDate: raw?.leaseEndDate,
+    leaseEnd: raw?.leaseEnd,
+    executionState: raw?.leaseExecutionState || raw?.leaseExecution?.executionStatus,
+    executionStatus: raw?.executionStatus,
+    endedAt: raw?.endedAt,
+    terminatedAt: raw?.terminatedAt,
+    terminationDate: raw?.terminationDate,
+    successorLeaseId: raw?.successorLeaseId || raw?.replacementLeaseId,
+    renewedByLeaseId: raw?.renewedByLeaseId || raw?.renewalLeaseId,
+    updatedAt: raw?.updatedAt,
+    createdAt: raw?.createdAt,
+  };
+}
+
+export function buildCanonicalLeaseOccupancyProjection(input: {
+  leases: Array<Record<string, any>>;
+  context?: CanonicalLeaseSelectorContext;
+  persistedUnitOccupancy?: unknown;
+  persistedTenancyStatus?: unknown;
+  persistedTenantStatus?: unknown;
+  currentLeasePointerId?: unknown;
+  tenantId?: unknown;
+}): CanonicalLeaseOccupancyProjection {
+  const selection = selectCanonicalCurrentLease(
+    input.leases.map(toCanonicalLeaseStateInput).filter((lease) => lease.id),
+    input.context
+  );
+  const occupancy = evaluateCanonicalOccupancy({
+    persistedUnitOccupancy: input.persistedUnitOccupancy,
+    persistedTenancyStatus: input.persistedTenancyStatus,
+    currentLeasePointerId: input.currentLeasePointerId,
+    selection,
+  });
+  const relationship = evaluateCanonicalTenantRelationship({
+    tenantId: input.tenantId,
+    persistedTenantStatus: input.persistedTenantStatus,
+    currentLeasePointerId: input.currentLeasePointerId,
+    selection,
+    occupancy,
+  });
+
+  const relevantLease = selection.lease || input.leases.map(toCanonicalLeaseStateInput).find((lease) => lease.id) || null;
+  const fallbackTerm = relevantLease
+    ? deriveCanonicalLeaseTermState(relevantLease, input.context?.asOfDate)
+    : null;
+
+  return {
+    leaseTermState: selection.lifecycle?.state || fallbackTerm?.state || null,
+    occupancyState: occupancy.occupancyState,
+    tenantRelationshipState: relationship.relationshipState,
+    supportingLeaseId: occupancy.supportingLeaseId,
+    reasons: Array.from(new Set([...selection.reasons, ...occupancy.reasons, ...relationship.reasons])),
+  };
+}
+
+export function canonicalTermLabel(state: CanonicalLeaseTermState | null): string {
+  switch (state) {
+    case "draft": return "Draft";
+    case "upcoming": return "Upcoming";
+    case "active": return "Active";
+    case "past": return "Expired";
+    case "ended": return "Ended";
+    case "terminated": return "Terminated";
+    default: return "Unknown";
+  }
+}
+
+export function canonicalOccupancyLabel(state: CanonicalOccupancyState): string {
+  if (state === "occupied") return "Occupied";
+  if (state === "vacant") return "Vacant";
+  return "Review needed";
+}
+
+export function canonicalTenantRelationshipLabel(state: CanonicalTenantRelationshipState): string {
+  if (state === "current_occupant") return "Current occupant";
+  if (state === "past_tenant") return "Past tenant";
+  return "Review needed";
+}

--- a/rentchain-api/src/lib/leases/canonicalLeaseOccupancyProjection.ts
+++ b/rentchain-api/src/lib/leases/canonicalLeaseOccupancyProjection.ts
@@ -19,6 +19,49 @@ export type CanonicalLeaseOccupancyProjection = {
   reasons: CanonicalLeaseConflictReason[];
 };
 
+export type CanonicalUnitProjectionInputs = {
+  persistedUnitOccupancy?: unknown;
+  persistedTenancyStatus?: unknown;
+  persistedTenantStatus?: unknown;
+  currentLeasePointerId?: unknown;
+  tenantId?: unknown;
+};
+
+function firstStatusEvidence(...values: unknown[]): unknown {
+  for (const candidate of values) {
+    if (typeof candidate === "boolean") return candidate ? "occupied" : "vacant";
+    if (typeof candidate === "string" && candidate.trim()) return candidate;
+  }
+  return undefined;
+}
+
+function firstIdentifierEvidence(...values: unknown[]): unknown {
+  for (const candidate of values) {
+    if (typeof candidate === "string" && candidate.trim()) return candidate;
+  }
+  return undefined;
+}
+
+export function resolveCanonicalUnitProjectionInputs(
+  unit: Record<string, any>
+): CanonicalUnitProjectionInputs {
+  const raw = unit?.raw && typeof unit.raw === "object" ? unit.raw : {};
+  return {
+    persistedUnitOccupancy:
+      firstStatusEvidence(unit?.occupancyStatus, unit?.status, unit?.isOccupied, unit?.occupied) ??
+      firstStatusEvidence(raw?.occupancyStatus, raw?.status, raw?.isOccupied, raw?.occupied),
+    persistedTenancyStatus:
+      firstStatusEvidence(unit?.tenancyStatus) ?? firstStatusEvidence(raw?.tenancyStatus),
+    persistedTenantStatus:
+      firstStatusEvidence(unit?.tenantStatus) ?? firstStatusEvidence(raw?.tenantStatus),
+    currentLeasePointerId:
+      firstIdentifierEvidence(unit?.currentLeaseId) ?? firstIdentifierEvidence(raw?.currentLeaseId),
+    tenantId:
+      firstIdentifierEvidence(unit?.currentTenantId, unit?.tenantId) ??
+      firstIdentifierEvidence(raw?.currentTenantId, raw?.tenantId),
+  };
+}
+
 export function canonicalLeaseMatchesUnit(raw: Record<string, any>, unitId: unknown): boolean {
   const expectedUnitId = String(unitId || "").trim();
   if (!expectedUnitId) return false;

--- a/rentchain-api/src/routes/__tests__/leaseRoutes.integrity.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.integrity.test.ts
@@ -130,18 +130,25 @@ vi.mock("../../services/leaseCanonicalizationService", () => ({
       candidateIds: unit ? [unit.id] : [],
     };
   }),
-  toCanonicalLeaseRecord: vi.fn((id: string, raw: any) => ({
+  toCanonicalLeaseRecord: vi.fn((id: string, raw: any, units: any[]) => ({
     id,
+    landlordId: String(raw?.landlordId || "").trim() || null,
     status: String(raw?.status || "").trim().toLowerCase(),
     unitId: String(raw?.unitId || "").trim() || null,
+    resolvedUnitId: units.find((unit) => unit.id === raw?.unitId)?.id || null,
     unitNumber: String(raw?.unitNumber || raw?.unit || "").trim() || null,
     propertyId: String(raw?.propertyId || "").trim() || null,
+    tenantId: String(raw?.tenantId || "").trim() || null,
+    primaryTenantId: String(raw?.primaryTenantId || raw?.tenantId || "").trim() || null,
+    startDate: raw?.startDate,
+    endDate: raw?.endDate,
+    executionStatus: raw?.executionStatus,
   })),
 }));
 
 vi.mock("../../services/leasePartyConsolidationService", () => ({
   evaluateSameLeaseAgreement: vi.fn(() => ({ decision: "separate" })),
-  groupLeaseAgreementCandidates: vi.fn(() => ({ mergeGroups: [], ambiguousGroups: [], singles: [] })),
+  groupLeaseAgreementCandidates: vi.fn((candidates: any[]) => ({ mergeGroups: [], ambiguousGroups: [], singles: candidates })),
   pickAgreementWinner: vi.fn((candidate: any) => candidate),
 }));
 
@@ -1077,5 +1084,65 @@ describe("leaseRoutes integrity repairs", () => {
     const notesRes = await request(app).get("/lease-1/notes");
     expect(notesRes.status).toBe(200);
     expect(notesRes.body?.notes?.[0]?.note).toBe("Keep this for audit.");
+  });
+
+  it("projects raw unit occupancy/current linkage when normalized property inputs are absent", async () => {
+    seedDoc("units", "unit-ref", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitNumber: "REF-EXPIRED",
+      occupancyStatus: "occupied",
+      status: "occupied",
+      currentLeaseId: "lease-ref",
+      currentTenantId: "tenant-ref",
+    });
+    seedDoc("units", "unit-control", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitNumber: "CTRL-ACTIVE",
+      occupancyStatus: "occupied",
+      status: "occupied",
+      currentLeaseId: "lease-control",
+      currentTenantId: "tenant-control",
+    });
+    seedDoc("leases", "lease-ref", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitId: "unit-ref",
+      tenantId: "tenant-ref",
+      primaryTenantId: "tenant-ref",
+      startDate: "2025-05-01",
+      endDate: "2026-04-30",
+      executionStatus: "fully_executed",
+      status: "active",
+    });
+    seedDoc("leases", "lease-control", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitId: "unit-control",
+      tenantId: "tenant-control",
+      primaryTenantId: "tenant-control",
+      startDate: "2026-05-01",
+      endDate: "2027-04-30",
+      executionStatus: "fully_executed",
+      status: "active",
+    });
+
+    const app = await makeApp();
+    const res = await request(app).get("/property/prop-1");
+
+    expect(res.status).toBe(200);
+    expect(res.body?.canonicalUnitStates?.["unit-ref"]).toMatchObject({
+      leaseTermState: "past",
+      occupancyState: "review_needed",
+      tenantRelationshipState: "occupancy_unresolved",
+      supportingLeaseId: null,
+    });
+    expect(res.body?.canonicalUnitStates?.["unit-control"]).toMatchObject({
+      leaseTermState: "active",
+      occupancyState: "occupied",
+      tenantRelationshipState: "current_occupant",
+      supportingLeaseId: "lease-control",
+    });
   });
 });

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -70,6 +70,11 @@ import { computeNoResponseState } from "../services/leaseNoticeWorkflowService";
 import { deriveLeaseLifecycleSummary } from "../services/leaseLifecycle/deriveLeaseLifecycleSummary";
 import { deriveLeaseLifecycleState } from "../lib/leases/leaseLifecycle";
 import { deriveLeaseOccupancyCoherence } from "../lib/leases/deriveLeaseOccupancyCoherence";
+import {
+  buildCanonicalLeaseOccupancyProjection,
+  toCanonicalLeaseStateInput,
+} from "../lib/leases/canonicalLeaseOccupancyProjection";
+import { deriveCanonicalLeaseTermState } from "../lib/leases/canonicalLeaseOccupancyState";
 import { evaluateJurisdictionPolicy } from "../lib/jurisdiction/operationalPolicyEvaluator";
 import { formatInternalReference, slugifyOperationalReference } from "../lib/identityReferences";
 import { syncPropertyUnitOccupancyForTenantContext } from "../services/tenantPortal/tenantOccupancySyncService";
@@ -1644,8 +1649,25 @@ async function listLandlordLeaseRows(landlordId: string, opts?: { archived?: boo
   return mergedLeases.map((lease: any) => {
     const rawLease = rawLeaseById.get(String(lease?.id || "").trim()) || null;
     const latestNotice = latestNoticeByLeaseId.get(String(lease?.id || "").trim()) || null;
+    const unitId = String(lease?.unitId || lease?.unitNumber || lease?.unitLabel || "").trim();
+    const propertyId = String(lease?.propertyId || "").trim();
+    const relatedLeases = mergedLeases.filter((candidate: any) =>
+      String(candidate?.propertyId || "").trim() === propertyId &&
+      String(candidate?.unitId || candidate?.unitNumber || candidate?.unitLabel || "").trim() === unitId
+    );
+    const canonicalState = buildCanonicalLeaseOccupancyProjection({
+      leases: relatedLeases,
+      context: { landlordId, propertyId, unitId },
+      persistedUnitOccupancy: lease?.stateCoherence?.sourceFields?.unitStatus,
+      persistedTenancyStatus: lease?.stateCoherence?.sourceFields?.occupancyStatus,
+      currentLeasePointerId: lease?.stateCoherence?.sourceFields?.currentLeaseId,
+      tenantId: lease?.primaryTenantId || lease?.tenantId || lease?.tenantIds?.[0],
+      persistedTenantStatus: lease?.stateCoherence?.sourceFields?.tenantStatus,
+    });
+    canonicalState.leaseTermState = deriveCanonicalLeaseTermState(toCanonicalLeaseStateInput(lease)).state;
     return {
       ...lease,
+      canonicalState,
       ...buildLeaseWorkflowGuidanceProjection(lease, rawLease, latestNotice),
     };
   });
@@ -3595,7 +3617,19 @@ router.get("/property/:propertyId", requireLandlord, async (req: any, res: Respo
     // Occupancy and rent roll consumers must operate on lease agreements, not per-tenant rows.
     const summaryLeases = mergeLeaseRows(combinedRows.filter((lease) => winnerIds.has(lease.id)));
     const displayLeases = summaryLeases.map((lease) => hydrateLeaseUnitDisplayFieldsFromUnits(lease, units));
-    const response: any = { leases: displayLeases };
+    const canonicalUnitStates = Object.fromEntries(
+      units.map((unit: any) => {
+        const unitId = String(unit?.id || "").trim();
+        const relatedLeases = groupedWinners.filter((lease: any) => String(lease?.unitId || "").trim() === unitId);
+        return [unitId, buildCanonicalLeaseOccupancyProjection({
+          leases: relatedLeases,
+          context: { landlordId, propertyId, unitId },
+          persistedUnitOccupancy: unit?.occupancyStatus || unit?.status,
+          currentLeasePointerId: unit?.currentLeaseId,
+        })];
+      }).filter(([unitId]) => Boolean(unitId))
+    );
+    const response: any = { leases: displayLeases, canonicalUnitStates };
     response.credibilitySummary = await loadPropertyCredibilitySummary({
       firestore: db as any,
       propertyId,

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -73,6 +73,7 @@ import { deriveLeaseOccupancyCoherence } from "../lib/leases/deriveLeaseOccupanc
 import {
   buildCanonicalLeaseOccupancyProjection,
   canonicalLeaseMatchesUnit,
+  resolveCanonicalUnitProjectionInputs,
   toCanonicalLeaseStateInput,
 } from "../lib/leases/canonicalLeaseOccupancyProjection";
 import { deriveCanonicalLeaseTermState } from "../lib/leases/canonicalLeaseOccupancyState";
@@ -3622,11 +3623,11 @@ router.get("/property/:propertyId", requireLandlord, async (req: any, res: Respo
       units.map((unit: any) => {
         const unitId = String(unit?.id || "").trim();
         const relatedLeases = groupedWinners.filter((lease: any) => canonicalLeaseMatchesUnit(lease, unitId));
+        const unitInputs = resolveCanonicalUnitProjectionInputs(unit);
         return [unitId, buildCanonicalLeaseOccupancyProjection({
           leases: relatedLeases,
-          context: { landlordId, propertyId, unitId },
-          persistedUnitOccupancy: unit?.occupancyStatus || unit?.status,
-          currentLeasePointerId: unit?.currentLeaseId,
+          context: { landlordId, propertyId, unitId, tenantId: unitInputs.tenantId },
+          ...unitInputs,
         })];
       }).filter(([unitId]) => Boolean(unitId))
     );

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -72,6 +72,7 @@ import { deriveLeaseLifecycleState } from "../lib/leases/leaseLifecycle";
 import { deriveLeaseOccupancyCoherence } from "../lib/leases/deriveLeaseOccupancyCoherence";
 import {
   buildCanonicalLeaseOccupancyProjection,
+  canonicalLeaseMatchesUnit,
   toCanonicalLeaseStateInput,
 } from "../lib/leases/canonicalLeaseOccupancyProjection";
 import { deriveCanonicalLeaseTermState } from "../lib/leases/canonicalLeaseOccupancyState";
@@ -3620,7 +3621,7 @@ router.get("/property/:propertyId", requireLandlord, async (req: any, res: Respo
     const canonicalUnitStates = Object.fromEntries(
       units.map((unit: any) => {
         const unitId = String(unit?.id || "").trim();
-        const relatedLeases = groupedWinners.filter((lease: any) => String(lease?.unitId || "").trim() === unitId);
+        const relatedLeases = groupedWinners.filter((lease: any) => canonicalLeaseMatchesUnit(lease, unitId));
         return [unitId, buildCanonicalLeaseOccupancyProjection({
           leases: relatedLeases,
           context: { landlordId, propertyId, unitId },
@@ -3635,6 +3636,7 @@ router.get("/property/:propertyId", requireLandlord, async (req: any, res: Respo
       propertyId,
       landlordId,
       leases: summaryLeases,
+      canonicalUnitStates,
     });
     if (String(req.query?.debug || "") === "1") {
       const integrity = await loadPropertyLeaseIntegrityDiagnostics(propertyId, landlordId, db as any);

--- a/rentchain-api/src/services/__tests__/propertyCredibilitySummary.test.ts
+++ b/rentchain-api/src/services/__tests__/propertyCredibilitySummary.test.ts
@@ -58,4 +58,46 @@ describe("propertyCredibilitySummary", () => {
     expect(summary.tenantScoreAverage).toBeNull();
     expect(summary.leaseRiskAverage).toBeNull();
   });
+
+  it("uses canonical lifecycle and occupancy for the property summary when supplied", () => {
+    const summary = computePropertyCredibilitySummary({
+      propertyId: "qa-pr1555-property",
+      leases: [
+        { id: "lease-expired", status: "active", tenantId: "tenant-expired", riskScore: 75, riskConfidence: 0.9 },
+        { id: "lease-active", status: "active", tenantId: "tenant-active", riskScore: 82, riskConfidence: 0.9 },
+      ],
+      tenants: [
+        { id: "tenant-expired", tenantScoreValue: 75, tenantScoreConfidence: 0.9 },
+        { id: "tenant-active", tenantScoreValue: 82, tenantScoreConfidence: 0.9 },
+      ],
+      canonicalUnitStates: {
+        "unit-expired": {
+          leaseTermState: "past",
+          occupancyState: "review_needed",
+          supportingLeaseId: null,
+        },
+        "unit-active": {
+          leaseTermState: "active",
+          occupancyState: "occupied",
+          supportingLeaseId: "lease-active",
+        },
+      },
+    });
+
+    expect(summary.activeLeaseCount).toBe(1);
+    expect(summary.lowConfidenceCount).toBe(1);
+    expect(summary.leasesWithRiskCount).toBe(1);
+    expect(summary.tenantsWithScoreCount).toBe(1);
+  });
+
+  it("preserves legacy status behavior when canonical unit states are absent", () => {
+    const summary = computePropertyCredibilitySummary({
+      propertyId: "property-legacy",
+      leases: [{ id: "lease-legacy", status: "active", tenantId: "tenant-legacy", riskScore: 80, riskConfidence: 0.9 }],
+      tenants: [{ id: "tenant-legacy", tenantScoreValue: 80, tenantScoreConfidence: 0.9 }],
+    });
+
+    expect(summary.activeLeaseCount).toBe(1);
+    expect(summary.lowConfidenceCount).toBe(0);
+  });
 });

--- a/rentchain-api/src/services/__tests__/tenantDetailsService.test.ts
+++ b/rentchain-api/src/services/__tests__/tenantDetailsService.test.ts
@@ -266,6 +266,87 @@ describe("getTenantsList", () => {
     });
   });
 
+  it("projects an expired occupied tenant as review-needed without a canonical current lease", async () => {
+    tenantDocs.clear();
+    tenantDocs.set("tenant-ref", {
+      landlordId: "landlord-1",
+      fullName: "Expired Tenant",
+      propertyId: "property-1",
+      unitId: "unit-ref",
+      currentLeaseId: "lease-ref",
+      status: "active",
+    });
+    propertyDocs.set("property-1", { landlordId: "landlord-1", name: "Canonical Property" });
+    unitDocs.set("unit-ref", {
+      landlordId: "landlord-1",
+      propertyId: "property-1",
+      unitNumber: "REF-EXPIRED",
+      occupancyStatus: "occupied",
+      currentLeaseId: "lease-ref",
+      currentTenantId: "tenant-ref",
+    });
+    leaseDocs.set("lease-ref", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-ref",
+      propertyId: "property-1",
+      unitId: "unit-ref",
+      status: "active",
+      startDate: "2025-05-01",
+      endDate: "2026-04-30",
+    });
+
+    const { getTenantsList } = await import("../tenantDetailsService");
+    const [tenant] = await getTenantsList({ landlordId: "landlord-1" });
+
+    expect(tenant.currentLeaseId).toBeNull();
+    expect(tenant.canonicalState).toMatchObject({
+      leaseTermState: "past",
+      occupancyState: "review_needed",
+      tenantRelationshipState: "occupancy_unresolved",
+      supportingLeaseId: null,
+    });
+  });
+
+  it("preserves the canonical current lease for a genuine active tenant", async () => {
+    tenantDocs.clear();
+    tenantDocs.set("tenant-control", {
+      landlordId: "landlord-1",
+      fullName: "Active Tenant",
+      propertyId: "property-1",
+      unitId: "unit-control",
+      currentLeaseId: "lease-control",
+      status: "active",
+    });
+    unitDocs.set("unit-control", {
+      landlordId: "landlord-1",
+      propertyId: "property-1",
+      unitNumber: "CTRL-ACTIVE",
+      occupancyStatus: "occupied",
+      currentLeaseId: "lease-control",
+      currentTenantId: "tenant-control",
+    });
+    leaseDocs.set("lease-control", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-control",
+      propertyId: "property-1",
+      unitId: "unit-control",
+      status: "active",
+      startDate: "2026-05-01",
+      endDate: "2027-04-30",
+    });
+
+    const { getTenantsList } = await import("../tenantDetailsService");
+    const [tenant] = await getTenantsList({ landlordId: "landlord-1" });
+
+    expect(tenant.currentLeaseId).toBe("lease-control");
+    expect(tenant.canonicalState).toMatchObject({
+      leaseTermState: "active",
+      occupancyState: "occupied",
+      tenantRelationshipState: "current_occupant",
+      supportingLeaseId: "lease-control",
+    });
+  });
+
   it("preserves fallback tenants when no tenant records exist outside landlord scope", async () => {
     tenantDocs.clear();
 
@@ -326,11 +407,61 @@ describe("getTenantDetailBundle", () => {
     expect(bundle.stateCoherence?.occupancyState).toBe("review_required");
   });
 
+  it("retains an expired lease as history without exposing it as current", async () => {
+    tenantDocs.set("tenant-ref", {
+      landlordId: "landlord-1",
+      fullName: "Expired Tenant",
+      propertyId: "property-1",
+      unitId: "unit-ref",
+      currentLeaseId: "lease-ref",
+      status: "active",
+    });
+    propertyDocs.set("property-1", { landlordId: "landlord-1", name: "Canonical Property" });
+    unitDocs.set("unit-ref", {
+      landlordId: "landlord-1",
+      propertyId: "property-1",
+      unitNumber: "REF-EXPIRED",
+      occupancyStatus: "occupied",
+      currentLeaseId: "lease-ref",
+      currentTenantId: "tenant-ref",
+    });
+    leaseDocs.set("lease-ref", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-ref",
+      propertyId: "property-1",
+      unitId: "unit-ref",
+      status: "active",
+      startDate: "2025-05-01",
+      endDate: "2026-04-30",
+    });
+
+    const { getTenantDetailBundle } = await import("../tenantDetailsService");
+    const bundle = await getTenantDetailBundle("tenant-ref", { landlordId: "landlord-1" });
+
+    expect(bundle.currentLease).toBeNull();
+    expect(bundle.lease).toEqual(expect.objectContaining({ id: "lease-ref" }));
+    expect(bundle.canonicalState).toMatchObject({
+      leaseTermState: "past",
+      occupancyState: "review_needed",
+      tenantRelationshipState: "occupancy_unresolved",
+      supportingLeaseId: null,
+    });
+  });
+
   it("exposes only a valid landlord-owned lease for the matching tenant", async () => {
     tenantDocs.set("tenant-1", { landlordId: "landlord-1", fullName: "Tenant One", currentLeaseId: "lease-1", status: "Current" });
     propertyDocs.set("property-1", { landlordId: "landlord-1", name: "Property" });
     unitDocs.set("unit-1", { landlordId: "landlord-1", propertyId: "property-1", unitNumber: "1", status: "occupied", occupancyStatus: "occupied" });
-    leaseDocs.set("lease-1", { landlordId: "landlord-1", tenantId: "tenant-1", propertyId: "property-1", unitId: "unit-1", status: "active", monthlyRent: 1800 });
+    leaseDocs.set("lease-1", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      propertyId: "property-1",
+      unitId: "unit-1",
+      status: "active",
+      startDate: "2026-05-01",
+      endDate: "2027-04-30",
+      monthlyRent: 1800,
+    });
 
     const { getTenantDetailBundle } = await import("../tenantDetailsService");
     const bundle = await getTenantDetailBundle("tenant-1", { landlordId: "landlord-1" });
@@ -469,7 +600,8 @@ describe("getTenantDetailBundle", () => {
     const { getTenantDetailBundle } = await import("../tenantDetailsService");
     const bundle = await getTenantDetailBundle("tenant-1", { landlordId: "landlord-1" });
 
-    expect(bundle.currentLease).toEqual(
+    expect(bundle.currentLease).toBeNull();
+    expect(bundle.lease).toEqual(
       expect.objectContaining({
         id: "lease-1",
         signedDocumentUrl: null,

--- a/rentchain-api/src/services/risk/propertyCredibilitySummary.ts
+++ b/rentchain-api/src/services/risk/propertyCredibilitySummary.ts
@@ -35,6 +35,12 @@ export type PropertyCredibilityLeaseRecord = {
   riskConfidence?: number | null;
 };
 
+type CanonicalUnitState = {
+  leaseTermState?: string | null;
+  occupancyState?: string | null;
+  supportingLeaseId?: string | null;
+};
+
 type TenantCredibilityRecord = {
   id: string;
   tenantScoreValue: number | null;
@@ -84,8 +90,24 @@ export function computePropertyCredibilitySummary(input: {
   propertyId: string;
   leases: PropertyCredibilityLeaseRecord[];
   tenants: TenantCredibilityRecord[];
+  canonicalUnitStates?: Record<string, CanonicalUnitState>;
 }): PropertyCredibilitySummary {
-  const activeLeases = input.leases.filter((lease) => isActiveLeaseStatus(lease.status));
+  const canonicalStates = input.canonicalUnitStates
+    ? Object.values(input.canonicalUnitStates)
+    : null;
+  const canonicalActiveLeaseIds = canonicalStates
+    ? new Set(
+        canonicalStates
+          .filter((state) => state.leaseTermState === "active" && asTrimmedString(state.supportingLeaseId))
+          .map((state) => asTrimmedString(state.supportingLeaseId))
+      )
+    : null;
+  const activeLeases = canonicalActiveLeaseIds
+    ? input.leases.filter((lease) => canonicalActiveLeaseIds.has(lease.id))
+    : input.leases.filter((lease) => isActiveLeaseStatus(lease.status));
+  const occupancyReviewCount = canonicalStates
+    ? canonicalStates.filter((state) => state.occupancyState === "review_needed").length
+    : 0;
   const uniqueTenantIds = Array.from(new Set(activeLeases.flatMap((lease) => toTenantIds(lease))));
   const tenantMap = new Map(input.tenants.map((tenant) => [tenant.id, tenant]));
 
@@ -118,7 +140,7 @@ export function computePropertyCredibilitySummary(input: {
   const activeLeaseCount = activeLeases.length;
   const tenantsWithScoreCount = tenantScores.length;
   const leasesWithRiskCount = leaseScores.length;
-  const lowConfidenceCount = leaseConfidenceCount + tenantConfidenceCount;
+  const lowConfidenceCount = leaseConfidenceCount + tenantConfidenceCount + occupancyReviewCount;
   const missingCredibilityCount = leaseMissingCount + tenantMissingCount;
   const totalEvidenceSlots = activeLeaseCount + uniqueTenantIds.length;
   const usableEvidenceCount = tenantsWithScoreCount + leasesWithRiskCount;
@@ -155,6 +177,7 @@ export async function loadPropertyCredibilitySummary(options: {
   propertyId: string;
   landlordId?: string | null;
   leases: PropertyCredibilityLeaseRecord[];
+  canonicalUnitStates?: Record<string, CanonicalUnitState>;
 }): Promise<PropertyCredibilitySummary> {
   const { included: scopedLeases, excluded } = filterPropertyScopedLeases({
     leases: options.leases,
@@ -193,5 +216,6 @@ export async function loadPropertyCredibilitySummary(options: {
     propertyId: options.propertyId,
     leases: scopedLeases,
     tenants: tenantSnapshots.filter((tenant): tenant is TenantCredibilityRecord => Boolean(tenant)),
+    canonicalUnitStates: options.canonicalUnitStates,
   });
 }

--- a/rentchain-api/src/services/tenantDetailsService.ts
+++ b/rentchain-api/src/services/tenantDetailsService.ts
@@ -34,7 +34,9 @@ import {
 import { deriveLeaseOccupancyCoherence } from "../lib/leases/deriveLeaseOccupancyCoherence";
 import {
   buildCanonicalLeaseOccupancyProjection,
+  resolveCanonicalUnitProjectionInputs,
   toCanonicalLeaseStateInput,
+  type CanonicalLeaseOccupancyProjection,
 } from "../lib/leases/canonicalLeaseOccupancyProjection";
 import { selectCanonicalCurrentLease } from "../lib/leases/canonicalLeaseOccupancyState";
 import { getSignedLeaseDocumentDownload } from "./signing/leaseSigningService";
@@ -68,6 +70,7 @@ export interface TenantRecord {
   source?: string | null;
   createdAt?: string | number | null;
   lifecycle?: TenantLifecycleResult;
+  canonicalState?: CanonicalLeaseOccupancyProjection;
 }
 
 export interface TenantLease {
@@ -506,10 +509,6 @@ async function loadTenantLeaseResolution(tenant: TenantRecord | null, landlordId
   }
 }
 
-async function loadCurrentLeaseSnapshot(tenant: TenantRecord | null, landlordId?: string | null) {
-  return (await loadTenantLeaseResolution(tenant, landlordId)).displayLease;
-}
-
 async function loadPropertyRecord(propertyId: string | null | undefined) {
   const target = String(propertyId || "").trim();
   if (!target) return null;
@@ -707,7 +706,8 @@ async function loadApplicationRawById(applicationId: string | null | undefined) 
 
 async function hydrateTenantDisplayFields(tenant: TenantRecord, landlordId?: string | null): Promise<TenantRecord> {
   const hydrated: TenantRecord = { ...tenant };
-  const canonicalLease = await loadCurrentLeaseSnapshot(hydrated, landlordId);
+  const leaseResolution = await loadTenantLeaseResolution(hydrated, landlordId);
+  const displayLease = leaseResolution.displayLease;
   const property = await loadPropertyRecord(hydrated.propertyId || null);
   const unit = await loadUnitRecord(
     hydrated.propertyId || null,
@@ -715,6 +715,24 @@ async function hydrateTenantDisplayFields(tenant: TenantRecord, landlordId?: str
     hydrated.unit || null,
     landlordId
   );
+  const unitInputs = resolveCanonicalUnitProjectionInputs(unit || {});
+  const canonicalState = buildCanonicalLeaseOccupancyProjection({
+    leases: leaseResolution.leases,
+    context: {
+      landlordId: hydrated.landlordId || landlordId,
+      propertyId: displayLease?.propertyId || hydrated.propertyId,
+      unitId: displayLease?.unitId || hydrated.unitId,
+      tenantId: hydrated.id,
+    },
+    ...unitInputs,
+    persistedTenantStatus: hydrated.status,
+    currentLeasePointerId: hydrated.currentLeaseId,
+    tenantId: hydrated.id,
+  });
+  hydrated.canonicalState = canonicalState;
+  const canonicalLease = canonicalState.supportingLeaseId
+    ? leaseResolution.leases.find((lease) => lease.id === canonicalState.supportingLeaseId) || null
+    : null;
 
   const propertyName = pickString(hydrated.propertyName, property?.name);
   if (propertyName) hydrated.propertyName = propertyName;
@@ -907,7 +925,7 @@ export async function getTenantDetailBundle(tenantId: string, opts: TenantQueryO
       unitId: currentLeaseRecord?.unitId || tenant?.unitId,
       tenantId,
     },
-    persistedUnitOccupancy: unit?.occupancyStatus || unit?.status,
+    ...resolveCanonicalUnitProjectionInputs(unit || {}),
     persistedTenancyStatus: currentTenancy?.status,
     persistedTenantStatus: tenant?.status,
     currentLeasePointerId: tenant?.currentLeaseId,
@@ -945,7 +963,7 @@ export async function getTenantDetailBundle(tenantId: string, opts: TenantQueryO
   return {
     tenant,
     lease,
-    currentLease: lease,
+    currentLease: canonicalState.supportingLeaseId === lease?.id ? lease : null,
     property,
     unit: unit
       ? {

--- a/rentchain-api/src/services/tenantDetailsService.ts
+++ b/rentchain-api/src/services/tenantDetailsService.ts
@@ -13,7 +13,6 @@ import {
 import {
   groupLeaseAgreementCandidates,
   pickAgreementWinner,
-  pickTenantWinningAgreement,
 } from "./leasePartyConsolidationService";
 import { buildCredibilityInsights, type CredibilityInsights } from "./risk/credibilityInsights";
 import { buildMoveInRequirements, type MoveInRequirements } from "./moveInRequirements";
@@ -33,6 +32,11 @@ import {
   type TenantLifecycleResult,
 } from "../lib/tenants/deriveTenantLifecycle";
 import { deriveLeaseOccupancyCoherence } from "../lib/leases/deriveLeaseOccupancyCoherence";
+import {
+  buildCanonicalLeaseOccupancyProjection,
+  toCanonicalLeaseStateInput,
+} from "../lib/leases/canonicalLeaseOccupancyProjection";
+import { selectCanonicalCurrentLease } from "../lib/leases/canonicalLeaseOccupancyState";
 import { getSignedLeaseDocumentDownload } from "./signing/leaseSigningService";
 
 export interface TenantRecord {
@@ -205,30 +209,16 @@ function normalizeTenantEmail(value: any): string | null {
 }
 
 const TENANT_PROFILE_LEASE_STATUSES = new Set([
-  "active",
-  "current",
-  "notice_pending",
-  "renewal_pending",
-  "renewal_accepted",
-  "move_out_pending",
-  "signed",
-  "signed_future",
-  "fully_executed",
-  "pending_signature",
-  "sent",
-  "ready_for_tenant_signature",
-  "tenant_signed",
-  "ready_for_landlord_signature",
-  "landlord_signed",
+  "active", "current", "notice_pending", "renewal_pending", "renewal_accepted", "move_out_pending",
+  "signed", "signed_future", "fully_executed", "pending_signature", "sent",
+  "ready_for_tenant_signature", "tenant_signed", "ready_for_landlord_signature", "landlord_signed",
 ]);
 
 function isTenantProfileLeaseCandidate(raw: Record<string, unknown>): boolean {
   const status = normalizeIdentityString((raw as any)?.status);
   const signingStatus = normalizeIdentityString(
-    (raw as any)?.currentSigningStatus ||
-      (raw as any)?.signingStatus ||
-      (raw as any)?.leaseSigningStatus ||
-      (raw as any)?.providerSigningStatus
+    (raw as any)?.currentSigningStatus || (raw as any)?.signingStatus ||
+    (raw as any)?.leaseSigningStatus || (raw as any)?.providerSigningStatus
   );
   return isCurrentLeaseStatus(status) || TENANT_PROFILE_LEASE_STATUSES.has(status) || TENANT_PROFILE_LEASE_STATUSES.has(signingStatus);
 }
@@ -435,9 +425,9 @@ async function loadTenantRecord(tenantId: string, landlordId?: string | null): P
   return null;
 }
 
-async function loadCurrentLeaseSnapshot(tenant: TenantRecord | null, landlordId?: string | null) {
+async function loadTenantLeaseResolution(tenant: TenantRecord | null, landlordId?: string | null) {
   const tenantId = String(tenant?.id || "").trim();
-  if (!tenantId) return null;
+  if (!tenantId) return { displayLease: null, leases: [] as any[] };
   try {
     const leasesRef = db.collection("leases");
     const hintedLeaseId = String(tenant?.currentLeaseId || "").trim();
@@ -464,9 +454,9 @@ async function loadCurrentLeaseSnapshot(tenant: TenantRecord | null, landlordId?
       const tenantMatch = Array.isArray((raw as any)?.tenantIds)
         ? (raw as any).tenantIds.map((value: any) => String(value || "").trim()).includes(tenantId)
         : String((raw as any)?.tenantId || (raw as any)?.primaryTenantId || "").trim() === tenantId;
-      return landlordMatch && tenantMatch && isTenantProfileLeaseCandidate(raw);
+      return landlordMatch && tenantMatch;
     });
-    if (!currentEntries.length) return null;
+    if (!currentEntries.length) return { displayLease: null, leases: [] as any[] };
 
     const propertyIds = Array.from(
       new Set(
@@ -490,21 +480,34 @@ async function loadCurrentLeaseSnapshot(tenant: TenantRecord | null, landlordId?
       };
     });
     const grouped = groupLeaseAgreementCandidates(agreementCandidates);
-    const tenantGroup = pickTenantWinningAgreement([...grouped.mergeGroups, ...grouped.ambiguousGroups], tenantId);
-    if (tenantGroup) {
-      return pickAgreementWinner(tenantGroup.candidates).lease;
-    }
-
-    const directMatch = agreementCandidates.find((candidate) =>
-      Array.isArray((candidate.raw as any)?.tenantIds)
-        ? (candidate.raw as any).tenantIds.map((value: any) => String(value || "").trim()).includes(tenantId)
-        : String((candidate.raw as any)?.tenantId || "").trim() === tenantId
-    );
-    return directMatch?.lease || pickAgreementWinner(agreementCandidates).lease;
+    const representatives = [
+      ...grouped.mergeGroups.map((group) => pickAgreementWinner(group.candidates).lease),
+      ...grouped.ambiguousGroups.map((group) => pickAgreementWinner(group.candidates).lease),
+      ...grouped.singles.map((candidate) => candidate.lease),
+    ];
+    const selection = selectCanonicalCurrentLease(representatives.map(toCanonicalLeaseStateInput), {
+      landlordId,
+      tenantId,
+    });
+    const selectedLease = selection.lease
+      ? representatives.find((lease) => lease.id === selection.lease?.id) || null
+      : null;
+    const displayCandidates = representatives.filter((lease) => isTenantProfileLeaseCandidate(lease));
+    const hintedLease = displayCandidates.find((lease) => lease.id === hintedLeaseId) || null;
+    return {
+      displayLease: selectedLease || hintedLease || (displayCandidates.length
+        ? pickAgreementWinner(displayCandidates.map((lease) => ({ lease, raw: lease }))).lease
+        : null),
+      leases: representatives,
+    };
   } catch (err) {
-    console.error("[tenantDetailsService] loadCurrentLeaseSnapshot error", err);
-    return null;
+    console.error("[tenantDetailsService] loadTenantLeaseResolution error", err);
+    return { displayLease: null, leases: [] as any[] };
   }
+}
+
+async function loadCurrentLeaseSnapshot(tenant: TenantRecord | null, landlordId?: string | null) {
+  return (await loadTenantLeaseResolution(tenant, landlordId)).displayLease;
 }
 
 async function loadPropertyRecord(propertyId: string | null | undefined) {
@@ -759,7 +762,8 @@ export async function getTenantDetailBundle(tenantId: string, opts: TenantQueryO
       FALLBACK_TENANTS[0];
   }
 
-  const currentLeaseRecord = await loadCurrentLeaseSnapshot(tenant, landlordId);
+  const leaseResolution = await loadTenantLeaseResolution(tenant, landlordId);
+  const currentLeaseRecord = leaseResolution.displayLease;
   const baseCurrentLeaseRaw = await loadLeaseRawById(currentLeaseRecord?.id || null);
   const [tenantInviteState, tenantTenancies, applicationRaw, latestSigningRequest, latestSigningSignedEvent] = await Promise.all([
     loadLatestTenantInviteState(tenant, landlordId),
@@ -893,6 +897,22 @@ export async function getTenantDetailBundle(tenantId: string, opts: TenantQueryO
     archivedAt: (tenant as any)?.archivedAt || (currentLeaseRaw as any)?.archivedAt,
     isArchived: (tenant as any)?.isArchived || (currentLeaseRaw as any)?.isArchived,
   });
+  const canonicalState = buildCanonicalLeaseOccupancyProjection({
+    leases: leaseResolution.leases.map((candidate) =>
+      candidate.id === currentLeaseRecord?.id ? { ...currentLeaseRaw, ...candidate } : candidate
+    ),
+    context: {
+      landlordId: tenant?.landlordId || landlordId,
+      propertyId: currentLeaseRecord?.propertyId || tenant?.propertyId,
+      unitId: currentLeaseRecord?.unitId || tenant?.unitId,
+      tenantId,
+    },
+    persistedUnitOccupancy: unit?.occupancyStatus || unit?.status,
+    persistedTenancyStatus: currentTenancy?.status,
+    persistedTenantStatus: tenant?.status,
+    currentLeasePointerId: tenant?.currentLeaseId,
+    tenantId,
+  });
   const insights: any[] = [];
   const credibilityInsights = buildCredibilityInsights({ tenant, leaseRaw: currentLeaseRaw });
   const moveInRequirements = buildMoveInRequirements({
@@ -945,5 +965,6 @@ export async function getTenantDetailBundle(tenantId: string, opts: TenantQueryO
     ledgerSummary,
     lifecycle,
     stateCoherence,
+    canonicalState,
   };
 }

--- a/rentchain-frontend/src/api/leasesApi.ts
+++ b/rentchain-frontend/src/api/leasesApi.ts
@@ -1,6 +1,7 @@
 import { apiJson } from "@/api/http";
 import type { LeaseRiskSnapshot } from "@/types/leaseRisk";
 import type { PropertyCredibilitySummary } from "@/types/credibilitySummary";
+import type { CanonicalLeaseOccupancyState } from "@/lib/leases/canonicalStatePresentation";
 
 export type LeaseStatus = "active" | "notice_pending" | "renewal_pending" | "renewal_accepted" | "move_out_pending" | "ended" | "archived";
 export type LeaseRenewalStatus = "unknown" | "offered" | "accepted" | "declined";
@@ -46,6 +47,7 @@ export interface Lease {
   riskConfidence?: number | null;
   createdAt: string;
   updatedAt: string;
+  canonicalState?: CanonicalLeaseOccupancyState | null;
 }
 
 export type LeaseStateCoherence = {
@@ -465,8 +467,8 @@ export async function getLeasesForTenant(
 
 export async function getLeasesForProperty(
   propertyId: string
-): Promise<{ leases: Lease[]; diagnostics?: PropertyLeaseDiagnostic[]; credibilitySummary?: PropertyCredibilitySummary | null }> {
-  return apiJson<{ leases: Lease[]; diagnostics?: PropertyLeaseDiagnostic[]; credibilitySummary?: PropertyCredibilitySummary | null }>(
+): Promise<{ leases: Lease[]; canonicalUnitStates?: Record<string, CanonicalLeaseOccupancyState>; diagnostics?: PropertyLeaseDiagnostic[]; credibilitySummary?: PropertyCredibilitySummary | null }> {
+  return apiJson<{ leases: Lease[]; canonicalUnitStates?: Record<string, CanonicalLeaseOccupancyState>; diagnostics?: PropertyLeaseDiagnostic[]; credibilitySummary?: PropertyCredibilitySummary | null }>(
     `/leases/property/${encodeURIComponent(propertyId)}`
   );
 }

--- a/rentchain-frontend/src/api/tenantDetail.ts
+++ b/rentchain-frontend/src/api/tenantDetail.ts
@@ -2,6 +2,7 @@
 import type { TenantApiModel, TenantLifecycle } from "./tenants";
 import type { CredibilityInsights } from "@/types/credibilityInsights";
 import type { LeaseStateCoherence } from "./leasesApi";
+import type { CanonicalLeaseOccupancyState } from "@/lib/leases/canonicalStatePresentation";
 import { apiFetch } from "./http";
 
 export interface TenantDetailTenant extends TenantApiModel {
@@ -246,6 +247,7 @@ export interface TenantDetailBundle {
   moveInReadiness?: MoveInReadiness | null;
   lifecycle?: TenantLifecycle | null;
   stateCoherence?: LeaseStateCoherence | null;
+  canonicalState?: CanonicalLeaseOccupancyState | null;
 }
 
 export async function fetchTenantDetail(tenantId: string): Promise<TenantDetailBundle> {

--- a/rentchain-frontend/src/api/tenantsApi.ts
+++ b/rentchain-frontend/src/api/tenantsApi.ts
@@ -2,6 +2,7 @@ import { apiJson, getAuthToken, resolveApiUrl } from "@/lib/apiClient";
 import { getFirebaseIdToken } from "@/lib/firebaseAuthToken";
 import { createPdfExportTimer, errorCodeFromUnknown, recordPdfExportEvent } from "@/lib/pdfExportObservability";
 import { apiFetch } from "./http";
+import type { CanonicalLeaseOccupancyState } from "@/lib/leases/canonicalStatePresentation";
 
 type TenantListResponse = TenantApiModel[] | { tenants?: TenantApiModel[] };
 type TenanciesResponse = TenancyApiModel[] | { tenancies?: TenancyApiModel[] };
@@ -90,6 +91,7 @@ export interface TenantApiModel {
   hiddenFromActiveLists?: boolean;
   tenancies?: TenancyApiModel[];
   lifecycle?: TenantLifecycle;
+  canonicalState?: CanonicalLeaseOccupancyState;
 }
 
 /**

--- a/rentchain-frontend/src/components/properties/PropertyDetailPanel.test.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyDetailPanel.test.tsx
@@ -520,6 +520,18 @@ describe("PropertyDetailPanel", () => {
     expect(screen.queryByText("tenant-1")).not.toBeInTheDocument();
   });
 
+  it("prefers canonical review-needed occupancy over a stale saved occupied status", async () => {
+    mocks.fetchUnitsForProperty.mockResolvedValue([{ id: "unit-1", unitNumber: "101", status: "occupied", rent: 1850 }]);
+    mocks.getLeasesForProperty.mockResolvedValue({
+      leases: [{ id: "lease-past", tenantId: "tenant-1", propertyId: "prop-1", unitId: "unit-1", unitNumber: "101", monthlyRent: 1850, startDate: "2025-05-01", endDate: "2026-04-30", status: "active", createdAt: "2025-01-01", updatedAt: "2025-01-01" }],
+      canonicalUnitStates: { "unit-1": { leaseTermState: "past", occupancyState: "review_needed", tenantRelationshipState: "occupancy_unresolved", supportingLeaseId: null, reasons: ["OCCUPIED_WITHOUT_CURRENT_LEASE"] } },
+      credibilitySummary: null,
+    });
+    render(<MemoryRouter><PropertyDetailPanel property={{ id: "prop-1", name: "Harbour View", addressLine1: "12 Wharf Street", city: "Halifax", province: "NS", postalCode: "B3H 1A1", country: "Canada", totalUnits: 1, amenities: [], units: [], createdAt: new Date().toISOString() }} /></MemoryRouter>);
+    expect((await screen.findAllByText("Review needed")).length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Past lease · Occupancy requires review").length).toBeGreaterThan(0);
+  });
+
   it("hydrates lease risk unit labels from property units instead of showing raw unit ids", async () => {
     mocks.fetchUnitsForProperty.mockResolvedValue([
       {

--- a/rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx
@@ -54,6 +54,7 @@ import {
   type UnitOccupancyStatus,
 } from "@/lib/leases/leaseLifecycle";
 import { getUnitsNeedingOccupancySetup } from "./occupancyPrompt";
+import type { CanonicalLeaseOccupancyState } from "@/lib/leases/canonicalStatePresentation";
 
 interface PropertyDetailPanelProps {
   property: Property | null;
@@ -320,6 +321,7 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
     currentPlan === "pro" ||
     currentPlan === "elite";
   const [leases, setLeases] = useState<Lease[]>([]);
+  const [canonicalUnitStates, setCanonicalUnitStates] = useState<Record<string, CanonicalLeaseOccupancyState>>({});
   const [credibilitySummary, setCredibilitySummary] = useState<PropertyCredibilitySummary | null>(null);
   const [isLeasesLoading, setIsLeasesLoading] = useState(false);
   const [leasesError, setLeasesError] = useState<string | null>(null);
@@ -709,6 +711,7 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
     const currentId = propertyId;
     if (!property) {
       setLeases([]);
+      setCanonicalUnitStates({});
       setCredibilitySummary(null);
       setLeasesLoadingStates(false, null);
       setPayments([]);
@@ -725,6 +728,7 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
         if (!cancelled) {
           if (currentId === propertyId) {
             setLeases(data.leases);
+            setCanonicalUnitStates(data.canonicalUnitStates ?? {});
             setCredibilitySummary(data.credibilitySummary ?? null);
             setLeasesError(null);
           }
@@ -733,6 +737,7 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
         console.error("[PropertyDetailPanel] Failed to load leases", err);
         if (!cancelled) {
           setLeases([]);
+          setCanonicalUnitStates({});
           setCredibilitySummary(null);
           setLeasesError("Leases could not be loaded");
         }
@@ -835,8 +840,29 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
   const collectionRate =
     currentOccupiedRentTotal > 0 ? totalCollectedThisMonth / currentOccupiedRentTotal : 0;
   const getUnitOccupancy = useCallback(
-    (unit: any) => applySavedUnitOccupancy(unit, deriveUnitOccupancyFromLeases(unit, leases)),
-    [leases]
+    (unit: any): UnitOccupancy => {
+      const unitId = String(unit?.id || unit?.unitId || "").trim();
+      const canonical = canonicalUnitStates[unitId];
+      if (!canonical) return applySavedUnitOccupancy(unit, deriveUnitOccupancyFromLeases(unit, leases));
+      const supportingLease = canonical.supportingLeaseId
+        ? leases.find((lease) => lease.id === canonical.supportingLeaseId) || null
+        : null;
+      if (canonical.occupancyState === "occupied") {
+        return { status: "occupied", label: "Occupied", lease: supportingLease };
+      }
+      if (canonical.occupancyState === "review_needed") {
+        return {
+          status: "review_required",
+          label: "Review needed",
+          lease: supportingLease,
+          reason: canonical.leaseTermState === "past"
+            ? "Past lease · Occupancy requires review"
+            : "Lease and occupancy records require review",
+        };
+      }
+      return { status: "vacant", label: "Vacant", lease: null };
+    },
+    [canonicalUnitStates, leases]
   );
   const getUnitOccupancyView = useCallback(
     (unit: any) => buildUnitOccupancyView(unit, getUnitOccupancy(unit)),

--- a/rentchain-frontend/src/components/tenants/TenantDetailPanel.test.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantDetailPanel.test.tsx
@@ -368,4 +368,17 @@ describe("TenantDetailPanel", () => {
     expect(screen.queryByText("Apr 29, 2027")).not.toBeInTheDocument();
     await waitFor(() => expect(mocks.fetchLeaseLedger).toHaveBeenCalledWith("lease-1"));
   });
+
+  it("uses canonical expired, review-needed occupancy, and review-needed relationship labels", async () => {
+    mocks.useTenantDetail.mockReturnValue({ loading: false, error: null, bundle: {
+      tenant: { id: "tenant-1", fullName: "Taylor Tenant", status: "Current", propertyName: "Harbour View", unit: "101" },
+      currentLease: { id: "lease-past", tenantId: "tenant-1", propertyName: "Harbour View", unit: "101", leaseStart: "2025-05-01", leaseEnd: "2026-04-30", monthlyRent: 1850, status: "active" },
+      canonicalState: { leaseTermState: "past", occupancyState: "review_needed", tenantRelationshipState: "occupancy_unresolved", supportingLeaseId: null, reasons: ["OCCUPIED_WITHOUT_CURRENT_LEASE"] },
+      property: { id: "prop-1", name: "Harbour View" }, unit: { id: "unit-1", unitNumber: "101" }, moveInReadiness: null,
+    }});
+    render(<MemoryRouter><TenantDetailPanel tenantId="tenant-1" /></MemoryRouter>);
+    expect((await screen.findAllByText("Expired")).length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Review needed").length).toBeGreaterThanOrEqual(2);
+    expect(screen.queryByText("Current")).not.toBeInTheDocument();
+  });
 });

--- a/rentchain-frontend/src/components/tenants/TenantDetailPanel.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantDetailPanel.tsx
@@ -30,6 +30,11 @@ import { FinancialActivityPanel } from "./FinancialActivityPanel";
 import { FeatureGate } from "@/components/billing/FeatureGate";
 import { LockedFeature } from "@/components/billing/LockedFeature";
 import { printSummaryDocument } from "@/utils/printSummary";
+import {
+  canonicalLeaseTermLabel,
+  canonicalOccupancyLabel,
+  canonicalTenantRelationshipLabel,
+} from "@/lib/leases/canonicalStatePresentation";
 
 interface TenantDetailPanelProps {
   tenantId: string | null;
@@ -167,6 +172,7 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityR
   const lease = bundle.currentLease || bundle.lease;
   const lifecycle = bundle.lifecycle || tenant.lifecycle || null;
   const stateCoherence = bundle.stateCoherence || null;
+  const canonicalState = bundle.canonicalState || null;
   const property = bundle.property || null;
   const unit = bundle.unit || null;
   const activeOccupantWithoutLease = !lease && [unit?.status, unit?.occupancyStatus].some((value) =>
@@ -594,9 +600,10 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityR
         />
         <DetailField
           label="Lease Status"
-          value={lease?.status ? formatLeaseStatus(lease.status) : activeOccupantWithoutLease ? "Active occupant — no lease linked" : "--"}
+          value={canonicalState ? canonicalLeaseTermLabel(canonicalState.leaseTermState) : lease?.status ? formatLeaseStatus(lease.status) : activeOccupantWithoutLease ? "Active occupant — no lease linked" : "--"}
         />
-        <DetailField label="Lifecycle" value={lifecycle?.lifecycleLabel ?? "--"} />
+        <DetailField label="Lifecycle" value={canonicalState ? canonicalLeaseTermLabel(canonicalState.leaseTermState) : lifecycle?.lifecycleLabel ?? "--"} />
+        {canonicalState ? <DetailField label="Occupancy" value={canonicalOccupancyLabel(canonicalState.occupancyState)} /> : null}
         {stateCoherence ? (
           <DetailField
             label="State Coherence"
@@ -615,7 +622,7 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityR
             tenant.balance != null ? `$${Number(tenant.balance).toLocaleString()}` : "$0"
           }
         />
-        <DetailField label="Tenant Status" value={tenant.status ?? "--"} />
+        <DetailField label="Tenant Status" value={canonicalState ? canonicalTenantRelationshipLabel(canonicalState.tenantRelationshipState) : tenant.status ?? "--"} />
         {lifecycle?.flags?.hasStateConflict ? (
           <DetailField label="Lifecycle Review" value="Source status conflict detected" />
         ) : null}
@@ -644,7 +651,7 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityR
           <div style={{ display: "grid", gridTemplateColumns: "repeat(2, minmax(0, 1fr))", gap: 10 }}>
             <DetailField label="Email" value={tenant.email ?? "--"} />
             <DetailField label="Phone" value={tenant.phone ?? "--"} />
-            <DetailField label="Current lease status" value={formatLeaseStatus(lease?.status)} />
+            <DetailField label="Current lease status" value={canonicalState ? canonicalLeaseTermLabel(canonicalState.leaseTermState) : formatLeaseStatus(lease?.status)} />
             <DetailField
               label="Monthly rent"
               value={
@@ -655,7 +662,7 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityR
             />
             <DetailField label="Lease start" value={formatDateLabel(tenant.leaseStart ?? lease?.leaseStart)} />
             <DetailField label="Lease end" value={formatDateLabel(tenant.leaseEnd ?? lease?.leaseEnd)} />
-            <DetailField label="Lifecycle" value={lifecycle?.lifecycleLabel ?? "--"} />
+            <DetailField label="Lifecycle" value={canonicalState ? canonicalLeaseTermLabel(canonicalState.leaseTermState) : lifecycle?.lifecycleLabel ?? "--"} />
             <DetailField label="Risk level" value={riskLevel} />
           </div>
           <section style={{ display: "grid", gap: 6 }}>

--- a/rentchain-frontend/src/lib/leases/canonicalStatePresentation.test.ts
+++ b/rentchain-frontend/src/lib/leases/canonicalStatePresentation.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import {
+  canonicalLeaseTermLabel,
+  canonicalOccupancyLabel,
+  canonicalTenantRelationshipLabel,
+} from "./canonicalStatePresentation";
+
+describe("canonical state presentation", () => {
+  it("keeps lease term, occupancy, and relationship as separate labels", () => {
+    expect(canonicalLeaseTermLabel("past")).toBe("Expired");
+    expect(canonicalOccupancyLabel("review_needed")).toBe("Review needed");
+    expect(canonicalTenantRelationshipLabel("occupancy_unresolved")).toBe("Review needed");
+  });
+
+  it("presents active canonical state without consulting legacy status", () => {
+    expect(canonicalLeaseTermLabel("active")).toBe("Active");
+    expect(canonicalOccupancyLabel("occupied")).toBe("Occupied");
+    expect(canonicalTenantRelationshipLabel("current_occupant")).toBe("Current occupant");
+  });
+});

--- a/rentchain-frontend/src/lib/leases/canonicalStatePresentation.ts
+++ b/rentchain-frontend/src/lib/leases/canonicalStatePresentation.ts
@@ -1,0 +1,36 @@
+export type CanonicalLeaseTermState =
+  | "draft"
+  | "upcoming"
+  | "active"
+  | "past"
+  | "ended"
+  | "terminated"
+  | "unknown";
+
+export type CanonicalLeaseOccupancyState = {
+  leaseTermState: CanonicalLeaseTermState | null;
+  occupancyState: "vacant" | "occupied" | "review_needed";
+  tenantRelationshipState: "current_occupant" | "past_tenant" | "occupancy_unresolved";
+  supportingLeaseId: string | null;
+  reasons: string[];
+};
+
+export function canonicalLeaseTermLabel(state: CanonicalLeaseTermState | null | undefined) {
+  if (state === "past") return "Expired";
+  if (!state || state === "unknown") return "Unknown";
+  return state.charAt(0).toUpperCase() + state.slice(1);
+}
+
+export function canonicalOccupancyLabel(state: CanonicalLeaseOccupancyState["occupancyState"] | null | undefined) {
+  if (state === "occupied") return "Occupied";
+  if (state === "vacant") return "Vacant";
+  return "Review needed";
+}
+
+export function canonicalTenantRelationshipLabel(
+  state: CanonicalLeaseOccupancyState["tenantRelationshipState"] | null | undefined
+) {
+  if (state === "current_occupant") return "Current occupant";
+  if (state === "past_tenant") return "Past tenant";
+  return "Review needed";
+}

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
@@ -1231,4 +1231,18 @@ describe("LandlordActiveLeasesPage", () => {
     expect(screen.getByRole("button", { name: "Archive lease" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Enable rent collection/i })).toBeInTheDocument();
   });
+
+  it("uses canonical expired and review-needed labels instead of a stale active status", async () => {
+    mocks.getActiveLeasesForLandlord.mockResolvedValue({
+      leases: [{
+        id: "lease-past", propertyId: "prop-1", propertyName: "Harbour View", unitNumber: "101",
+        monthlyRent: 1850, startDate: "2025-05-01", endDate: "2026-04-30", status: "active",
+        tenantName: "Jane Tenant", tenantEmail: "jane@example.com",
+        canonicalState: { leaseTermState: "past", occupancyState: "review_needed", tenantRelationshipState: "occupancy_unresolved", supportingLeaseId: null, reasons: ["OCCUPIED_WITHOUT_CURRENT_LEASE"] },
+      }],
+    });
+    render(<MemoryRouter><LandlordActiveLeasesPage /></MemoryRouter>);
+    expect((await screen.findAllByText("Expired")).length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Review needed").length).toBeGreaterThan(0);
+  });
 });

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
@@ -27,6 +27,7 @@ import { LockedFeature } from "@/components/billing/LockedFeature";
 import { useEntitlements } from "@/hooks/useEntitlements";
 import { isUpgradeRequiredError } from "@/lib/gatedFeatureErrors";
 import "./LandlordActiveLeasesPage.css";
+import { canonicalLeaseTermLabel, canonicalOccupancyLabel } from "@/lib/leases/canonicalStatePresentation";
 
 function formatCurrency(value: number | null | undefined) {
   const amount = typeof value === "number" ? value : 0;
@@ -204,6 +205,7 @@ function formatCoherenceToken(value: string | null | undefined) {
 }
 
 function occupancyDisplayLabel(lease: LandlordActiveLease) {
+  if (lease.canonicalState) return canonicalOccupancyLabel(lease.canonicalState.occupancyState);
   const coherence = lease.stateCoherence;
   if (!coherence) return null;
   if (coherence.flags?.requiresReview || coherence.occupancyState === "review_required" || coherence.occupancyState === "unknown") {
@@ -1042,7 +1044,7 @@ export default function LandlordActiveLeasesPage() {
                       <div style={{ color: leaseWorkspaceTheme.neutralText, fontSize: 12 }}>{lease.tenantEmail || "No email on file"}</div>
                     </td>
                     <td style={{ padding: 12 }}>
-                      <div>{statusBadge(lease.status)}</div>
+                      <div>{statusBadge(lease.canonicalState ? canonicalLeaseTermLabel(lease.canonicalState.leaseTermState) : lease.status)}</div>
                       {renderOccupancyDisplay(lease)}
                       {lease.leaseExecution ? (
                         <div style={{ display: "grid", gap: 4, marginTop: 6 }}>
@@ -1151,7 +1153,7 @@ export default function LandlordActiveLeasesPage() {
               <div style={{ display: "grid", gap: 10, gridTemplateColumns: "repeat(2, minmax(0, 1fr))" }}>
                 <div>
                   <div style={{ color: leaseWorkspaceTheme.neutralText, fontSize: 12 }}>Status</div>
-                  <div style={{ marginTop: 6 }}>{statusBadge(lease.status)}</div>
+                  <div style={{ marginTop: 6 }}>{statusBadge(lease.canonicalState ? canonicalLeaseTermLabel(lease.canonicalState.leaseTermState) : lease.status)}</div>
                   {renderOccupancyDisplay(lease)}
                 </div>
                 <div>

--- a/rentchain-frontend/src/pages/TenantsPage.test.tsx
+++ b/rentchain-frontend/src/pages/TenantsPage.test.tsx
@@ -386,6 +386,14 @@ describe("TenantsPage", () => {
         unit: "Unit 4",
         unitId: "unit-4",
         currentLeaseId: "lease-signed-1",
+        status: "active",
+        canonicalState: {
+          leaseTermState: "active",
+          occupancyState: "occupied",
+          tenantRelationshipState: "current_occupant",
+          supportingLeaseId: "lease-signed-1",
+          reasons: [],
+        },
       },
     ]);
     mocks.fetchTenantTenanciesMock.mockResolvedValue([
@@ -501,6 +509,14 @@ describe("TenantsPage", () => {
         unit: "Unit 4",
         unitId: "unit-4",
         currentLeaseId: "lease-signed-1",
+        status: "active",
+        canonicalState: {
+          leaseTermState: "active",
+          occupancyState: "occupied",
+          tenantRelationshipState: "current_occupant",
+          supportingLeaseId: "lease-signed-1",
+          reasons: [],
+        },
       },
     ]);
     mocks.fetchTenantTenanciesMock.mockResolvedValue([]);
@@ -519,6 +535,13 @@ describe("TenantsPage", () => {
           monthlyRent: 1850,
           status: "active",
         },
+        canonicalState: {
+          leaseTermState: "active",
+          occupancyState: "occupied",
+          tenantRelationshipState: "current_occupant",
+          supportingLeaseId: "lease-signed-1",
+          reasons: [],
+        },
       },
       loading: false,
       error: null,
@@ -531,6 +554,7 @@ describe("TenantsPage", () => {
     );
 
     expect(await screen.findByText("Tenant actions")).toBeInTheDocument();
+    expect(screen.getAllByText("Current occupant").length).toBeGreaterThanOrEqual(2);
     expect(
       screen.getByText(
         "Current lease links this tenant to the active lease and unit; no separate active tenancy registration is recorded yet."
@@ -542,6 +566,77 @@ describe("TenantsPage", () => {
     expect(registeredUnitsCard).not.toBeNull();
     expect(within(registeredUnitsCard as HTMLElement).getByText("1")).toBeInTheDocument();
     expect(screen.queryByText("No active tenancy registrations are linked to this tenant.")).not.toBeInTheDocument();
+  });
+
+  it("uses canonical review state and fails closed on an expired historical lease", async () => {
+    mocks.useCapabilitiesMock.mockReturnValue({ features: { tenant_invites: true } });
+    mocks.fetchTenantsMock.mockResolvedValue([
+      {
+        id: "tenant-ref",
+        fullName: "Preview QA Expired Tenant",
+        propertyName: "PR1555 Canonical QA Property",
+        propertyId: "property-1",
+        unit: "REF-EXPIRED",
+        unitId: "unit-ref",
+        currentLeaseId: null,
+        status: "active",
+        lifecycle: { lifecycleLabel: "Active" },
+        canonicalState: {
+          leaseTermState: "past",
+          occupancyState: "review_needed",
+          tenantRelationshipState: "occupancy_unresolved",
+          supportingLeaseId: null,
+          reasons: ["OCCUPIED_WITHOUT_CURRENT_LEASE"],
+        },
+      },
+    ]);
+    mocks.fetchTenantTenanciesMock.mockResolvedValue([
+      { id: "tenancy-stale", tenantId: "tenant-ref", status: "active", unitLabel: "REF-EXPIRED" },
+    ]);
+    mocks.useTenantDetailMock.mockReturnValue({
+      bundle: {
+        tenant: { id: "tenant-ref", fullName: "Preview QA Expired Tenant", status: "active" },
+        currentLease: null,
+        lease: {
+          id: "lease-ref",
+          tenantId: "tenant-ref",
+          propertyId: "property-1",
+          propertyName: "PR1555 Canonical QA Property",
+          unitId: "unit-ref",
+          unit: "REF-EXPIRED",
+          leaseStart: "2025-05-01",
+          leaseEnd: "2026-04-30",
+          monthlyRent: 1800,
+          status: "active",
+        },
+        canonicalState: {
+          leaseTermState: "past",
+          occupancyState: "review_needed",
+          tenantRelationshipState: "occupancy_unresolved",
+          supportingLeaseId: null,
+          reasons: ["OCCUPIED_WITHOUT_CURRENT_LEASE"],
+        },
+      },
+      loading: false,
+      error: null,
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/tenants?tenantId=tenant-ref"]}>
+        <TenantsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Tenant actions")).toBeInTheDocument();
+    expect(screen.getAllByText("Review needed").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText("No current lease linked").length).toBeGreaterThanOrEqual(1);
+    const registeredUnitsCard = screen.getByText("Active registered units").parentElement;
+    expect(registeredUnitsCard).not.toBeNull();
+    expect(within(registeredUnitsCard as HTMLElement).getByText("0")).toBeInTheDocument();
+    expect(
+      screen.getByText("Canonical occupancy requires review; historical property, unit, and lease links are not treated as current.")
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Current lease links this tenant to the active lease and unit/)).not.toBeInTheDocument();
   });
 
   it("shows no current lease linked when neither list nor detail has a current lease", async () => {

--- a/rentchain-frontend/src/pages/TenantsPage.tsx
+++ b/rentchain-frontend/src/pages/TenantsPage.tsx
@@ -27,6 +27,10 @@ import { openUpgradeFlow } from "@/billing/openUpgradeFlow";
 import { isTargetedHiddenTenantId } from "@/lib/testDataVisibilityTargets";
 import { isPlanAtLeast, normalizePlan } from "@/lib/plan";
 import type { TenantLeaseSummary } from "@/api/tenantDetail";
+import {
+  canonicalTenantRelationshipLabel,
+  type CanonicalLeaseOccupancyState,
+} from "@/lib/leases/canonicalStatePresentation";
 import "./TenantsPage.css";
 
 type TenantWithTenancies = TenantApiModel & { tenancies?: TenancyApiModel[] };
@@ -140,7 +144,11 @@ function tenancyStatusLabel(status?: string | null): "Active" | "Inactive" {
   return String(status || "").toLowerCase() === "inactive" ? "Inactive" : "Active";
 }
 
-function tenantLifecycleLabel(tenant?: TenantApiModel | null): string {
+function tenantLifecycleLabel(
+  tenant?: TenantApiModel | null,
+  canonicalState: CanonicalLeaseOccupancyState | null | undefined = tenant?.canonicalState
+): string {
+  if (canonicalState) return canonicalTenantRelationshipLabel(canonicalState.tenantRelationshipState);
   return tenant?.lifecycle?.lifecycleLabel || tenant?.status || "Unknown";
 }
 
@@ -166,20 +174,31 @@ function getErrorMessage(error: unknown, fallback: string): string {
 
 function describeTenantLinkage(
   tenant: TenantApiModel & { tenancies?: TenancyApiModel[] },
-  currentLease?: TenantLeaseSummary | null
+  currentLease?: TenantLeaseSummary | null,
+  canonicalState?: CanonicalLeaseOccupancyState | null
 ) {
   const tenancies = Array.isArray(tenant.tenancies) ? tenant.tenancies : [];
   const activeTenancies = tenancies.filter((tenancy) => tenancy.status !== "inactive");
   const primaryProperty = tenant.propertyName || tenant.propertyId || "No property linked";
   const primaryUnit = tenant.unit || tenant.unitLabel || tenant.unitId || "No unit linked";
-  const currentLeaseId = String(currentLease?.id || "").trim();
+  const candidateLeaseId = String(currentLease?.id || "").trim();
+  const currentLeaseId = canonicalState
+    ? canonicalState.supportingLeaseId === candidateLeaseId
+      ? candidateLeaseId
+      : ""
+    : candidateLeaseId;
   const hasCurrentLeaseLink = Boolean(currentLeaseId);
   const leaseLabel = currentLeaseId
     ? [primaryProperty !== "No property linked" ? primaryProperty : null, primaryUnit !== "No unit linked" ? primaryUnit : null, "Lease"]
         .filter(Boolean)
         .join(" · ")
     : "No current lease linked";
-  const activeTenancyCount = activeTenancies.length || (hasCurrentLeaseLink ? 1 : 0);
+  const canonicalCurrentRelationship = canonicalState?.tenantRelationshipState === "current_occupant";
+  const activeTenancyCount = canonicalState
+    ? canonicalCurrentRelationship
+      ? activeTenancies.length || (hasCurrentLeaseLink ? 1 : 0)
+      : 0
+    : activeTenancies.length || (hasCurrentLeaseLink ? 1 : 0);
 
   return {
     propertyLabel: primaryProperty,
@@ -188,7 +207,9 @@ function describeTenantLinkage(
     leaseId: currentLeaseId || null,
     activeTenancyCount,
     linkageNote:
-      !tenant.propertyId && !tenant.unitId && !currentLeaseId
+      canonicalState && !canonicalCurrentRelationship
+        ? "Canonical occupancy requires review; historical property, unit, and lease links are not treated as current."
+        : !tenant.propertyId && !tenant.unitId && !currentLeaseId
         ? "This tenant record has no canonical property, unit, or current lease linkage yet."
         : activeTenancies.length === 0
         ? hasCurrentLeaseLink
@@ -550,11 +571,12 @@ const loadTenants = useCallback(async () => {
     : null;
   const tenantExists = Boolean(selectedTenant);
   const { bundle: selectedTenantDetailBundle } = useTenantDetail(tenantExists ? selectedTenantId : null);
-  const selectedCurrentLease =
-    selectedTenantDetailBundle?.currentLease || selectedTenantDetailBundle?.lease || null;
+  const selectedCanonicalState =
+    selectedTenantDetailBundle?.canonicalState || selectedTenant?.canonicalState || null;
+  const selectedCurrentLease = selectedTenantDetailBundle?.currentLease || null;
   const selectedCurrentLeaseId = getTenantCurrentLeaseId(selectedTenant, selectedCurrentLease);
   const selectedTenantLinkage = selectedTenant
-    ? describeTenantLinkage(selectedTenant, selectedCurrentLease)
+    ? describeTenantLinkage(selectedTenant, selectedCurrentLease, selectedCanonicalState)
     : null;
   const selectedLeaseLedgerPath = selectedCurrentLeaseId
     ? `/leases/${encodeURIComponent(selectedCurrentLeaseId)}/ledger`
@@ -1038,7 +1060,7 @@ const loadTenants = useCallback(async () => {
                       <Card style={tenantWorkspaceCardStyle}>
                         <div style={{ fontSize: 11, fontWeight: 700, color: text.muted }}>Lifecycle</div>
                         <div style={{ marginTop: 4, fontSize: 14, color: text.primary }}>
-                          {tenantLifecycleLabel(selectedTenant)}
+                          {tenantLifecycleLabel(selectedTenant, selectedCanonicalState)}
                         </div>
                       </Card>
                       <Card style={tenantWorkspaceCardStyle}>


### PR DESCRIPTION
## Summary
- expose additive backend canonical lease, occupancy, and tenant relationship projections
- use the shared canonical state on Properties, Leases, and Tenant Detail while preserving legacy response fields as fallbacks
- fail closed to Review needed for expired occupied records, stale pointers, vacant/current conflicts, and multiple current leases

## Scope
- canonical read-only page integration only
- no occupancy mutation, automatic lease end, automatic vacancy, renewal creation, or legal conclusions
- Resolve Occupancy remains deferred to PR C

## Validation
- frontend: 360 files, 1,784 tests passed
- backend focused canonical and tenant suites: 30 tests passed
- backend active lease routes: 49 tests passed
- backend integrity routes: 17 tests passed
- frontend and backend production builds passed
- package-manager and production deployment governance checks passed
- diff and credential scans passed

## QA
Manual Preview QA remains required for the user-visible Properties, Leases, and Tenants labels before readiness.