### PR TITLE
Add fail-closed temporary Preview backend target support

### DIFF
--- a/rentchain-frontend/server/previewBackendProxy.ts
+++ b/rentchain-frontend/server/previewBackendProxy.ts
@@ -16,6 +16,72 @@ export const PREVIEW_PROXY_CONFIG = {
     "https://rentchain-preview-backend-glistw4pya-nn.a.run.app",
 } as const;
 
+export const PREVIEW_BACKEND_TARGET_KEYS = {
+  permanent: "permanent",
+  pr1555: "pr1555-c99145e5",
+} as const;
+
+export type PreviewBackendTarget = {
+  key: string;
+  cloudRunServiceUrl: string;
+  cloudRunIdTokenAudience: string;
+  temporary: boolean;
+};
+
+const PREVIEW_BACKEND_TARGETS: Record<string, PreviewBackendTarget> = {
+  [PREVIEW_BACKEND_TARGET_KEYS.permanent]: {
+    key: PREVIEW_BACKEND_TARGET_KEYS.permanent,
+    cloudRunServiceUrl: PREVIEW_PROXY_CONFIG.cloudRunServiceUrl,
+    cloudRunIdTokenAudience: PREVIEW_PROXY_CONFIG.cloudRunServiceUrl,
+    temporary: false,
+  },
+  [PREVIEW_BACKEND_TARGET_KEYS.pr1555]: {
+    key: PREVIEW_BACKEND_TARGET_KEYS.pr1555,
+    cloudRunServiceUrl:
+      "https://rentchain-pr1555-qa-c99145e5-glistw4pya-nn.a.run.app",
+    cloudRunIdTokenAudience:
+      "https://rentchain-pr1555-qa-c99145e5-glistw4pya-nn.a.run.app",
+    temporary: true,
+  },
+};
+
+export function assertPreviewBackendTarget(
+  target: PreviewBackendTarget,
+  environment: string,
+): void {
+  const expected = PREVIEW_BACKEND_TARGETS[target.key];
+  if (
+    !expected ||
+    target.cloudRunServiceUrl !== expected.cloudRunServiceUrl ||
+    target.cloudRunIdTokenAudience !== expected.cloudRunIdTokenAudience ||
+    target.cloudRunServiceUrl !== target.cloudRunIdTokenAudience ||
+    target.temporary !== expected.temporary ||
+    (target.temporary && environment !== "preview")
+  ) {
+    throw new Error("PREVIEW_PROXY_TARGET_REJECTED");
+  }
+}
+
+export function resolvePreviewBackendTarget(input: {
+  vercelEnvironment: unknown;
+  targetKey: unknown;
+}): PreviewBackendTarget {
+  const environment = typeof input.vercelEnvironment === "string"
+    ? input.vercelEnvironment.trim()
+    : "";
+  const hasExplicitTarget = input.targetKey !== undefined && input.targetKey !== null;
+  const key = hasExplicitTarget && typeof input.targetKey === "string"
+    ? input.targetKey.trim()
+    : PREVIEW_BACKEND_TARGET_KEYS.permanent;
+  const target = PREVIEW_BACKEND_TARGETS[key];
+
+  if (!key || !target) {
+    throw new Error("PREVIEW_PROXY_TARGET_REJECTED");
+  }
+  assertPreviewBackendTarget(target, environment);
+  return target;
+}
+
 const PROVIDER_PATH =
   `projects/${PREVIEW_PROXY_CONFIG.projectNumber}/locations/global/` +
   `workloadIdentityPools/${PREVIEW_PROXY_CONFIG.workloadIdentityPoolId}/` +
@@ -29,6 +95,14 @@ export const PREVIEW_PROXY_AUTH_CONFIG: PreviewAuthConfig = {
   cloudRunServiceUrl: PREVIEW_PROXY_CONFIG.cloudRunServiceUrl,
   expectedSpikeCommit: "",
 };
+
+function previewAuthConfigForTarget(target: PreviewBackendTarget): PreviewAuthConfig {
+  return {
+    ...PREVIEW_PROXY_AUTH_CONFIG,
+    cloudRunIdTokenAudience: target.cloudRunIdTokenAudience,
+    cloudRunServiceUrl: target.cloudRunServiceUrl,
+  };
+}
 
 export const PREVIEW_PROXY_BODY_LIMIT_BYTES = 10 * 1024 * 1024;
 export const PREVIEW_PROXY_TOKEN_TIMEOUT_MS = 5_000;
@@ -252,6 +326,17 @@ export async function handlePreviewBackendProxy(
     return jsonError(res, 403, "PREVIEW_PROXY_ENVIRONMENT_REJECTED");
   }
 
+  let target: PreviewBackendTarget;
+  try {
+    target = resolvePreviewBackendTarget({
+      vercelEnvironment: process.env.VERCEL_ENV,
+      targetKey: process.env.PREVIEW_BACKEND_TARGET,
+    });
+  } catch {
+    return jsonError(res, 502, "PREVIEW_PROXY_TARGET_REJECTED");
+  }
+  const authConfig = previewAuthConfigForTarget(target);
+
   let route: { backendPath: string; query: string };
   let method: string;
   let body: BodyInit | undefined;
@@ -288,7 +373,7 @@ export async function handlePreviewBackendProxy(
   let googleIdToken: string;
   try {
     vercelOidcToken = await acquireVercelOidcToken(
-      PREVIEW_PROXY_AUTH_CONFIG,
+      authConfig,
       dependencies.getVercelOidcToken,
     );
     if (!vercelOidcToken) {
@@ -301,13 +386,13 @@ export async function handlePreviewBackendProxy(
   try {
     const federatedAccessToken = await exchangeVercelToken(
       vercelOidcToken,
-      PREVIEW_PROXY_AUTH_CONFIG,
+      authConfig,
       stsFetch,
     );
     googleIdToken = await generateCloudRunIdToken(
       federatedAccessToken,
-      PREVIEW_PROXY_AUTH_CONFIG,
-      PREVIEW_PROXY_AUTH_CONFIG.cloudRunIdTokenAudience,
+      authConfig,
+      authConfig.cloudRunIdTokenAudience,
       iamFetch,
     );
   } catch (error) {
@@ -316,7 +401,7 @@ export async function handlePreviewBackendProxy(
   }
 
   const targetUrl =
-    `${PREVIEW_PROXY_CONFIG.cloudRunServiceUrl}${route.backendPath}` +
+    `${target.cloudRunServiceUrl}${route.backendPath}` +
     (route.query ? `?${route.query}` : "");
 
   try {

--- a/rentchain-frontend/src/platform/previewBackendProxy.test.ts
+++ b/rentchain-frontend/src/platform/previewBackendProxy.test.ts
@@ -8,6 +8,9 @@ import {
   PREVIEW_PROXY_AUTH_CONFIG,
   PREVIEW_PROXY_BODY_LIMIT_BYTES,
   PREVIEW_PROXY_CONFIG,
+  PREVIEW_BACKEND_TARGET_KEYS,
+  resolvePreviewBackendTarget,
+  assertPreviewBackendTarget,
   resolvePreviewBackendPath,
 } from "../../server/previewBackendProxy";
 
@@ -92,15 +95,110 @@ function successfulDependencies(upstreamStatus = 200) {
 
 describe("Preview backend proxy", () => {
   const originalVercelEnv = process.env.VERCEL_ENV;
+  const originalPreviewBackendTarget = process.env.PREVIEW_BACKEND_TARGET;
 
   beforeEach(() => {
     process.env.VERCEL_ENV = "preview";
+    delete process.env.PREVIEW_BACKEND_TARGET;
     vi.restoreAllMocks();
   });
 
   afterEach(() => {
     if (originalVercelEnv == null) delete process.env.VERCEL_ENV;
     else process.env.VERCEL_ENV = originalVercelEnv;
+    if (originalPreviewBackendTarget == null) delete process.env.PREVIEW_BACKEND_TARGET;
+    else process.env.PREVIEW_BACKEND_TARGET = originalPreviewBackendTarget;
+  });
+
+  it("keeps the permanent Preview backend as the default target", () => {
+    expect(resolvePreviewBackendTarget({ vercelEnvironment: "preview", targetKey: undefined })).toEqual({
+      key: "permanent",
+      cloudRunServiceUrl: PREVIEW_PROXY_CONFIG.cloudRunServiceUrl,
+      cloudRunIdTokenAudience: PREVIEW_PROXY_CONFIG.cloudRunServiceUrl,
+      temporary: false,
+    });
+  });
+
+  it("couples the authorized PR #1555 service URL and audience internally", () => {
+    const target = resolvePreviewBackendTarget({
+      vercelEnvironment: "preview",
+      targetKey: PREVIEW_BACKEND_TARGET_KEYS.pr1555,
+    });
+    expect(target).toEqual({
+      key: "pr1555-c99145e5",
+      cloudRunServiceUrl: "https://rentchain-pr1555-qa-c99145e5-glistw4pya-nn.a.run.app",
+      cloudRunIdTokenAudience: "https://rentchain-pr1555-qa-c99145e5-glistw4pya-nn.a.run.app",
+      temporary: true,
+    });
+  });
+
+  it.each([
+    ["production", PREVIEW_BACKEND_TARGET_KEYS.pr1555],
+    ["development", PREVIEW_BACKEND_TARGET_KEYS.pr1555],
+    ["preview", ""],
+    ["preview", "unknown"],
+    ["preview", "https://metadata.google.internal"],
+    ["preview", "https://rentchain-landlord-api-cyaabkl54a-uc.a.run.app"],
+    ["preview", "rentchain-pr1555-qa-wrong-region"],
+    ["preview", "rentchain-pr1555-qa-cross-project"],
+  ])("rejects unsafe target selection for %s / %s", (vercelEnvironment, targetKey) => {
+    expect(() => resolvePreviewBackendTarget({ vercelEnvironment, targetKey })).toThrow(
+      "PREVIEW_PROXY_TARGET_REJECTED",
+    );
+  });
+
+  it.each([
+    ["mismatched audience", {
+      key: PREVIEW_BACKEND_TARGET_KEYS.pr1555,
+      cloudRunServiceUrl: "https://rentchain-pr1555-qa-c99145e5-glistw4pya-nn.a.run.app",
+      cloudRunIdTokenAudience: "https://rentchain-preview-backend-glistw4pya-nn.a.run.app",
+      temporary: true,
+    }],
+    ["Production Cloud Run host", {
+      key: PREVIEW_BACKEND_TARGET_KEYS.pr1555,
+      cloudRunServiceUrl: "https://rentchain-landlord-api-cyaabkl54a-uc.a.run.app",
+      cloudRunIdTokenAudience: "https://rentchain-landlord-api-cyaabkl54a-uc.a.run.app",
+      temporary: true,
+    }],
+    ["cross-project host", {
+      key: PREVIEW_BACKEND_TARGET_KEYS.pr1555,
+      cloudRunServiceUrl: "https://rentchain-pr1555-qa-c99145e5-other-project.a.run.app",
+      cloudRunIdTokenAudience: "https://rentchain-pr1555-qa-c99145e5-other-project.a.run.app",
+      temporary: true,
+    }],
+    ["wrong-region host", {
+      key: PREVIEW_BACKEND_TARGET_KEYS.pr1555,
+      cloudRunServiceUrl: "https://rentchain-pr1555-qa-c99145e5-uc.a.run.app",
+      cloudRunIdTokenAudience: "https://rentchain-pr1555-qa-c99145e5-uc.a.run.app",
+      temporary: true,
+    }],
+  ])("rejects a tampered trusted mapping: %s", (_label, target) => {
+    expect(() => assertPreviewBackendTarget(target, "preview")).toThrow(
+      "PREVIEW_PROXY_TARGET_REJECTED",
+    );
+  });
+
+  it("routes the authorized target using the same URL for ID-token audience and upstream", async () => {
+    process.env.PREVIEW_BACKEND_TARGET = PREVIEW_BACKEND_TARGET_KEYS.pr1555;
+    const { requests, dependencies } = successfulDependencies();
+    const res = responseRecorder();
+    await handlePreviewBackendProxy(
+      request("/api/preview-backend/api/me", "GET", {
+        headers: {
+          "x-preview-backend-target": "https://attacker.invalid",
+          cookie: "PREVIEW_BACKEND_TARGET=https://attacker.invalid",
+        },
+        query: { target: "https://attacker.invalid" },
+        body: { target: "https://attacker.invalid" },
+      }),
+      res,
+      dependencies,
+    );
+
+    const expected = "https://rentchain-pr1555-qa-c99145e5-glistw4pya-nn.a.run.app";
+    expect(requests[1].init?.body).toBe(JSON.stringify({ audience: expected, includeEmail: false }));
+    expect(requests[2].url).toBe(`${expected}/api/me`);
+    expect(requests.every(({ url }) => !url.includes("attacker.invalid"))).toBe(true);
   });
 
   it("accepts only Preview and rejects Production or Development", async () => {


### PR DESCRIPTION
## Summary

- preserve the permanent Preview backend as the default
- add one static server-side PR #1555 QA target key
- bind the Cloud Run URL and ID-token audience through one immutable mapping
- reject temporary selection outside Vercel Preview and reject unknown or tampered targets
- ignore browser query/header/body/cookie target injection

## Security boundaries

- no arbitrary backend URL or generic proxy selection
- no Production target or Production environment support
- no cross-project/wrong-region target
- no Terraform, IAM, Cloud Run, product UI, or permanent Preview mutation

## Validation

- focused proxy/auth/route suite: 64 passed
- full frontend: 1,790 passed
- production build: passed
- package governance, credential scan, and diff check: passed

This PR is the separately governed proxy prerequisite for exact-head PR #1555 temporary backend QA.