### PR TITLE
PR C: add bounded Resolve Occupancy workflow

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -93,6 +93,7 @@ import landlordApplicationLinksRoutes from "./routes/landlordApplicationLinksRou
 import publicApplicationLinksRoutes from "./routes/publicApplicationLinksRoutes";
 import tenantsRoutes from "./routes/tenantsRoutes";
 import tenanciesRoutes from "./routes/tenanciesRoutes";
+import occupancyResolutionRoutes from "./routes/occupancyResolutionRoutes";
 import messagesRoutes, { previewQaComposeRoutes } from "./routes/messagesRoutes";
 import propertyNoticesRoutes, { previewQaPropertyNoticesRoutes } from "./routes/propertyNoticesRoutes";
 import rentalApplicationsRoutes from "./routes/rentalApplicationsRoutes";
@@ -646,6 +647,7 @@ app.use("/api/compliance", routeSource("complianceRoutes.ts"), complianceRoutes)
 app.use("/api/decisions", routeSource("decisionRoutes.ts"), decisionRoutes);
 app.get("/api/leases/:leaseId/document-url", routeSource("leaseRoutes.ts"), requireLandlord, handleLeaseDocumentUrl);
 app.use("/api/leases", routeSource("leaseRoutes.ts"), leaseRoutes);
+app.use("/api/occupancy-resolutions", routeSource("occupancyResolutionRoutes.ts"), occupancyResolutionRoutes);
 app.use("/api/tenants", routeSource("tenantsRoutes.ts"), tenantsRoutes);
 app.use("/api", routeSource("tenanciesRoutes.ts"), tenanciesRoutes);
 

--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -449,6 +449,63 @@ describe("leaseRoutes GET /active", () => {
     );
   });
 
+  it("keeps a canonically executed linked lease coherent when signing artifacts are absent", async () => {
+    seedDoc("properties", "prop-link", { landlordId: "landlord-1", name: "Harbour View" });
+    seedDoc("tenants", "tenant-link", {
+      landlordId: "landlord-1",
+      fullName: "Linked Tenant",
+      propertyId: "prop-link",
+      unitId: "unit-link",
+      currentLeaseId: "lease-link",
+      status: "Current",
+    });
+    seedDoc("units", "unit-link", {
+      landlordId: "landlord-1",
+      propertyId: "prop-link",
+      unitNumber: "101",
+      status: "occupied",
+      occupancyStatus: "occupied",
+      tenantId: "tenant-link",
+      currentTenantId: "tenant-link",
+      leaseId: "lease-link",
+      currentLeaseId: "lease-link",
+    });
+    seedDoc("leases", "lease-link", {
+      landlordId: "landlord-1",
+      propertyId: "prop-link",
+      tenantId: "tenant-link",
+      tenantIds: ["tenant-link"],
+      primaryTenantId: "tenant-link",
+      unitId: "unit-link",
+      unitNumber: "101",
+      monthlyRent: 1850,
+      startDate: "2026-01-01",
+      endDate: "2099-12-31",
+      status: "active",
+      executionStatus: "fully_executed",
+    });
+
+    const router = (await import("../leaseRoutes")).default;
+    const res = await invokeRouter(router, { method: "GET", url: "/active" });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.leases?.[0]).toEqual(expect.objectContaining({
+      id: "lease-link",
+      canonicalState: expect.objectContaining({
+        occupancyState: "occupied",
+        tenantRelationshipState: "current_occupant",
+        supportingLeaseId: "lease-link",
+      }),
+      leaseExecution: expect.objectContaining({ executionStatus: "fully_executed" }),
+      stateCoherence: expect.objectContaining({
+        coherenceStatus: "coherent",
+        leaseOperationalState: "active",
+        occupancyState: "occupied",
+        flags: expect.objectContaining({ requiresReview: false }),
+      }),
+    }));
+  });
+
   it("projects generated primary lease document availability from leaseDocuments metadata", async () => {
     getPrimaryLeaseDocumentSummaryMock.mockResolvedValueOnce({
       id: "ldoc_generated",

--- a/rentchain-api/src/routes/__tests__/leaseRoutes.integrity.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.integrity.test.ts
@@ -142,6 +142,9 @@ vi.mock("../../services/leaseCanonicalizationService", () => ({
     primaryTenantId: String(raw?.primaryTenantId || raw?.tenantId || "").trim() || null,
     startDate: raw?.startDate,
     endDate: raw?.endDate,
+    leaseStartDate: raw?.startDate,
+    leaseEndDate: raw?.endDate,
+    logicalUnitKey: String(raw?.unitId || "").trim() || null,
     executionStatus: raw?.executionStatus,
   })),
 }));
@@ -150,6 +153,7 @@ vi.mock("../../services/leasePartyConsolidationService", () => ({
   evaluateSameLeaseAgreement: vi.fn(() => ({ decision: "separate" })),
   groupLeaseAgreementCandidates: vi.fn((candidates: any[]) => ({ mergeGroups: [], ambiguousGroups: [], singles: candidates })),
   pickAgreementWinner: vi.fn((candidate: any) => candidate),
+  preserveCanonicalLeaseEvidence: vi.fn((candidates: any[]) => Array.from(new Map(candidates.map((candidate) => [candidate.lease.id, candidate.lease])).values())),
 }));
 
 vi.mock("../../services/leaseIntegrityService", () => ({
@@ -1144,5 +1148,53 @@ describe("leaseRoutes integrity repairs", () => {
       tenantRelationshipState: "current_occupant",
       supportingLeaseId: "lease-control",
     });
+  });
+
+  it("keeps independently valid same-term leases visible to the property canonical projection", async () => {
+    const { groupLeaseAgreementCandidates, pickAgreementWinner } = await import("../../services/leasePartyConsolidationService");
+    vi.mocked(groupLeaseAgreementCandidates).mockImplementationOnce((candidates: any[]) => ({
+      mergeGroups: [{
+        groupKey: "landlord-1::prop-1::unit-conflict",
+        representativeKey: "same-term",
+        candidates,
+        mergedTenantIds: ["tenant-1"],
+        ambiguous: false,
+        reasons: ["same_unit_same_term_signature"],
+      }],
+      ambiguousGroups: [],
+      singles: [],
+    }));
+    vi.mocked(pickAgreementWinner).mockImplementationOnce((candidates: any[]) => candidates[0]);
+    seedDoc("units", "unit-conflict", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitNumber: "MULTI-1",
+      occupancyStatus: "occupied",
+      status: "occupied",
+      currentTenantId: "tenant-1",
+    });
+    for (const leaseId of ["lease-current-a", "lease-current-b"]) {
+      seedDoc("leases", leaseId, {
+        landlordId: "landlord-1",
+        propertyId: "prop-1",
+        unitId: "unit-conflict",
+        tenantId: "tenant-1",
+        primaryTenantId: "tenant-1",
+        startDate: "2026-05-01",
+        endDate: "2027-04-30",
+        executionStatus: "fully_executed",
+        status: "active",
+      });
+    }
+
+    const app = await makeApp();
+    const res = await request(app).get("/property/prop-1");
+
+    expect(res.status).toBe(200);
+    expect(res.body?.canonicalUnitStates?.["unit-conflict"]).toMatchObject({
+      occupancyState: "review_needed",
+      supportingLeaseId: null,
+    });
+    expect(res.body?.canonicalUnitStates?.["unit-conflict"]?.reasons).toContain("MULTIPLE_CURRENT_LEASES");
   });
 });

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -29,7 +29,7 @@ import {
   resolveUnitReference,
   toCanonicalLeaseRecord,
 } from "../services/leaseCanonicalizationService";
-import { evaluateSameLeaseAgreement, groupLeaseAgreementCandidates, pickAgreementWinner } from "../services/leasePartyConsolidationService";
+import { evaluateSameLeaseAgreement, groupLeaseAgreementCandidates, pickAgreementWinner, preserveCanonicalLeaseEvidence } from "../services/leasePartyConsolidationService";
 import { loadPropertyLeaseIntegrityDiagnostics } from "../services/leaseIntegrityService";
 import { buildLeaseRiskPersistenceFields, computeLeaseRiskSnapshot } from "../services/risk/recomputeLeaseRisk";
 import { loadPropertyCredibilitySummary } from "../services/risk/propertyCredibilitySummary";
@@ -3612,6 +3612,7 @@ router.get("/property/:propertyId", requireLandlord, async (req: any, res: Respo
       ...grouped.ambiguousGroups.map((group) => pickAgreementWinner(group.candidates).lease),
       ...grouped.singles.map((candidate) => candidate.lease),
     ];
+    const canonicalEvidenceLeases = preserveCanonicalLeaseEvidence(filteredAgreementCandidates);
     const winnerIds = new Set(
       dedupePropertyScopedLeasesByUnit(groupedWinners).map((lease) => lease.id)
     );
@@ -3622,7 +3623,7 @@ router.get("/property/:propertyId", requireLandlord, async (req: any, res: Respo
     const canonicalUnitStates = Object.fromEntries(
       units.map((unit: any) => {
         const unitId = String(unit?.id || "").trim();
-        const relatedLeases = groupedWinners.filter((lease: any) => canonicalLeaseMatchesUnit(lease, unitId));
+        const relatedLeases = canonicalEvidenceLeases.filter((lease: any) => canonicalLeaseMatchesUnit(lease, unitId));
         const unitInputs = resolveCanonicalUnitProjectionInputs(unit);
         return [unitId, buildCanonicalLeaseOccupancyProjection({
           leases: relatedLeases,

--- a/rentchain-api/src/routes/occupancyResolutionRoutes.ts
+++ b/rentchain-api/src/routes/occupancyResolutionRoutes.ts
@@ -1,0 +1,83 @@
+import { Router } from "express";
+import { requireLandlord } from "../middleware/requireLandlord";
+import { requireCapability } from "../services/capabilityGuard";
+import {
+  getOccupancyResolutionContext,
+  OccupancyResolutionError,
+  resolveOccupancy,
+  type OccupancyResolutionType,
+} from "../services/occupancyResolutionService";
+
+const router = Router();
+const TYPES = new Set<OccupancyResolutionType>([
+  "record_operational_move_out",
+  "clear_stale_occupancy_record",
+  "link_existing_lease",
+]);
+
+function landlordId(req: any): string {
+  return String(req.user?.landlordId || req.user?.id || "").trim();
+}
+
+async function enforceCapability(req: any, res: any) {
+  if (String(req.user?.role || "").toLowerCase() === "admin") return true;
+  const capability = await requireCapability(landlordId(req), "leases", req.user);
+  if (capability.ok) return true;
+  res.status(403).json({ ok: false, error: "Upgrade required", capability: "leases", plan: capability.plan });
+  return false;
+}
+
+function handleError(res: any, error: unknown) {
+  if (error instanceof OccupancyResolutionError) {
+    return res.status(error.status).json({ ok: false, error: error.code, freshContext: error.freshContext || null });
+  }
+  console.error("[occupancy-resolutions] request failed", error);
+  return res.status(500).json({ ok: false, error: "occupancy_resolution_failed" });
+}
+
+router.get("/context", requireLandlord, async (req: any, res) => {
+  try {
+    if (!(await enforceCapability(req, res))) return;
+    const propertyId = String(req.query?.propertyId || "").trim();
+    const unitId = String(req.query?.unitId || "").trim();
+    const tenantId = String(req.query?.tenantId || "").trim() || null;
+    if (!propertyId || !unitId) return res.status(400).json({ ok: false, error: "property_and_unit_required" });
+    const context = await getOccupancyResolutionContext({ landlordId: landlordId(req), propertyId, unitId, tenantId });
+    return res.status(200).json({ ok: true, context });
+  } catch (error) {
+    return handleError(res, error);
+  }
+});
+
+router.post("/", requireLandlord, async (req: any, res) => {
+  try {
+    if (!(await enforceCapability(req, res))) return;
+    const type = String(req.body?.type || "") as OccupancyResolutionType;
+    if (!TYPES.has(type)) return res.status(400).json({ ok: false, error: "resolution_type_invalid" });
+    const propertyId = String(req.body?.propertyId || "").trim();
+    const unitId = String(req.body?.unitId || "").trim();
+    const expectedStateToken = String(req.body?.expectedStateToken || "").trim();
+    const idempotencyKey = String(req.body?.idempotencyKey || "").trim();
+    if (!propertyId || !unitId || !expectedStateToken || !idempotencyKey) {
+      return res.status(400).json({ ok: false, error: "resolution_context_required" });
+    }
+    const result = await resolveOccupancy({
+      landlordId: landlordId(req),
+      actorId: String(req.user?.id || req.user?.uid || landlordId(req)),
+      propertyId,
+      unitId,
+      tenantId: String(req.body?.tenantId || "").trim() || null,
+      type,
+      expectedStateToken,
+      idempotencyKey,
+      confirmation: req.body?.confirmation === true,
+      effectiveDate: String(req.body?.effectiveDate || "").trim() || null,
+      selectedLeaseId: String(req.body?.selectedLeaseId || "").trim() || null,
+    });
+    return res.status(200).json({ ok: true, ...result });
+  } catch (error) {
+    return handleError(res, error);
+  }
+});
+
+export default router;

--- a/rentchain-api/src/services/__tests__/leasePartyConsolidationService.test.ts
+++ b/rentchain-api/src/services/__tests__/leasePartyConsolidationService.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { buildCanonicalLeaseOccupancyProjection } from "../../lib/leases/canonicalLeaseOccupancyProjection";
+import { preserveCanonicalLeaseEvidence, type LeaseAgreementCandidate } from "../leasePartyConsolidationService";
+
+function candidate(id: string): LeaseAgreementCandidate {
+  const lease: any = {
+    id,
+    landlordId: "landlord-1",
+    propertyId: "property-1",
+    unitId: "unit-1",
+    resolvedUnitId: "unit-1",
+    logicalUnitKey: "unit-1",
+    tenantId: "tenant-1",
+    primaryTenantId: "tenant-1",
+    status: "active",
+    startDate: "2026-05-01",
+    endDate: "2027-04-30",
+    executionStatus: "fully_executed",
+  };
+  return { lease, raw: lease };
+}
+
+describe("preserveCanonicalLeaseEvidence", () => {
+  it.each([
+    [[candidate("lease-a"), candidate("lease-b")]],
+    [[candidate("lease-b"), candidate("lease-a")]],
+  ])("fails closed for two distinct current leases regardless of input order", (candidates) => {
+    const projection = buildCanonicalLeaseOccupancyProjection({
+      leases: preserveCanonicalLeaseEvidence(candidates),
+      context: { landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-1", asOfDate: "2026-08-18" },
+      persistedUnitOccupancy: "occupied",
+      tenantId: "tenant-1",
+    });
+    expect(projection).toMatchObject({ occupancyState: "review_needed", supportingLeaseId: null });
+    expect(projection.reasons).toContain("MULTIPLE_CURRENT_LEASES");
+  });
+
+  it("does not manufacture ambiguity from a repeated representation of the same lease id", () => {
+    const repeated = candidate("lease-a");
+    const projection = buildCanonicalLeaseOccupancyProjection({
+      leases: preserveCanonicalLeaseEvidence([repeated, { ...repeated, raw: { ...repeated.raw } }]),
+      context: { landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-1", asOfDate: "2026-08-18" },
+      persistedUnitOccupancy: "occupied",
+      tenantId: "tenant-1",
+    });
+    expect(projection).toMatchObject({ occupancyState: "occupied", supportingLeaseId: "lease-a" });
+    expect(projection.reasons).not.toContain("MULTIPLE_CURRENT_LEASES");
+  });
+});

--- a/rentchain-api/src/services/__tests__/occupancyResolutionService.test.ts
+++ b/rentchain-api/src/services/__tests__/occupancyResolutionService.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { fakeDb, seed, read, failAudit, reset } = vi.hoisted(() => {
+const { fakeDb, seed, read, list, failAudit, reset } = vi.hoisted(() => {
   const store = new Map<string, Map<string, any>>();
   let rejectAudit = false;
   const collection = (name: string) => {
@@ -44,6 +44,7 @@ const { fakeDb, seed, read, failAudit, reset } = vi.hoisted(() => {
     fakeDb,
     seed: (name: string, id: string, value: any) => collection(name).set(id, value),
     read: (name: string, id: string) => collection(name).get(id),
+    list: (name: string) => [...collection(name).values()],
     failAudit: (value: boolean) => { rejectAudit = value; },
     reset: () => { store.clear(); rejectAudit = false; },
   };
@@ -121,5 +122,22 @@ describe("occupancyResolutionService", () => {
     const result = await resolveOccupancy({ ...base, actorId: "landlord-1", type: "link_existing_lease", selectedLeaseId: "lease-current", expectedStateToken: fresh.expectedStateToken, idempotencyKey: "link-current", confirmation: true });
     expect(result.context.canonicalState).toMatchObject({ occupancyState: "occupied", tenantRelationshipState: "current_occupant", supportingLeaseId: "lease-current" });
     expect(read("units", "unit-1")).toMatchObject({ occupancyStatus: "occupied", currentLeaseId: "lease-current" });
+    expect(read("properties", "property-1").units[0]).toMatchObject({ occupancyStatus: "occupied", currentTenantId: "tenant-1", currentLeaseId: "lease-current" });
+    expect(read("tenants", "tenant-1")).toMatchObject({ status: "Current", currentLeaseId: "lease-current" });
+    expect(read("tenancies", "tenancy-1")).toMatchObject({ status: "active" });
+    expect(read("leases", "lease-current")).toMatchObject({ status: "active", executionStatus: "fully_executed", startDate: "2026-05-01", endDate: "2027-04-30" });
+  });
+
+  it("rejects a draft link candidate with zero operational or audit writes", async () => {
+    seedExpiredReview();
+    seed("leases", "lease-draft", { landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-1", status: "draft", executionStatus: "draft", startDate: "2026-05-01", endDate: "2027-04-30" });
+    const context = await getOccupancyResolutionContext(base);
+    expect(context.existingLeaseCandidates.map((lease) => lease.id)).not.toContain("lease-draft");
+
+    await expect(resolveOccupancy({ ...base, actorId: "landlord-1", type: "link_existing_lease", selectedLeaseId: "lease-draft", expectedStateToken: context.expectedStateToken, idempotencyKey: "draft-link", confirmation: true })).rejects.toMatchObject({ code: "resolution_not_applicable" });
+
+    expect(read("units", "unit-1")).toMatchObject({ occupancyStatus: "occupied", currentLeaseId: "lease-past" });
+    expect(list("canonicalEvents")).toEqual([]);
+    expect(list("occupancyResolutionRequests")).toEqual([]);
   });
 });

--- a/rentchain-api/src/services/__tests__/occupancyResolutionService.test.ts
+++ b/rentchain-api/src/services/__tests__/occupancyResolutionService.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fakeDb, seed, read, failAudit, reset } = vi.hoisted(() => {
+  const store = new Map<string, Map<string, any>>();
+  let rejectAudit = false;
+  const collection = (name: string) => {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  };
+  const doc = (name: string, id: string) => ({
+    id,
+    get: async () => { const value = collection(name).get(id); return { id, exists: Boolean(value), data: () => value, ref: doc(name, id) }; },
+    set: async (value: any, options?: any) => collection(name).set(id, options?.merge ? { ...(collection(name).get(id) || {}), ...value } : value),
+    create: async (value: any) => { if (collection(name).has(id)) throw new Error("already_exists"); collection(name).set(id, value); },
+  });
+  const query = (name: string, filters: any[] = []) => ({
+    where: (field: string, op: string, value: any) => query(name, [...filters, { field, op, value }]),
+    get: async () => ({ docs: [...collection(name).entries()].filter(([, value]) => filters.every((filter) => filter.op === "==" && value[filter.field] === filter.value)).map(([id, value]) => ({ id, exists: true, data: () => value, ref: doc(name, id) })) }),
+  });
+  const fakeDb = {
+    collection: (name: string) => ({ ...query(name), doc: (id: string) => doc(name, id) }),
+    runTransaction: async (callback: any) => {
+      const writes: Array<() => Promise<void>> = [];
+      const result = await callback({
+        get: (target: any) => target.get(),
+        set: (ref: any, value: any, options?: any) => writes.push(() => ref.set(value, options)),
+        create: (ref: any, value: any) => writes.push(() => {
+          if (rejectAudit && String(value?.action) === "occupancy_resolution_recorded") throw new Error("audit_failed");
+          return ref.create(value);
+        }),
+      });
+      const snapshot = new Map([...store.entries()].map(([name, values]) => [name, new Map([...values.entries()].map(([id, value]) => [id, structuredClone(value)]))]));
+      try {
+        for (const write of writes) await write();
+      } catch (error) {
+        store.clear();
+        for (const [name, values] of snapshot) store.set(name, values);
+        throw error;
+      }
+      return result;
+    },
+  };
+  return {
+    fakeDb,
+    seed: (name: string, id: string, value: any) => collection(name).set(id, value),
+    read: (name: string, id: string) => collection(name).get(id),
+    failAudit: (value: boolean) => { rejectAudit = value; },
+    reset: () => { store.clear(); rejectAudit = false; },
+  };
+});
+
+vi.mock("../../firebase", () => ({ db: fakeDb }));
+
+import { getOccupancyResolutionContext, resolveOccupancy } from "../occupancyResolutionService";
+
+const base = { landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-1" };
+
+function seedExpiredReview() {
+  seed("properties", "property-1", { landlordId: "landlord-1", name: "Harbour House", units: [{ id: "unit-1", unitNumber: "1A", status: "occupied", occupancyStatus: "occupied", currentLeaseId: "lease-past", currentTenantId: "tenant-1" }] });
+  seed("units", "unit-1", { landlordId: "landlord-1", propertyId: "property-1", unitNumber: "1A", status: "occupied", occupancyStatus: "occupied", currentLeaseId: "lease-past", currentTenantId: "tenant-1" });
+  seed("tenants", "tenant-1", { landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", status: "Current", currentLeaseId: "lease-past" });
+  seed("tenancies", "tenancy-1", { landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-1", status: "active" });
+  seed("leases", "lease-past", { landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-1", status: "active", executionStatus: "fully_executed", startDate: "2025-05-01", endDate: "2026-04-30" });
+}
+
+describe("occupancyResolutionService", () => {
+  beforeEach(() => reset());
+
+  it("keeps passive expiry unresolved until an explicit move-out is committed atomically", async () => {
+    seedExpiredReview();
+    const context = await getOccupancyResolutionContext(base);
+    expect(context.canonicalState).toMatchObject({ leaseTermState: "past", occupancyState: "review_needed", tenantRelationshipState: "occupancy_unresolved", supportingLeaseId: null });
+    const result = await resolveOccupancy({ ...base, actorId: "landlord-1", type: "record_operational_move_out", expectedStateToken: context.expectedStateToken, idempotencyKey: "move-out-1", confirmation: true, effectiveDate: "2026-08-18" });
+    expect(result.context.canonicalState).toMatchObject({ occupancyState: "vacant", tenantRelationshipState: "past_tenant" });
+    expect(read("leases", "lease-past")).toMatchObject({ status: "active", endDate: "2026-04-30" });
+    expect(read("units", "unit-1")).toMatchObject({ occupancyStatus: "vacant", currentLeaseId: null, currentTenantId: null });
+    expect(read("tenants", "tenant-1")).toMatchObject({ status: "Past", currentLeaseId: null });
+    expect(read("tenancies", "tenancy-1")).toMatchObject({ status: "inactive", moveOutReason: "OTHER" });
+    expect(read("canonicalEvents", result.auditEventId)).toMatchObject({ action: "occupancy_resolution_recorded", immutable: true });
+  });
+
+  it("returns the committed result for an identical idempotent retry and rejects changed payload", async () => {
+    seedExpiredReview();
+    const context = await getOccupancyResolutionContext(base);
+    const input = { ...base, actorId: "landlord-1", type: "clear_stale_occupancy_record" as const, expectedStateToken: context.expectedStateToken, idempotencyKey: "retry-1", confirmation: true };
+    const first = await resolveOccupancy(input);
+    const second = await resolveOccupancy(input);
+    expect(second.idempotent).toBe(true);
+    expect(second.auditEventId).toBe(first.auditEventId);
+    await expect(resolveOccupancy({ ...input, type: "record_operational_move_out", effectiveDate: "2026-08-18" })).rejects.toMatchObject({ code: "idempotency_key_reused" });
+  });
+
+  it("rolls back operational writes when immutable audit creation fails", async () => {
+    seedExpiredReview();
+    const context = await getOccupancyResolutionContext(base);
+    failAudit(true);
+    await expect(resolveOccupancy({ ...base, actorId: "landlord-1", type: "clear_stale_occupancy_record", expectedStateToken: context.expectedStateToken, idempotencyKey: "audit-fail", confirmation: true })).rejects.toThrow("audit_failed");
+    expect(read("units", "unit-1")).toMatchObject({ occupancyStatus: "occupied", currentLeaseId: "lease-past" });
+    expect(read("occupancyResolutionRequests", "6f04eb5f")).toBeUndefined();
+  });
+
+  it("fails closed for multiple current leases and cross-landlord context", async () => {
+    seedExpiredReview();
+    seed("leases", "lease-active-1", { landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-1", status: "active", executionStatus: "fully_executed", startDate: "2026-05-01", endDate: "2027-04-30" });
+    seed("leases", "lease-active-2", { landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-1", status: "active", executionStatus: "fully_executed", startDate: "2026-05-01", endDate: "2027-04-30" });
+    const context = await getOccupancyResolutionContext(base);
+    expect(context.canonicalState.reasons).toContain("MULTIPLE_CURRENT_LEASES");
+    expect(context.eligibleResolutionTypes).toEqual([]);
+    await expect(getOccupancyResolutionContext({ ...base, landlordId: "landlord-2" })).rejects.toMatchObject({ code: "forbidden" });
+  });
+
+  it("links one explicitly selected eligible lease and rejects a stale token", async () => {
+    seedExpiredReview();
+    seed("leases", "lease-current", { landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-1", status: "active", executionStatus: "fully_executed", startDate: "2026-05-01", endDate: "2027-04-30" });
+    const context = await getOccupancyResolutionContext(base);
+    expect(context.eligibleResolutionTypes).toContain("link_existing_lease");
+    seed("units", "unit-1", { ...read("units", "unit-1"), notes: "concurrent change" });
+    await expect(resolveOccupancy({ ...base, actorId: "landlord-1", type: "link_existing_lease", selectedLeaseId: "lease-current", expectedStateToken: context.expectedStateToken, idempotencyKey: "link-stale", confirmation: true })).rejects.toMatchObject({ code: "occupancy_state_stale" });
+
+    const fresh = await getOccupancyResolutionContext(base);
+    const result = await resolveOccupancy({ ...base, actorId: "landlord-1", type: "link_existing_lease", selectedLeaseId: "lease-current", expectedStateToken: fresh.expectedStateToken, idempotencyKey: "link-current", confirmation: true });
+    expect(result.context.canonicalState).toMatchObject({ occupancyState: "occupied", tenantRelationshipState: "current_occupant", supportingLeaseId: "lease-current" });
+    expect(read("units", "unit-1")).toMatchObject({ occupancyStatus: "occupied", currentLeaseId: "lease-current" });
+  });
+});

--- a/rentchain-api/src/services/__tests__/propertyCredibilitySummary.test.ts
+++ b/rentchain-api/src/services/__tests__/propertyCredibilitySummary.test.ts
@@ -90,6 +90,27 @@ describe("propertyCredibilitySummary", () => {
     expect(summary.tenantsWithScoreCount).toBe(1);
   });
 
+  it("counts a multiple-current unit as review instead of one coherent active lease", () => {
+    const summary = computePropertyCredibilitySummary({
+      propertyId: "property-conflict",
+      leases: [
+        { id: "lease-a", status: "active", tenantId: "tenant-1", riskScore: 80, riskConfidence: 0.9 },
+        { id: "lease-b", status: "active", tenantId: "tenant-1", riskScore: 80, riskConfidence: 0.9 },
+      ],
+      tenants: [{ id: "tenant-1", tenantScoreValue: 80, tenantScoreConfidence: 0.9 }],
+      canonicalUnitStates: {
+        "unit-1": {
+          leaseTermState: "active",
+          occupancyState: "review_needed",
+          supportingLeaseId: null,
+        },
+      },
+    });
+
+    expect(summary.activeLeaseCount).toBe(0);
+    expect(summary.lowConfidenceCount).toBe(1);
+  });
+
   it("preserves legacy status behavior when canonical unit states are absent", () => {
     const summary = computePropertyCredibilitySummary({
       propertyId: "property-legacy",

--- a/rentchain-api/src/services/__tests__/tenantDetailsService.test.ts
+++ b/rentchain-api/src/services/__tests__/tenantDetailsService.test.ts
@@ -347,6 +347,48 @@ describe("getTenantsList", () => {
     });
   });
 
+  it("preserves multiple same-term lease evidence for tenant canonical review", async () => {
+    tenantDocs.set("tenant-visible", {
+      landlordId: "landlord-1",
+      fullName: "Visible Tenant",
+      propertyId: "property-1",
+      unitId: "unit-1",
+      currentLeaseId: "lease-a",
+      status: "Current",
+    });
+    unitDocs.set("unit-1", {
+      landlordId: "landlord-1",
+      propertyId: "property-1",
+      unitNumber: "101",
+      occupancyStatus: "occupied",
+      currentTenantId: "tenant-visible",
+      currentLeaseId: "lease-a",
+    });
+    for (const leaseId of ["lease-a", "lease-b"]) {
+      leaseDocs.set(leaseId, {
+        landlordId: "landlord-1",
+        tenantId: "tenant-visible",
+        primaryTenantId: "tenant-visible",
+        propertyId: "property-1",
+        unitId: "unit-1",
+        status: "active",
+        startDate: "2026-05-01",
+        endDate: "2027-04-30",
+        executionStatus: "fully_executed",
+      });
+    }
+
+    const { getTenantsList } = await import("../tenantDetailsService");
+    const tenant = (await getTenantsList({ landlordId: "landlord-1" }))
+      .find((candidate) => candidate.id === "tenant-visible");
+
+    expect(tenant?.canonicalState).toMatchObject({
+      occupancyState: "review_needed",
+      supportingLeaseId: null,
+    });
+    expect(tenant?.canonicalState?.reasons).toContain("MULTIPLE_CURRENT_LEASES");
+  });
+
   it("preserves fallback tenants when no tenant records exist outside landlord scope", async () => {
     tenantDocs.clear();
 

--- a/rentchain-api/src/services/leaseExecution/__tests__/deriveLeaseExecution.test.ts
+++ b/rentchain-api/src/services/leaseExecution/__tests__/deriveLeaseExecution.test.ts
@@ -144,6 +144,20 @@ describe("deriveLeaseExecution", () => {
     expect(result.completedAt).toBe("2026-05-09T12:00:00.000Z");
   });
 
+  it("preserves an explicit canonical fully-executed status without inventing signing timestamps", () => {
+    const result = deriveLeaseExecution({
+      leaseId: "lease-linked",
+      startDate: "2026-05-01",
+      monthlyRent: 1800,
+      status: "active",
+      raw: { executionStatus: "fully_executed" },
+    });
+
+    expect(result.executionStatus).toBe("fully_executed");
+    expect(result.requiredNextAction).toBe("none");
+    expect(result.completedAt).toBeNull();
+  });
+
   it("derives ready_for_tenant_signature from provider pending signature state", () => {
     const result = deriveLeaseExecution({
       leaseId: "lease-1",

--- a/rentchain-api/src/services/leaseExecution/deriveLeaseExecution.ts
+++ b/rentchain-api/src/services/leaseExecution/deriveLeaseExecution.ts
@@ -107,6 +107,12 @@ export function deriveLeaseExecution(input: DeriveLeaseExecutionInput): LeaseExe
   const normalizedSigningStatus = normalizeStatus(
     raw?.currentSigningStatus || raw?.signingStatus || raw?.leaseSigningStatus || raw?.providerSigningStatus
   );
+  const persistedExecutionStatus = normalizeStatus(
+    raw?.executionStatus || raw?.leaseExecutionState || raw?.leaseExecution?.executionStatus
+  );
+  const persistentlyExecuted = ["fully_executed", "executed", "complete", "completed"].includes(
+    persistedExecutionStatus
+  );
   const providerSigningComplete = ["signed", "completed", "complete"].includes(normalizedSigningStatus);
   const providerSignedAt = providerSigningComplete
     ? firstIso(raw, ["currentStatusAt", "signedAt", "signingCompletedAt", "providerSignedAt", "fullyExecutedAt"])
@@ -157,7 +163,9 @@ export function deriveLeaseExecution(input: DeriveLeaseExecutionInput): LeaseExe
       fullyExecutedAt
   );
 
-  const executed = Boolean(providerSigningComplete || providerSignedAt || (tenantSignatureCaptured && landlordSignatureCaptured));
+  const executed = Boolean(
+    persistentlyExecuted || providerSigningComplete || providerSignedAt || (tenantSignatureCaptured && landlordSignatureCaptured)
+  );
   const landlordSigned = Boolean(!executed && landlordSignatureCaptured);
   const readyForLandlord = Boolean(!executed && !landlordSigned && statusImpliesReadyForLandlord);
   const tenantSigned = Boolean(

--- a/rentchain-api/src/services/leasePartyConsolidationService.ts
+++ b/rentchain-api/src/services/leasePartyConsolidationService.ts
@@ -140,6 +140,21 @@ export function pickAgreementWinner(group: LeaseAgreementCandidate[]): LeaseAgre
   return [...group].sort((a, b) => compareLeaseWinner(a.lease, b.lease))[0];
 }
 
+/**
+ * Canonical occupancy must evaluate every distinct lease record. Agreement
+ * consolidation is a display/migration concern and cannot choose a winner
+ * before the fail-closed current-lease selector runs.
+ */
+export function preserveCanonicalLeaseEvidence(candidates: LeaseAgreementCandidate[]): CanonicalLeaseRecord[] {
+  const byId = new Map<string, CanonicalLeaseRecord>();
+  for (const candidate of candidates) {
+    const id = String(candidate?.lease?.id || "").trim();
+    if (!id || byId.has(id)) continue;
+    byId.set(id, candidate.lease);
+  }
+  return [...byId.values()];
+}
+
 export function groupLeaseAgreementCandidates(candidates: LeaseAgreementCandidate[]): {
   mergeGroups: LeaseAgreementGroup[];
   ambiguousGroups: LeaseAgreementGroup[];

--- a/rentchain-api/src/services/occupancyResolutionService.ts
+++ b/rentchain-api/src/services/occupancyResolutionService.ts
@@ -1,0 +1,369 @@
+import crypto from "crypto";
+import { db } from "../firebase";
+import {
+  buildCanonicalLeaseOccupancyProjection,
+  resolveCanonicalUnitProjectionInputs,
+  toCanonicalLeaseStateInput,
+  type CanonicalLeaseOccupancyProjection,
+} from "../lib/leases/canonicalLeaseOccupancyProjection";
+import { deriveCanonicalLeaseTermState } from "../lib/leases/canonicalLeaseOccupancyState";
+import { resolveUnitReference, toCanonicalLeaseRecord, toCanonicalUnitRecord } from "./leaseCanonicalizationService";
+
+export type OccupancyResolutionType =
+  | "record_operational_move_out"
+  | "clear_stale_occupancy_record"
+  | "link_existing_lease";
+
+type ResolutionContextInput = {
+  landlordId: string;
+  propertyId: string;
+  unitId: string;
+  tenantId?: string | null;
+};
+
+export type OccupancyResolutionContext = {
+  propertyId: string;
+  unitId: string;
+  tenantId: string | null;
+  unitLabel: string;
+  propertyLabel: string;
+  canonicalState: CanonicalLeaseOccupancyProjection;
+  expectedStateToken: string;
+  eligibleResolutionTypes: OccupancyResolutionType[];
+  existingLeaseCandidates: Array<{
+    id: string;
+    label: string;
+    tenantId: string | null;
+    startDate: string | null;
+    endDate: string | null;
+  }>;
+  activeLeaseRequiresEndWorkflow: boolean;
+};
+
+export class OccupancyResolutionError extends Error {
+  constructor(public code: string, public status: number, public freshContext?: OccupancyResolutionContext) {
+    super(code);
+  }
+}
+
+function text(value: unknown): string {
+  return String(value || "").trim();
+}
+
+function stable(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stable).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, entry]) => `${JSON.stringify(key)}:${stable(entry)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function hash(value: unknown): string {
+  return crypto.createHash("sha256").update(stable(value)).digest("hex");
+}
+
+function safeRef(prefix: string, value: unknown): string {
+  return `${prefix}:${hash([prefix, text(value)]).slice(0, 32)}`;
+}
+
+function matchesEmbeddedUnit(unit: any, unitId: string, unitNumber: string): boolean {
+  const candidates = [unit?.id, unit?.unitId, unit?.unitNumber, unit?.label, unit?.unit].map(text);
+  return candidates.includes(unitId) || (Boolean(unitNumber) && candidates.includes(unitNumber));
+}
+
+function stateToken(input: {
+  canonicalState: CanonicalLeaseOccupancyProjection;
+  property: any;
+  unit: any;
+  tenant: any;
+  leases: any[];
+  tenancies: any[];
+}): string {
+  return hash({
+    canonicalState: { ...input.canonicalState, reasons: [...input.canonicalState.reasons].sort() },
+    propertyUpdatedAt: input.property?.updatedAt || null,
+    embeddedUnits: input.property?.units || [],
+    unit: input.unit || null,
+    tenant: input.tenant || null,
+    leases: input.leases.map((lease) => ({
+      id: lease.id,
+      landlordId: lease.landlordId,
+      propertyId: lease.propertyId,
+      unitId: lease.unitId,
+      tenantId: lease.tenantId || lease.primaryTenantId,
+      status: lease.status,
+      startDate: lease.startDate || lease.leaseStartDate,
+      endDate: lease.endDate || lease.leaseEndDate,
+      executionStatus: lease.executionStatus || lease.leaseExecutionState || lease.leaseExecution?.executionStatus,
+    })).sort((a, b) => a.id.localeCompare(b.id)),
+    tenancies: input.tenancies.map((row) => ({ id: row.id, status: row.status, moveOutAt: row.moveOutAt, updatedAt: row.updatedAt }))
+      .sort((a, b) => a.id.localeCompare(b.id)),
+  });
+}
+
+async function readResolutionContext(
+  reader: any,
+  input: ResolutionContextInput
+): Promise<{ context: OccupancyResolutionContext; records: any }> {
+  const propertyRef = db.collection("properties").doc(input.propertyId);
+  const unitRef = db.collection("units").doc(input.unitId);
+  const unitsQuery = db.collection("units").where("propertyId", "==", input.propertyId).where("landlordId", "==", input.landlordId);
+  const tenantRef = input.tenantId ? db.collection("tenants").doc(input.tenantId) : null;
+  const leasesQuery = db.collection("leases").where("landlordId", "==", input.landlordId).where("propertyId", "==", input.propertyId);
+  const tenanciesQuery = input.tenantId ? db.collection("tenancies").where("tenantId", "==", input.tenantId) : null;
+  const get = (target: any) => typeof reader.get === "function" ? reader.get(target) : target.get();
+  const [propertySnap, unitSnap, unitsSnap, tenantSnap, leaseSnap, tenancySnap] = await Promise.all([
+    get(propertyRef),
+    get(unitRef),
+    get(unitsQuery),
+    tenantRef ? get(tenantRef) : Promise.resolve(null),
+    get(leasesQuery),
+    tenanciesQuery ? get(tenanciesQuery) : Promise.resolve({ docs: [] }),
+  ]);
+  if (!propertySnap.exists) throw new OccupancyResolutionError("property_not_found", 404);
+  if (!unitSnap.exists) throw new OccupancyResolutionError("unit_not_found", 404);
+  const property = propertySnap.data() || {};
+  const unit = { id: unitSnap.id, ...(unitSnap.data() || {}) };
+  if (text(property.landlordId || property.ownerId || property.owner) !== input.landlordId) {
+    throw new OccupancyResolutionError("forbidden", 403);
+  }
+  if (text(unit.landlordId) !== input.landlordId || text(unit.propertyId) !== input.propertyId) {
+    throw new OccupancyResolutionError("forbidden", 403);
+  }
+  const tenant = tenantSnap?.exists ? { id: tenantSnap.id, ...(tenantSnap.data() || {}) } : null;
+  if (input.tenantId && (!tenant || text(tenant.landlordId) !== input.landlordId)) {
+    throw new OccupancyResolutionError("tenant_not_found", 404);
+  }
+
+  const canonicalUnits = (unitsSnap.docs || []).map((doc: any) => toCanonicalUnitRecord(doc.id, doc.data() || {}));
+  const unitResolution = resolveUnitReference(canonicalUnits, input.unitId);
+  if (unitResolution.ambiguous || !unitResolution.unit || unitResolution.unit.id !== input.unitId) {
+    throw new OccupancyResolutionError("unit_context_ambiguous", 409);
+  }
+  const unitLabel = text(unit.unitNumber || unit.label);
+  if (unitLabel && resolveUnitReference(canonicalUnits, unitLabel).ambiguous) {
+    throw new OccupancyResolutionError("unit_context_ambiguous", 409);
+  }
+  const allLeases = (leaseSnap.docs || []).map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) }));
+  const relatedLeases = allLeases
+    .map((lease: any) => toCanonicalLeaseRecord(lease.id, lease, canonicalUnits))
+    .filter((lease: any) => lease.resolvedUnitId === input.unitId);
+  const unitInputs = resolveCanonicalUnitProjectionInputs(unit);
+  if (!input.tenantId && text(unitInputs.tenantId)) {
+    throw new OccupancyResolutionError("tenant_context_required", 400);
+  }
+  const tenantId = text(input.tenantId || unitInputs.tenantId) || null;
+  const tenancies = (tenancySnap.docs || [])
+    .map((doc: any) => ({ id: doc.id, ref: doc.ref, ...(doc.data() || {}) }))
+    .filter((row: any) => !row.landlordId || text(row.landlordId) === input.landlordId)
+    .filter((row: any) => !row.propertyId || text(row.propertyId) === input.propertyId)
+    .filter((row: any) => !row.unitId || text(row.unitId) === input.unitId || text(row.unitLabel) === text(unit.unitNumber));
+  const canonicalState = buildCanonicalLeaseOccupancyProjection({
+    leases: relatedLeases,
+    context: { landlordId: input.landlordId, propertyId: input.propertyId, unitId: input.unitId, tenantId },
+    ...unitInputs,
+    persistedTenancyStatus: tenancies.some((row: any) => row.status === "active") ? "active" : unitInputs.persistedTenancyStatus,
+    persistedTenantStatus: tenant?.status,
+    currentLeasePointerId: tenant?.currentLeaseId || unitInputs.currentLeasePointerId,
+    tenantId,
+  });
+
+  const blockerReasons = new Set(["MULTIPLE_CURRENT_LEASES", "INVALID_LEASE_DATE_RANGE", "CURRENT_LEASE_CONTEXT_MISMATCH"]);
+  const mutationBlocked = canonicalState.reasons.some((reason) => blockerReasons.has(reason));
+  const reviewNeeded = canonicalState.occupancyState === "review_needed" || canonicalState.tenantRelationshipState === "occupancy_unresolved";
+  const candidates = relatedLeases.filter((lease: any) => {
+    const lifecycle = deriveCanonicalLeaseTermState(toCanonicalLeaseStateInput(lease));
+    const leaseTenant = text(lease.primaryTenantId || lease.tenantId || lease.tenantIds?.[0]);
+    return lifecycle.supportsCurrentOccupancy && (!tenantId || leaseTenant === tenantId);
+  });
+  const activeLeaseRequiresEndWorkflow = reviewNeeded && candidates.length === 1 && canonicalState.supportingLeaseId === candidates[0].id;
+  const eligibleResolutionTypes: OccupancyResolutionType[] = [];
+  if (reviewNeeded && !mutationBlocked) {
+    if (!canonicalState.supportingLeaseId) {
+      eligibleResolutionTypes.push("record_operational_move_out", "clear_stale_occupancy_record");
+    }
+    if (candidates.length === 1 && canonicalState.reasons.includes("STALE_CURRENT_LEASE_POINTER")) {
+      eligibleResolutionTypes.push("link_existing_lease");
+    }
+  }
+  const context: OccupancyResolutionContext = {
+    propertyId: input.propertyId,
+    unitId: input.unitId,
+    tenantId,
+    unitLabel: text(unit.unitNumber || unit.label) || "Unit",
+    propertyLabel: text(property.name || property.addressLine1) || "Property",
+    canonicalState,
+    expectedStateToken: "",
+    eligibleResolutionTypes,
+    existingLeaseCandidates: mutationBlocked ? [] : candidates.map((lease: any) => ({
+      id: lease.id,
+      label: `${text(property.name || property.addressLine1) || "Property"} · Unit ${text(unit.unitNumber || unit.label) || ""}`,
+      tenantId: text(lease.primaryTenantId || lease.tenantId || lease.tenantIds?.[0]) || null,
+      startDate: text(lease.startDate || lease.leaseStartDate) || null,
+      endDate: text(lease.endDate || lease.leaseEndDate) || null,
+    })),
+    activeLeaseRequiresEndWorkflow,
+  };
+  context.expectedStateToken = stateToken({ canonicalState, property, unit, tenant, leases: relatedLeases, tenancies });
+  return { context, records: { propertyRef, unitRef, tenantRef, property, unit, tenant, leases: relatedLeases, tenancies } };
+}
+
+export async function getOccupancyResolutionContext(input: ResolutionContextInput): Promise<OccupancyResolutionContext> {
+  const { context } = await readResolutionContext(db as any, input);
+  return context;
+}
+
+export async function resolveOccupancy(input: ResolutionContextInput & {
+  actorId: string;
+  type: OccupancyResolutionType;
+  expectedStateToken: string;
+  idempotencyKey: string;
+  confirmation: boolean;
+  effectiveDate?: string | null;
+  selectedLeaseId?: string | null;
+}): Promise<{ context: OccupancyResolutionContext; auditEventId: string; idempotent: boolean }> {
+  if (!input.confirmation) throw new OccupancyResolutionError("confirmation_required", 400);
+  if (!text(input.idempotencyKey) || text(input.idempotencyKey).length > 160) throw new OccupancyResolutionError("idempotency_key_invalid", 400);
+  if (input.type === "record_operational_move_out" && !/^\d{4}-\d{2}-\d{2}$/.test(text(input.effectiveDate))) {
+    throw new OccupancyResolutionError("effective_date_required", 400);
+  }
+  if (input.type === "record_operational_move_out" && !text(input.tenantId)) {
+    throw new OccupancyResolutionError("tenant_required_for_move_out", 400);
+  }
+  const requestId = hash([input.landlordId, input.idempotencyKey]).slice(0, 40);
+  const requestRef = db.collection("occupancyResolutionRequests").doc(requestId);
+  const payloadHash = hash({ propertyId: input.propertyId, unitId: input.unitId, tenantId: input.tenantId || null, type: input.type, effectiveDate: input.effectiveDate || null, selectedLeaseId: input.selectedLeaseId || null });
+
+  return (db as any).runTransaction(async (transaction: any) => {
+    const prior = await transaction.get(requestRef);
+    if (prior.exists) {
+      const data = prior.data() || {};
+      if (data.payloadHash !== payloadHash) throw new OccupancyResolutionError("idempotency_key_reused", 409);
+      return { context: data.resultContext, auditEventId: data.auditEventId, idempotent: true };
+    }
+    const loaded = await readResolutionContext(transaction, input);
+    if (loaded.context.expectedStateToken !== input.expectedStateToken) {
+      throw new OccupancyResolutionError("occupancy_state_stale", 409, loaded.context);
+    }
+    if (!loaded.context.eligibleResolutionTypes.includes(input.type)) {
+      if (input.type === "record_operational_move_out" && loaded.context.activeLeaseRequiresEndWorkflow) {
+        throw new OccupancyResolutionError("end_lease_workflow_required", 409, loaded.context);
+      }
+      throw new OccupancyResolutionError("resolution_not_applicable", 409, loaded.context);
+    }
+
+    const { records } = loaded;
+    const embeddedUnits = Array.isArray(records.property.units) ? records.property.units : [];
+    const matches = embeddedUnits.map((unit: any, index: number) => ({ unit, index }))
+      .filter(({ unit }: any) => matchesEmbeddedUnit(unit, input.unitId, text(records.unit.unitNumber)));
+    if (matches.length !== 1) throw new OccupancyResolutionError("embedded_unit_ambiguous", 409, loaded.context);
+    const now = new Date().toISOString();
+    let nextUnit = { ...records.unit };
+    let nextTenant = records.tenant ? { ...records.tenant } : null;
+    let selectedLease: any = null;
+    const changedFields = new Set<string>();
+
+    if (input.type === "link_existing_lease") {
+      selectedLease = records.leases.find((lease: any) => lease.id === text(input.selectedLeaseId));
+      if (!selectedLease || !loaded.context.existingLeaseCandidates.some((lease) => lease.id === selectedLease.id)) {
+        throw new OccupancyResolutionError("selected_lease_not_eligible", 409, loaded.context);
+      }
+      const selectedTenantId = text(selectedLease.primaryTenantId || selectedLease.tenantId || selectedLease.tenantIds?.[0]);
+      nextUnit = { ...nextUnit, status: "occupied", occupancyStatus: "occupied", tenantId: selectedTenantId || null, currentTenantId: selectedTenantId || null, leaseId: selectedLease.id, currentLeaseId: selectedLease.id, occupancySource: "occupancy_resolution", occupancyUpdatedAt: now, updatedAt: now };
+      if (nextTenant) nextTenant.currentLeaseId = selectedLease.id;
+      ["status", "occupancyStatus", "tenantId", "currentTenantId", "leaseId", "currentLeaseId"].forEach((field) => changedFields.add(`unit.${field}`));
+      changedFields.add("tenant.currentLeaseId");
+    } else {
+      nextUnit = { ...nextUnit, status: "vacant", occupancyStatus: "vacant", tenantId: null, currentTenantId: null, leaseId: null, currentLeaseId: null, occupancySource: "occupancy_resolution", occupancyUpdatedAt: now, updatedAt: now };
+      if (nextTenant) {
+        nextTenant.currentLeaseId = null;
+        nextTenant.status = "Past";
+      }
+      ["status", "occupancyStatus", "tenantId", "currentTenantId", "leaseId", "currentLeaseId"].forEach((field) => changedFields.add(`unit.${field}`));
+      changedFields.add("tenant.currentLeaseId");
+      changedFields.add("tenant.status");
+    }
+
+    const nextEmbeddedUnits = embeddedUnits.map((unit: any, index: number) => index === matches[0].index ? {
+      ...unit,
+      status: nextUnit.status,
+      occupancyStatus: nextUnit.occupancyStatus,
+      tenantId: nextUnit.tenantId,
+      currentTenantId: nextUnit.currentTenantId,
+      leaseId: nextUnit.leaseId,
+      currentLeaseId: nextUnit.currentLeaseId,
+      occupancySource: "occupancy_resolution",
+      occupancyUpdatedAt: now,
+      updatedAt: now,
+    } : unit);
+
+    if (input.type !== "link_existing_lease") {
+      for (const tenancy of records.tenancies.filter((row: any) => row.status === "active")) {
+        transaction.set(tenancy.ref, input.type === "record_operational_move_out"
+          ? { status: "inactive", moveOutAt: `${input.effectiveDate}T00:00:00.000Z`, moveOutReason: "OTHER", moveOutReasonNote: "Operational occupancy reconciliation", updatedAt: now }
+          : { status: "inactive", updatedAt: now }, { merge: true });
+      }
+      changedFields.add("tenancy.status");
+      if (input.type === "record_operational_move_out") changedFields.add("tenancy.moveOutAt");
+    }
+
+    const resultingCanonicalState = buildCanonicalLeaseOccupancyProjection({
+      leases: records.leases,
+      context: { landlordId: input.landlordId, propertyId: input.propertyId, unitId: input.unitId, tenantId: loaded.context.tenantId },
+      ...resolveCanonicalUnitProjectionInputs(nextUnit),
+      persistedTenancyStatus: input.type === "link_existing_lease" && records.tenancies.some((row: any) => row.status === "active") ? "active" : "inactive",
+      persistedTenantStatus: nextTenant?.status,
+      currentLeasePointerId: nextTenant?.currentLeaseId || nextUnit.currentLeaseId,
+      tenantId: loaded.context.tenantId,
+    });
+    const expectedOccupancy = input.type === "link_existing_lease" ? "occupied" : "vacant";
+    if (resultingCanonicalState.occupancyState !== expectedOccupancy || (input.type === "link_existing_lease" && resultingCanonicalState.supportingLeaseId !== selectedLease.id)) {
+      throw new OccupancyResolutionError("unsafe_canonical_postcondition", 409, loaded.context);
+    }
+
+    transaction.set(records.propertyRef, { units: nextEmbeddedUnits, updatedAt: now }, { merge: true });
+    transaction.set(records.unitRef, nextUnit, { merge: true });
+    if (records.tenantRef && nextTenant) transaction.set(records.tenantRef, { currentLeaseId: nextTenant.currentLeaseId, ...(input.type === "link_existing_lease" ? {} : { status: nextTenant.status }), updatedAt: now }, { merge: true });
+
+    const auditEventId = `occupancy_resolution:${requestId}`;
+    const auditRef = db.collection("canonicalEvents").doc(auditEventId);
+    transaction.create(auditRef, {
+      id: auditEventId,
+      version: "v1",
+      type: "lease.occupancy_resolution_recorded",
+      domain: "lease",
+      action: "occupancy_resolution_recorded",
+      status: "succeeded",
+      actor: { type: "landlord", id: safeRef("actor", input.actorId), role: "landlord", displayName: null },
+      resource: { type: "unit", id: safeRef("unit", input.unitId), parentType: "property", parentId: safeRef("property", input.propertyId) },
+      occurredAt: now,
+      recordedAt: now,
+      visibility: "internal",
+      summary: "Operational occupancy records reconciled by landlord confirmation.",
+      metadata: {
+        landlordRef: safeRef("landlord", input.landlordId),
+        tenantRef: loaded.context.tenantId ? safeRef("tenant", loaded.context.tenantId) : null,
+        leaseRefs: records.leases.map((lease: any) => safeRef("lease", lease.id)),
+        requestRef: safeRef("request", requestId),
+        idempotencyRef: safeRef("idempotency", input.idempotencyKey),
+        originalReasons: [...loaded.context.canonicalState.reasons].sort(),
+        resolutionType: input.type,
+        landlordAssertion: input.type === "record_operational_move_out" ? "operational_occupancy_ended" : input.type === "link_existing_lease" ? "selected_lease_supports_current_occupancy" : "occupancy_projection_is_stale",
+        effectiveDate: input.effectiveDate || null,
+        changedFields: [...changedFields].sort(),
+        before: { occupancyState: loaded.context.canonicalState.occupancyState, tenantRelationshipState: loaded.context.canonicalState.tenantRelationshipState, supportingLeaseRef: loaded.context.canonicalState.supportingLeaseId ? safeRef("lease", loaded.context.canonicalState.supportingLeaseId) : null },
+        after: { occupancyState: resultingCanonicalState.occupancyState, tenantRelationshipState: resultingCanonicalState.tenantRelationshipState, supportingLeaseRef: resultingCanonicalState.supportingLeaseId ? safeRef("lease", resultingCanonicalState.supportingLeaseId) : null },
+        legalDetermination: false,
+      },
+      tags: ["occupancy_resolution", input.type],
+      appendOnly: true,
+      immutable: true,
+    });
+    const resultContext = { ...loaded.context, canonicalState: resultingCanonicalState, expectedStateToken: "committed" };
+    transaction.create(requestRef, { landlordId: input.landlordId, payloadHash, auditEventId, createdAt: now, resultContext });
+    return { context: resultContext, auditEventId, idempotent: false };
+  });
+}

--- a/rentchain-api/src/services/tenantDetailsService.ts
+++ b/rentchain-api/src/services/tenantDetailsService.ts
@@ -13,6 +13,7 @@ import {
 import {
   groupLeaseAgreementCandidates,
   pickAgreementWinner,
+  preserveCanonicalLeaseEvidence,
 } from "./leasePartyConsolidationService";
 import { buildCredibilityInsights, type CredibilityInsights } from "./risk/credibilityInsights";
 import { buildMoveInRequirements, type MoveInRequirements } from "./moveInRequirements";
@@ -483,12 +484,13 @@ async function loadTenantLeaseResolution(tenant: TenantRecord | null, landlordId
       };
     });
     const grouped = groupLeaseAgreementCandidates(agreementCandidates);
+    const canonicalEvidenceLeases = preserveCanonicalLeaseEvidence(agreementCandidates);
     const representatives = [
       ...grouped.mergeGroups.map((group) => pickAgreementWinner(group.candidates).lease),
       ...grouped.ambiguousGroups.map((group) => pickAgreementWinner(group.candidates).lease),
       ...grouped.singles.map((candidate) => candidate.lease),
     ];
-    const selection = selectCanonicalCurrentLease(representatives.map(toCanonicalLeaseStateInput), {
+    const selection = selectCanonicalCurrentLease(canonicalEvidenceLeases.map(toCanonicalLeaseStateInput), {
       landlordId,
       tenantId,
     });
@@ -501,7 +503,7 @@ async function loadTenantLeaseResolution(tenant: TenantRecord | null, landlordId
       displayLease: selectedLease || hintedLease || (displayCandidates.length
         ? pickAgreementWinner(displayCandidates.map((lease) => ({ lease, raw: lease }))).lease
         : null),
-      leases: representatives,
+      leases: canonicalEvidenceLeases,
     };
   } catch (err) {
     console.error("[tenantDetailsService] loadTenantLeaseResolution error", err);

--- a/rentchain-frontend/playwright.occupancy.config.ts
+++ b/rentchain-frontend/playwright.occupancy.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "@playwright/test";
+import baseConfig from "./playwright.config";
+
+const localBaseUrl = "http://localhost:4179";
+
+export default defineConfig({
+  ...baseConfig,
+  webServer: process.env.BASE_URL
+    ? undefined
+    : {
+        command: "VITE_API_BASE_URL=https://local-api.rentchain.test npm run build:app && npm run preview -- --host --port 4179",
+        url: localBaseUrl,
+        reuseExistingServer: false,
+        timeout: 120_000,
+      },
+  use: {
+    ...baseConfig.use,
+    baseURL: process.env.BASE_URL || localBaseUrl,
+  },
+});

--- a/rentchain-frontend/src/api/occupancyResolutionApi.ts
+++ b/rentchain-frontend/src/api/occupancyResolutionApi.ts
@@ -1,0 +1,50 @@
+import { apiJson } from "@/api/http";
+import type { CanonicalLeaseOccupancyState } from "@/lib/leases/canonicalStatePresentation";
+
+export type OccupancyResolutionType =
+  | "record_operational_move_out"
+  | "clear_stale_occupancy_record"
+  | "link_existing_lease";
+
+export type OccupancyResolutionContext = {
+  propertyId: string;
+  unitId: string;
+  tenantId: string | null;
+  unitLabel: string;
+  propertyLabel: string;
+  canonicalState: CanonicalLeaseOccupancyState;
+  expectedStateToken: string;
+  eligibleResolutionTypes: OccupancyResolutionType[];
+  existingLeaseCandidates: Array<{ id: string; label: string; tenantId: string | null; startDate: string | null; endDate: string | null }>;
+  activeLeaseRequiresEndWorkflow: boolean;
+};
+
+export async function getOccupancyResolutionContext(input: { propertyId: string; unitId: string; tenantId?: string | null }) {
+  const query = new URLSearchParams({ propertyId: input.propertyId, unitId: input.unitId });
+  if (input.tenantId) query.set("tenantId", input.tenantId);
+  return apiJson<{ ok: true; context: OccupancyResolutionContext }>(`/occupancy-resolutions/context?${query.toString()}`);
+}
+
+export async function submitOccupancyResolution(input: {
+  context: OccupancyResolutionContext;
+  type: OccupancyResolutionType;
+  idempotencyKey: string;
+  effectiveDate?: string;
+  selectedLeaseId?: string;
+}) {
+  return apiJson<{ ok: true; context: OccupancyResolutionContext; auditEventId: string; idempotent: boolean }>("/occupancy-resolutions", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      propertyId: input.context.propertyId,
+      unitId: input.context.unitId,
+      tenantId: input.context.tenantId,
+      expectedStateToken: input.context.expectedStateToken,
+      type: input.type,
+      idempotencyKey: input.idempotencyKey,
+      confirmation: true,
+      effectiveDate: input.effectiveDate || null,
+      selectedLeaseId: input.selectedLeaseId || null,
+    }),
+  });
+}

--- a/rentchain-frontend/src/components/occupancy/ResolveOccupancyDrawer.test.tsx
+++ b/rentchain-frontend/src/components/occupancy/ResolveOccupancyDrawer.test.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ResolveOccupancyDrawer } from "./ResolveOccupancyDrawer";
+
+const { getContext, submit } = vi.hoisted(() => ({ getContext: vi.fn(), submit: vi.fn() }));
+vi.mock("@/api/occupancyResolutionApi", async () => {
+  const actual = await vi.importActual<any>("@/api/occupancyResolutionApi");
+  return { ...actual, getOccupancyResolutionContext: getContext, submitOccupancyResolution: submit };
+});
+
+const context = {
+  propertyId: "property-1",
+  unitId: "unit-1",
+  tenantId: "tenant-1",
+  propertyLabel: "Harbour House",
+  unitLabel: "1A",
+  canonicalState: { leaseTermState: "past", occupancyState: "review_needed", tenantRelationshipState: "occupancy_unresolved", supportingLeaseId: null, reasons: ["PAST_LEASE_CANNOT_SUPPORT_OCCUPANCY", "OCCUPIED_WITHOUT_CURRENT_LEASE"] },
+  expectedStateToken: "token-1",
+  eligibleResolutionTypes: ["record_operational_move_out", "clear_stale_occupancy_record"],
+  existingLeaseCandidates: [],
+  activeLeaseRequiresEndWorkflow: false,
+};
+
+describe("ResolveOccupancyDrawer", () => {
+  afterEach(() => cleanup());
+  beforeEach(() => {
+    getContext.mockReset().mockResolvedValue({ ok: true, context });
+    submit.mockReset().mockResolvedValue({ ok: true, context: { ...context, canonicalState: { ...context.canonicalState, occupancyState: "vacant" } } });
+  });
+
+  it("uses neutral confirmation language and requires an effective date", async () => {
+    render(<ResolveOccupancyDrawer open propertyId="property-1" unitId="unit-1" tenantId="tenant-1" onClose={vi.fn()} />);
+    expect(await screen.findByRole("dialog", { name: "Resolve Occupancy" })).toBeInTheDocument();
+    expect(screen.getByText(/without making a legal tenancy determination/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText("Record operational move-out"));
+    expect(screen.getByRole("button", { name: "Confirm operational reconciliation" })).toBeDisabled();
+    fireEvent.change(screen.getByLabelText("Operational move-out effective date"), { target: { value: "2026-08-18" } });
+    expect(screen.getByRole("button", { name: "Confirm operational reconciliation" })).toBeEnabled();
+  });
+
+  it("keeps the workflow open and refreshes context after a stale-state response", async () => {
+    submit.mockRejectedValue(Object.assign(new Error("stale"), { body: { error: "occupancy_state_stale", freshContext: { ...context, expectedStateToken: "token-2" } } }));
+    render(<ResolveOccupancyDrawer open propertyId="property-1" unitId="unit-1" tenantId="tenant-1" onClose={vi.fn()} />);
+    fireEvent.click(await screen.findByLabelText("Correct stale occupancy records"));
+    fireEvent.click(screen.getByRole("button", { name: "Confirm operational reconciliation" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent(/changed while this review was open/i);
+    expect(screen.getByRole("dialog", { name: "Resolve Occupancy" })).toBeInTheDocument();
+  });
+
+  it("Review later closes with zero mutation", async () => {
+    const onClose = vi.fn();
+    render(<ResolveOccupancyDrawer open propertyId="property-1" unitId="unit-1" onClose={onClose} />);
+    fireEvent.click(await screen.findByRole("button", { name: "Review later" }));
+    expect(onClose).toHaveBeenCalledOnce();
+    expect(submit).not.toHaveBeenCalled();
+  });
+});

--- a/rentchain-frontend/src/components/occupancy/ResolveOccupancyDrawer.test.tsx
+++ b/rentchain-frontend/src/components/occupancy/ResolveOccupancyDrawer.test.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import React, { useState } from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ResolveOccupancyDrawer } from "./ResolveOccupancyDrawer";
 
@@ -21,6 +21,24 @@ const context = {
   existingLeaseCandidates: [],
   activeLeaseRequiresEndWorkflow: false,
 };
+
+function DrawerHarness({ removeTriggerOnResolve = false }: { removeTriggerOnResolve?: boolean }) {
+  const [open, setOpen] = useState(false);
+  const [resolved, setResolved] = useState(false);
+  return (
+    <main aria-label="Occupancy workspace">
+      {!resolved ? <button type="button" onClick={() => setOpen(true)}>Resolve occupancy</button> : null}
+      <ResolveOccupancyDrawer
+        open={open}
+        propertyId="property-1"
+        unitId="unit-1"
+        tenantId="tenant-1"
+        onClose={() => setOpen(false)}
+        onResolved={() => { if (removeTriggerOnResolve) setResolved(true); }}
+      />
+    </main>
+  );
+}
 
 describe("ResolveOccupancyDrawer", () => {
   afterEach(() => cleanup());
@@ -54,5 +72,70 @@ describe("ResolveOccupancyDrawer", () => {
     fireEvent.click(await screen.findByRole("button", { name: "Review later" }));
     expect(onClose).toHaveBeenCalledOnce();
     expect(submit).not.toHaveBeenCalled();
+  });
+
+  it("moves focus through the named modal in both directions and contains repeated Tab", async () => {
+    render(<DrawerHarness />);
+    const opener = screen.getByRole("button", { name: "Resolve occupancy" });
+    opener.focus();
+    fireEvent.click(opener);
+
+    const dialog = await screen.findByRole("dialog", { name: "Resolve Occupancy" });
+    const close = screen.getByRole("button", { name: "Close Resolve Occupancy" });
+    await waitFor(() => expect(close).toHaveFocus());
+
+    fireEvent.keyDown(close, { key: "Tab" });
+    expect(screen.getByLabelText("Record operational move-out")).toHaveFocus();
+    fireEvent.keyDown(document.activeElement!, { key: "Tab" });
+    expect(screen.getByLabelText("Correct stale occupancy records")).toHaveFocus();
+    fireEvent.keyDown(document.activeElement!, { key: "Tab" });
+    expect(screen.getByRole("button", { name: "Review later" })).toHaveFocus();
+    fireEvent.keyDown(document.activeElement!, { key: "Tab" });
+    expect(close).toHaveFocus();
+    fireEvent.keyDown(close, { key: "Tab", shiftKey: true });
+    expect(screen.getByRole("button", { name: "Review later" })).toHaveFocus();
+    expect(dialog).toContainElement(document.activeElement as HTMLElement);
+  });
+
+  it("Escape closes without mutation and restores focus to the opener", async () => {
+    render(<DrawerHarness />);
+    const opener = screen.getByRole("button", { name: "Resolve occupancy" });
+    opener.focus();
+    fireEvent.click(opener);
+    const dialog = await screen.findByRole("dialog", { name: "Resolve Occupancy" });
+
+    fireEvent.keyDown(dialog, { key: "Escape" });
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    await waitFor(() => expect(opener).toHaveFocus());
+    expect(submit).not.toHaveBeenCalled();
+  });
+
+  it.each(["Close Resolve Occupancy", "Review later"])(
+    "%s restores focus to the opener",
+    async (buttonName) => {
+      render(<DrawerHarness />);
+      const opener = screen.getByRole("button", { name: "Resolve occupancy" });
+      opener.focus();
+      fireEvent.click(opener);
+      fireEvent.click(await screen.findByRole("button", { name: buttonName }));
+
+      await waitFor(() => expect(opener).toHaveFocus());
+      expect(submit).not.toHaveBeenCalled();
+    }
+  );
+
+  it("focuses a stable workspace fallback after success removes the opener", async () => {
+    render(<DrawerHarness removeTriggerOnResolve />);
+    const opener = screen.getByRole("button", { name: "Resolve occupancy" });
+    opener.focus();
+    fireEvent.click(opener);
+    fireEvent.click(await screen.findByLabelText("Correct stale occupancy records"));
+    fireEvent.click(screen.getByRole("button", { name: "Confirm operational reconciliation" }));
+
+    const workspace = screen.getByRole("main", { name: "Occupancy workspace" });
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    await waitFor(() => expect(workspace).toHaveFocus());
+    expect(screen.queryByRole("button", { name: "Resolve occupancy" })).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/components/occupancy/ResolveOccupancyDrawer.test.tsx
+++ b/rentchain-frontend/src/components/occupancy/ResolveOccupancyDrawer.test.tsx
@@ -112,7 +112,7 @@ describe("ResolveOccupancyDrawer", () => {
   });
 
   it.each(["Close Resolve Occupancy", "Review later"])(
-    "%s restores focus to the opener",
+    "%s dismisses the controlled drawer and restores focus to the opener",
     async (buttonName) => {
       render(<DrawerHarness />);
       const opener = screen.getByRole("button", { name: "Resolve occupancy" });
@@ -120,6 +120,7 @@ describe("ResolveOccupancyDrawer", () => {
       fireEvent.click(opener);
       fireEvent.click(await screen.findByRole("button", { name: buttonName }));
 
+      await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
       await waitFor(() => expect(opener).toHaveFocus());
       expect(submit).not.toHaveBeenCalled();
     }

--- a/rentchain-frontend/src/components/occupancy/ResolveOccupancyDrawer.tsx
+++ b/rentchain-frontend/src/components/occupancy/ResolveOccupancyDrawer.tsx
@@ -49,6 +49,8 @@ export function ResolveOccupancyDrawer(props: {
   const [selectedLeaseId, setSelectedLeaseId] = useState("");
   const idempotencyKey = useRef(key());
   const closeRef = useRef<HTMLButtonElement | null>(null);
+  const dialogRef = useRef<HTMLElement | null>(null);
+  const openerRef = useRef<HTMLElement | null>(null);
 
   useEffect(() => {
     if (!props.open) return;
@@ -65,9 +67,63 @@ export function ResolveOccupancyDrawer(props: {
     return () => { cancelled = true; };
   }, [props.open, props.propertyId, props.unitId, props.tenantId]);
 
+  useEffect(() => {
+    if (!props.open) return;
+    openerRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  }, [props.open]);
+
   useEffect(() => { if (props.open && !loading) closeRef.current?.focus(); }, [props.open, loading]);
   const canSubmit = useMemo(() => Boolean(context && type && !submitting && (type !== "record_operational_move_out" || effectiveDate) && (type !== "link_existing_lease" || selectedLeaseId)), [context, type, submitting, effectiveDate, selectedLeaseId]);
   if (!props.open) return null;
+
+  const restoreFocus = () => {
+    window.setTimeout(() => {
+      const opener = openerRef.current;
+      if (opener?.isConnected && !opener.hasAttribute("disabled")) {
+        opener.focus();
+        return;
+      }
+      const fallback = document.querySelector<HTMLElement>(
+        "[data-occupancy-focus-fallback], main, [role=main], h1"
+      );
+      if (fallback) {
+        if (!fallback.hasAttribute("tabindex")) fallback.setAttribute("tabindex", "-1");
+        fallback.focus();
+      }
+    }, 0);
+  };
+
+  const close = () => {
+    props.onClose();
+    restoreFocus();
+  };
+
+  const handleDialogKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
+    if (event.key === "Escape" && !submitting) {
+      event.preventDefault();
+      close();
+      return;
+    }
+    if (event.key !== "Tab") return;
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    const focusable = Array.from(
+      dialog.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      )
+    ).filter((element) => element.getAttribute("aria-hidden") !== "true");
+    if (!focusable.length) {
+      event.preventDefault();
+      dialog.focus();
+      return;
+    }
+    const activeIndex = focusable.indexOf(document.activeElement as HTMLElement);
+    const nextIndex = event.shiftKey
+      ? activeIndex <= 0 ? focusable.length - 1 : activeIndex - 1
+      : activeIndex < 0 || activeIndex === focusable.length - 1 ? 0 : activeIndex + 1;
+    event.preventDefault();
+    focusable[nextIndex].focus();
+  };
 
   const submit = async () => {
     if (!context || !type || !canSubmit) return;
@@ -76,7 +132,7 @@ export function ResolveOccupancyDrawer(props: {
     try {
       await submitOccupancyResolution({ context, type, idempotencyKey: idempotencyKey.current, effectiveDate, selectedLeaseId });
       await props.onResolved?.();
-      props.onClose();
+      close();
     } catch (reason) {
       const apiError = reason as ApiError;
       if (apiError?.body?.freshContext) setContext(apiError.body.freshContext);
@@ -87,11 +143,11 @@ export function ResolveOccupancyDrawer(props: {
   };
 
   return (
-    <div role="presentation" onKeyDown={(event) => { if (event.key === "Escape" && !submitting) props.onClose(); }} style={{ position: "fixed", inset: 0, zIndex: 1000, background: "rgba(15,23,42,.45)", display: "flex", justifyContent: "flex-end" }}>
-      <section role="dialog" aria-modal="true" aria-labelledby="resolve-occupancy-title" style={{ width: "min(100%, 520px)", height: "100%", overflowY: "auto", background: "#fffaf1", padding: 24, boxShadow: "-12px 0 32px rgba(15,23,42,.18)", display: "grid", alignContent: "start", gap: 18 }}>
+    <div role="presentation" style={{ position: "fixed", inset: 0, zIndex: 1000, background: "rgba(15,23,42,.45)", display: "flex", justifyContent: "flex-end" }}>
+      <section ref={dialogRef} role="dialog" aria-modal="true" aria-labelledby="resolve-occupancy-title" tabIndex={-1} onKeyDown={handleDialogKeyDown} style={{ width: "min(100%, 520px)", maxWidth: "100vw", height: "100dvh", maxHeight: "100dvh", boxSizing: "border-box", overflowX: "hidden", overflowY: "auto", overscrollBehavior: "contain", background: "#fffaf1", padding: 24, boxShadow: "-12px 0 32px rgba(15,23,42,.18)", display: "grid", alignContent: "start", gap: 18 }}>
         <header style={{ display: "flex", justifyContent: "space-between", gap: 16 }}>
           <div><h2 id="resolve-occupancy-title" style={{ margin: 0 }}>Resolve Occupancy</h2><p style={{ margin: "6px 0 0", color: "#63594d" }}>Reconcile operational records without making a legal tenancy determination.</p></div>
-          <button ref={closeRef} type="button" onClick={props.onClose} disabled={submitting} aria-label="Close Resolve Occupancy">Close</button>
+          <button ref={closeRef} type="button" onClick={close} disabled={submitting} aria-label="Close Resolve Occupancy">Close</button>
         </header>
         {loading ? <p>Loading current occupancy records…</p> : null}
         {error ? <div role="alert" style={{ color: "#991b1b", background: "#fef2f2", padding: 12, borderRadius: 10 }}>{error}</div> : null}
@@ -103,7 +159,7 @@ export function ResolveOccupancyDrawer(props: {
           {type === "record_operational_move_out" ? <label>Effective date<input aria-label="Operational move-out effective date" type="date" value={effectiveDate} onChange={(event) => setEffectiveDate(event.target.value)} style={{ display: "block", marginTop: 6 }} /></label> : null}
           {type === "link_existing_lease" ? <label>Existing lease<select aria-label="Existing valid lease" value={selectedLeaseId} onChange={(event) => setSelectedLeaseId(event.target.value)} style={{ display: "block", marginTop: 6, maxWidth: "100%" }}><option value="">Select a lease</option>{context.existingLeaseCandidates.map((lease) => <option key={lease.id} value={lease.id}>{lease.label} · {lease.startDate || "Unknown start"} to {lease.endDate || "No end date"}</option>)}</select></label> : null}
           {type ? <div style={{ padding: 12, background: "#f8fafc", borderRadius: 10 }}>Historical lease and relationship records remain preserved. Confirming changes operational occupancy records only and does not determine legal tenancy rights.</div> : null}
-          <footer style={{ display: "flex", justifyContent: "flex-end", gap: 10, flexWrap: "wrap" }}><button type="button" onClick={props.onClose} disabled={submitting}>Review later</button>{type ? <button type="button" onClick={submit} disabled={!canSubmit}>{submitting ? "Reconciling…" : "Confirm operational reconciliation"}</button> : null}</footer>
+          <footer style={{ display: "flex", justifyContent: "flex-end", gap: 10, flexWrap: "wrap" }}><button type="button" onClick={close} disabled={submitting}>Review later</button>{type ? <button type="button" onClick={submit} disabled={!canSubmit}>{submitting ? "Reconciling…" : "Confirm operational reconciliation"}</button> : null}</footer>
         </> : null}
       </section>
     </div>

--- a/rentchain-frontend/src/components/occupancy/ResolveOccupancyDrawer.tsx
+++ b/rentchain-frontend/src/components/occupancy/ResolveOccupancyDrawer.tsx
@@ -1,0 +1,111 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import {
+  getOccupancyResolutionContext,
+  submitOccupancyResolution,
+  type OccupancyResolutionContext,
+  type OccupancyResolutionType,
+} from "@/api/occupancyResolutionApi";
+import type { ApiError } from "@/api/http";
+
+const REASON_COPY: Record<string, string> = {
+  MULTIPLE_CURRENT_LEASES: "More than one lease could support current occupancy. RentChain will not select one automatically.",
+  INVALID_LEASE_DATE_RANGE: "A lease has contradictory start and end dates.",
+  CURRENT_LEASE_CONTEXT_MISMATCH: "A lease or pointer does not match this property, unit, or tenant.",
+  DRAFT_LEASE_CANNOT_SUPPORT_OCCUPANCY: "A draft lease cannot support current occupancy.",
+  UPCOMING_LEASE_CANNOT_SUPPORT_OCCUPANCY: "An upcoming lease does not yet support current occupancy.",
+  PAST_LEASE_CANNOT_SUPPORT_OCCUPANCY: "A past lease does not by itself establish current occupancy or vacancy.",
+  ENDED_LEASE_CANNOT_SUPPORT_OCCUPANCY: "An ended lease cannot support current occupancy.",
+  LEASE_EXECUTION_INCOMPLETE: "Lease execution is incomplete.",
+  OCCUPIED_WITHOUT_CURRENT_LEASE: "Current records show occupancy without a lease that can support it.",
+  VACANT_WITH_CURRENT_LEASE: "Current records show vacancy while a valid current lease exists.",
+  STALE_CURRENT_LEASE_POINTER: "A current lease pointer no longer matches the canonical lease state.",
+  TENANT_CURRENT_WITHOUT_CURRENT_LEASE: "The tenant is marked current without a current supporting lease.",
+};
+
+const LABELS: Record<OccupancyResolutionType, string> = {
+  record_operational_move_out: "Record operational move-out",
+  clear_stale_occupancy_record: "Correct stale occupancy records",
+  link_existing_lease: "Link an existing valid lease",
+};
+
+function key() {
+  return globalThis.crypto?.randomUUID?.() || `occupancy-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+export function ResolveOccupancyDrawer(props: {
+  open: boolean;
+  propertyId: string;
+  unitId: string;
+  tenantId?: string | null;
+  onClose: () => void;
+  onResolved?: () => void | Promise<void>;
+}) {
+  const [context, setContext] = useState<OccupancyResolutionContext | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [type, setType] = useState<OccupancyResolutionType | "">("");
+  const [effectiveDate, setEffectiveDate] = useState("");
+  const [selectedLeaseId, setSelectedLeaseId] = useState("");
+  const idempotencyKey = useRef(key());
+  const closeRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    if (!props.open) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setContext(null);
+    setType("");
+    idempotencyKey.current = key();
+    getOccupancyResolutionContext(props)
+      .then((result) => { if (!cancelled) setContext(result.context); })
+      .catch((reason) => { if (!cancelled) setError((reason as ApiError)?.body?.error || "Occupancy review could not be loaded."); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [props.open, props.propertyId, props.unitId, props.tenantId]);
+
+  useEffect(() => { if (props.open && !loading) closeRef.current?.focus(); }, [props.open, loading]);
+  const canSubmit = useMemo(() => Boolean(context && type && !submitting && (type !== "record_operational_move_out" || effectiveDate) && (type !== "link_existing_lease" || selectedLeaseId)), [context, type, submitting, effectiveDate, selectedLeaseId]);
+  if (!props.open) return null;
+
+  const submit = async () => {
+    if (!context || !type || !canSubmit) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await submitOccupancyResolution({ context, type, idempotencyKey: idempotencyKey.current, effectiveDate, selectedLeaseId });
+      await props.onResolved?.();
+      props.onClose();
+    } catch (reason) {
+      const apiError = reason as ApiError;
+      if (apiError?.body?.freshContext) setContext(apiError.body.freshContext);
+      setError(apiError?.body?.error === "occupancy_state_stale" ? "Occupancy records changed while this review was open. Review the refreshed state before trying again." : apiError?.body?.error || "Occupancy records were not changed.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div role="presentation" onKeyDown={(event) => { if (event.key === "Escape" && !submitting) props.onClose(); }} style={{ position: "fixed", inset: 0, zIndex: 1000, background: "rgba(15,23,42,.45)", display: "flex", justifyContent: "flex-end" }}>
+      <section role="dialog" aria-modal="true" aria-labelledby="resolve-occupancy-title" style={{ width: "min(100%, 520px)", height: "100%", overflowY: "auto", background: "#fffaf1", padding: 24, boxShadow: "-12px 0 32px rgba(15,23,42,.18)", display: "grid", alignContent: "start", gap: 18 }}>
+        <header style={{ display: "flex", justifyContent: "space-between", gap: 16 }}>
+          <div><h2 id="resolve-occupancy-title" style={{ margin: 0 }}>Resolve Occupancy</h2><p style={{ margin: "6px 0 0", color: "#63594d" }}>Reconcile operational records without making a legal tenancy determination.</p></div>
+          <button ref={closeRef} type="button" onClick={props.onClose} disabled={submitting} aria-label="Close Resolve Occupancy">Close</button>
+        </header>
+        {loading ? <p>Loading current occupancy records…</p> : null}
+        {error ? <div role="alert" style={{ color: "#991b1b", background: "#fef2f2", padding: 12, borderRadius: 10 }}>{error}</div> : null}
+        {context ? <>
+          <div><strong>{context.propertyLabel} · {context.unitLabel}</strong><div style={{ color: "#92400e", marginTop: 4 }}>Current state: Review needed</div></div>
+          <section><h3>Why review is required</h3><ul>{context.canonicalState.reasons.map((reason) => <li key={reason}>{REASON_COPY[reason] || "Current occupancy records require review."}</li>)}</ul></section>
+          {context.activeLeaseRequiresEndWorkflow ? <div style={{ padding: 12, background: "#fff7ed", borderRadius: 10 }}>A valid active lease still supports this occupancy. Use the existing End Lease workflow if the operational occupancy has ended.</div> : null}
+          {context.eligibleResolutionTypes.length ? <fieldset style={{ border: 0, padding: 0, display: "grid", gap: 10 }}><legend style={{ fontWeight: 800, marginBottom: 8 }}>Choose a reconciliation action</legend>{context.eligibleResolutionTypes.map((option) => <label key={option} style={{ display: "flex", gap: 8 }}><input type="radio" name="occupancy-resolution" checked={type === option} onChange={() => setType(option)} />{LABELS[option]}</label>)}</fieldset> : <p>These records do not have a safe automated resolution. They will remain visible for review.</p>}
+          {type === "record_operational_move_out" ? <label>Effective date<input aria-label="Operational move-out effective date" type="date" value={effectiveDate} onChange={(event) => setEffectiveDate(event.target.value)} style={{ display: "block", marginTop: 6 }} /></label> : null}
+          {type === "link_existing_lease" ? <label>Existing lease<select aria-label="Existing valid lease" value={selectedLeaseId} onChange={(event) => setSelectedLeaseId(event.target.value)} style={{ display: "block", marginTop: 6, maxWidth: "100%" }}><option value="">Select a lease</option>{context.existingLeaseCandidates.map((lease) => <option key={lease.id} value={lease.id}>{lease.label} · {lease.startDate || "Unknown start"} to {lease.endDate || "No end date"}</option>)}</select></label> : null}
+          {type ? <div style={{ padding: 12, background: "#f8fafc", borderRadius: 10 }}>Historical lease and relationship records remain preserved. Confirming changes operational occupancy records only and does not determine legal tenancy rights.</div> : null}
+          <footer style={{ display: "flex", justifyContent: "flex-end", gap: 10, flexWrap: "wrap" }}><button type="button" onClick={props.onClose} disabled={submitting}>Review later</button>{type ? <button type="button" onClick={submit} disabled={!canSubmit}>{submitting ? "Reconciling…" : "Confirm operational reconciliation"}</button> : null}</footer>
+        </> : null}
+      </section>
+    </div>
+  );
+}

--- a/rentchain-frontend/src/components/occupancy/ResolveOccupancyDrawer.tsx
+++ b/rentchain-frontend/src/components/occupancy/ResolveOccupancyDrawer.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import {
   getOccupancyResolutionContext,
   submitOccupancyResolution,
@@ -142,8 +143,8 @@ export function ResolveOccupancyDrawer(props: {
     }
   };
 
-  return (
-    <div role="presentation" style={{ position: "fixed", inset: 0, zIndex: 1000, background: "rgba(15,23,42,.45)", display: "flex", justifyContent: "flex-end" }}>
+  return createPortal((
+    <div role="presentation" style={{ position: "fixed", inset: 0, zIndex: 4030, background: "rgba(15,23,42,.45)", display: "flex", justifyContent: "flex-end" }}>
       <section ref={dialogRef} role="dialog" aria-modal="true" aria-labelledby="resolve-occupancy-title" tabIndex={-1} onKeyDown={handleDialogKeyDown} style={{ width: "min(100%, 520px)", maxWidth: "100vw", height: "100dvh", maxHeight: "100dvh", boxSizing: "border-box", overflowX: "hidden", overflowY: "auto", overscrollBehavior: "contain", background: "#fffaf1", padding: 24, boxShadow: "-12px 0 32px rgba(15,23,42,.18)", display: "grid", alignContent: "start", gap: 18 }}>
         <header style={{ display: "flex", justifyContent: "space-between", gap: 16 }}>
           <div><h2 id="resolve-occupancy-title" style={{ margin: 0 }}>Resolve Occupancy</h2><p style={{ margin: "6px 0 0", color: "#63594d" }}>Reconcile operational records without making a legal tenancy determination.</p></div>
@@ -163,5 +164,5 @@ export function ResolveOccupancyDrawer(props: {
         </> : null}
       </section>
     </div>
-  );
+  ), document.body);
 }

--- a/rentchain-frontend/src/components/properties/PropertyDetailPanel.test.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyDetailPanel.test.tsx
@@ -530,6 +530,7 @@ describe("PropertyDetailPanel", () => {
     render(<MemoryRouter><PropertyDetailPanel property={{ id: "prop-1", name: "Harbour View", addressLine1: "12 Wharf Street", city: "Halifax", province: "NS", postalCode: "B3H 1A1", country: "Canada", totalUnits: 1, amenities: [], units: [], createdAt: new Date().toISOString() }} /></MemoryRouter>);
     expect((await screen.findAllByText("Review needed")).length).toBeGreaterThan(0);
     expect(screen.getAllByText("Past lease · Occupancy requires review").length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("button", { name: "Resolve occupancy" }).length).toBeGreaterThan(0);
   });
 
   it("hydrates lease risk unit labels from property units instead of showing raw unit ids", async () => {

--- a/rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx
@@ -55,6 +55,7 @@ import {
 } from "@/lib/leases/leaseLifecycle";
 import { getUnitsNeedingOccupancySetup } from "./occupancyPrompt";
 import type { CanonicalLeaseOccupancyState } from "@/lib/leases/canonicalStatePresentation";
+import { ResolveOccupancyDrawer } from "@/components/occupancy/ResolveOccupancyDrawer";
 
 interface PropertyDetailPanelProps {
   property: Property | null;
@@ -322,6 +323,8 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
     currentPlan === "elite";
   const [leases, setLeases] = useState<Lease[]>([]);
   const [canonicalUnitStates, setCanonicalUnitStates] = useState<Record<string, CanonicalLeaseOccupancyState>>({});
+  const [resolvingOccupancyUnit, setResolvingOccupancyUnit] = useState<any | null>(null);
+  const [occupancyRefreshKey, setOccupancyRefreshKey] = useState(0);
   const [credibilitySummary, setCredibilitySummary] = useState<PropertyCredibilitySummary | null>(null);
   const [isLeasesLoading, setIsLeasesLoading] = useState(false);
   const [leasesError, setLeasesError] = useState<string | null>(null);
@@ -755,7 +758,7 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
     return () => {
       cancelled = true;
     };
-  }, [propertyId]);
+  }, [propertyId, occupancyRefreshKey]);
 
   // no plan fetch needed; starter supports unlimited units
 
@@ -1916,6 +1919,7 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
                           {occupancyView.reviewReason ? (
                             <div style={{ fontSize: "0.78rem", color: "#92400e" }}>
                               {occupancyView.reviewReason}
+                              <div><button type="button" onClick={() => setResolvingOccupancyUnit(u)}>Resolve occupancy</button></div>
                             </div>
                           ) : null}
                           {(u as any).leaseDocument?.fileName ? (
@@ -2065,6 +2069,7 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
                     {occupancyView.reviewReason ? (
                       <div style={{ fontSize: "0.78rem", color: "#92400e", marginTop: 4 }}>
                         {occupancyView.reviewReason}
+                        <div><button type="button" onClick={() => setResolvingOccupancyUnit(u)}>Resolve occupancy</button></div>
                       </div>
                     ) : null}
                     {(u as any).leaseDocument?.fileName ? (
@@ -2458,6 +2463,16 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
         issues={unitCsvIssues}
         isImporting={isImporting}
       />
+      {propertyId && resolvingOccupancyUnit ? (
+        <ResolveOccupancyDrawer
+          open
+          propertyId={propertyId}
+          unitId={String(resolvingOccupancyUnit.id || resolvingOccupancyUnit.unitId || "")}
+          tenantId={String(resolvingOccupancyUnit.currentTenantId || resolvingOccupancyUnit.tenantId || "") || null}
+          onClose={() => setResolvingOccupancyUnit(null)}
+          onResolved={async () => { setOccupancyRefreshKey((value) => value + 1); await onRefresh?.(); }}
+        />
+      ) : null}
     </>
   );
 };

--- a/rentchain-frontend/src/components/tenants/TenantDetailPanel.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantDetailPanel.tsx
@@ -35,6 +35,7 @@ import {
   canonicalOccupancyLabel,
   canonicalTenantRelationshipLabel,
 } from "@/lib/leases/canonicalStatePresentation";
+import { ResolveOccupancyDrawer } from "@/components/occupancy/ResolveOccupancyDrawer";
 
 interface TenantDetailPanelProps {
   tenantId: string | null;
@@ -182,6 +183,7 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityR
   const credibilityInsights = bundle.credibilityInsights || null;
   const [moveInReadiness, setMoveInReadiness] = useState<MoveInReadiness | null>(bundle.moveInReadiness || null);
   const [readinessSaving, setReadinessSaving] = useState(false);
+  const [resolveOccupancyOpen, setResolveOccupancyOpen] = useState(false);
 
   const [ledgerItems, setLedgerItems] = useState<any[]>([]);
   const [leaseLedgerItems, setLeaseLedgerItems] = useState<LeaseLedgerEntry[]>([]);
@@ -623,6 +625,7 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityR
           }
         />
         <DetailField label="Tenant Status" value={canonicalState ? canonicalTenantRelationshipLabel(canonicalState.tenantRelationshipState) : tenant.status ?? "--"} />
+        {canonicalState?.tenantRelationshipState === "occupancy_unresolved" && property?.id && unit?.id ? <button type="button" onClick={() => setResolveOccupancyOpen(true)}>Resolve occupancy</button> : null}
         {lifecycle?.flags?.hasStateConflict ? (
           <DetailField label="Lifecycle Review" value="Source status conflict detected" />
         ) : null}
@@ -1032,6 +1035,7 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityR
         lease={lease}
         landlordName={String(user?.displayName || user?.name || user?.email || "Landlord")}
       />
+      {resolveOccupancyOpen && property?.id && unit?.id ? <ResolveOccupancyDrawer open propertyId={property.id} unitId={unit.id} tenantId={tenantId} onClose={() => setResolveOccupancyOpen(false)} onResolved={() => navigate(0)} /> : null}
     </div>
   );
 };

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
@@ -28,6 +28,7 @@ import { useEntitlements } from "@/hooks/useEntitlements";
 import { isUpgradeRequiredError } from "@/lib/gatedFeatureErrors";
 import "./LandlordActiveLeasesPage.css";
 import { canonicalLeaseTermLabel, canonicalOccupancyLabel } from "@/lib/leases/canonicalStatePresentation";
+import { ResolveOccupancyDrawer } from "@/components/occupancy/ResolveOccupancyDrawer";
 
 function formatCurrency(value: number | null | undefined) {
   const amount = typeof value === "number" ? value : 0;
@@ -446,6 +447,7 @@ export default function LandlordActiveLeasesPage() {
   const [convertError, setConvertError] = React.useState<string | null>(null);
   const [paymentRailBusyLeaseId, setPaymentRailBusyLeaseId] = React.useState<string | null>(null);
   const [documentBusyLeaseId, setDocumentBusyLeaseId] = React.useState<string | null>(null);
+  const [resolvingLease, setResolvingLease] = React.useState<LandlordActiveLease | null>(null);
   const [occupantName, setOccupantName] = React.useState("");
   const [tenantEmail, setTenantEmail] = React.useState("");
   const [tenantPhone, setTenantPhone] = React.useState("");
@@ -1046,6 +1048,7 @@ export default function LandlordActiveLeasesPage() {
                     <td style={{ padding: 12 }}>
                       <div>{statusBadge(lease.canonicalState ? canonicalLeaseTermLabel(lease.canonicalState.leaseTermState) : lease.status)}</div>
                       {renderOccupancyDisplay(lease)}
+                      {lease.canonicalState?.occupancyState === "review_needed" && lease.propertyId && lease.unitId ? <button type="button" onClick={() => setResolvingLease(lease)}>Resolve occupancy</button> : null}
                       {lease.leaseExecution ? (
                         <div style={{ display: "grid", gap: 4, marginTop: 6 }}>
                           <div style={{ fontSize: 12, fontWeight: 700, color: leaseWorkspaceTheme.charcoal }}>
@@ -1155,6 +1158,7 @@ export default function LandlordActiveLeasesPage() {
                   <div style={{ color: leaseWorkspaceTheme.neutralText, fontSize: 12 }}>Status</div>
                   <div style={{ marginTop: 6 }}>{statusBadge(lease.canonicalState ? canonicalLeaseTermLabel(lease.canonicalState.leaseTermState) : lease.status)}</div>
                   {renderOccupancyDisplay(lease)}
+                  {lease.canonicalState?.occupancyState === "review_needed" && lease.propertyId && lease.unitId ? <button type="button" onClick={() => setResolvingLease(lease)}>Resolve occupancy</button> : null}
                 </div>
                 <div>
                   <div style={{ color: leaseWorkspaceTheme.neutralText, fontSize: 12 }}>Rent</div>
@@ -1321,6 +1325,7 @@ export default function LandlordActiveLeasesPage() {
           </div>
         </div>
       ) : null}
+      {resolvingLease?.propertyId && resolvingLease.unitId ? <ResolveOccupancyDrawer open propertyId={resolvingLease.propertyId} unitId={resolvingLease.unitId} tenantId={resolvingLease.primaryTenantId || resolvingLease.tenantId || null} onClose={() => setResolvingLease(null)} onResolved={load} /> : null}
     </div>
   );
 }

--- a/rentchain-frontend/src/pages/TenantsPage.tsx
+++ b/rentchain-frontend/src/pages/TenantsPage.tsx
@@ -32,6 +32,7 @@ import {
   type CanonicalLeaseOccupancyState,
 } from "@/lib/leases/canonicalStatePresentation";
 import "./TenantsPage.css";
+import { ResolveOccupancyDrawer } from "@/components/occupancy/ResolveOccupancyDrawer";
 
 type TenantWithTenancies = TenantApiModel & { tenancies?: TenancyApiModel[] };
 type MoveOutReason = "LEASE_TERM_END" | "EARLY_LEASE_END" | "EVICTED" | "OTHER";
@@ -360,6 +361,7 @@ class TenantsErrorBoundary extends React.Component<
 }
 
 export const TenantsPage: React.FC = () => {
+  const [resolveOccupancyOpen, setResolveOccupancyOpen] = useState(false);
   const navigate = useNavigate();
   const { user, ready, isLoading: authLoading, authStatus } = useAuth();
   const [searchParams] = useSearchParams();
@@ -1062,6 +1064,7 @@ const loadTenants = useCallback(async () => {
                         <div style={{ marginTop: 4, fontSize: 14, color: text.primary }}>
                           {tenantLifecycleLabel(selectedTenant, selectedCanonicalState)}
                         </div>
+                        {selectedCanonicalState?.tenantRelationshipState === "occupancy_unresolved" && selectedTenant.propertyId && selectedTenant.unitId ? <button type="button" onClick={() => setResolveOccupancyOpen(true)}>Resolve occupancy</button> : null}
                       </Card>
                       <Card style={tenantWorkspaceCardStyle}>
                         <div style={{ fontSize: 11, fontWeight: 700, color: text.muted }}>Property</div>
@@ -1529,6 +1532,7 @@ const loadTenants = useCallback(async () => {
           </Card>
         </div>
       ) : null}
+      {resolveOccupancyOpen && selectedTenant?.propertyId && selectedTenant.unitId ? <ResolveOccupancyDrawer open propertyId={selectedTenant.propertyId} unitId={selectedTenant.unitId} tenantId={selectedTenant.id} onClose={() => setResolveOccupancyOpen(false)} onResolved={refreshAfterLeaseEnded} /> : null}
       </div>
     </TenantsErrorBoundary>
   );

--- a/rentchain-frontend/tests/playwright/resolve-occupancy-accessibility.spec.ts
+++ b/rentchain-frontend/tests/playwright/resolve-occupancy-accessibility.spec.ts
@@ -1,0 +1,154 @@
+import { expect, test, type Page } from "@playwright/test";
+import { installLegacySmokeHarness } from "./legacy-smoke-setup";
+
+test.use({ serviceWorkers: "block" });
+
+const viewports = [
+  { width: 1920, height: 1080 },
+  { width: 1440, height: 900 },
+  { width: 1280, height: 800 },
+  { width: 1024, height: 768 },
+];
+
+const canonicalState = {
+  leaseTermState: "past",
+  occupancyState: "review_needed",
+  tenantRelationshipState: "occupancy_unresolved",
+  supportingLeaseId: null,
+  reasons: ["PAST_LEASE_CANNOT_SUPPORT_OCCUPANCY", "OCCUPIED_WITHOUT_CURRENT_LEASE"],
+};
+
+async function installOccupancyHarness(page: Page) {
+  await installLegacySmokeHarness(page, { devPreviewUnlock: true });
+  await page.route("**/api/**", async (route) => {
+    const url = new URL(route.request().url());
+    const fulfill = (body: unknown) => route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(body),
+    });
+
+    if (url.pathname === "/api/tenants") {
+      await fulfill({ tenants: [{
+        id: "viewport-tenant",
+        fullName: "Viewport Tenant",
+        email: "viewport@example.test",
+        propertyId: "viewport-property",
+        propertyName: "Viewport House",
+        unitId: "viewport-unit",
+        unitLabel: "1A",
+        status: "active",
+        canonicalState,
+        tenancies: [],
+      }] });
+      return;
+    }
+    if (url.pathname === "/api/tenants/viewport-tenant/tenancies") {
+      await fulfill({ tenancies: [] });
+      return;
+    }
+    if (url.pathname === "/api/occupancy-resolutions/context") {
+      await fulfill({ ok: true, context: {
+        propertyId: "viewport-property",
+        unitId: "viewport-unit",
+        tenantId: "viewport-tenant",
+        propertyLabel: "Viewport House",
+        unitLabel: "1A",
+        canonicalState,
+        expectedStateToken: "viewport-token",
+        eligibleResolutionTypes: ["record_operational_move_out", "clear_stale_occupancy_record"],
+        existingLeaseCandidates: [],
+        activeLeaseRequiresEndWorkflow: false,
+      } });
+      return;
+    }
+    await route.fallback();
+  });
+}
+
+async function openDrawer(page: Page) {
+  const runtimeErrors: string[] = [];
+  page.on("pageerror", (error) => runtimeErrors.push(`pageerror: ${error.message}`));
+  page.on("console", (message) => {
+    if (message.type() === "error") runtimeErrors.push(`console: ${message.text()}`);
+  });
+  await page.goto("/tenants?tenantId=viewport-tenant", { waitUntil: "domcontentloaded" });
+  const trigger = page.getByRole("button", { name: "Resolve occupancy" }).first();
+  await expect(trigger).toBeVisible({ timeout: 10_000 }).catch(async (error) => {
+    throw new Error(`${error.message}\nPAGE_STATE=${JSON.stringify({
+      url: page.url(),
+      title: await page.title(),
+      body: await page.locator("body").innerText(),
+      runtimeErrors,
+    })}`);
+  });
+  await trigger.click();
+  await expect(page.getByRole("dialog", { name: "Resolve Occupancy" })).toBeVisible();
+  return trigger;
+}
+
+for (const viewport of viewports) {
+  test(`fits and remains operable at ${viewport.width}x${viewport.height}`, async ({ page }) => {
+    await page.setViewportSize(viewport);
+    await installOccupancyHarness(page);
+    await openDrawer(page);
+
+    const dialog = page.getByRole("dialog", { name: "Resolve Occupancy" });
+    await expect(page.getByRole("heading", { name: "Resolve Occupancy" })).toBeVisible();
+    await expect(page.getByText(/without making a legal tenancy determination/i)).toBeVisible();
+    await expect(page.getByLabel("Record operational move-out")).toBeVisible();
+    await expect(page.getByLabel("Correct stale occupancy records")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Close Resolve Occupancy" })).toBeVisible();
+
+    await page.getByLabel("Record operational move-out").check();
+    await expect(page.getByLabel("Operational move-out effective date")).toBeVisible();
+    await dialog.evaluate((element) => { element.scrollTop = element.scrollHeight; });
+    await expect(page.getByRole("button", { name: "Review later" })).toBeInViewport();
+    await expect(page.getByRole("button", { name: "Confirm operational reconciliation" })).toBeInViewport();
+
+    const geometry = await page.evaluate(() => {
+      const dialogElement = document.querySelector<HTMLElement>('[role="dialog"][aria-modal="true"]')!;
+      const rect = dialogElement.getBoundingClientRect();
+      return {
+        documentWidth: document.documentElement.scrollWidth,
+        viewportWidth: innerWidth,
+        viewportHeight: innerHeight,
+        left: rect.left,
+        right: rect.right,
+        top: rect.top,
+        bottom: rect.bottom,
+        overflowX: getComputedStyle(dialogElement).overflowX,
+        overflowY: getComputedStyle(dialogElement).overflowY,
+        scrollHeight: dialogElement.scrollHeight,
+        clientHeight: dialogElement.clientHeight,
+      };
+    });
+
+    expect(geometry.documentWidth).toBeLessThanOrEqual(viewport.width + 1);
+    expect(geometry.left).toBeGreaterThanOrEqual(0);
+    expect(geometry.right).toBeLessThanOrEqual(viewport.width + 1);
+    expect(geometry.top).toBeGreaterThanOrEqual(0);
+    expect(geometry.bottom).toBeLessThanOrEqual(viewport.height + 1);
+    expect(geometry.overflowX).toBe("hidden");
+    expect(geometry.overflowY).toBe("auto");
+    expect(geometry.scrollHeight).toBeGreaterThanOrEqual(geometry.clientHeight);
+  });
+}
+
+test("traps keyboard focus and returns it to the opener", async ({ page }) => {
+  await page.setViewportSize({ width: 1024, height: 768 });
+  await installOccupancyHarness(page);
+  const trigger = await openDrawer(page);
+  const dialog = page.getByRole("dialog", { name: "Resolve Occupancy" });
+
+  await expect(page.getByRole("button", { name: "Close Resolve Occupancy" })).toBeFocused();
+  await page.keyboard.press("Tab");
+  await expect(page.getByLabel("Record operational move-out")).toBeFocused();
+  for (let index = 0; index < 8; index += 1) await page.keyboard.press("Tab");
+  await expect.poll(async () => dialog.evaluate((element) => element.contains(document.activeElement))).toBe(true);
+  await page.keyboard.press("Shift+Tab");
+  await expect.poll(async () => dialog.evaluate((element) => element.contains(document.activeElement))).toBe(true);
+  await page.keyboard.press("Escape");
+  await expect(dialog).toBeHidden();
+  await expect(trigger).toBeFocused();
+});

--- a/rentchain-frontend/tests/playwright/resolve-occupancy-accessibility.spec.ts
+++ b/rentchain-frontend/tests/playwright/resolve-occupancy-accessibility.spec.ts
@@ -152,3 +152,29 @@ test("traps keyboard focus and returns it to the opener", async ({ page }) => {
   await expect(dialog).toBeHidden();
   await expect(trigger).toBeFocused();
 });
+
+test("Close dismisses through native click, Enter, and Space activation without mutation", async ({ page }) => {
+  await page.setViewportSize({ width: 1024, height: 768 });
+  await installOccupancyHarness(page);
+  const mutationRequests: string[] = [];
+  page.on("request", (request) => {
+    if (["POST", "PUT", "PATCH", "DELETE"].includes(request.method())) {
+      mutationRequests.push(`${request.method()} ${request.url()}`);
+    }
+  });
+
+  for (const activation of ["click", "Enter", "Space"] as const) {
+    const trigger = await openDrawer(page);
+    const dialog = page.getByRole("dialog", { name: "Resolve Occupancy" });
+    const closeButton = page.getByRole("button", { name: "Close Resolve Occupancy" });
+    await expect(closeButton).toBeFocused();
+
+    if (activation === "click") await closeButton.click();
+    else await page.keyboard.press(activation);
+
+    await expect(dialog).not.toBeVisible();
+    await expect(trigger).toBeFocused();
+  }
+
+  expect(mutationRequests).toEqual([]);
+});


### PR DESCRIPTION
## Summary
- add one server-authoritative occupancy-resolution context and mutation boundary
- atomically reconcile operational records, immutable audit evidence, and idempotency results
- add one shared responsive Resolve Occupancy drawer across properties, leases, tenants, and tenant detail
- preserve historical lease evidence and route valid active-lease termination to the existing End Lease workflow

## Supported actions
- record operational move-out
- correct stale occupancy records
- link one explicitly selected eligible lease

## Safety
- recomputes canonical state inside the Firestore transaction
- checks a server-generated expected-state token and fails closed on drift or ambiguity
- validates landlord/capability and exact property, unit, tenant, tenancy, and lease context
- creates the immutable canonical audit event in the same transaction
- leaves multiple-current, invalid-date, context-mismatch, and ambiguous unit cases unresolved
- does not change End Lease behavior, historical lease records, infrastructure, Preview, or Production

## Validation
- backend targeted regression: 5 files, 92 tests passed
- backend TypeScript build passed
- frontend targeted regression: 5 files, 66 tests passed
- frontend production build passed
- git diff --check passed

## QA boundary
Exact-head browser/Preview QA is intentionally deferred for separate authorization.