### PR TITLE
fix: harden tenant detail Firestore reads

### DIFF
--- a/rentchain-api/firestore.indexes.json
+++ b/rentchain-api/firestore.indexes.json
@@ -283,6 +283,16 @@
       ]
     },
     {
+      "collectionGroup": "tenantEvents",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "landlordId", "order": "ASCENDING" },
+        { "fieldPath": "tenantId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" },
+        { "fieldPath": "__name__", "order": "DESCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "registryImports",
       "queryScope": "COLLECTION",
       "fields": [

--- a/rentchain-api/src/routes/__tests__/firestoreIndexes.test.ts
+++ b/rentchain-api/src/routes/__tests__/firestoreIndexes.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+type IndexField = { fieldPath: string; order: string };
+type CompositeIndex = {
+  collectionGroup: string;
+  queryScope: string;
+  fields: IndexField[];
+};
+
+const manifest = JSON.parse(
+  readFileSync(new URL("../../../firestore.indexes.json", import.meta.url), "utf8")
+) as { indexes: CompositeIndex[] };
+
+function expectIndex(collectionGroup: string, fields: IndexField[]) {
+  expect(manifest.indexes).toContainEqual({
+    collectionGroup,
+    queryScope: "COLLECTION",
+    fields,
+  });
+}
+
+describe("tenant detail Firestore indexes", () => {
+  it("declares the tenant-scoped ledgerEventsV2 query index", () => {
+    expectIndex("ledgerEventsV2", [
+      { fieldPath: "landlordId", order: "ASCENDING" },
+      { fieldPath: "tenantId", order: "ASCENDING" },
+      { fieldPath: "occurredAt", order: "DESCENDING" },
+      { fieldPath: "__name__", order: "DESCENDING" },
+    ]);
+  });
+
+  it("declares the tenantEvents timeline query index", () => {
+    expectIndex("tenantEvents", [
+      { fieldPath: "landlordId", order: "ASCENDING" },
+      { fieldPath: "tenantId", order: "ASCENDING" },
+      { fieldPath: "createdAt", order: "DESCENDING" },
+      { fieldPath: "__name__", order: "DESCENDING" },
+    ]);
+  });
+});

--- a/rentchain-api/src/routes/__tests__/tenantEventsWriteRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantEventsWriteRoutes.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const tenantDocs = new Map<string, any>();
 const createdEvents: any[] = [];
+let tenantEventQueryDocs: any[] = [];
+let tenantEventQueryError: Error | null = null;
 
 vi.mock("../../firebase", () => ({
   Timestamp: {
@@ -30,7 +32,10 @@ vi.mock("../../firebase", () => ({
             where: () => ({
               orderBy: () => ({
                 limit: () => ({
-                  get: async () => ({ docs: [] }),
+                  get: async () => {
+                    if (tenantEventQueryError) throw tenantEventQueryError;
+                    return { docs: tenantEventQueryDocs };
+                  },
                 }),
               }),
             }),
@@ -69,6 +74,7 @@ async function invokeRouter(router: any, options: {
   body?: any;
 }) {
   return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [, queryString = ""] = options.url.split("?");
     const req: any = {
       method: options.method,
       url: options.url,
@@ -76,7 +82,7 @@ async function invokeRouter(router: any, options: {
       path: options.url,
       body: options.body ?? {},
       headers: {},
-      query: {},
+      query: Object.fromEntries(new URLSearchParams(queryString).entries()),
       params: {},
     };
     const res: any = {
@@ -106,6 +112,8 @@ describe("tenantEventsWriteRoutes", () => {
   beforeEach(() => {
     tenantDocs.clear();
     createdEvents.length = 0;
+    tenantEventQueryDocs = [];
+    tenantEventQueryError = null;
     tenantDocs.set("tenant-1", {
       landlordId: "landlord-1",
       fullName: "Taylor Tenant",
@@ -159,5 +167,59 @@ describe("tenantEventsWriteRoutes", () => {
         currency: "CAD",
       })
     );
+  });
+
+  it("returns an empty page for an authorized tenant with no event history", async () => {
+    const router = (await import("../tenantEventsWriteRoutes")).default;
+    const result = await invokeRouter(router, {
+      method: "GET",
+      url: "/tenant-events?tenantId=tenant-1&limit=25",
+    });
+
+    expect(result).toEqual({
+      status: 200,
+      body: { ok: true, items: [], nextCursor: null },
+    });
+  });
+
+  it("returns populated tenant event history", async () => {
+    const createdAt = { toMillis: () => 1_725_000_000_000 };
+    tenantEventQueryDocs = [
+      {
+        id: "event-1",
+        data: () => ({ tenantId: "tenant-1", type: "NOTE_ADDED", createdAt }),
+      },
+    ];
+    const router = (await import("../tenantEventsWriteRoutes")).default;
+    const result = await invokeRouter(router, {
+      method: "GET",
+      url: "/tenant-events?tenantId=tenant-1&limit=25",
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.body.items).toEqual([
+      { id: "event-1", tenantId: "tenant-1", type: "NOTE_ADDED", createdAt },
+    ]);
+    expect(result.body.nextCursor).toBe(1_725_000_000_000);
+  });
+
+  it("returns a bounded error when the tenant event query fails", async () => {
+    tenantEventQueryError = new Error("FAILED_PRECONDITION: query requires an index");
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const router = (await import("../tenantEventsWriteRoutes")).default;
+    const result = await invokeRouter(router, {
+      method: "GET",
+      url: "/tenant-events?tenantId=tenant-1&limit=25",
+    });
+
+    expect(result).toEqual({
+      status: 500,
+      body: { error: "Failed to load tenant events" },
+    });
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[tenant-events GET /tenant-events] error",
+      tenantEventQueryError
+    );
+    errorSpy.mockRestore();
   });
 });

--- a/rentchain-api/src/routes/__tests__/tenantSignalsRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantSignalsRoutes.test.ts
@@ -1,0 +1,109 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  authenticatedUser: { id: "landlord-1", landlordId: "landlord-1" } as any,
+  listLedgerEventsV2: vi.fn(),
+}));
+
+vi.mock("../../middleware/authMiddleware", () => ({
+  authenticateJwt: (req: any, _res: any, next: any) => {
+    req.user = mocks.authenticatedUser;
+    next();
+  },
+}));
+
+vi.mock("../../services/ledgerEventsFirestoreService", () => ({
+  listLedgerEventsV2: mocks.listLedgerEventsV2,
+}));
+
+import tenantSignalsRoutes from "../tenantSignalsRoutes";
+
+function createApp() {
+  const app = express();
+  app.use(tenantSignalsRoutes);
+  return app;
+}
+
+describe("tenantSignalsRoutes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.authenticatedUser = { id: "landlord-1", landlordId: "landlord-1" };
+    mocks.listLedgerEventsV2.mockResolvedValue({ items: [] });
+  });
+
+  it("returns neutral signals for an authorized tenant with no ledger history", async () => {
+    const response = await request(createApp()).get("/tenants/tenant-1/signals");
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      ok: true,
+      signals: expect.objectContaining({
+        tenantId: "tenant-1",
+        landlordId: "landlord-1",
+        riskLevel: "LOW",
+        latePaymentsCount: 0,
+        nsfCount: 0,
+        missedPaymentsCount: 0,
+        evictionNoticeCount: 0,
+        positiveNotesCount: 0,
+        lastEventAt: null,
+      }),
+    });
+  });
+
+  it("computes signals from populated ledger history", async () => {
+    mocks.listLedgerEventsV2.mockResolvedValue({
+      items: [
+        {
+          id: "ledger-1",
+          title: "Late rent payment",
+          summary: "Returned payment NSF",
+          eventType: "STATUS_CHANGED",
+          occurredAt: 1_725_000_000_000,
+          tags: ["late"],
+        },
+      ],
+    });
+
+    const response = await request(createApp()).get("/tenants/tenant-1/signals");
+
+    expect(response.status).toBe(200);
+    expect(response.body.signals).toEqual(
+      expect.objectContaining({
+        tenantId: "tenant-1",
+        latePaymentsCount: 1,
+        nsfCount: 1,
+        riskLevel: "MEDIUM",
+        lastEventAt: 1_725_000_000_000,
+      })
+    );
+  });
+
+  it("returns a bounded observable error when the ledger query rejects", async () => {
+    const queryError = new Error("FAILED_PRECONDITION: query requires an index");
+    mocks.listLedgerEventsV2.mockRejectedValue(queryError);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const response = await request(createApp()).get("/tenants/tenant-1/signals");
+
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({ ok: false, error: "Failed to load tenant signals" });
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[tenant-signals GET /tenants/:tenantId/signals] error",
+      queryError
+    );
+    errorSpy.mockRestore();
+  });
+
+  it("preserves authorization behavior", async () => {
+    mocks.authenticatedUser = null;
+
+    const response = await request(createApp()).get("/tenants/tenant-1/signals");
+
+    expect(response.status).toBe(401);
+    expect(response.body).toEqual({ ok: false, error: "Unauthorized" });
+    expect(mocks.listLedgerEventsV2).not.toHaveBeenCalled();
+  });
+});

--- a/rentchain-api/src/routes/tenantSignalsRoutes.ts
+++ b/rentchain-api/src/routes/tenantSignalsRoutes.ts
@@ -14,14 +14,19 @@ router.get("/tenants/:tenantId/signals", async (req: any, res) => {
   const tenantId = String(req.params?.tenantId || "").trim();
   if (!tenantId) return res.status(400).json({ ok: false, error: "tenantId required" });
 
-  const result = await listLedgerEventsV2({
-    landlordId,
-    tenantId,
-    limit: 200,
-  });
+  try {
+    const result = await listLedgerEventsV2({
+      landlordId,
+      tenantId,
+      limit: 200,
+    });
 
-  const signals = computeTenantSignals(result.items || [], tenantId, landlordId);
-  return res.json({ ok: true, signals });
+    const signals = computeTenantSignals(result.items || [], tenantId, landlordId);
+    return res.json({ ok: true, signals });
+  } catch (error: any) {
+    console.error("[tenant-signals GET /tenants/:tenantId/signals] error", error);
+    return res.status(500).json({ ok: false, error: "Failed to load tenant signals" });
+  }
 });
 
 export default router;


### PR DESCRIPTION
## Summary
- add the managed tenantEvents composite index required by the landlord tenant timeline query
- return a bounded logged 500 response when the tenant signals ledger query rejects
- cover empty and populated histories, query failures, authorization, and both required index declarations

## Validation
- 28 relevant backend tests passed
- backend TypeScript build passed
- git diff --check passed

## Deployment boundary
No Preview or Production deployment was performed. After review and separate Founder authorization, reconcile Preview with `firebase deploy --only firestore:indexes --project rentchain-preview`, then verify both tenant-scoped ledgerEventsV2 and tenantEvents indexes reach READY before resuming PR #1557 browser certification.

PR #1557 remains frozen and unchanged.