### PR TITLE
PR D1: define canonical lease-start contract

### DIFF
--- a/rentchain-api/src/lib/leases/__tests__/canonicalLeaseStart.test.ts
+++ b/rentchain-api/src/lib/leases/__tests__/canonicalLeaseStart.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from "vitest";
+import { evaluateCanonicalLeaseStart, type CanonicalLeaseStartInput } from "../canonicalLeaseStart";
+
+const instant = "2026-05-01T12:00:00.000Z";
+
+function baseInput(): CanonicalLeaseStartInput {
+  return {
+    landlordId: "landlord-1",
+    propertyId: "property-1",
+    unitId: "unit-1",
+    tenantId: "tenant-1",
+    evaluationInstant: instant,
+    candidateLease: {
+      id: "lease-1",
+      landlordId: "landlord-1",
+      propertyId: "property-1",
+      unitId: "unit-1",
+      tenantId: "tenant-1",
+      status: "active",
+      executionStatus: "fully_executed",
+      startDate: "2026-01-01",
+      endDate: "2026-12-31",
+    },
+    contextLeases: [],
+    standaloneUnits: [{ id: "unit-1", landlordId: "landlord-1", propertyId: "property-1", status: "vacant", occupancyStatus: "vacant" }],
+    embeddedUnits: [{ id: "unit-1", landlordId: "landlord-1", propertyId: "property-1", status: "vacant", occupancyStatus: "vacant" }],
+    tenant: { id: "tenant-1", landlordId: "landlord-1", status: "past" },
+    tenancies: [],
+  };
+}
+
+function coherentInput(): CanonicalLeaseStartInput {
+  const input = baseInput();
+  const unit = {
+    id: "unit-1",
+    landlordId: "landlord-1",
+    propertyId: "property-1",
+    status: "occupied",
+    occupancyStatus: "occupied",
+    tenantId: "tenant-1",
+    currentTenantId: "tenant-1",
+    leaseId: "lease-1",
+    currentLeaseId: "lease-1",
+  };
+  input.standaloneUnits = [{ ...unit }];
+  input.embeddedUnits = [{ ...unit }];
+  input.tenant = { id: "tenant-1", landlordId: "landlord-1", status: "current", currentLeaseId: "lease-1" };
+  input.tenancies = [{
+    id: "tenancy-1",
+    landlordId: "landlord-1",
+    propertyId: "property-1",
+    unitId: "unit-1",
+    tenantId: "tenant-1",
+    leaseId: "lease-1",
+    status: "active",
+    moveInAt: "2026-04-01T12:00:00.000Z",
+  }];
+  return input;
+}
+
+describe("canonical lease start", () => {
+  it("makes a fully executed current lease occupancy-effective", () => {
+    expect(evaluateCanonicalLeaseStart(baseInput())).toMatchObject({ outcome: "occupancy_effective", occupancyEffective: true, reasons: [] });
+  });
+
+  it("keeps a fully executed future lease without current occupancy", () => {
+    const input = baseInput();
+    input.candidateLease.startDate = "2026-06-01";
+    expect(evaluateCanonicalLeaseStart(input)).toMatchObject({ outcome: "created_without_occupancy", occupancyEffective: false, reasons: ["UPCOMING_LEASE_CANNOT_SUPPORT_OCCUPANCY"], postcondition: null });
+  });
+
+  it("keeps a draft current lease without current occupancy", () => {
+    const input = baseInput();
+    input.candidateLease.status = "draft";
+    input.candidateLease.executionStatus = "draft";
+    expect(evaluateCanonicalLeaseStart(input)).toMatchObject({ outcome: "created_without_occupancy", reasons: ["DRAFT_LEASE_CANNOT_SUPPORT_OCCUPANCY"] });
+  });
+
+  it("keeps execution-incomplete current leases without occupancy", () => {
+    const input = baseInput();
+    input.candidateLease.executionStatus = "tenant_signed";
+    expect(evaluateCanonicalLeaseStart(input)).toMatchObject({ outcome: "created_without_occupancy", reasons: ["LEASE_EXECUTION_INCOMPLETE"] });
+  });
+
+  it("requires affirmative execution evidence even for legacy active status", () => {
+    const input = baseInput();
+    delete input.candidateLease.executionStatus;
+    expect(evaluateCanonicalLeaseStart(input)).toMatchObject({ outcome: "created_without_occupancy", reasons: ["LEASE_EXECUTION_INCOMPLETE"], postcondition: null });
+  });
+
+  it("does not create occupancy for a past lease", () => {
+    const input = baseInput();
+    input.candidateLease.endDate = "2026-04-30";
+    expect(evaluateCanonicalLeaseStart(input)).toMatchObject({ outcome: "created_without_occupancy", reasons: ["PAST_LEASE_CANNOT_SUPPORT_OCCUPANCY"] });
+  });
+
+  it("does not create occupancy for an ended lease", () => {
+    const input = baseInput();
+    input.candidateLease.status = "ended";
+    expect(evaluateCanonicalLeaseStart(input)).toMatchObject({ outcome: "created_without_occupancy", reasons: ["ENDED_LEASE_CANNOT_SUPPORT_OCCUPANCY"] });
+  });
+
+  it("rejects an invalid date range", () => {
+    const input = baseInput();
+    input.candidateLease.startDate = "2027-01-01";
+    expect(evaluateCanonicalLeaseStart(input)).toMatchObject({ outcome: "rejected", reasons: ["INVALID_LEASE_DATE_RANGE"] });
+  });
+
+  it("fails closed for multiple eligible current leases", () => {
+    const input = baseInput();
+    input.contextLeases = [{ ...input.candidateLease, id: "lease-2" }];
+    expect(evaluateCanonicalLeaseStart(input)).toMatchObject({ outcome: "rejected", reasons: ["MULTIPLE_CURRENT_LEASES"], postcondition: null });
+  });
+
+  it("rejects standalone and embedded unit identity mismatch", () => {
+    const input = baseInput();
+    input.embeddedUnits[0].id = "unit-2";
+    expect(evaluateCanonicalLeaseStart(input)).toMatchObject({ outcome: "rejected", reasons: ["CURRENT_LEASE_CONTEXT_MISMATCH"] });
+  });
+
+  it("rejects a tenant who is not the canonical lease party", () => {
+    const input = baseInput();
+    input.candidateLease.tenantId = "tenant-2";
+    expect(evaluateCanonicalLeaseStart(input)).toMatchObject({ outcome: "rejected", reasons: ["CURRENT_LEASE_CONTEXT_MISMATCH"] });
+  });
+
+  it("builds the complete pure postcondition for a vacant unit", () => {
+    const result = evaluateCanonicalLeaseStart(baseInput());
+    expect(result.postcondition).toMatchObject({
+      lease: { id: "lease-1", occupancyEffective: true },
+      standaloneUnit: { status: "occupied", currentTenantId: "tenant-1", currentLeaseId: "lease-1" },
+      embeddedPropertyUnit: { status: "occupied", currentTenantId: "tenant-1", currentLeaseId: "lease-1" },
+      tenant: { currentLeaseId: "lease-1" },
+      tenancy: { action: "create", moveInAt: instant },
+      canonicalEvent: { type: "lease.occupancy_started" },
+      idempotencyResult: { operation: "canonical_lease_start" },
+    });
+  });
+
+  it("rejects an occupied unit with an unrelated tenant", () => {
+    const input = baseInput();
+    input.standaloneUnits[0] = { ...input.standaloneUnits[0], status: "occupied", tenantId: "tenant-2" };
+    expect(evaluateCanonicalLeaseStart(input)).toMatchObject({ outcome: "rejected", reasons: ["OCCUPIED_WITHOUT_CURRENT_LEASE", "STALE_CURRENT_LEASE_POINTER"] });
+  });
+
+  it("rejects stale unit and tenant lease pointers", () => {
+    const unitInput = baseInput();
+    unitInput.standaloneUnits[0].currentLeaseId = "lease-stale";
+    expect(evaluateCanonicalLeaseStart(unitInput)).toMatchObject({ outcome: "rejected", reasons: ["STALE_CURRENT_LEASE_POINTER"] });
+    const tenantInput = baseInput();
+    tenantInput.tenant!.currentLeaseId = "lease-stale";
+    expect(evaluateCanonicalLeaseStart(tenantInput)).toMatchObject({ outcome: "rejected", reasons: ["STALE_CURRENT_LEASE_POINTER"] });
+  });
+
+  it("recognizes already coherent occupancy", () => {
+    expect(evaluateCanonicalLeaseStart(coherentInput())).toMatchObject({ outcome: "already_coherent", occupancyEffective: true, reasons: [], postcondition: null });
+  });
+
+  it("returns zero required writes on an already coherent replay", () => {
+    const first = evaluateCanonicalLeaseStart(coherentInput());
+    const replay = evaluateCanonicalLeaseStart(coherentInput());
+    expect(replay).toEqual(first);
+    expect(replay.postcondition).toBeNull();
+  });
+
+  it("keeps a future successor non-current while its predecessor is active", () => {
+    const input = baseInput();
+    const predecessor = { ...input.candidateLease, id: "lease-predecessor", startDate: "2025-06-01", endDate: "2026-05-31" };
+    input.candidateLease.startDate = "2026-06-01";
+    input.candidateLease.endDate = "2027-05-31";
+    input.contextLeases = [predecessor];
+    expect(evaluateCanonicalLeaseStart(input)).toMatchObject({ outcome: "created_without_occupancy", postcondition: null });
+  });
+
+  it("reconciles same-tenant occupied state with safely missing pointers", () => {
+    const input = baseInput();
+    input.standaloneUnits[0] = { ...input.standaloneUnits[0], status: "occupied", occupancyStatus: "occupied", tenantId: "tenant-1" };
+    input.embeddedUnits[0] = { ...input.embeddedUnits[0], status: "occupied", occupancyStatus: "occupied", tenantId: "tenant-1" };
+    expect(evaluateCanonicalLeaseStart(input)).toMatchObject({ outcome: "occupancy_effective" });
+  });
+
+  it("rejects ambiguous matching tenancies", () => {
+    const input = baseInput();
+    const tenancy = { id: "tenancy-1", landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-1", status: "inactive" };
+    input.tenancies = [tenancy, { ...tenancy, id: "tenancy-2" }];
+    expect(evaluateCanonicalLeaseStart(input)).toMatchObject({ outcome: "rejected", reasons: ["CURRENT_LEASE_CONTEXT_MISMATCH"] });
+  });
+
+  it("carries legacy occupancy booleans only when already present", () => {
+    const absent = evaluateCanonicalLeaseStart(baseInput()).postcondition!;
+    expect(absent.standaloneUnit).not.toHaveProperty("occupied");
+    expect(absent.standaloneUnit).not.toHaveProperty("isOccupied");
+    const presentInput = baseInput();
+    presentInput.standaloneUnits[0].occupied = false;
+    presentInput.embeddedUnits[0].isOccupied = false;
+    const present = evaluateCanonicalLeaseStart(presentInput).postcondition!;
+    expect(present.standaloneUnit.occupied).toBe(true);
+    expect(present.embeddedPropertyUnit.isOccupied).toBe(true);
+  });
+
+  it("uses UTC calendar boundaries independent of offset spelling", () => {
+    const before = baseInput();
+    before.candidateLease.startDate = "2026-05-01";
+    before.evaluationInstant = "2026-05-01T00:30:00+14:00";
+    expect(evaluateCanonicalLeaseStart(before).outcome).toBe("created_without_occupancy");
+    const atBoundary = baseInput();
+    atBoundary.candidateLease.startDate = "2026-05-01";
+    atBoundary.evaluationInstant = "2026-05-01T00:00:00Z";
+    expect(evaluateCanonicalLeaseStart(atBoundary).outcome).toBe("occupancy_effective");
+  });
+
+  it("is invariant to context lease and tenancy input ordering", () => {
+    const left = baseInput();
+    left.contextLeases = [
+      { ...left.candidateLease, id: "past-z", endDate: "2025-12-31" },
+      { ...left.candidateLease, id: "future-a", startDate: "2027-01-01", endDate: "2027-12-31" },
+    ];
+    left.tenancies = [{ id: "foreign-z", landlordId: "landlord-1", propertyId: "property-2", unitId: "unit-2", tenantId: "tenant-2", status: "inactive" }];
+    const right = { ...left, contextLeases: [...left.contextLeases].reverse(), tenancies: [...left.tenancies].reverse() };
+    expect(evaluateCanonicalLeaseStart(right)).toEqual(evaluateCanonicalLeaseStart(left));
+  });
+
+  it("preserves a verified earlier move-in instant and reconciles a unique inactive tenancy", () => {
+    const input = baseInput();
+    input.tenancies = [{ id: "tenancy-1", landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-1", status: "inactive", moveInAt: "2026-04-01T12:00:00Z" }];
+    expect(evaluateCanonicalLeaseStart(input).postcondition?.tenancy).toMatchObject({ action: "reconcile", moveInAt: "2026-04-01T12:00:00.000Z" });
+  });
+});

--- a/rentchain-api/src/lib/leases/__tests__/canonicalLeaseStart.test.ts
+++ b/rentchain-api/src/lib/leases/__tests__/canonicalLeaseStart.test.ts
@@ -143,6 +143,62 @@ describe("canonical lease start", () => {
     expect(evaluateCanonicalLeaseStart(input)).toMatchObject({ outcome: "rejected", reasons: ["OCCUPIED_WITHOUT_CURRENT_LEASE", "STALE_CURRENT_LEASE_POINTER"] });
   });
 
+  it("rejects occupied legacy unit state without tenant or lease identity evidence", () => {
+    const input = baseInput();
+    input.standaloneUnits[0] = { ...input.standaloneUnits[0], status: "occupied", occupancyStatus: "occupied" };
+    input.embeddedUnits[0] = { ...input.embeddedUnits[0], status: "occupied", occupancyStatus: "occupied" };
+    expect(evaluateCanonicalLeaseStart(input)).toMatchObject({
+      outcome: "rejected",
+      occupancyEffective: false,
+      reasons: ["OCCUPIED_WITHOUT_CURRENT_LEASE"],
+      postcondition: null,
+    });
+  });
+
+  it("rejects when only one occupied unit representation identifies the tenant", () => {
+    const standaloneOnly = baseInput();
+    standaloneOnly.standaloneUnits[0] = { ...standaloneOnly.standaloneUnits[0], status: "occupied", tenantId: "tenant-1" };
+    standaloneOnly.embeddedUnits[0] = { ...standaloneOnly.embeddedUnits[0], status: "occupied" };
+    expect(evaluateCanonicalLeaseStart(standaloneOnly)).toMatchObject({ outcome: "rejected", reasons: ["OCCUPIED_WITHOUT_CURRENT_LEASE"] });
+
+    const embeddedOnly = baseInput();
+    embeddedOnly.standaloneUnits[0] = { ...embeddedOnly.standaloneUnits[0], status: "occupied" };
+    embeddedOnly.embeddedUnits[0] = { ...embeddedOnly.embeddedUnits[0], status: "occupied", currentTenantId: "tenant-1" };
+    expect(evaluateCanonicalLeaseStart(embeddedOnly)).toMatchObject({ outcome: "rejected", reasons: ["OCCUPIED_WITHOUT_CURRENT_LEASE"] });
+  });
+
+  it("rejects an occupied unit with the candidate lease pointer but no tenant identity", () => {
+    const input = baseInput();
+    input.standaloneUnits[0] = { ...input.standaloneUnits[0], status: "occupied", currentLeaseId: "lease-1" };
+    input.embeddedUnits[0] = { ...input.embeddedUnits[0], status: "occupied", currentLeaseId: "lease-1" };
+    expect(evaluateCanonicalLeaseStart(input)).toMatchObject({ outcome: "rejected", reasons: ["OCCUPIED_WITHOUT_CURRENT_LEASE"], postcondition: null });
+  });
+
+  it("rejects contradictory identities across occupied unit representations", () => {
+    const input = baseInput();
+    input.standaloneUnits[0] = { ...input.standaloneUnits[0], status: "occupied", tenantId: "tenant-1" };
+    input.embeddedUnits[0] = { ...input.embeddedUnits[0], status: "occupied", tenantId: "tenant-2" };
+    expect(evaluateCanonicalLeaseStart(input)).toMatchObject({
+      outcome: "rejected",
+      reasons: ["OCCUPIED_WITHOUT_CURRENT_LEASE", "STALE_CURRENT_LEASE_POINTER"],
+      postcondition: null,
+    });
+  });
+
+  it("rejects legacy occupied=true without identity evidence", () => {
+    const input = baseInput();
+    input.standaloneUnits[0] = { ...input.standaloneUnits[0], status: "", occupancyStatus: "", occupied: true };
+    input.embeddedUnits[0] = { ...input.embeddedUnits[0], status: "", occupancyStatus: "", occupied: true };
+    expect(evaluateCanonicalLeaseStart(input)).toMatchObject({ outcome: "rejected", reasons: ["OCCUPIED_WITHOUT_CURRENT_LEASE"], postcondition: null });
+  });
+
+  it("rejects legacy isOccupied=true without identity evidence", () => {
+    const input = baseInput();
+    input.standaloneUnits[0] = { ...input.standaloneUnits[0], status: "", occupancyStatus: "", isOccupied: true };
+    input.embeddedUnits[0] = { ...input.embeddedUnits[0], status: "", occupancyStatus: "", isOccupied: true };
+    expect(evaluateCanonicalLeaseStart(input)).toMatchObject({ outcome: "rejected", reasons: ["OCCUPIED_WITHOUT_CURRENT_LEASE"], postcondition: null });
+  });
+
   it("rejects stale unit and tenant lease pointers", () => {
     const unitInput = baseInput();
     unitInput.standaloneUnits[0].currentLeaseId = "lease-stale";

--- a/rentchain-api/src/lib/leases/__tests__/canonicalLeaseStart.test.ts
+++ b/rentchain-api/src/lib/leases/__tests__/canonicalLeaseStart.test.ts
@@ -159,19 +159,34 @@ describe("canonical lease start", () => {
     const standaloneOnly = baseInput();
     standaloneOnly.standaloneUnits[0] = { ...standaloneOnly.standaloneUnits[0], status: "occupied", tenantId: "tenant-1" };
     standaloneOnly.embeddedUnits[0] = { ...standaloneOnly.embeddedUnits[0], status: "occupied" };
-    expect(evaluateCanonicalLeaseStart(standaloneOnly)).toMatchObject({ outcome: "rejected", reasons: ["OCCUPIED_WITHOUT_CURRENT_LEASE"] });
+    expect(evaluateCanonicalLeaseStart(standaloneOnly)).toMatchObject({
+      outcome: "rejected",
+      occupancyEffective: false,
+      reasons: ["OCCUPIED_WITHOUT_CURRENT_LEASE"],
+      postcondition: null,
+    });
 
     const embeddedOnly = baseInput();
     embeddedOnly.standaloneUnits[0] = { ...embeddedOnly.standaloneUnits[0], status: "occupied" };
     embeddedOnly.embeddedUnits[0] = { ...embeddedOnly.embeddedUnits[0], status: "occupied", currentTenantId: "tenant-1" };
-    expect(evaluateCanonicalLeaseStart(embeddedOnly)).toMatchObject({ outcome: "rejected", reasons: ["OCCUPIED_WITHOUT_CURRENT_LEASE"] });
+    expect(evaluateCanonicalLeaseStart(embeddedOnly)).toMatchObject({
+      outcome: "rejected",
+      occupancyEffective: false,
+      reasons: ["OCCUPIED_WITHOUT_CURRENT_LEASE"],
+      postcondition: null,
+    });
   });
 
   it("rejects an occupied unit with the candidate lease pointer but no tenant identity", () => {
     const input = baseInput();
     input.standaloneUnits[0] = { ...input.standaloneUnits[0], status: "occupied", currentLeaseId: "lease-1" };
     input.embeddedUnits[0] = { ...input.embeddedUnits[0], status: "occupied", currentLeaseId: "lease-1" };
-    expect(evaluateCanonicalLeaseStart(input)).toMatchObject({ outcome: "rejected", reasons: ["OCCUPIED_WITHOUT_CURRENT_LEASE"], postcondition: null });
+    expect(evaluateCanonicalLeaseStart(input)).toMatchObject({
+      outcome: "rejected",
+      occupancyEffective: false,
+      reasons: ["OCCUPIED_WITHOUT_CURRENT_LEASE"],
+      postcondition: null,
+    });
   });
 
   it("rejects contradictory identities across occupied unit representations", () => {
@@ -180,6 +195,7 @@ describe("canonical lease start", () => {
     input.embeddedUnits[0] = { ...input.embeddedUnits[0], status: "occupied", tenantId: "tenant-2" };
     expect(evaluateCanonicalLeaseStart(input)).toMatchObject({
       outcome: "rejected",
+      occupancyEffective: false,
       reasons: ["OCCUPIED_WITHOUT_CURRENT_LEASE", "STALE_CURRENT_LEASE_POINTER"],
       postcondition: null,
     });
@@ -189,14 +205,24 @@ describe("canonical lease start", () => {
     const input = baseInput();
     input.standaloneUnits[0] = { ...input.standaloneUnits[0], status: "", occupancyStatus: "", occupied: true };
     input.embeddedUnits[0] = { ...input.embeddedUnits[0], status: "", occupancyStatus: "", occupied: true };
-    expect(evaluateCanonicalLeaseStart(input)).toMatchObject({ outcome: "rejected", reasons: ["OCCUPIED_WITHOUT_CURRENT_LEASE"], postcondition: null });
+    expect(evaluateCanonicalLeaseStart(input)).toMatchObject({
+      outcome: "rejected",
+      occupancyEffective: false,
+      reasons: ["OCCUPIED_WITHOUT_CURRENT_LEASE"],
+      postcondition: null,
+    });
   });
 
   it("rejects legacy isOccupied=true without identity evidence", () => {
     const input = baseInput();
     input.standaloneUnits[0] = { ...input.standaloneUnits[0], status: "", occupancyStatus: "", isOccupied: true };
     input.embeddedUnits[0] = { ...input.embeddedUnits[0], status: "", occupancyStatus: "", isOccupied: true };
-    expect(evaluateCanonicalLeaseStart(input)).toMatchObject({ outcome: "rejected", reasons: ["OCCUPIED_WITHOUT_CURRENT_LEASE"], postcondition: null });
+    expect(evaluateCanonicalLeaseStart(input)).toMatchObject({
+      outcome: "rejected",
+      occupancyEffective: false,
+      reasons: ["OCCUPIED_WITHOUT_CURRENT_LEASE"],
+      postcondition: null,
+    });
   });
 
   it("rejects stale unit and tenant lease pointers", () => {
@@ -232,7 +258,9 @@ describe("canonical lease start", () => {
     const input = baseInput();
     input.standaloneUnits[0] = { ...input.standaloneUnits[0], status: "occupied", occupancyStatus: "occupied", tenantId: "tenant-1" };
     input.embeddedUnits[0] = { ...input.embeddedUnits[0], status: "occupied", occupancyStatus: "occupied", tenantId: "tenant-1" };
-    expect(evaluateCanonicalLeaseStart(input)).toMatchObject({ outcome: "occupancy_effective" });
+    const result = evaluateCanonicalLeaseStart(input);
+    expect(result).toMatchObject({ outcome: "occupancy_effective", occupancyEffective: true });
+    expect(result.postcondition).not.toBeNull();
   });
 
   it("rejects ambiguous matching tenancies", () => {

--- a/rentchain-api/src/lib/leases/canonicalLeaseStart.ts
+++ b/rentchain-api/src/lib/leases/canonicalLeaseStart.ts
@@ -1,0 +1,306 @@
+import {
+  deriveCanonicalLeaseTermState,
+  type CanonicalLeaseConflictReason,
+  type CanonicalLeaseStateInput,
+} from "./canonicalLeaseOccupancyState";
+
+export type CanonicalLeaseStartOutcome =
+  | "created_without_occupancy"
+  | "occupancy_effective"
+  | "already_coherent"
+  | "rejected";
+
+export type CanonicalLeaseStartUnitInput = {
+  id?: unknown;
+  landlordId?: unknown;
+  propertyId?: unknown;
+  status?: unknown;
+  occupancyStatus?: unknown;
+  tenantId?: unknown;
+  currentTenantId?: unknown;
+  leaseId?: unknown;
+  currentLeaseId?: unknown;
+  occupied?: unknown;
+  isOccupied?: unknown;
+};
+
+export type CanonicalLeaseStartTenantInput = {
+  id?: unknown;
+  landlordId?: unknown;
+  currentLeaseId?: unknown;
+  status?: unknown;
+};
+
+export type CanonicalLeaseStartTenancyInput = {
+  id: string;
+  landlordId?: unknown;
+  propertyId?: unknown;
+  unitId?: unknown;
+  tenantId?: unknown;
+  leaseId?: unknown;
+  status?: unknown;
+  moveInAt?: unknown;
+  moveOutAt?: unknown;
+};
+
+export type CanonicalLeaseStartInput = {
+  landlordId: unknown;
+  propertyId: unknown;
+  unitId: unknown;
+  tenantId: unknown;
+  evaluationInstant: unknown;
+  candidateLease: CanonicalLeaseStateInput & { tenantIds?: unknown };
+  contextLeases: CanonicalLeaseStateInput[];
+  standaloneUnits: CanonicalLeaseStartUnitInput[];
+  embeddedUnits: CanonicalLeaseStartUnitInput[];
+  tenant: CanonicalLeaseStartTenantInput | null;
+  tenancies: CanonicalLeaseStartTenancyInput[];
+};
+
+export type CanonicalLeaseStartUnitPostcondition = {
+  status: "occupied";
+  occupancyStatus: "occupied";
+  tenantId: string;
+  currentTenantId: string;
+  leaseId: string;
+  currentLeaseId: string;
+  occupancySource: "canonical_lease_start";
+  occupancyUpdatedAt: string;
+  updatedAt: string;
+  occupied?: true;
+  isOccupied?: true;
+};
+
+export type CanonicalLeaseStartPostcondition = {
+  lease: { id: string; occupancyEffective: true };
+  embeddedPropertyUnit: CanonicalLeaseStartUnitPostcondition;
+  standaloneUnit: CanonicalLeaseStartUnitPostcondition;
+  tenant: { id: string; currentLeaseId: string; status: "current" };
+  tenancy: {
+    action: "create" | "reuse" | "reconcile";
+    id: string | null;
+    landlordId: string;
+    propertyId: string;
+    unitId: string;
+    tenantId: string;
+    leaseId: string;
+    status: "active";
+    moveInAt: string;
+  };
+  canonicalEvent: { type: "lease.occupancy_started"; leaseId: string; occurredAt: string };
+  idempotencyResult: { operation: "canonical_lease_start"; leaseId: string };
+};
+
+export type CanonicalLeaseStartContext = {
+  evaluationInstant: string;
+  candidateLeaseId: string | null;
+  eligibleCurrentLeaseIds: string[];
+  standaloneUnitIds: string[];
+  embeddedUnitIds: string[];
+  tenancyIds: string[];
+};
+
+export type CanonicalLeaseStartResult = {
+  outcome: CanonicalLeaseStartOutcome;
+  occupancyEffective: boolean;
+  reasons: CanonicalLeaseConflictReason[];
+  postcondition: CanonicalLeaseStartPostcondition | null;
+  context: CanonicalLeaseStartContext;
+};
+
+const REASON_ORDER: CanonicalLeaseConflictReason[] = [
+  "INVALID_LEASE_DATE_RANGE",
+  "CURRENT_LEASE_CONTEXT_MISMATCH",
+  "DRAFT_LEASE_CANNOT_SUPPORT_OCCUPANCY",
+  "UPCOMING_LEASE_CANNOT_SUPPORT_OCCUPANCY",
+  "PAST_LEASE_CANNOT_SUPPORT_OCCUPANCY",
+  "ENDED_LEASE_CANNOT_SUPPORT_OCCUPANCY",
+  "LEASE_EXECUTION_INCOMPLETE",
+  "MULTIPLE_CURRENT_LEASES",
+  "OCCUPIED_WITHOUT_CURRENT_LEASE",
+  "VACANT_WITH_CURRENT_LEASE",
+  "STALE_CURRENT_LEASE_POINTER",
+  "TENANT_CURRENT_WITHOUT_CURRENT_LEASE",
+];
+const OCCUPIED = new Set(["occupied", "active", "current", "leased", "rented"]);
+const ACTIVE_TENANCY = new Set(["active", "current", "occupied"]);
+
+function text(value: unknown): string | null {
+  const normalized = String(value ?? "").trim();
+  return normalized || null;
+}
+
+function state(value: unknown): string {
+  return String(value ?? "").trim().toLowerCase().replace(/[\s-]+/g, "_");
+}
+
+function explicitInstant(value: unknown): string | null {
+  if (value == null || value === "") return null;
+  const date = value instanceof Date ? value : new Date(String(value));
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+function orderedReasons(reasons: CanonicalLeaseConflictReason[]): CanonicalLeaseConflictReason[] {
+  const unique = new Set(reasons);
+  return REASON_ORDER.filter((reason) => unique.has(reason));
+}
+
+function idMatches(value: unknown, expected: string): boolean {
+  return text(value) === expected;
+}
+
+function canonicalParty(lease: CanonicalLeaseStartInput["candidateLease"], tenantId: string): boolean {
+  if (idMatches(lease.tenantId, tenantId)) return true;
+  return Array.isArray(lease.tenantIds) && lease.tenantIds.some((id) => idMatches(id, tenantId));
+}
+
+function isAffirmativelyExecuted(lease: CanonicalLeaseStateInput): boolean {
+  return state(lease.executionState || lease.executionStatus) === "fully_executed";
+}
+
+function sameContext(lease: CanonicalLeaseStateInput, landlordId: string, propertyId: string, unitId: string): boolean {
+  return idMatches(lease.landlordId, landlordId) && idMatches(lease.propertyId, propertyId) && idMatches(lease.unitId, unitId);
+}
+
+function isOccupied(unit: CanonicalLeaseStartUnitInput): boolean {
+  return OCCUPIED.has(state(unit.occupancyStatus)) || OCCUPIED.has(state(unit.status)) || unit.occupied === true || unit.isOccupied === true;
+}
+
+function pointerConflict(unit: CanonicalLeaseStartUnitInput, leaseId: string, tenantId: string): boolean {
+  const leasePointers = [text(unit.leaseId), text(unit.currentLeaseId)].filter(Boolean) as string[];
+  const tenantPointers = [text(unit.tenantId), text(unit.currentTenantId)].filter(Boolean) as string[];
+  return leasePointers.some((id) => id !== leaseId) || tenantPointers.some((id) => id !== tenantId);
+}
+
+function unitCoherent(unit: CanonicalLeaseStartUnitInput, leaseId: string, tenantId: string): boolean {
+  return state(unit.status) === "occupied" && state(unit.occupancyStatus) === "occupied" &&
+    idMatches(unit.tenantId, tenantId) && idMatches(unit.currentTenantId, tenantId) &&
+    idMatches(unit.leaseId, leaseId) && idMatches(unit.currentLeaseId, leaseId);
+}
+
+export function evaluateCanonicalLeaseStart(input: CanonicalLeaseStartInput): CanonicalLeaseStartResult {
+  const landlordId = text(input.landlordId);
+  const propertyId = text(input.propertyId);
+  const unitId = text(input.unitId);
+  const tenantId = text(input.tenantId);
+  const leaseId = text(input.candidateLease?.id);
+  const instant = explicitInstant(input.evaluationInstant);
+  const context: CanonicalLeaseStartContext = {
+    evaluationInstant: instant || "",
+    candidateLeaseId: leaseId,
+    eligibleCurrentLeaseIds: [],
+    standaloneUnitIds: input.standaloneUnits.map((unit) => text(unit.id) || "").sort(),
+    embeddedUnitIds: input.embeddedUnits.map((unit) => text(unit.id) || "").sort(),
+    tenancyIds: input.tenancies.map((tenancy) => tenancy.id).sort(),
+  };
+  const result = (
+    outcome: CanonicalLeaseStartOutcome,
+    reasons: CanonicalLeaseConflictReason[] = [],
+    postcondition: CanonicalLeaseStartPostcondition | null = null
+  ): CanonicalLeaseStartResult => ({ outcome, occupancyEffective: outcome === "occupancy_effective" || outcome === "already_coherent", reasons: orderedReasons(reasons), postcondition, context });
+
+  if (!landlordId || !propertyId || !unitId || !tenantId || !leaseId || !instant) {
+    return result("rejected", ["CURRENT_LEASE_CONTEXT_MISMATCH"]);
+  }
+  if (!sameContext(input.candidateLease, landlordId, propertyId, unitId) || !idMatches(input.candidateLease.tenantId, tenantId) ||
+      !input.tenant || !idMatches(input.tenant.id, tenantId) || !idMatches(input.tenant.landlordId, landlordId)) {
+    return result("rejected", ["CURRENT_LEASE_CONTEXT_MISMATCH"]);
+  }
+  if (input.standaloneUnits.length !== 1 || input.embeddedUnits.length !== 1) {
+    return result("rejected", ["CURRENT_LEASE_CONTEXT_MISMATCH"]);
+  }
+  const standalone = input.standaloneUnits[0];
+  const embedded = input.embeddedUnits[0];
+  if (!idMatches(standalone.id, unitId) || !idMatches(standalone.landlordId, landlordId) || !idMatches(standalone.propertyId, propertyId) ||
+      !idMatches(embedded.id, unitId) || !idMatches(embedded.landlordId, landlordId) || !idMatches(embedded.propertyId, propertyId)) {
+    return result("rejected", ["CURRENT_LEASE_CONTEXT_MISMATCH"]);
+  }
+
+  const lifecycle = deriveCanonicalLeaseTermState(input.candidateLease, instant);
+  if (lifecycle.reasons.includes("INVALID_LEASE_DATE_RANGE") || lifecycle.state === "unknown") {
+    return result("rejected", lifecycle.reasons.length ? lifecycle.reasons : ["INVALID_LEASE_DATE_RANGE"]);
+  }
+  if (["draft", "upcoming", "past", "ended", "terminated"].includes(lifecycle.state)) {
+    return result("created_without_occupancy", lifecycle.reasons);
+  }
+  if (!isAffirmativelyExecuted(input.candidateLease)) {
+    return result("created_without_occupancy", ["LEASE_EXECUTION_INCOMPLETE"]);
+  }
+  if (!canonicalParty(input.candidateLease, tenantId)) {
+    return result("rejected", ["CURRENT_LEASE_CONTEXT_MISMATCH"]);
+  }
+
+  const eligible = [input.candidateLease, ...input.contextLeases]
+    .slice()
+    .sort((left, right) => left.id.localeCompare(right.id))
+    .filter((lease, index, leases) => leases.findIndex((candidate) => candidate.id === lease.id) === index)
+    .filter((lease) => sameContext(lease, landlordId, propertyId, unitId))
+    .filter((lease) => deriveCanonicalLeaseTermState(lease, instant).state === "active" && isAffirmativelyExecuted(lease))
+    .map((lease) => lease.id)
+    .sort();
+  context.eligibleCurrentLeaseIds = eligible;
+  if (eligible.length !== 1 || eligible[0] !== leaseId) {
+    return result("rejected", eligible.length > 1 ? ["MULTIPLE_CURRENT_LEASES"] : ["CURRENT_LEASE_CONTEXT_MISMATCH"]);
+  }
+
+  if ((isOccupied(standalone) && pointerConflict(standalone, leaseId, tenantId)) ||
+      (isOccupied(embedded) && pointerConflict(embedded, leaseId, tenantId))) {
+    return result("rejected", ["OCCUPIED_WITHOUT_CURRENT_LEASE", "STALE_CURRENT_LEASE_POINTER"]);
+  }
+  if (pointerConflict(standalone, leaseId, tenantId) || pointerConflict(embedded, leaseId, tenantId)) {
+    return result("rejected", ["STALE_CURRENT_LEASE_POINTER"]);
+  }
+  const tenantPointer = text(input.tenant.currentLeaseId);
+  if (tenantPointer && tenantPointer !== leaseId) return result("rejected", ["STALE_CURRENT_LEASE_POINTER"]);
+
+  const relevantTenancies = input.tenancies.filter((tenancy) => idMatches(tenancy.tenantId, tenantId) && idMatches(tenancy.propertyId, propertyId) && idMatches(tenancy.unitId, unitId));
+  const unrelatedActive = input.tenancies.some((tenancy) => ACTIVE_TENANCY.has(state(tenancy.status)) && !relevantTenancies.includes(tenancy));
+  const active = relevantTenancies.filter((tenancy) => ACTIVE_TENANCY.has(state(tenancy.status)) && !text(tenancy.moveOutAt));
+  if (unrelatedActive || active.length > 1 || relevantTenancies.length > 1) {
+    return result("rejected", ["CURRENT_LEASE_CONTEXT_MISMATCH"]);
+  }
+  const tenancy = active[0] || relevantTenancies[0] || null;
+  if (tenancy && (!idMatches(tenancy.landlordId, landlordId) || (text(tenancy.leaseId) && !idMatches(tenancy.leaseId, leaseId)))) {
+    return result("rejected", ["CURRENT_LEASE_CONTEXT_MISMATCH"]);
+  }
+
+  const tenancyCoherent = Boolean(tenancy && active.length === 1 && idMatches(tenancy.leaseId, leaseId));
+  if (unitCoherent(standalone, leaseId, tenantId) && unitCoherent(embedded, leaseId, tenantId) && tenantPointer === leaseId && tenancyCoherent) {
+    return result("already_coherent");
+  }
+
+  const unitDesired = (unit: CanonicalLeaseStartUnitInput): CanonicalLeaseStartUnitPostcondition => ({
+    status: "occupied",
+    occupancyStatus: "occupied",
+    tenantId,
+    currentTenantId: tenantId,
+    leaseId,
+    currentLeaseId: leaseId,
+    occupancySource: "canonical_lease_start",
+    occupancyUpdatedAt: instant,
+    updatedAt: instant,
+    ...(Object.prototype.hasOwnProperty.call(unit, "occupied") ? { occupied: true as const } : {}),
+    ...(Object.prototype.hasOwnProperty.call(unit, "isOccupied") ? { isOccupied: true as const } : {}),
+  });
+  const verifiedMoveInAt = tenancy ? explicitInstant(tenancy.moveInAt) : null;
+  const postcondition: CanonicalLeaseStartPostcondition = {
+    lease: { id: leaseId, occupancyEffective: true },
+    embeddedPropertyUnit: unitDesired(embedded),
+    standaloneUnit: unitDesired(standalone),
+    tenant: { id: tenantId, currentLeaseId: leaseId, status: "current" },
+    tenancy: {
+      action: !tenancy ? "create" : active.length === 1 ? "reuse" : "reconcile",
+      id: tenancy?.id || null,
+      landlordId,
+      propertyId,
+      unitId,
+      tenantId,
+      leaseId,
+      status: "active",
+      moveInAt: verifiedMoveInAt && verifiedMoveInAt < instant ? verifiedMoveInAt : instant,
+    },
+    canonicalEvent: { type: "lease.occupancy_started", leaseId, occurredAt: instant },
+    idempotencyResult: { operation: "canonical_lease_start", leaseId },
+  };
+  return result("occupancy_effective", [], postcondition);
+}

--- a/rentchain-api/src/lib/leases/canonicalLeaseStart.ts
+++ b/rentchain-api/src/lib/leases/canonicalLeaseStart.ts
@@ -172,6 +172,11 @@ function pointerConflict(unit: CanonicalLeaseStartUnitInput, leaseId: string, te
   return leasePointers.some((id) => id !== leaseId) || tenantPointers.some((id) => id !== tenantId);
 }
 
+function occupiedWithoutTenantIdentity(unit: CanonicalLeaseStartUnitInput, tenantId: string): boolean {
+  if (!isOccupied(unit)) return false;
+  return ![text(unit.tenantId), text(unit.currentTenantId)].some((id) => id === tenantId);
+}
+
 function unitCoherent(unit: CanonicalLeaseStartUnitInput, leaseId: string, tenantId: string): boolean {
   return state(unit.status) === "occupied" && state(unit.occupancyStatus) === "occupied" &&
     idMatches(unit.tenantId, tenantId) && idMatches(unit.currentTenantId, tenantId) &&
@@ -246,6 +251,9 @@ export function evaluateCanonicalLeaseStart(input: CanonicalLeaseStartInput): Ca
   if ((isOccupied(standalone) && pointerConflict(standalone, leaseId, tenantId)) ||
       (isOccupied(embedded) && pointerConflict(embedded, leaseId, tenantId))) {
     return result("rejected", ["OCCUPIED_WITHOUT_CURRENT_LEASE", "STALE_CURRENT_LEASE_POINTER"]);
+  }
+  if (occupiedWithoutTenantIdentity(standalone, tenantId) || occupiedWithoutTenantIdentity(embedded, tenantId)) {
+    return result("rejected", ["OCCUPIED_WITHOUT_CURRENT_LEASE"]);
   }
   if (pointerConflict(standalone, leaseId, tenantId) || pointerConflict(embedded, leaseId, tenantId)) {
     return result("rejected", ["STALE_CURRENT_LEASE_POINTER"]);


### PR DESCRIPTION
## Summary
- add a pure canonical lease-start evaluator with deterministic outcomes, reasons, context, and future transactional postcondition intent
- require affirmative `fully_executed` evidence before current occupancy can become effective
- fail closed for multiple-current and incoherent unit, tenant, pointer, or tenancy context
- add 23 deterministic tests covering the required D1 matrix

## Scope boundaries
- pure decision contract only
- no mutation behavior or Firestore writes
- no route or signing integration
- no frontend, Preview, or Production change
- no schema, index, or data migration
- D2 requires separate Founder authorization

## Validation
- D1 test file: 23 passed
- focused canonical regression suite: 60 passed across 5 files, including D1
- backend TypeScript build: passed
- `git diff --check`: passed