### PR TITLE
PR D2: add transactional canonical lease-start boundary

### DIFF
--- a/rentchain-api/src/services/leaseStart/__tests__/leaseStartService.test.ts
+++ b/rentchain-api/src/services/leaseStart/__tests__/leaseStartService.test.ts
@@ -8,14 +8,28 @@ import {
 
 function createFakeFirestore() {
   const store = new Map<string, Map<string, any>>();
-  let queue = Promise.resolve();
+  const versions = new Map<string, number>();
+  let commitQueue = Promise.resolve();
   let failCollection: string | null = null;
   let retryNext = false;
+  let overlapRemaining = 0;
+  let releaseOverlap: (() => void) | null = null;
+  let overlapPromise: Promise<void> | null = null;
+  const stats = { callbackAttempts: 0, activeCallbacks: 0, maxConcurrentCallbacks: 0, conflicts: 0 };
+  class OptimisticConflict extends Error {}
+  const docVersionKey = (name: string, id: string) => `doc:${name}:${id}`;
+  const collectionVersionKey = (name: string) => `collection:${name}`;
+  const version = (key: string) => versions.get(key) || 0;
+  const bump = (name: string, id: string) => {
+    versions.set(docVersionKey(name, id), version(docVersionKey(name, id)) + 1);
+    versions.set(collectionVersionKey(name), version(collectionVersionKey(name)) + 1);
+  };
   const collectionData = (name: string) => {
     if (!store.has(name)) store.set(name, new Map());
     return store.get(name)!;
   };
   const ref = (name: string, id: string): any => ({
+    kind: "doc",
     collectionName: name,
     id,
     get: async () => {
@@ -25,13 +39,16 @@ function createFakeFirestore() {
     set: async (value: any, options?: any) => {
       const prior = collectionData(name).get(id);
       collectionData(name).set(id, options?.merge ? { ...(prior || {}), ...structuredClone(value) } : structuredClone(value));
+      bump(name, id);
     },
     create: async (value: any) => {
       if (collectionData(name).has(id)) throw new Error("already_exists");
       collectionData(name).set(id, structuredClone(value));
+      bump(name, id);
     },
   });
   const query = (name: string, filters: any[] = []): any => ({
+    kind: "query",
     collectionName: name,
     filters,
     where: (field: string, op: string, value: any) => query(name, [...filters, { field, op, value }]),
@@ -41,50 +58,87 @@ function createFakeFirestore() {
         .map(([id, value]) => ({ id, exists: true, data: () => value, ref: ref(name, id) })),
     }),
   });
-  const transactionAttempt = async (callback: any, apply: boolean) => {
+  const transactionAttempt = async (callback: any, attempt: number) => {
     const writes: Array<{ kind: "set" | "create"; target: any; value: any; options?: any }> = [];
-    const result = await callback({
-      get: (target: any) => target.get(),
-      set: (target: any, value: any, options?: any) => writes.push({ kind: "set", target, value, options }),
-      create: (target: any, value: any) => writes.push({ kind: "create", target, value }),
-    });
-    if (!apply) return result;
-    const snapshot = structuredClone([...store.entries()].map(([name, values]) => [name, [...values.entries()]]));
+    const readVersions = new Map<string, number>();
+    stats.callbackAttempts += 1;
+    stats.activeCallbacks += 1;
+    stats.maxConcurrentCallbacks = Math.max(stats.maxConcurrentCallbacks, stats.activeCallbacks);
+    let result: any;
     try {
-      for (const write of writes) {
-        if (write.target.collectionName === failCollection) throw new Error("forced_transaction_failure");
-        if (write.kind === "create") await write.target.create(write.value);
-        else await write.target.set(write.value, write.options);
-      }
-    } catch (error) {
-      store.clear();
-      for (const [name, entries] of snapshot) store.set(name, new Map(entries));
-      throw error;
+      result = await callback({
+        get: async (target: any) => {
+          const key = target.kind === "query" ? collectionVersionKey(target.collectionName) : docVersionKey(target.collectionName, target.id);
+          if (!readVersions.has(key)) readVersions.set(key, version(key));
+          return target.get();
+        },
+        set: (target: any, value: any, options?: any) => writes.push({ kind: "set", target, value, options }),
+        create: (target: any, value: any) => writes.push({ kind: "create", target, value }),
+      });
+    } finally {
+      stats.activeCallbacks -= 1;
     }
+    if (attempt === 0 && overlapRemaining > 0 && overlapPromise) {
+      overlapRemaining -= 1;
+      if (overlapRemaining === 0) releaseOverlap?.();
+      await overlapPromise;
+    }
+    if (retryNext && attempt === 0) {
+      retryNext = false;
+      stats.conflicts += 1;
+      throw new OptimisticConflict();
+    }
+    const commit = commitQueue.then(async () => {
+      if ([...readVersions].some(([key, readVersion]) => version(key) !== readVersion)) {
+        stats.conflicts += 1;
+        throw new OptimisticConflict();
+      }
+      const storeSnapshot = structuredClone([...store.entries()].map(([name, values]) => [name, [...values.entries()]]));
+      const versionSnapshot = new Map(versions);
+      try {
+        for (const write of writes) {
+          if (write.target.collectionName === failCollection) throw new Error("forced_transaction_failure");
+          if (write.kind === "create") await write.target.create(write.value);
+          else await write.target.set(write.value, write.options);
+        }
+      } catch (error) {
+        store.clear();
+        for (const [name, entries] of storeSnapshot) store.set(name, new Map(entries));
+        versions.clear();
+        for (const [key, value] of versionSnapshot) versions.set(key, value);
+        throw error;
+      }
+    });
+    commitQueue = commit.then(() => undefined, () => undefined);
+    await commit;
     return result;
   };
   const firestore: any = {
     collection: (name: string) => ({ ...query(name), doc: (id: string) => ref(name, id) }),
-    runTransaction: (callback: any) => {
-      const run = queue.then(async () => {
-        if (retryNext) {
-          retryNext = false;
-          await transactionAttempt(callback, false);
+    runTransaction: async (callback: any) => {
+      for (let attempt = 0; attempt < 4; attempt += 1) {
+        try {
+          return await transactionAttempt(callback, attempt);
+        } catch (error) {
+          if (!(error instanceof OptimisticConflict) || attempt === 3) throw error;
         }
-        return transactionAttempt(callback, true);
-      });
-      queue = run.then(() => undefined, () => undefined);
-      return run;
+      }
+      throw new Error("transaction_retry_exhausted");
     },
   };
   return {
     firestore,
-    seed: (name: string, id: string, value: any) => collectionData(name).set(id, structuredClone(value)),
+    seed: (name: string, id: string, value: any) => { collectionData(name).set(id, structuredClone(value)); bump(name, id); },
     read: (name: string, id: string) => structuredClone(collectionData(name).get(id)),
     list: (name: string) => [...collectionData(name).values()].map((value) => structuredClone(value)),
     ids: (name: string) => [...collectionData(name).keys()],
     failWritesTo: (name: string | null) => { failCollection = name; },
     retryNextTransaction: () => { retryNext = true; },
+    overlapNextTransactions: (count: number) => {
+      overlapRemaining = count;
+      overlapPromise = new Promise<void>((resolve) => { releaseOverlap = resolve; });
+    },
+    stats,
   };
 }
 
@@ -188,7 +242,49 @@ describe("leaseStartService", () => {
     const result = await startCanonicalLeaseOccupancy(await mutationInput());
     expect(result).toMatchObject({ outcome: "created_without_occupancy", occupancyEffective: false, reasons: [reason] });
     expect(domainSnapshot()).toEqual(before);
-    expect(fake.list("leaseStartRequests")).toHaveLength(1);
+    expect(fake.list("leaseStartRequests")).toEqual([]);
+  });
+
+  it("fails closed for a cross-tenant active tenancy on the target unit", async () => {
+    fake.seed("tenancies", "tenancy-foreign", { landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-2", leaseId: "lease-foreign", status: "active" });
+    const before = domainSnapshot();
+    const result = await startCanonicalLeaseOccupancy(await mutationInput());
+    expect(result).toMatchObject({ outcome: "rejected", occupancyEffective: false, reasons: ["CURRENT_LEASE_CONTEXT_MISMATCH"] });
+    expect(domainSnapshot()).toEqual(before);
+    expect(fake.read("tenants", "tenant-1")).not.toHaveProperty("currentLeaseId");
+    expect(fake.list("leaseStartRequests")).toEqual([]);
+  });
+
+  it("fails closed for candidate-active plus foreign-active and two foreign-active tenancies", async () => {
+    fake.seed("tenancies", "tenancy-candidate", { landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-1", leaseId: "lease-1", status: "active" });
+    fake.seed("tenancies", "tenancy-foreign", { landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-2", leaseId: "lease-2", status: "active" });
+    expect(await startCanonicalLeaseOccupancy(await mutationInput())).toMatchObject({ outcome: "rejected", occupancyEffective: false });
+    expect(fake.list("canonicalEvents")).toEqual([]);
+
+    fake = createFakeFirestore();
+    seedBase();
+    fake.seed("tenancies", "tenancy-foreign-1", { landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-2", status: "active" });
+    fake.seed("tenancies", "tenancy-foreign-2", { landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-3", status: "active" });
+    expect(await startCanonicalLeaseOccupancy(await mutationInput())).toMatchObject({ outcome: "rejected", occupancyEffective: false });
+    expect(fake.list("tenancies")).toHaveLength(2);
+    expect(fake.list("leaseStartRequests")).toEqual([]);
+  });
+
+  it("ignores an unrelated tenancy on another unit", async () => {
+    fake.seed("tenancies", "tenancy-other-unit", { landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-2", tenantId: "tenant-2", status: "active" });
+    const result = await startCanonicalLeaseOccupancy(await mutationInput());
+    expect(result.outcome).toBe("occupancy_effective");
+    expect(fake.ids("tenancies")).toContain("tenancy-other-unit");
+    expect(fake.list("canonicalEvents")).toHaveLength(1);
+  });
+
+  it("includes cross-tenant target-unit tenancy evidence in the expected-state token", async () => {
+    fake.seed("tenancies", "tenancy-foreign", { landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-2", status: "inactive", updatedAt: "2026-04-01T00:00:00.000Z" });
+    const before = await getCanonicalLeaseStartContext({ ...base, firestore: fake.firestore });
+    fake.seed("tenancies", "tenancy-foreign", { ...fake.read("tenancies", "tenancy-foreign"), status: "active", updatedAt: evaluationInstant });
+    const after = await getCanonicalLeaseStartContext({ ...base, firestore: fake.firestore });
+    expect(after.expectedStateToken).not.toBe(before.expectedStateToken);
+    expect(after.decision).toMatchObject({ outcome: "rejected", occupancyEffective: false });
   });
 
   it("fails closed for multiple current leases with no success idempotency result", async () => {
@@ -280,17 +376,22 @@ describe("leaseStartService", () => {
     expect(fake.list("canonicalEvents")).toEqual([]);
   });
 
-  it("recomputes expected state inside the transaction and serializes concurrent starts", async () => {
+  it("overlaps optimistic transaction reads and retries the losing concurrent start", async () => {
     const context = await getCanonicalLeaseStartContext({ ...base, firestore: fake.firestore });
     const common = { ...await mutationInput(), expectedStateToken: context.expectedStateToken };
+    fake.overlapNextTransactions(2);
     const settled = await Promise.allSettled([
       startCanonicalLeaseOccupancy({ ...common, idempotencyKey: "race-a" }),
       startCanonicalLeaseOccupancy({ ...common, idempotencyKey: "race-b" }),
     ]);
     expect(settled.filter((entry) => entry.status === "fulfilled")).toHaveLength(1);
     expect(settled.filter((entry) => entry.status === "rejected")).toHaveLength(1);
+    expect(fake.stats.maxConcurrentCallbacks).toBeGreaterThanOrEqual(2);
+    expect(fake.stats.conflicts).toBeGreaterThanOrEqual(1);
+    expect(fake.stats.callbackAttempts).toBeGreaterThanOrEqual(3);
     expect(fake.list("canonicalEvents")).toHaveLength(1);
     expect(fake.list("tenancies")).toHaveLength(1);
+    expect(fake.list("leaseStartRequests")).toHaveLength(1);
   });
 
   it("returns an identical durable replay with no duplicate writes", async () => {
@@ -318,6 +419,22 @@ describe("leaseStartService", () => {
     });
     expect(replayAcrossOperation.canonicalOutcome).toBe("already_coherent");
     expect(fake.list("canonicalEvents")).toHaveLength(1);
+  });
+
+  it("binds expected state, actor, effective instant, and trigger into idempotency payload identity", async () => {
+    const input = await mutationInput();
+    await startCanonicalLeaseOccupancy(input);
+    const mismatches = [
+      { expectedStateToken: `${input.expectedStateToken}-changed` },
+      { actorId: "landlord-2" },
+      { evaluationInstant: "2026-05-01T12:00:01.000Z" },
+      { trigger: "signing_completion" as const },
+    ];
+    for (const mismatch of mismatches) {
+      await expect(startCanonicalLeaseOccupancy({ ...input, ...mismatch })).rejects.toMatchObject({ code: "lease_start_idempotency_key_reused" });
+    }
+    expect(fake.list("canonicalEvents")).toHaveLength(1);
+    expect(fake.list("leaseStartRequests")).toHaveLength(1);
   });
 
   it("does not duplicate events when the transaction callback retries", async () => {

--- a/rentchain-api/src/services/leaseStart/__tests__/leaseStartService.test.ts
+++ b/rentchain-api/src/services/leaseStart/__tests__/leaseStartService.test.ts
@@ -1,0 +1,370 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  getCanonicalLeaseStartContext,
+  LeaseStartServiceError,
+  startCanonicalLeaseOccupancy,
+  type StartCanonicalLeaseOccupancyInput,
+} from "../leaseStartService";
+
+function createFakeFirestore() {
+  const store = new Map<string, Map<string, any>>();
+  let queue = Promise.resolve();
+  let failCollection: string | null = null;
+  let retryNext = false;
+  const collectionData = (name: string) => {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  };
+  const ref = (name: string, id: string): any => ({
+    collectionName: name,
+    id,
+    get: async () => {
+      const value = collectionData(name).get(id);
+      return { id, exists: value !== undefined, data: () => value, ref: ref(name, id) };
+    },
+    set: async (value: any, options?: any) => {
+      const prior = collectionData(name).get(id);
+      collectionData(name).set(id, options?.merge ? { ...(prior || {}), ...structuredClone(value) } : structuredClone(value));
+    },
+    create: async (value: any) => {
+      if (collectionData(name).has(id)) throw new Error("already_exists");
+      collectionData(name).set(id, structuredClone(value));
+    },
+  });
+  const query = (name: string, filters: any[] = []): any => ({
+    collectionName: name,
+    filters,
+    where: (field: string, op: string, value: any) => query(name, [...filters, { field, op, value }]),
+    get: async () => ({
+      docs: [...collectionData(name).entries()]
+        .filter(([, value]) => filters.every((filter) => filter.op === "==" && value[filter.field] === filter.value))
+        .map(([id, value]) => ({ id, exists: true, data: () => value, ref: ref(name, id) })),
+    }),
+  });
+  const transactionAttempt = async (callback: any, apply: boolean) => {
+    const writes: Array<{ kind: "set" | "create"; target: any; value: any; options?: any }> = [];
+    const result = await callback({
+      get: (target: any) => target.get(),
+      set: (target: any, value: any, options?: any) => writes.push({ kind: "set", target, value, options }),
+      create: (target: any, value: any) => writes.push({ kind: "create", target, value }),
+    });
+    if (!apply) return result;
+    const snapshot = structuredClone([...store.entries()].map(([name, values]) => [name, [...values.entries()]]));
+    try {
+      for (const write of writes) {
+        if (write.target.collectionName === failCollection) throw new Error("forced_transaction_failure");
+        if (write.kind === "create") await write.target.create(write.value);
+        else await write.target.set(write.value, write.options);
+      }
+    } catch (error) {
+      store.clear();
+      for (const [name, entries] of snapshot) store.set(name, new Map(entries));
+      throw error;
+    }
+    return result;
+  };
+  const firestore: any = {
+    collection: (name: string) => ({ ...query(name), doc: (id: string) => ref(name, id) }),
+    runTransaction: (callback: any) => {
+      const run = queue.then(async () => {
+        if (retryNext) {
+          retryNext = false;
+          await transactionAttempt(callback, false);
+        }
+        return transactionAttempt(callback, true);
+      });
+      queue = run.then(() => undefined, () => undefined);
+      return run;
+    },
+  };
+  return {
+    firestore,
+    seed: (name: string, id: string, value: any) => collectionData(name).set(id, structuredClone(value)),
+    read: (name: string, id: string) => structuredClone(collectionData(name).get(id)),
+    list: (name: string) => [...collectionData(name).values()].map((value) => structuredClone(value)),
+    ids: (name: string) => [...collectionData(name).keys()],
+    failWritesTo: (name: string | null) => { failCollection = name; },
+    retryNextTransaction: () => { retryNext = true; },
+  };
+}
+
+const evaluationInstant = "2026-05-01T12:00:00.000Z";
+const base = { landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-1", leaseId: "lease-1", evaluationInstant };
+let fake: ReturnType<typeof createFakeFirestore>;
+
+function seedBase(overrides: { lease?: any; unit?: any; embedded?: any; tenant?: any } = {}) {
+  const embedded = {
+    id: "unit-1", unitNumber: "1A", status: "vacant", occupancyStatus: "vacant", updatedAt: "2026-04-30T12:00:00.000Z",
+    ...(overrides.embedded || {}),
+  };
+  fake.seed("properties", "property-1", { landlordId: "landlord-1", name: "Harbour House", units: [embedded], updatedAt: "2026-04-30T12:00:00.000Z" });
+  fake.seed("units", "unit-1", {
+    landlordId: "landlord-1", propertyId: "property-1", unitNumber: "1A", status: "vacant", occupancyStatus: "vacant",
+    updatedAt: "2026-04-30T12:00:00.000Z", ...(overrides.unit || {}),
+  });
+  fake.seed("tenants", "tenant-1", { landlordId: "landlord-1", status: "past", updatedAt: "2026-04-30T12:00:00.000Z", ...(overrides.tenant || {}) });
+  fake.seed("leases", "lease-1", {
+    landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-1",
+    status: "active", executionStatus: "fully_executed", startDate: "2026-01-01", endDate: "2026-12-31",
+    updatedAt: "2026-04-30T12:00:00.000Z", ...(overrides.lease || {}),
+  });
+}
+
+async function mutationInput(overrides: Partial<StartCanonicalLeaseOccupancyInput> = {}): Promise<StartCanonicalLeaseOccupancyInput> {
+  const context = await getCanonicalLeaseStartContext({ ...base, firestore: fake.firestore });
+  return {
+    ...base,
+    operationKind: "explicit_start",
+    trigger: "explicit_start",
+    idempotencyKey: "request-1",
+    expectedStateToken: context.expectedStateToken,
+    actorId: "landlord-1",
+    source: "test",
+    firestore: fake.firestore,
+    ...overrides,
+  };
+}
+
+function domainSnapshot() {
+  return {
+    lease: fake.read("leases", "lease-1"),
+    property: fake.read("properties", "property-1"),
+    unit: fake.read("units", "unit-1"),
+    tenant: fake.read("tenants", "tenant-1"),
+    tenancies: fake.list("tenancies"),
+    events: fake.list("canonicalEvents"),
+  };
+}
+
+describe("leaseStartService", () => {
+  beforeEach(() => {
+    fake = createFakeFirestore();
+    seedBase();
+  });
+
+  it("starts an existing fully executed current lease as one atomic postcondition", async () => {
+    const result = await startCanonicalLeaseOccupancy(await mutationInput());
+    expect(result).toMatchObject({ outcome: "occupancy_effective", canonicalOutcome: "occupancy_effective", occupancyEffective: true });
+    expect(fake.read("leases", "lease-1")).toMatchObject({ occupancyEffective: true, occupancyEffectiveAt: evaluationInstant });
+    expect(fake.read("units", "unit-1")).toMatchObject({ status: "occupied", occupancyStatus: "occupied", tenantId: "tenant-1", currentTenantId: "tenant-1", leaseId: "lease-1", currentLeaseId: "lease-1", occupancyUpdatedAt: evaluationInstant });
+    expect(fake.read("properties", "property-1").units[0]).toMatchObject({ status: "occupied", currentTenantId: "tenant-1", currentLeaseId: "lease-1" });
+    expect(fake.read("tenants", "tenant-1")).toMatchObject({ status: "current", currentLeaseId: "lease-1" });
+    expect(fake.list("tenancies")).toHaveLength(1);
+    expect(fake.list("tenancies")[0]).toMatchObject({ status: "active", tenantId: "tenant-1", leaseId: "lease-1", moveInAt: evaluationInstant });
+    expect(fake.list("canonicalEvents")).toHaveLength(1);
+    expect(fake.list("canonicalEvents")[0]).toMatchObject({ type: "lease.occupancy_started", immutable: true });
+    expect(fake.list("leaseStartRequests")).toHaveLength(1);
+    const fresh = await getCanonicalLeaseStartContext({ ...base, firestore: fake.firestore });
+    expect(fresh.decision.outcome).toBe("already_coherent");
+    expect(result.expectedStateToken).toBe(fresh.expectedStateToken);
+  });
+
+  it("reuses a coherent active tenancy without rewriting it", async () => {
+    fake.seed("tenancies", "tenancy-existing", { landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-1", leaseId: "lease-1", status: "active", moveInAt: "2026-04-01T12:00:00.000Z" });
+    const result = await startCanonicalLeaseOccupancy(await mutationInput());
+    expect(fake.ids("tenancies")).toEqual(["tenancy-existing"]);
+    expect(fake.read("tenancies", "tenancy-existing").moveInAt).toBe("2026-04-01T12:00:00.000Z");
+    const fresh = await getCanonicalLeaseStartContext({ ...base, firestore: fake.firestore });
+    expect(result.expectedStateToken).toBe(fresh.expectedStateToken);
+  });
+
+  it("reconciles one inactive tenancy and preserves its verified earlier move-in", async () => {
+    fake.seed("tenancies", "tenancy-existing", { landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-1", leaseId: "lease-1", status: "inactive", moveInAt: "2026-04-01T12:00:00.000Z", moveOutAt: "2026-04-15T12:00:00.000Z" });
+    await startCanonicalLeaseOccupancy(await mutationInput());
+    expect(fake.read("tenancies", "tenancy-existing")).toMatchObject({ status: "active", moveInAt: "2026-04-01T12:00:00.000Z", moveOutAt: null });
+  });
+
+  it.each([
+    ["future", { startDate: "2026-06-01", endDate: "2027-05-31" }, "UPCOMING_LEASE_CANNOT_SUPPORT_OCCUPANCY"],
+    ["incomplete", { executionStatus: "tenant_signed" }, "LEASE_EXECUTION_INCOMPLETE"],
+    ["missing execution", { executionStatus: undefined }, "LEASE_EXECUTION_INCOMPLETE"],
+    ["draft", { status: "draft", executionStatus: "draft" }, "DRAFT_LEASE_CANNOT_SUPPORT_OCCUPANCY"],
+    ["past", { endDate: "2026-04-30" }, "PAST_LEASE_CANNOT_SUPPORT_OCCUPANCY"],
+    ["ended", { status: "ended" }, "ENDED_LEASE_CANNOT_SUPPORT_OCCUPANCY"],
+  ])("returns created_without_occupancy with zero domain writes for a %s lease", async (_label, lease, reason) => {
+    fake = createFakeFirestore();
+    seedBase({ lease });
+    const before = domainSnapshot();
+    const result = await startCanonicalLeaseOccupancy(await mutationInput());
+    expect(result).toMatchObject({ outcome: "created_without_occupancy", occupancyEffective: false, reasons: [reason] });
+    expect(domainSnapshot()).toEqual(before);
+    expect(fake.list("leaseStartRequests")).toHaveLength(1);
+  });
+
+  it("fails closed for multiple current leases with no success idempotency result", async () => {
+    fake.seed("leases", "lease-2", { ...fake.read("leases", "lease-1"), tenantId: "tenant-1" });
+    const before = domainSnapshot();
+    const result = await startCanonicalLeaseOccupancy(await mutationInput());
+    expect(result).toMatchObject({ outcome: "rejected", reasons: ["MULTIPLE_CURRENT_LEASES"], occupancyEffective: false });
+    expect(domainSnapshot()).toEqual(before);
+    expect(fake.list("leaseStartRequests")).toEqual([]);
+  });
+
+  it("cannot bypass D1 anonymous legacy occupancy rejection", async () => {
+    fake = createFakeFirestore();
+    seedBase({ unit: { status: "occupied", occupancyStatus: "occupied" }, embedded: { status: "occupied", occupancyStatus: "occupied" } });
+    const before = domainSnapshot();
+    const result = await startCanonicalLeaseOccupancy(await mutationInput());
+    expect(result).toMatchObject({ outcome: "rejected", reasons: ["OCCUPIED_WITHOUT_CURRENT_LEASE"], occupancyEffective: false });
+    expect(domainSnapshot()).toEqual(before);
+    expect(fake.list("leaseStartRequests")).toEqual([]);
+  });
+
+  it.each([
+    ["unrelated tenant occupancy", { unit: { status: "occupied", tenantId: "tenant-2" }, embedded: { status: "occupied", tenantId: "tenant-2" } }, "STALE_CURRENT_LEASE_POINTER"],
+    ["unrelated lease pointer", { unit: { currentLeaseId: "lease-2" }, embedded: { currentLeaseId: "lease-2" } }, "STALE_CURRENT_LEASE_POINTER"],
+  ])("rejects %s with zero domain or success-idempotency writes", async (_label, overrides, reason) => {
+    fake = createFakeFirestore();
+    seedBase(overrides as any);
+    const before = domainSnapshot();
+    const result = await startCanonicalLeaseOccupancy(await mutationInput());
+    expect(result.outcome).toBe("rejected");
+    expect(result.reasons).toContain(reason);
+    expect(domainSnapshot()).toEqual(before);
+    expect(fake.list("leaseStartRequests")).toEqual([]);
+  });
+
+  it("rejects ambiguous tenancy and invalid date range without writes", async () => {
+    fake.seed("tenancies", "tenancy-1", { landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-1", status: "inactive" });
+    fake.seed("tenancies", "tenancy-2", { landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-1", status: "inactive" });
+    expect((await startCanonicalLeaseOccupancy(await mutationInput())).outcome).toBe("rejected");
+    expect(fake.list("leaseStartRequests")).toEqual([]);
+
+    fake = createFakeFirestore();
+    seedBase({ lease: { startDate: "2027-01-01", endDate: "2026-12-31" } });
+    expect(await startCanonicalLeaseOccupancy(await mutationInput())).toMatchObject({ outcome: "rejected", reasons: ["INVALID_LEASE_DATE_RANGE"] });
+    expect(fake.list("leaseStartRequests")).toEqual([]);
+  });
+
+  it("rejects tenant-party, cross-landlord, and embedded-unit context mismatches", async () => {
+    fake = createFakeFirestore();
+    seedBase({ lease: { tenantId: "tenant-2" } });
+    expect((await startCanonicalLeaseOccupancy(await mutationInput())).outcome).toBe("rejected");
+
+    fake = createFakeFirestore();
+    seedBase({ unit: { landlordId: "landlord-2" } });
+    await expect(getCanonicalLeaseStartContext({ ...base, firestore: fake.firestore })).rejects.toMatchObject({ code: "lease_start_context_ambiguous" });
+
+    fake = createFakeFirestore();
+    seedBase({ embedded: { id: "unit-2", unitNumber: "2A" } });
+    await expect(getCanonicalLeaseStartContext({ ...base, firestore: fake.firestore })).rejects.toMatchObject({ code: "lease_start_context_ambiguous" });
+  });
+
+  it("rejects a duplicate standalone logical-unit alias", async () => {
+    fake.seed("units", "unit-duplicate", { landlordId: "landlord-1", propertyId: "property-1", unitNumber: "1A", status: "vacant" });
+    await expect(getCanonicalLeaseStartContext({ ...base, firestore: fake.firestore })).rejects.toMatchObject({ code: "lease_start_context_ambiguous" });
+    expect(fake.list("canonicalEvents")).toEqual([]);
+    expect(fake.list("leaseStartRequests")).toEqual([]);
+  });
+
+  it("rejects a stale token after authoritative state changes", async () => {
+    const input = await mutationInput();
+    fake.seed("units", "unit-1", { ...fake.read("units", "unit-1"), currentLeaseId: "lease-racing", updatedAt: evaluationInstant });
+    await expect(startCanonicalLeaseOccupancy(input)).rejects.toMatchObject({ code: "lease_start_state_stale", freshContext: expect.any(Object) });
+    expect(fake.list("canonicalEvents")).toEqual([]);
+  });
+
+  it("fails stale when a competing current lease appears after context generation", async () => {
+    const input = await mutationInput();
+    fake.seed("leases", "lease-2", { ...fake.read("leases", "lease-1"), tenantId: "tenant-1", updatedAt: evaluationInstant });
+    await expect(startCanonicalLeaseOccupancy(input)).rejects.toMatchObject({ code: "lease_start_state_stale" });
+    expect(fake.list("canonicalEvents")).toEqual([]);
+    expect(fake.list("leaseStartRequests")).toEqual([]);
+  });
+
+  it("fails stale when an End-Lease-style terminal change wins the race", async () => {
+    const input = await mutationInput();
+    fake.seed("leases", "lease-1", { ...fake.read("leases", "lease-1"), status: "ended", endedAt: evaluationInstant, updatedAt: evaluationInstant });
+    await expect(startCanonicalLeaseOccupancy(input)).rejects.toMatchObject({ code: "lease_start_state_stale" });
+    expect(fake.read("units", "unit-1")).toMatchObject({ status: "vacant", occupancyStatus: "vacant" });
+    expect(fake.list("canonicalEvents")).toEqual([]);
+  });
+
+  it("recomputes expected state inside the transaction and serializes concurrent starts", async () => {
+    const context = await getCanonicalLeaseStartContext({ ...base, firestore: fake.firestore });
+    const common = { ...await mutationInput(), expectedStateToken: context.expectedStateToken };
+    const settled = await Promise.allSettled([
+      startCanonicalLeaseOccupancy({ ...common, idempotencyKey: "race-a" }),
+      startCanonicalLeaseOccupancy({ ...common, idempotencyKey: "race-b" }),
+    ]);
+    expect(settled.filter((entry) => entry.status === "fulfilled")).toHaveLength(1);
+    expect(settled.filter((entry) => entry.status === "rejected")).toHaveLength(1);
+    expect(fake.list("canonicalEvents")).toHaveLength(1);
+    expect(fake.list("tenancies")).toHaveLength(1);
+  });
+
+  it("returns an identical durable replay with no duplicate writes", async () => {
+    const input = await mutationInput();
+    const first = await startCanonicalLeaseOccupancy(input);
+    const before = domainSnapshot();
+    const replay = await startCanonicalLeaseOccupancy(input);
+    expect(replay).toMatchObject({ outcome: "idempotent_replay", canonicalOutcome: first.canonicalOutcome, auditEventIds: first.auditEventIds, idempotency: { replay: true } });
+    expect(domainSnapshot()).toEqual(before);
+    expect(fake.list("canonicalEvents")).toHaveLength(1);
+    expect(fake.list("tenancies")).toHaveLength(1);
+  });
+
+  it("rejects changed payload reuse while allowing the same client key for another operation kind", async () => {
+    const input = await mutationInput();
+    await startCanonicalLeaseOccupancy(input);
+    await expect(startCanonicalLeaseOccupancy({ ...input, source: "changed" })).rejects.toBeInstanceOf(LeaseStartServiceError);
+    await expect(startCanonicalLeaseOccupancy({ ...input, source: "changed" })).rejects.toMatchObject({ code: "lease_start_idempotency_key_reused" });
+    const fresh = await getCanonicalLeaseStartContext({ ...base, firestore: fake.firestore });
+    const replayAcrossOperation = await startCanonicalLeaseOccupancy({
+      ...input,
+      operationKind: "signing_completion",
+      trigger: "signing_completion",
+      expectedStateToken: fresh.expectedStateToken,
+    });
+    expect(replayAcrossOperation.canonicalOutcome).toBe("already_coherent");
+    expect(fake.list("canonicalEvents")).toHaveLength(1);
+  });
+
+  it("does not duplicate events when the transaction callback retries", async () => {
+    fake.retryNextTransaction();
+    await startCanonicalLeaseOccupancy(await mutationInput());
+    expect(fake.list("canonicalEvents")).toHaveLength(1);
+    expect(fake.list("tenancies")).toHaveLength(1);
+    expect(fake.list("leaseStartRequests")).toHaveLength(1);
+  });
+
+  it("rolls back every record when a required transaction write fails", async () => {
+    const input = await mutationInput();
+    const before = domainSnapshot();
+    fake.failWritesTo("canonicalEvents");
+    await expect(startCanonicalLeaseOccupancy(input)).rejects.toThrow("forced_transaction_failure");
+    expect(domainSnapshot()).toEqual(before);
+    expect(fake.list("leaseStartRequests")).toEqual([]);
+  });
+
+  it("returns already_coherent with zero domain writes and no duplicate event", async () => {
+    fake = createFakeFirestore();
+    const occupied = { status: "occupied", occupancyStatus: "occupied", tenantId: "tenant-1", currentTenantId: "tenant-1", leaseId: "lease-1", currentLeaseId: "lease-1" };
+    seedBase({ unit: occupied, embedded: occupied, tenant: { status: "current", currentLeaseId: "lease-1" } });
+    fake.seed("tenancies", "tenancy-existing", { landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-1", leaseId: "lease-1", status: "active", moveInAt: "2026-04-01T12:00:00.000Z" });
+    const before = domainSnapshot();
+    const result = await startCanonicalLeaseOccupancy(await mutationInput());
+    expect(result).toMatchObject({ outcome: "already_coherent", occupancyEffective: true, auditEventIds: [] });
+    expect(domainSnapshot()).toEqual(before);
+    expect(fake.list("leaseStartRequests")).toHaveLength(1);
+  });
+
+  it("conditionally updates legacy occupancy booleans without introducing absent fields", async () => {
+    await startCanonicalLeaseOccupancy(await mutationInput());
+    expect(fake.read("units", "unit-1")).not.toHaveProperty("occupied");
+    expect(fake.read("units", "unit-1")).not.toHaveProperty("isOccupied");
+    expect(fake.read("properties", "property-1").units[0]).not.toHaveProperty("occupied");
+    expect(fake.read("properties", "property-1").units[0]).not.toHaveProperty("isOccupied");
+
+    fake = createFakeFirestore();
+    seedBase({ unit: { occupied: false, isOccupied: false }, embedded: { occupied: false, isOccupied: false } });
+    await startCanonicalLeaseOccupancy(await mutationInput());
+    expect(fake.read("units", "unit-1")).toMatchObject({ occupied: true, isOccupied: true });
+    expect(fake.read("properties", "property-1").units[0]).toMatchObject({ occupied: true, isOccupied: true });
+  });
+
+  it("requires a nonempty expected-state token for an occupancy-effective mutation", async () => {
+    await expect(startCanonicalLeaseOccupancy({ ...await mutationInput(), expectedStateToken: "" })).rejects.toMatchObject({ code: "lease_start_state_stale" });
+    expect(fake.list("canonicalEvents")).toEqual([]);
+  });
+});

--- a/rentchain-api/src/services/leaseStart/leaseStartExpectedState.ts
+++ b/rentchain-api/src/services/leaseStart/leaseStartExpectedState.ts
@@ -1,0 +1,100 @@
+import crypto from "crypto";
+import type { CanonicalLeaseStartInput, CanonicalLeaseStartResult } from "../../lib/leases/canonicalLeaseStart";
+
+function stable(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stable).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .filter(([, entry]) => entry !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => `${JSON.stringify(key)}:${stable(entry)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+export function leaseStartHash(value: unknown): string {
+  return crypto.createHash("sha256").update(stable(value)).digest("hex");
+}
+
+function leaseMaterial(lease: CanonicalLeaseStartInput["candidateLease"]) {
+  return {
+    id: lease.id,
+    landlordId: lease.landlordId ?? null,
+    propertyId: lease.propertyId ?? null,
+    unitId: lease.unitId ?? null,
+    tenantId: lease.tenantId ?? null,
+    tenantIds: lease.tenantIds ?? null,
+    status: lease.status ?? null,
+    startDate: lease.startDate ?? lease.leaseStartDate ?? lease.leaseStart ?? null,
+    endDate: lease.endDate ?? lease.leaseEndDate ?? lease.leaseEnd ?? null,
+    executionState: lease.executionState ?? null,
+    executionStatus: lease.executionStatus ?? null,
+    endedAt: lease.endedAt ?? null,
+    terminatedAt: lease.terminatedAt ?? null,
+    terminationDate: lease.terminationDate ?? null,
+    updatedAt: lease.updatedAt ?? null,
+  };
+}
+
+function unitMaterial(unit: CanonicalLeaseStartInput["standaloneUnits"][number]) {
+  return {
+    id: unit.id ?? null,
+    landlordId: unit.landlordId ?? null,
+    propertyId: unit.propertyId ?? null,
+    status: unit.status ?? null,
+    occupancyStatus: unit.occupancyStatus ?? null,
+    tenantId: unit.tenantId ?? null,
+    currentTenantId: unit.currentTenantId ?? null,
+    leaseId: unit.leaseId ?? null,
+    currentLeaseId: unit.currentLeaseId ?? null,
+    occupied: unit.occupied ?? null,
+    isOccupied: unit.isOccupied ?? null,
+    updatedAt: (unit as any).updatedAt ?? null,
+  };
+}
+
+export function buildLeaseStartExpectedStateToken(
+  input: CanonicalLeaseStartInput,
+  decision: CanonicalLeaseStartResult,
+  versionMarkers: { propertyUpdatedAt?: unknown } = {}
+): string {
+  return leaseStartHash({
+    version: "lease_start_expected_state_v1",
+    landlordId: input.landlordId,
+    propertyId: input.propertyId,
+    unitId: input.unitId,
+    tenantId: input.tenantId,
+    evaluationInstant: decision.context.evaluationInstant,
+    propertyUpdatedAt: versionMarkers.propertyUpdatedAt ?? null,
+    candidateLease: leaseMaterial(input.candidateLease),
+    contextLeases: input.contextLeases.map(leaseMaterial).sort((left, right) => left.id.localeCompare(right.id)),
+    standaloneUnits: input.standaloneUnits.map(unitMaterial).sort((left, right) => String(left.id).localeCompare(String(right.id))),
+    embeddedUnits: input.embeddedUnits.map(unitMaterial).sort((left, right) => String(left.id).localeCompare(String(right.id))),
+    tenant: input.tenant ? {
+      id: input.tenant.id ?? null,
+      landlordId: input.tenant.landlordId ?? null,
+      currentLeaseId: input.tenant.currentLeaseId ?? null,
+      status: input.tenant.status ?? null,
+      updatedAt: (input.tenant as any).updatedAt ?? null,
+    } : null,
+    tenancies: input.tenancies.map((tenancy) => ({
+      id: tenancy.id,
+      landlordId: tenancy.landlordId ?? null,
+      propertyId: tenancy.propertyId ?? null,
+      unitId: tenancy.unitId ?? null,
+      tenantId: tenancy.tenantId ?? null,
+      leaseId: tenancy.leaseId ?? null,
+      status: tenancy.status ?? null,
+      moveInAt: tenancy.moveInAt ?? null,
+      moveOutAt: tenancy.moveOutAt ?? null,
+      updatedAt: (tenancy as any).updatedAt ?? null,
+    })).sort((left, right) => left.id.localeCompare(right.id)),
+    canonicalOutcome: decision.outcome,
+    canonicalReasons: decision.reasons,
+  });
+}
+
+export function leaseStartDeterministicId(prefix: string, parts: unknown[]): string {
+  return `${prefix}:${leaseStartHash([prefix, ...parts]).slice(0, 40)}`;
+}

--- a/rentchain-api/src/services/leaseStart/leaseStartService.ts
+++ b/rentchain-api/src/services/leaseStart/leaseStartService.ts
@@ -1,0 +1,329 @@
+import { db } from "../../firebase";
+import {
+  evaluateCanonicalLeaseStart,
+  type CanonicalLeaseStartInput,
+  type CanonicalLeaseStartOutcome,
+  type CanonicalLeaseStartResult,
+} from "../../lib/leases/canonicalLeaseStart";
+import type { CanonicalLeaseConflictReason, CanonicalLeaseStateInput } from "../../lib/leases/canonicalLeaseOccupancyState";
+import { buildLeaseStartExpectedStateToken, leaseStartDeterministicId, leaseStartHash } from "./leaseStartExpectedState";
+
+export type LeaseStartOperationKind =
+  | "direct_create"
+  | "draft_activation"
+  | "signing_completion"
+  | "date_transition"
+  | "explicit_start"
+  | "conversion";
+
+export type LeaseStartTrigger = LeaseStartOperationKind;
+export type LeaseStartServiceOutcome = CanonicalLeaseStartOutcome | "idempotent_replay";
+export type LeaseStartErrorCode =
+  | "lease_start_state_stale"
+  | "lease_start_idempotency_key_reused"
+  | "lease_start_postcondition_failed"
+  | "lease_start_context_ambiguous";
+
+export type LeaseStartContext = {
+  expectedStateToken: string;
+  evaluationInstant: string;
+  decision: CanonicalLeaseStartResult;
+  stateSummary: {
+    leaseId: string;
+    propertyId: string;
+    unitId: string;
+    tenantId: string;
+    eligibleCurrentLeaseIds: string[];
+    tenancyIds: string[];
+  };
+};
+
+export type LeaseStartServiceResult = {
+  outcome: LeaseStartServiceOutcome;
+  canonicalOutcome: CanonicalLeaseStartOutcome;
+  occupancyEffective: boolean;
+  reasons: CanonicalLeaseConflictReason[];
+  expectedStateToken: string;
+  auditEventIds: string[];
+  idempotency: { key: string; replay: boolean; resultId: string | null };
+  stateSummary: LeaseStartContext["stateSummary"];
+};
+
+export type StartCanonicalLeaseOccupancyInput = {
+  landlordId: string;
+  propertyId: string;
+  unitId: string;
+  tenantId: string;
+  leaseId: string;
+  operationKind: LeaseStartOperationKind;
+  idempotencyKey: string;
+  expectedStateToken: string;
+  evaluationInstant: string;
+  trigger: LeaseStartTrigger;
+  actorId?: string | null;
+  source?: string | null;
+  firestore?: any;
+};
+
+type ContextInput = Pick<StartCanonicalLeaseOccupancyInput, "landlordId" | "propertyId" | "unitId" | "tenantId" | "leaseId" | "evaluationInstant"> & { firestore?: any };
+
+export class LeaseStartServiceError extends Error {
+  constructor(public code: LeaseStartErrorCode, public freshContext?: LeaseStartContext) {
+    super(code);
+  }
+}
+
+function text(value: unknown): string {
+  return String(value ?? "").trim();
+}
+
+function instant(value: unknown): string | null {
+  if (!value) return null;
+  const parsed = new Date(String(value));
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+}
+
+function docData(snapshot: any): any {
+  return snapshot?.exists ? { id: snapshot.id, ...(snapshot.data() || {}) } : null;
+}
+
+function matchesEmbeddedUnit(unit: any, unitId: string, unitNumber: string): boolean {
+  return [unit?.id, unit?.unitId, unit?.unitNumber].map(text).includes(unitId) || (Boolean(unitNumber) && text(unit?.unitNumber) === unitNumber);
+}
+
+function canonicalLease(lease: any): CanonicalLeaseStateInput & { tenantIds?: unknown } {
+  return {
+    ...lease,
+    id: text(lease?.id),
+    tenantId: lease?.tenantId || lease?.primaryTenantId || (Array.isArray(lease?.tenantIds) ? lease.tenantIds[0] : null),
+    executionState: lease?.executionState || lease?.leaseExecutionState || lease?.leaseExecution?.executionStatus,
+    executionStatus: lease?.executionStatus || lease?.leaseExecution?.executionStatus,
+  };
+}
+
+async function readContext(reader: any, input: ContextInput): Promise<{ context: LeaseStartContext; records: any }> {
+  const firestore = input.firestore || db;
+  const propertyRef = firestore.collection("properties").doc(input.propertyId);
+  const unitRef = firestore.collection("units").doc(input.unitId);
+  const leaseRef = firestore.collection("leases").doc(input.leaseId);
+  const tenantRef = firestore.collection("tenants").doc(input.tenantId);
+  const unitsQuery = firestore.collection("units").where("landlordId", "==", input.landlordId).where("propertyId", "==", input.propertyId);
+  const leasesQuery = firestore.collection("leases").where("landlordId", "==", input.landlordId).where("propertyId", "==", input.propertyId);
+  const tenanciesQuery = firestore.collection("tenancies").where("tenantId", "==", input.tenantId);
+  const get = (target: any) => reader?.get ? reader.get(target) : target.get();
+  const [propertySnap, unitSnap, leaseSnap, tenantSnap, unitsSnap, leasesSnap, tenanciesSnap] = await Promise.all([
+    get(propertyRef), get(unitRef), get(leaseRef), get(tenantRef), get(unitsQuery), get(leasesQuery), get(tenanciesQuery),
+  ]);
+  const property = docData(propertySnap);
+  const unit = docData(unitSnap);
+  const candidateLease = docData(leaseSnap);
+  const tenant = docData(tenantSnap);
+  if (!property || !unit || !candidateLease || !tenant) throw new LeaseStartServiceError("lease_start_context_ambiguous");
+  if (text(property.landlordId || property.ownerId || property.owner) !== input.landlordId ||
+      text(unit.landlordId) !== input.landlordId || text(unit.propertyId) !== input.propertyId ||
+      text(tenant.landlordId) !== input.landlordId) {
+    throw new LeaseStartServiceError("lease_start_context_ambiguous");
+  }
+  const embeddedUnits = Array.isArray(property.units) ? property.units : [];
+  const unitNumber = text(unit.unitNumber);
+  const matchingStandaloneUnits = (unitsSnap.docs || []).map(docData).filter((entry: any) =>
+    entry && (entry.id === input.unitId || (Boolean(unitNumber) && text(entry.unitNumber) === unitNumber))
+  );
+  if (matchingStandaloneUnits.length !== 1 || matchingStandaloneUnits[0].id !== input.unitId) {
+    throw new LeaseStartServiceError("lease_start_context_ambiguous");
+  }
+  const matches = embeddedUnits.map((entry: any, index: number) => ({ entry, index }))
+    .filter(({ entry }: any) => matchesEmbeddedUnit(entry, input.unitId, unitNumber));
+  if (matches.length !== 1) throw new LeaseStartServiceError("lease_start_context_ambiguous");
+
+  const leases = (leasesSnap.docs || []).map(docData)
+    .filter((lease: any) => lease && text(lease.unitId) === input.unitId)
+    .map(canonicalLease);
+  if (!leases.some((lease: any) => lease.id === input.leaseId)) leases.push(canonicalLease(candidateLease));
+  const tenancies = (tenanciesSnap.docs || []).map(docData).filter(Boolean);
+  const embedded = {
+    ...matches[0].entry,
+    id: text(matches[0].entry.id || matches[0].entry.unitId || input.unitId),
+    landlordId: input.landlordId,
+    propertyId: input.propertyId,
+  };
+  const canonicalInput: CanonicalLeaseStartInput = {
+    landlordId: input.landlordId,
+    propertyId: input.propertyId,
+    unitId: input.unitId,
+    tenantId: input.tenantId,
+    evaluationInstant: input.evaluationInstant,
+    candidateLease: canonicalLease(candidateLease),
+    contextLeases: leases.filter((lease: any) => lease.id !== input.leaseId),
+    standaloneUnits: [unit],
+    embeddedUnits: [embedded],
+    tenant,
+    tenancies,
+  };
+  const decision = evaluateCanonicalLeaseStart(canonicalInput);
+  const expectedStateToken = buildLeaseStartExpectedStateToken(canonicalInput, decision, { propertyUpdatedAt: property.updatedAt });
+  const stateSummary = {
+    leaseId: input.leaseId,
+    propertyId: input.propertyId,
+    unitId: input.unitId,
+    tenantId: input.tenantId,
+    eligibleCurrentLeaseIds: [...decision.context.eligibleCurrentLeaseIds],
+    tenancyIds: [...decision.context.tenancyIds],
+  };
+  return {
+    context: { expectedStateToken, evaluationInstant: decision.context.evaluationInstant, decision, stateSummary },
+    records: { propertyRef, unitRef, leaseRef, tenantRef, property, unit, candidateLease, tenant, embeddedUnits, embeddedIndex: matches[0].index, tenancies, canonicalInput },
+  };
+}
+
+export async function getCanonicalLeaseStartContext(input: ContextInput): Promise<LeaseStartContext> {
+  const normalized = instant(input.evaluationInstant);
+  if (!normalized) throw new LeaseStartServiceError("lease_start_context_ambiguous");
+  return (await readContext(input.firestore || db, { ...input, evaluationInstant: normalized })).context;
+}
+
+function resultFrom(context: LeaseStartContext, input: StartCanonicalLeaseOccupancyInput, resultId: string | null, replay = false): LeaseStartServiceResult {
+  return {
+    outcome: replay ? "idempotent_replay" : context.decision.outcome,
+    canonicalOutcome: context.decision.outcome,
+    occupancyEffective: context.decision.occupancyEffective,
+    reasons: [...context.decision.reasons],
+    expectedStateToken: context.expectedStateToken,
+    auditEventIds: [],
+    idempotency: { key: input.idempotencyKey, replay, resultId },
+    stateSummary: context.stateSummary,
+  };
+}
+
+function assertPostcondition(context: LeaseStartContext, next: { unit: any; embedded: any; tenant: any; tenancy: any }) {
+  const expected = context.decision.postcondition;
+  if (!expected ||
+      ["status", "occupancyStatus", "tenantId", "currentTenantId", "leaseId", "currentLeaseId", "occupancySource", "occupancyUpdatedAt", "updatedAt"]
+        .some((key) => next.unit[key] !== (expected.standaloneUnit as any)[key] || next.embedded[key] !== (expected.embeddedPropertyUnit as any)[key]) ||
+      next.tenant.currentLeaseId !== expected.tenant.currentLeaseId || next.tenancy.leaseId !== expected.tenancy.leaseId ||
+      next.tenancy.tenantId !== expected.tenancy.tenantId || next.tenancy.status !== "active" || next.tenancy.moveInAt !== expected.tenancy.moveInAt) {
+    throw new LeaseStartServiceError("lease_start_postcondition_failed", context);
+  }
+  for (const field of ["occupied", "isOccupied"] as const) {
+    for (const [actual, desired] of [[next.unit, expected.standaloneUnit], [next.embedded, expected.embeddedPropertyUnit]] as const) {
+      if (Object.prototype.hasOwnProperty.call(desired, field) !== Object.prototype.hasOwnProperty.call(actual, field) ||
+          (Object.prototype.hasOwnProperty.call(desired, field) && actual[field] !== true)) {
+        throw new LeaseStartServiceError("lease_start_postcondition_failed", context);
+      }
+    }
+  }
+}
+
+export async function startCanonicalLeaseOccupancy(input: StartCanonicalLeaseOccupancyInput): Promise<LeaseStartServiceResult> {
+  const firestore = input.firestore || db;
+  const normalizedInstant = instant(input.evaluationInstant);
+  if (!normalizedInstant || !text(input.idempotencyKey) || input.idempotencyKey.length > 160 || !text(input.expectedStateToken)) {
+    throw new LeaseStartServiceError("lease_start_state_stale");
+  }
+  const requestId = leaseStartDeterministicId("lease_start", [input.landlordId, input.operationKind, input.idempotencyKey]);
+  const requestRef = firestore.collection("leaseStartRequests").doc(requestId);
+  const payloadHash = leaseStartHash({
+    landlordId: input.landlordId, propertyId: input.propertyId, unitId: input.unitId, tenantId: input.tenantId,
+    leaseId: input.leaseId, operationKind: input.operationKind, trigger: input.trigger, source: input.source || null,
+    evaluationInstant: normalizedInstant,
+  });
+
+  return firestore.runTransaction(async (transaction: any) => {
+    const prior = await transaction.get(requestRef);
+    if (prior.exists) {
+      const data = prior.data() || {};
+      if (data.payloadHash !== payloadHash) throw new LeaseStartServiceError("lease_start_idempotency_key_reused");
+      return { ...data.result, outcome: "idempotent_replay", idempotency: { ...data.result.idempotency, replay: true } };
+    }
+    const loaded = await readContext(transaction, { ...input, evaluationInstant: normalizedInstant, firestore });
+    if (loaded.context.expectedStateToken !== input.expectedStateToken) {
+      throw new LeaseStartServiceError("lease_start_state_stale", loaded.context);
+    }
+    if (loaded.context.decision.outcome === "rejected") return resultFrom(loaded.context, input, null);
+
+    const baseResult = resultFrom(loaded.context, input, requestId);
+    if (loaded.context.decision.outcome === "created_without_occupancy" || loaded.context.decision.outcome === "already_coherent") {
+      const committedResult = { ...baseResult, idempotency: { ...baseResult.idempotency, resultId: requestId } };
+      transaction.create(requestRef, {
+        landlordId: input.landlordId, operationKind: input.operationKind, idempotencyKey: input.idempotencyKey,
+        payloadHash, leaseId: input.leaseId, canonicalOutcome: committedResult.canonicalOutcome,
+        reasons: committedResult.reasons, occupancyEffective: committedResult.occupancyEffective,
+        resultingExpectedStateToken: committedResult.expectedStateToken, canonicalEventIds: [], committedAt: normalizedInstant,
+        result: committedResult,
+      });
+      return committedResult;
+    }
+
+    const postcondition = loaded.context.decision.postcondition;
+    if (!postcondition) throw new LeaseStartServiceError("lease_start_postcondition_failed", loaded.context);
+    const nextUnit = { ...loaded.records.unit, ...postcondition.standaloneUnit };
+    const currentEmbedded = loaded.records.embeddedUnits[loaded.records.embeddedIndex];
+    const nextEmbedded = { ...currentEmbedded, ...postcondition.embeddedPropertyUnit };
+    const nextTenant = { ...loaded.records.tenant, ...postcondition.tenant, updatedAt: normalizedInstant };
+    const tenancyId = postcondition.tenancy.id || leaseStartDeterministicId("tenancy", [input.landlordId, input.propertyId, input.unitId, input.tenantId, input.leaseId]);
+    const tenancyRef = firestore.collection("tenancies").doc(tenancyId);
+    const existingTenancy = loaded.records.tenancies.find((tenancy: any) => tenancy.id === tenancyId);
+    const nextTenancy = postcondition.tenancy.action === "reuse"
+      ? { ...existingTenancy }
+      : { ...existingTenancy, ...postcondition.tenancy, id: tenancyId, updatedAt: normalizedInstant, moveOutAt: null };
+    assertPostcondition(loaded.context, { unit: nextUnit, embedded: nextEmbedded, tenant: nextTenant, tenancy: nextTenancy });
+
+    const nextEmbeddedUnits = loaded.records.embeddedUnits.map((entry: any, index: number) => index === loaded.records.embeddedIndex ? nextEmbedded : entry);
+    const nextTenancies = postcondition.tenancy.action === "create"
+      ? [...loaded.records.tenancies, nextTenancy]
+      : loaded.records.tenancies.map((tenancy: any) => tenancy.id === tenancyId ? nextTenancy : tenancy);
+    const nextCanonicalInput: CanonicalLeaseStartInput = {
+      ...loaded.records.canonicalInput,
+      candidateLease: { ...loaded.records.canonicalInput.candidateLease, occupancyEffective: true, occupancyEffectiveAt: normalizedInstant, updatedAt: normalizedInstant },
+      standaloneUnits: [nextUnit],
+      embeddedUnits: [{ ...nextEmbedded, landlordId: input.landlordId, propertyId: input.propertyId }],
+      tenant: nextTenant,
+      tenancies: nextTenancies,
+    };
+    const verifiedDecision = evaluateCanonicalLeaseStart(nextCanonicalInput);
+    if (verifiedDecision.outcome !== "already_coherent" || verifiedDecision.postcondition !== null) {
+      throw new LeaseStartServiceError("lease_start_postcondition_failed", loaded.context);
+    }
+    const resultingExpectedStateToken = buildLeaseStartExpectedStateToken(
+      nextCanonicalInput,
+      verifiedDecision,
+      { propertyUpdatedAt: normalizedInstant }
+    );
+    const eventId = leaseStartDeterministicId("lease_occupancy_started", [input.landlordId, input.operationKind, input.idempotencyKey, input.leaseId]);
+    const eventRef = firestore.collection("canonicalEvents").doc(eventId);
+    const committedResult: LeaseStartServiceResult = {
+      ...baseResult,
+      auditEventIds: [eventId],
+      idempotency: { ...baseResult.idempotency, resultId: requestId },
+      expectedStateToken: resultingExpectedStateToken,
+    };
+
+    transaction.set(loaded.records.leaseRef, { occupancyEffective: true, occupancyEffectiveAt: normalizedInstant, updatedAt: normalizedInstant }, { merge: true });
+    transaction.set(loaded.records.propertyRef, { units: nextEmbeddedUnits, updatedAt: normalizedInstant }, { merge: true });
+    transaction.set(loaded.records.unitRef, nextUnit, { merge: true });
+    transaction.set(loaded.records.tenantRef, { currentLeaseId: input.leaseId, status: "current", updatedAt: normalizedInstant }, { merge: true });
+    if (postcondition.tenancy.action === "create") transaction.create(tenancyRef, nextTenancy);
+    else if (postcondition.tenancy.action === "reconcile") transaction.set(tenancyRef, nextTenancy, { merge: true });
+    transaction.create(eventRef, {
+      id: eventId, version: "v1", type: "lease.occupancy_started", domain: "lease", action: "occupancy_started", status: "succeeded",
+      actor: { type: "landlord", id: leaseStartDeterministicId("actor", [input.actorId || input.landlordId]), role: "landlord", displayName: null },
+      resource: { type: "lease", id: leaseStartDeterministicId("lease", [input.leaseId]), parentType: "property", parentId: leaseStartDeterministicId("property", [input.propertyId]) },
+      occurredAt: normalizedInstant, recordedAt: normalizedInstant, visibility: "internal",
+      summary: "Canonical lease occupancy started.",
+      metadata: {
+        landlordRef: leaseStartDeterministicId("landlord", [input.landlordId]), tenantRef: leaseStartDeterministicId("tenant", [input.tenantId]),
+        unitRef: leaseStartDeterministicId("unit", [input.unitId]), requestRef: leaseStartDeterministicId("request", [requestId]),
+        operationKind: input.operationKind, trigger: input.trigger, source: input.source || null, legalDetermination: false,
+      },
+      tags: ["lease_start", input.trigger], appendOnly: true, immutable: true,
+    });
+    transaction.create(requestRef, {
+      landlordId: input.landlordId, operationKind: input.operationKind, idempotencyKey: input.idempotencyKey,
+      payloadHash, leaseId: input.leaseId, canonicalOutcome: committedResult.canonicalOutcome,
+      reasons: committedResult.reasons, occupancyEffective: committedResult.occupancyEffective,
+      resultingExpectedStateToken: committedResult.expectedStateToken, canonicalEventIds: [eventId], committedAt: normalizedInstant,
+      result: committedResult,
+    });
+    return committedResult;
+  });
+}

--- a/rentchain-api/src/services/leaseStart/leaseStartService.ts
+++ b/rentchain-api/src/services/leaseStart/leaseStartService.ts
@@ -109,7 +109,9 @@ async function readContext(reader: any, input: ContextInput): Promise<{ context:
   const tenantRef = firestore.collection("tenants").doc(input.tenantId);
   const unitsQuery = firestore.collection("units").where("landlordId", "==", input.landlordId).where("propertyId", "==", input.propertyId);
   const leasesQuery = firestore.collection("leases").where("landlordId", "==", input.landlordId).where("propertyId", "==", input.propertyId);
-  const tenanciesQuery = firestore.collection("tenancies").where("tenantId", "==", input.tenantId);
+  // A property-scoped single-field query avoids a new composite index while
+  // ensuring cross-tenant occupancy evidence for this logical unit is reread.
+  const tenanciesQuery = firestore.collection("tenancies").where("propertyId", "==", input.propertyId);
   const get = (target: any) => reader?.get ? reader.get(target) : target.get();
   const [propertySnap, unitSnap, leaseSnap, tenantSnap, unitsSnap, leasesSnap, tenanciesSnap] = await Promise.all([
     get(propertyRef), get(unitRef), get(leaseRef), get(tenantRef), get(unitsQuery), get(leasesQuery), get(tenanciesQuery),
@@ -140,7 +142,12 @@ async function readContext(reader: any, input: ContextInput): Promise<{ context:
     .filter((lease: any) => lease && text(lease.unitId) === input.unitId)
     .map(canonicalLease);
   if (!leases.some((lease: any) => lease.id === input.leaseId)) leases.push(canonicalLease(candidateLease));
-  const tenancies = (tenanciesSnap.docs || []).map(docData).filter(Boolean);
+  const tenancies = (tenanciesSnap.docs || []).map(docData).filter((tenancy: any) => {
+    if (!tenancy) return false;
+    const sameLogicalUnit = text(tenancy.unitId) === input.unitId ||
+      (Boolean(unitNumber) && [tenancy.unitNumber, tenancy.unitLabel].map(text).includes(unitNumber));
+    return sameLogicalUnit;
+  });
   const embedded = {
     ...matches[0].entry,
     id: text(matches[0].entry.id || matches[0].entry.unitId || input.unitId),
@@ -224,7 +231,8 @@ export async function startCanonicalLeaseOccupancy(input: StartCanonicalLeaseOcc
   const requestRef = firestore.collection("leaseStartRequests").doc(requestId);
   const payloadHash = leaseStartHash({
     landlordId: input.landlordId, propertyId: input.propertyId, unitId: input.unitId, tenantId: input.tenantId,
-    leaseId: input.leaseId, operationKind: input.operationKind, trigger: input.trigger, source: input.source || null,
+    leaseId: input.leaseId, operationKind: input.operationKind, expectedStateToken: input.expectedStateToken,
+    actorId: input.actorId || null, trigger: input.trigger, source: input.source || null,
     evaluationInstant: normalizedInstant,
   });
 
@@ -239,10 +247,15 @@ export async function startCanonicalLeaseOccupancy(input: StartCanonicalLeaseOcc
     if (loaded.context.expectedStateToken !== input.expectedStateToken) {
       throw new LeaseStartServiceError("lease_start_state_stale", loaded.context);
     }
-    if (loaded.context.decision.outcome === "rejected") return resultFrom(loaded.context, input, null);
+    // D2 has no live route caller. Canonical rejected and deferred decisions
+    // therefore return deterministically with no durable audit or idempotency
+    // record. D3 must define authenticated route-attempt persistence policy.
+    if (loaded.context.decision.outcome === "rejected" || loaded.context.decision.outcome === "created_without_occupancy") {
+      return resultFrom(loaded.context, input, null);
+    }
 
     const baseResult = resultFrom(loaded.context, input, requestId);
-    if (loaded.context.decision.outcome === "created_without_occupancy" || loaded.context.decision.outcome === "already_coherent") {
+    if (loaded.context.decision.outcome === "already_coherent") {
       const committedResult = { ...baseResult, idempotency: { ...baseResult.idempotency, resultId: requestId } };
       transaction.create(requestRef, {
         landlordId: input.landlordId, operationKind: input.operationKind, idempotencyKey: input.idempotencyKey,


### PR DESCRIPTION
## Summary

- add a server-only transactional boundary for starting occupancy from an existing persisted lease
- recompute the merged D1 decision and deterministic expected-state token from authoritative transaction reads
- atomically reconcile the lease, embedded and standalone units, tenant pointer, tenancy, canonical event, and durable idempotency result
- add deterministic rollback, stale-state, optimistic-concurrency retry, idempotency, legacy-compatibility, and fail-closed coverage

## Scope

This is backend transactional foundation only. Existing persisted lease start is implemented; create-and-start composition is deferred to D3.

- no existing route is integrated
- no live runtime caller is added
- no current product-path behavior changes
- no frontend change
- no Preview or Production deployment
- no Firestore index change
- no data migration
- D3 requires separate Founder authorization

Rejected and deferred canonical decisions intentionally create no durable rejected-attempt audit or idempotency record in D2. D3 route integration must define which authenticated route attempts warrant that persistence. Successful occupancy transitions remain durably idempotent, and `already_coherent` operations retain the existing D2 idempotency behavior.

## Validation

- D2 tests: 32 passed
- D1 tests: 29 passed
- canonical occupancy and execution regressions: 37 passed
- occupancy-resolution regressions: 6 passed
- backend TypeScript build: passed
- `git diff --check`: passed
