### PR TITLE
PR D3: migrate lease workflows to canonical start boundary

### DIFF
--- a/docs/lease-pack-v1.md
+++ b/docs/lease-pack-v1.md
@@ -40,6 +40,9 @@
 - `PATCH /api/leases/drafts/:id`
 - `POST /api/leases/drafts/:id/generate`
 - `GET /api/leases/snapshots/:id`
+- `POST /api/leases/drafts/:id/activate` (`Idempotency-Key` required)
+
+Lease mutation requests that create a lease or can start canonical occupancy require a caller-owned `Idempotency-Key`, including direct creation, draft activation, and occupied-unit conversion. Retry the same logical mutation with the same key; use a new key for new user intent. Reusing a key with changed semantic input returns a conflict. `x-request-id` remains tracing metadata and is never an idempotency fallback.
 
 ## Validation Rules (v1)
 - Landlord-scoped access only.

--- a/rentchain-api/src/lib/http/__tests__/mutationIdempotency.test.ts
+++ b/rentchain-api/src/lib/http/__tests__/mutationIdempotency.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { readMutationIdempotencyKey } from "../mutationIdempotency";
+
+function request(value: string | undefined) {
+  return { get: () => value } as any;
+}
+
+describe("readMutationIdempotencyKey", () => {
+  it("requires a caller-owned mutation identity", () => {
+    expect(readMutationIdempotencyKey(request(undefined))).toEqual({ ok: false, error: "idempotency_key_required" });
+    expect(readMutationIdempotencyKey(request("   "))).toEqual({ ok: false, error: "idempotency_key_required" });
+  });
+
+  it("accepts a bounded opaque key and trims transport whitespace", () => {
+    expect(readMutationIdempotencyKey(request(" mutation:lease:123 "))).toEqual({ ok: true, key: "mutation:lease:123" });
+  });
+
+  it("rejects control characters and unreasonable length", () => {
+    expect(readMutationIdempotencyKey(request("bad\nkey"))).toEqual({ ok: false, error: "idempotency_key_invalid" });
+    expect(readMutationIdempotencyKey(request("first, second"))).toEqual({ ok: false, error: "idempotency_key_invalid" });
+    expect(readMutationIdempotencyKey(request("x".repeat(129)))).toEqual({ ok: false, error: "idempotency_key_invalid" });
+  });
+});

--- a/rentchain-api/src/lib/http/mutationIdempotency.ts
+++ b/rentchain-api/src/lib/http/mutationIdempotency.ts
@@ -1,0 +1,22 @@
+import type { Request } from "express";
+
+export const IDEMPOTENCY_KEY_HEADER = "Idempotency-Key";
+export const MAX_IDEMPOTENCY_KEY_LENGTH = 128;
+
+export type MutationIdempotencyValidation =
+  | { ok: true; key: string }
+  | { ok: false; error: "idempotency_key_required" | "idempotency_key_invalid" };
+
+export function readMutationIdempotencyKey(req: Pick<Request, "get"> & { headers?: Record<string, unknown> }): MutationIdempotencyValidation {
+  const raw = typeof req.get === "function"
+    ? req.get(IDEMPOTENCY_KEY_HEADER)
+    : req.headers?.[IDEMPOTENCY_KEY_HEADER.toLowerCase()];
+  if (raw == null) return { ok: false, error: "idempotency_key_required" };
+
+  const key = String(raw).trim();
+  if (!key) return { ok: false, error: "idempotency_key_required" };
+  if (key.length > MAX_IDEMPOTENCY_KEY_LENGTH || /[\u0000-\u001f\u007f,]/.test(key)) {
+    return { ok: false, error: "idempotency_key_invalid" };
+  }
+  return { ok: true, key };
+}

--- a/rentchain-api/src/routes/__tests__/leaseConflictResponses.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseConflictResponses.test.ts
@@ -63,6 +63,11 @@ const { fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
     },
     seedDoc: (name: string, id: string, data: any) => ensureCollection(name).set(id, { id, data }),
     fakeDb: {
+      runTransaction: async (callback: any) => callback({
+        get: (target: any) => target.get(),
+        set: (ref: any, value: any, options?: any) => ref.set(value, options),
+        create: (ref: any, value: any) => ref.set(value),
+      }),
       collection: (name: string) => ({
         where: (field: string, op: string, value: any) => makeQuery(name, [{ field, op, value }]),
         orderBy: () => makeQuery(name),
@@ -143,27 +148,31 @@ describe("lease conflict responses", () => {
 
   it("returns the machine-readable conflict code for direct create overlaps", async () => {
     seedUnit("unit-1", { unitNumber: "A", status: "occupied" });
-    seedLease("lease-1", {});
+    seedDoc("properties", "prop-1", { landlordId: "landlord-1", units: [{ id: "unit-1", unitId: "unit-1", unitNumber: "A", status: "occupied", tenantId: "tenant-1" }] });
+    seedDoc("tenants", "tenant-2", { landlordId: "landlord-1", currentLeaseId: null });
+    seedLease("lease-1", { executionStatus: "fully_executed" });
     const app = await makeApp();
 
-    const res = await request(app).post("/").send({
+    const res = await request(app).post("/").set("Idempotency-Key", "conflict-create").send({
       tenantId: "tenant-2",
       propertyId: "prop-1",
       unitNumber: "unit-1",
       monthlyRent: 1900,
       startDate: "2026-01-15",
       endDate: "2026-11-30",
+      executionStatus: "fully_executed",
     });
 
     expect(res.status).toBe(409);
     expect(res.body?.error).toBe("conflicting_active_lease_agreement");
-    expect(res.body?.message).toBe("A conflicting active lease agreement already exists for this unit and term");
-    expect(res.body?.conflictLeaseIds).toContain("lease-1");
+    expect(res.body?.reasons).toContain("MULTIPLE_CURRENT_LEASES");
   });
 
   it("keeps the same machine-readable conflict code for draft activation overlaps", async () => {
     seedUnit("unit-1", { unitNumber: "A", status: "occupied" });
-    seedLease("lease-1", {});
+    seedDoc("properties", "prop-1", { landlordId: "landlord-1", units: [{ id: "unit-1", unitId: "unit-1", unitNumber: "A", status: "occupied", tenantId: "tenant-1" }] });
+    seedDoc("tenants", "tenant-2", { landlordId: "landlord-1", currentLeaseId: null });
+    seedLease("lease-1", { executionStatus: "fully_executed" });
     seedDoc("leaseDrafts", "draft-1", {
       landlordId: "landlord-1",
       propertyId: "prop-1",
@@ -177,13 +186,14 @@ describe("lease conflict responses", () => {
       dueDay: 1,
       paymentMethod: "etransfer",
       templateVersion: "ns-schedule-a-v1",
+      executionStatus: "fully_executed",
     });
     const app = await makeApp();
 
-    const res = await request(app).post("/drafts/draft-1/activate").send({});
+    const res = await request(app).post("/drafts/draft-1/activate").set("Idempotency-Key", "conflict-draft").send({});
 
     expect(res.status).toBe(409);
     expect(res.body?.error).toBe("conflicting_active_lease_agreement");
-    expect(res.body?.conflictLeaseIds).toContain("lease-1");
+    expect(res.body?.reasons).toContain("MULTIPLE_CURRENT_LEASES");
   });
 });

--- a/rentchain-api/src/routes/__tests__/leaseDraftRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseDraftRoutes.test.ts
@@ -344,6 +344,7 @@ describe("lease draft routes", () => {
     expect(sendEmailMock).not.toHaveBeenCalled();
     expect(activateRes.body?.lease).toEqual(
       expect.objectContaining({
+        status: "pending",
         documentUrl: "https://example.invalid/new-lease.pdf",
         approvedDocumentUrl: "https://example.invalid/new-lease.pdf",
         documentRef: "https://example.invalid/new-lease.pdf",
@@ -572,6 +573,7 @@ describe("lease draft routes", () => {
       .send({});
     expect(activateRes.status).toBe(200);
     expect(activateRes.body?.ok).toBe(true);
+    expect(activateRes.body?.lease).toEqual(expect.objectContaining({ status: "pending", occupancyEffective: false }));
     const leaseId = String(activateRes.body?.leaseId || "");
     expect(leaseId).toBeTruthy();
     expect(activateRes.body?.leaseNotification).toEqual(
@@ -601,6 +603,32 @@ describe("lease draft routes", () => {
         occupancyStatus: "vacant",
       })
     );
+    const persistedLease = await fakeDb.collection("leases").doc(leaseId).get();
+    expect(persistedLease.data()).toEqual(expect.objectContaining({ status: "pending", occupancyEffective: false }));
+    expect(leaseService.getById(leaseId)).toBeUndefined();
+  });
+
+  it.each([
+    ["future", { startDate: "2027-01-01", endDate: "2027-12-31", executionStatus: "fully_executed" }, "pending", false],
+    ["eligible current", { startDate: "2026-01-01", endDate: "2026-12-31", executionStatus: "fully_executed" }, "active", true],
+  ])("activates a %s draft with canonical compatibility status", async (_label, overrides, expectedStatus, occupancyEffective) => {
+    const draftId = `draft-${String(_label).replace(/\s/g, "-")}`;
+    await fakeDb.collection("leaseDrafts").doc(draftId).set({ ...payload, ...overrides, landlordId: "landlord-1", status: "generated" });
+    const router = (await import("../leaseRoutes")).default;
+    const app = express();
+    app.use(express.json());
+    app.use(router);
+
+    const first = await request(app).post(`/drafts/${draftId}/activate`).set(auth).set("Idempotency-Key", `activate-${draftId}`).send({});
+    expect(first.status).toBe(200);
+    expect(first.body?.lease).toEqual(expect.objectContaining({ status: expectedStatus, occupancyEffective }));
+    expect((await fakeDb.collection("leases").doc(first.body.leaseId).get()).data()).toEqual(expect.objectContaining({ status: expectedStatus, occupancyEffective }));
+    expect(leaseService.getById(first.body.leaseId) !== undefined).toBe(occupancyEffective);
+
+    const replay = await request(app).post(`/drafts/${draftId}/activate`).set(auth).set("Idempotency-Key", `activate-${draftId}`).send({});
+    expect(replay.status).toBe(200);
+    expect(replay.body?.leaseId).toBe(first.body?.leaseId);
+    expect((await fakeDb.collection("leases").get()).docs).toHaveLength(1);
   });
 
   it("returns 401 for activate when unauthorized", async () => {

--- a/rentchain-api/src/routes/__tests__/leaseDraftRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseDraftRoutes.test.ts
@@ -8,7 +8,7 @@ import * as leaseDraftsService from "../../services/leaseDraftsService";
 type DocShape = { id: string; data: any };
 const sendEmailMock = vi.fn(async () => undefined);
 
-const { store, fakeDb, resetFakeDb } = vi.hoisted(() => {
+const { store, fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
   const store = new Map<string, Map<string, DocShape>>();
   let idSeq = 0;
 
@@ -62,6 +62,11 @@ const { store, fakeDb, resetFakeDb } = vi.hoisted(() => {
   }
 
   const fakeDb = {
+    runTransaction: async (callback: any) => callback({
+      get: (target: any) => target.get(),
+      set: (ref: any, value: any, options?: any) => ref.set(value, options),
+      create: (ref: any, value: any) => ref.set(value),
+    }),
     collection: (name: string) => ({
       where: (field: string, op: string, value: any) => makeQuery(name, [{ field, op, value }]),
       orderBy: () => makeQuery(name),
@@ -74,6 +79,7 @@ const { store, fakeDb, resetFakeDb } = vi.hoisted(() => {
   return {
     store,
     fakeDb,
+    seedDoc: (name: string, id: string, data: any) => ensureCollection(name).set(id, { id, data }),
     resetFakeDb: () => {
       store.clear();
       idSeq = 0;
@@ -133,6 +139,12 @@ describe("lease draft routes", () => {
     sendEmailMock.mockClear();
     sendEmailMock.mockResolvedValue(undefined);
     process.env.EMAIL_FROM = "noreply@example.com";
+    seedDoc("properties", "prop-1", {
+      landlordId: "landlord-1",
+      units: [{ id: "unit-1", unitId: "unit-1", unitNumber: "unit-1", status: "vacant", occupancyStatus: "vacant" }],
+    });
+    seedDoc("units", "unit-1", { landlordId: "landlord-1", propertyId: "prop-1", unitNumber: "unit-1", status: "vacant", occupancyStatus: "vacant" });
+    seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", status: "applicant", currentLeaseId: null });
   });
 
   const payload = {
@@ -194,7 +206,7 @@ describe("lease draft routes", () => {
     const attachmentDocsAfterGenerate = Array.from(store.get("ledgerAttachments")?.values() || []).map((doc) => doc.data);
     expect(attachmentDocsAfterGenerate).toEqual([]);
 
-    const activateRes = await request(app).post(`/drafts/${encodeURIComponent(draftId)}/activate`).set(auth).send({});
+    const activateRes = await request(app).post(`/drafts/${encodeURIComponent(draftId)}/activate`).set(auth).set("Idempotency-Key", "activate-1").send({});
     expect(activateRes.status).toBe(200);
     expect(activateRes.body?.lease?.documentUrl).toBeUndefined();
     expect(activateRes.body?.lease?.approvedDocumentUrl).toBeUndefined();
@@ -324,7 +336,7 @@ describe("lease draft routes", () => {
       generatedFiles: [{ kind: "lease-pdf", url: "https://example.invalid/new-lease.pdf" }],
     });
 
-    const activateRes = await request(app).post(`/drafts/${encodeURIComponent(draftId)}/activate`).set(auth).send({});
+    const activateRes = await request(app).post(`/drafts/${encodeURIComponent(draftId)}/activate`).set(auth).set("Idempotency-Key", "activate-2").send({});
     expect(activateRes.status).toBe(200);
     expect(activateRes.body?.leaseNotification).toEqual(
       expect.objectContaining({ attempted: false, sent: false, reason: "lease_document_not_available" })
@@ -392,7 +404,7 @@ describe("lease draft routes", () => {
       generatedFiles: [{ kind: "lease-pdf", url: "https://example.invalid/existing-lease.pdf" }],
     });
 
-    const firstRes = await request(app).post(`/drafts/${encodeURIComponent(draftId)}/activate`).set(auth).send({});
+    const firstRes = await request(app).post(`/drafts/${encodeURIComponent(draftId)}/activate`).set(auth).set("Idempotency-Key", "activate-repair").send({});
     expect(firstRes.status).toBe(200);
     expect(firstRes.body?.leaseId).toBe(leaseId);
     expect(firstRes.body?.lease).toEqual(
@@ -413,7 +425,7 @@ describe("lease draft routes", () => {
       generatedFiles: [{ kind: "lease-pdf", url: "https://example.invalid/existing-lease-new.pdf" }],
     });
 
-    const secondRes = await request(app).post(`/drafts/${encodeURIComponent(draftId)}/activate`).set(auth).send({});
+    const secondRes = await request(app).post(`/drafts/${encodeURIComponent(draftId)}/activate`).set("Authorization", "Bearer landlord-1").set("Idempotency-Key", "activate-repair").send({});
     expect(secondRes.status).toBe(200);
     expect(secondRes.body?.leaseId).toBe(leaseId);
 
@@ -556,6 +568,7 @@ describe("lease draft routes", () => {
     const activateRes = await request(app)
       .post(`/drafts/${encodeURIComponent(draftId)}/activate`)
       .set(auth)
+      .set("Idempotency-Key", "activate-tenant-fetch")
       .send({});
     expect(activateRes.status).toBe(200);
     expect(activateRes.body?.ok).toBe(true);
@@ -576,21 +589,16 @@ describe("lease draft routes", () => {
     expect(propertySnap.data()?.units).toEqual([
       expect.objectContaining({
         id: "unit-1",
-        status: "occupied",
-        occupancyStatus: "occupied",
-        currentTenantId: "tenant-1",
-        currentLeaseId: leaseId,
+        status: "vacant",
+        occupancyStatus: "vacant",
       }),
       expect.objectContaining({ id: "unit-2", status: "vacant" }),
     ]);
     const unitSnap = await fakeDb.collection("units").doc("unit-1").get();
     expect(unitSnap.data()).toEqual(
       expect.objectContaining({
-        status: "occupied",
-        occupancyStatus: "occupied",
-        currentTenantId: "tenant-1",
-        currentLeaseId: leaseId,
-        occupancySource: "canonical_lease",
+        status: "vacant",
+        occupancyStatus: "vacant",
       })
     );
   });
@@ -601,7 +609,7 @@ describe("lease draft routes", () => {
     app.use(express.json());
     app.use(router);
 
-    const res = await request(app).post("/drafts/draft-missing/activate").send({});
+    const res = await request(app).post("/drafts/draft-missing/activate").set("Idempotency-Key", "activate-unauthorized").send({});
     expect(res.status).toBe(401);
   });
 
@@ -614,6 +622,7 @@ describe("lease draft routes", () => {
     const res = await request(app)
       .post("/drafts/draft-missing/activate")
       .set(auth)
+      .set("Idempotency-Key", "activate-missing")
       .send({});
     expect(res.status).toBe(404);
     expect(res.body?.error).toBe("draft_not_found");
@@ -640,6 +649,7 @@ describe("lease draft routes", () => {
     const res = await request(app)
       .post(`/drafts/${encodeURIComponent(draftId)}/activate`)
       .set(auth)
+      .set("Idempotency-Key", "activate-no-end")
       .send({});
     expect(res.status).toBe(400);
     expect(res.body?.error).toBe("end_date_required");
@@ -690,6 +700,7 @@ describe("lease draft routes", () => {
     const res = await request(app)
       .post(`/drafts/${encodeURIComponent(draftId)}/activate`)
       .set(auth)
+      .set("Idempotency-Key", "activate-invalid-range")
       .send({});
     expect(res.status).toBe(400);
     expect(res.body).toEqual(

--- a/rentchain-api/src/routes/__tests__/leaseRiskRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRiskRoutes.test.ts
@@ -87,6 +87,11 @@ const { store, fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
     },
     seedDoc: (name: string, id: string, data: any) => ensureCollection(name).set(id, { id, data }),
     fakeDb: {
+      runTransaction: async (callback: any) => callback({
+        get: (target: any) => target.get(),
+        set: (ref: any, value: any, options?: any) => ref.set(value, options),
+        create: (ref: any, value: any) => ref.set(value),
+      }),
       collection: (name: string) => ({
         where: (field: string, op: string, value: any) => makeQuery(name, [{ field, op, value }]),
         orderBy: () => makeQuery(name),
@@ -142,6 +147,17 @@ describe("lease route risk integration", () => {
     buildLeaseRiskInput.mockResolvedValue({ monthlyRent: 1900, monthlyIncome: 4800 });
     safeAssessLeaseRisk.mockReset();
     safeAssessLeaseRisk.mockResolvedValue(sampleRisk);
+    seedDoc("properties", "prop-1", {
+      landlordId: "landlord-1",
+      units: [
+        { id: "unit-1", unitId: "unit-1", unitNumber: "unit-1", status: "vacant", occupancyStatus: "vacant" },
+        { id: "unit-2", unitId: "unit-2", unitNumber: "unit-2", status: "vacant", occupancyStatus: "vacant" },
+      ],
+    });
+    seedDoc("units", "unit-1", { landlordId: "landlord-1", propertyId: "prop-1", unitNumber: "unit-1", status: "vacant", occupancyStatus: "vacant" });
+    seedDoc("units", "unit-2", { landlordId: "landlord-1", propertyId: "prop-1", unitNumber: "unit-2", status: "vacant", occupancyStatus: "vacant" });
+    seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", status: "applicant", currentLeaseId: null });
+    seedDoc("tenants", "tenant-2", { landlordId: "landlord-1", status: "applicant", currentLeaseId: null });
   });
 
   async function makeApp() {
@@ -156,10 +172,24 @@ describe("lease route risk integration", () => {
     return app;
   }
 
+  it("rejects missing mutation identity before any lease write and does not accept x-request-id", async () => {
+    const app = await makeApp();
+    const payload = { tenantId: "tenant-1", propertyId: "prop-1", unitNumber: "unit-1", monthlyRent: 1900, startDate: "2026-04-01" };
+    const missing = await request(app).post("/").send(payload);
+    const traceOnly = await request(app).post("/").set("x-request-id", "trace-only").send(payload);
+    expect(missing.status).toBe(400);
+    expect(missing.body?.error).toBe("idempotency_key_required");
+    expect(traceOnly.status).toBe(400);
+    expect(traceOnly.body?.error).toBe("idempotency_key_required");
+    expect(store.get("leases")?.size || 0).toBe(0);
+    expect(store.get("leaseStartRequests")?.size || 0).toBe(0);
+    expect(store.get("canonicalEvents")?.size || 0).toBe(0);
+  });
+
   it("returns and stores a first risk timeline entry on direct lease create", async () => {
     const app = await makeApp();
 
-    const res = await request(app).post("/").send({
+    const res = await request(app).post("/").set("Idempotency-Key", "risk-create-1").send({
       tenantId: "tenant-1",
       propertyId: "prop-1",
       unitNumber: "unit-1",
@@ -192,7 +222,7 @@ describe("lease route risk integration", () => {
     });
     const app = await makeApp();
 
-    const res = await request(app).post("/drafts/draft-1/activate").send({});
+    const res = await request(app).post("/drafts/draft-1/activate").set("Idempotency-Key", "risk-draft-1").send({});
 
     expect(res.status).toBe(200);
     expect(res.body.lease.risk.grade).toBe("B");
@@ -208,7 +238,7 @@ describe("lease route risk integration", () => {
     buildLeaseRiskInput.mockRejectedValueOnce(new Error("risk input unavailable"));
     const app = await makeApp();
 
-    const res = await request(app).post("/").send({
+    const res = await request(app).post("/").set("Idempotency-Key", "risk-create-fail-open").send({
       tenantId: "tenant-2",
       propertyId: "prop-1",
       unitNumber: "unit-2",

--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -69,6 +69,7 @@ const { fakeDb, listDocs, resetFakeDb, seedDoc } = vi.hoisted(() => {
       runTransaction: async (callback: any) =>
         callback({
           get: async (ref: any) => ref.get(),
+          create: async (ref: any, value: any) => ref.set(value),
           set: async (ref: any, value: any, options?: any) => ref.set(value, options),
         }),
       collection: (name: string) => ({
@@ -1244,6 +1245,7 @@ describe("leaseRoutes GET /active", () => {
     const res = await invokeRouter(router, {
       method: "POST",
       url: "/",
+      headers: { "idempotency-key": "active-create-no-document" },
       body: {
         tenantId: "tenant-1",
         propertyId: "prop-1",
@@ -1265,6 +1267,7 @@ describe("leaseRoutes GET /active", () => {
     seedDoc("properties", "prop-1", {
       landlordId: "landlord-1",
       name: "Harbour View",
+      units: [{ id: "unit-1", unitId: "unit-1", unitNumber: "101", status: "occupied", occupancyStatus: "occupied", tenantId: "tenant-1", currentTenantId: "tenant-1" }],
     });
     seedDoc("units", "unit-1", {
       landlordId: "landlord-1",
@@ -1279,13 +1282,19 @@ describe("leaseRoutes GET /active", () => {
         bucket: "bucket-1",
         path: "leases/supporting-reference.pdf",
       },
+      tenantId: "tenant-1",
+      currentTenantId: "tenant-1",
+      executionStatus: "fully_executed",
     });
+    seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", fullName: "Recovered Tenant", email: "recovered@example.com", currentLeaseId: null });
 
     const router = (await import("../leaseRoutes")).default;
     const res = await invokeRouter(router, {
       method: "POST",
       url: "/reconciliation-candidates/unit-1/convert",
+      headers: { "idempotency-key": "active-conversion-no-document" },
       body: {
+        occupantName: "Recovered Tenant",
         tenantEmail: "recovered@example.com",
         startDate: "2026-05-01",
         endDate: "2027-04-30",
@@ -1319,6 +1328,7 @@ describe("leaseRoutes GET /active", () => {
     const res = await invokeRouter(router, {
       method: "POST",
       url: "/",
+      headers: { "idempotency-key": "active-create-invalid-date" },
       body: {
         tenantId: "tenant-1",
         propertyId: "prop-1",
@@ -1359,6 +1369,7 @@ describe("leaseRoutes GET /active", () => {
     const res = await invokeRouter(router, {
       method: "POST",
       url: "/",
+      headers: { "idempotency-key": "active-create-recipient" },
       body: {
         tenantId: "tenant-1",
         propertyId: "prop-1",
@@ -1754,12 +1765,15 @@ describe("leaseRoutes GET /active", () => {
     const res = await invokeRouter(router, {
       method: "POST",
       url: "/",
+      headers: { "idempotency-key": "active-create-occupancy" },
       body: {
         tenantId: "tenant-1",
         propertyId: "prop-1",
         unitNumber: "unit-1",
         monthlyRent: 1850,
         startDate: "2026-01-01",
+        endDate: "2026-12-31",
+        executionStatus: "fully_executed",
       },
     });
 
@@ -1812,9 +1826,6 @@ describe("leaseRoutes GET /active", () => {
         occupancyStatus: "occupied",
         currentTenantId: "tenant-1",
         currentLeaseId: leaseId,
-        tenantName: "Jane Tenant",
-        tenantFullName: "Jane Tenant",
-        currentTenantName: "Jane Tenant",
       }),
       expect.objectContaining({ id: "unit-2", status: "vacant" }),
     ]);
@@ -1825,19 +1836,17 @@ describe("leaseRoutes GET /active", () => {
         occupancyStatus: "occupied",
         currentTenantId: "tenant-1",
         currentLeaseId: leaseId,
-        tenantName: "Jane Tenant",
-        tenantFullName: "Jane Tenant",
-        currentTenantName: "Jane Tenant",
-        occupancySource: "canonical_lease",
+        occupancySource: "canonical_lease_start",
       })
     );
   });
 
-  it("does not block direct lease creation when occupancy sync cannot find a unit", async () => {
+  it("fails closed when direct lease creation cannot resolve canonical unit context", async () => {
     const router = (await import("../leaseRoutes")).default;
     const res = await invokeRouter(router, {
       method: "POST",
       url: "/",
+      headers: { "idempotency-key": "active-create-missing-unit" },
       body: {
         tenantId: "tenant-1",
         propertyId: "prop-missing",
@@ -1847,8 +1856,8 @@ describe("leaseRoutes GET /active", () => {
       },
     });
 
-    expect(res.status).toBe(201);
-    expect(res.body?.lease?.id).toBeTruthy();
+    expect(res.status).toBe(409);
+    expect(res.body?.error).toBe("lease_start_context_ambiguous");
   });
 
   it("hydrates property lease rows with canonical unit labels for display", async () => {

--- a/rentchain-api/src/routes/__tests__/leaseRoutes.integrity.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.integrity.test.ts
@@ -65,6 +65,11 @@ const { fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
     },
     seedDoc: (name: string, id: string, data: any) => ensureCollection(name).set(id, { id, data }),
     fakeDb: {
+      runTransaction: async (callback: any) => callback({
+        get: (target: any) => target.get(),
+        set: (ref: any, value: any, options?: any) => ref.set(value, options),
+        create: (ref: any, value: any) => ref.set(value),
+      }),
       collection: (name: string) => ({
         where: (field: string, op: string, value: any) => makeQuery(name, [{ field, op, value }]),
         orderBy: () => {
@@ -891,8 +896,8 @@ describe("leaseRoutes integrity repairs", () => {
     expect(res.body.length).toBeGreaterThan(500);
   });
 
-  it("converts an occupied unit reference into a canonical lease and tenant", async () => {
-    seedDoc("properties", "prop-1", { landlordId: "landlord-1", name: "Harbour View" });
+  it("converts identified occupied-unit evidence into a canonical lease for the existing tenant", async () => {
+    seedDoc("properties", "prop-1", { landlordId: "landlord-1", name: "Harbour View", units: [{ id: "unit-1", unitId: "unit-1", unitNumber: "101", status: "occupied", occupancyStatus: "occupied", tenantId: "tenant-1", currentTenantId: "tenant-1" }] });
     seedDoc("units", "unit-1", {
       landlordId: "landlord-1",
       propertyId: "prop-1",
@@ -900,18 +905,25 @@ describe("leaseRoutes integrity repairs", () => {
       status: "occupied",
       occupantName: "Recovered Tenant",
       rent: 1850,
+      tenantId: "tenant-1",
+      currentTenantId: "tenant-1",
+      executionStatus: "fully_executed",
       leaseDocument: {
         fileName: "lease.pdf",
         bucket: "bucket-1",
         path: "leases/lease.pdf",
       },
     });
+    seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", fullName: "Recovered Tenant", status: "current", currentLeaseId: null });
 
     const app = await makeApp();
     const res = await request(app)
       .post("/reconciliation-candidates/unit-1/convert")
+      .set("Idempotency-Key", "convert-unit-1")
       .send({
+        occupantName: "Recovered Tenant",
         startDate: "2026-04-01",
+        endDate: "2027-03-31",
         monthlyRent: 1850,
         tenantPhone: "(902) 555-1111 ext 9",
         coApplicantEmail: "coapplicant@example.com",
@@ -933,7 +945,7 @@ describe("leaseRoutes integrity repairs", () => {
   });
 
   it("rejects occupied unit conversion when the start date is after the end date", async () => {
-    seedDoc("properties", "prop-1", { landlordId: "landlord-1", name: "Harbour View" });
+    seedDoc("properties", "prop-1", { landlordId: "landlord-1", name: "Harbour View", units: [{ id: "unit-1", unitId: "unit-1", unitNumber: "101", status: "occupied", occupancyStatus: "occupied", tenantId: "tenant-1" }] });
     seedDoc("units", "unit-1", {
       landlordId: "landlord-1",
       propertyId: "prop-1",
@@ -941,11 +953,15 @@ describe("leaseRoutes integrity repairs", () => {
       status: "occupied",
       occupantName: "Recovered Tenant",
       rent: 1850,
+      tenantId: "tenant-1",
+      executionStatus: "fully_executed",
     });
+    seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", fullName: "Recovered Tenant", status: "current", currentLeaseId: null });
 
     const app = await makeApp();
     const res = await request(app)
       .post("/reconciliation-candidates/unit-1/convert")
+      .set("Idempotency-Key", "convert-invalid-range")
       .send({
         startDate: "2026-09-01",
         endDate: "2026-08-31",
@@ -960,6 +976,57 @@ describe("leaseRoutes integrity repairs", () => {
         message: "Lease start date must be on or before the end date.",
       })
     );
+  });
+
+  it("fails closed before mutation for anonymous occupied-unit conversion", async () => {
+    seedDoc("properties", "prop-1", { landlordId: "landlord-1", units: [{ id: "unit-1", unitId: "unit-1", unitNumber: "101", status: "occupied", occupancyStatus: "occupied" }] });
+    seedDoc("units", "unit-1", { landlordId: "landlord-1", propertyId: "prop-1", unitNumber: "101", status: "occupied", occupancyStatus: "occupied", occupantName: "Unknown", rent: 1800, executionStatus: "fully_executed" });
+    const app = await makeApp();
+    const res = await request(app).post("/reconciliation-candidates/unit-1/convert").set("Idempotency-Key", "anonymous-conversion").send({ occupantName: "Unknown", startDate: "2026-01-01", endDate: "2026-12-31", monthlyRent: 1800 });
+    expect(res.status).toBe(409);
+    expect(res.body?.error).toBe("anonymous_occupied_unit");
+    expect((await fakeDb.collection("leases").get()).docs).toHaveLength(0);
+    expect((await fakeDb.collection("canonicalEvents").get()).docs).toHaveLength(0);
+  });
+
+  it("does not accept caller-claimed execution in place of server evidence", async () => {
+    seedDoc("properties", "prop-1", { landlordId: "landlord-1", units: [{ id: "unit-1", unitId: "unit-1", unitNumber: "101", status: "occupied", occupancyStatus: "occupied", tenantId: "tenant-1" }] });
+    seedDoc("units", "unit-1", { landlordId: "landlord-1", propertyId: "prop-1", unitNumber: "101", status: "occupied", occupancyStatus: "occupied", tenantId: "tenant-1", occupantName: "Tenant One", rent: 1800 });
+    seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", fullName: "Tenant One", currentLeaseId: null });
+    const app = await makeApp();
+    const res = await request(app).post("/reconciliation-candidates/unit-1/convert").set("Idempotency-Key", "claimed-execution").send({ occupantName: "Tenant One", executionStatus: "fully_executed", startDate: "2026-01-01", endDate: "2026-12-31", monthlyRent: 1800 });
+    expect(res.status).toBe(400);
+    expect(res.body?.error).toBe("lease_execution_evidence_required");
+    expect((await fakeDb.collection("leases").get()).docs).toHaveLength(0);
+  });
+
+  it("atomically starts occupancy when an executed upcoming lease is edited to current", async () => {
+    seedDoc("properties", "prop-1", { landlordId: "landlord-1", units: [{ id: "unit-1", unitId: "unit-1", unitNumber: "101", status: "vacant", occupancyStatus: "vacant" }] });
+    seedDoc("units", "unit-1", { landlordId: "landlord-1", propertyId: "prop-1", unitNumber: "101", status: "vacant", occupancyStatus: "vacant" });
+    seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", currentLeaseId: null, status: "applicant" });
+    seedDoc("leases", "lease-upcoming", {
+      landlordId: "landlord-1", propertyId: "prop-1", unitId: "unit-1", tenantId: "tenant-1",
+      status: "active", executionStatus: "fully_executed", startDate: "2026-09-01", endDate: "2027-08-31", occupancyEffective: false,
+    });
+    const app = await makeApp();
+    const res = await request(app).put("/lease-upcoming").set("Idempotency-Key", "date-start-1").send({ startDate: "2026-08-01" });
+    expect(res.status).toBe(200);
+    expect((await fakeDb.collection("leases").doc("lease-upcoming").get()).data()).toMatchObject({ startDate: "2026-08-01", occupancyEffective: true });
+    expect((await fakeDb.collection("units").doc("unit-1").get()).data()).toMatchObject({ status: "occupied", currentLeaseId: "lease-upcoming" });
+  });
+
+  it.each([
+    ["current to upcoming", { status: "active", startDate: "2026-01-01", endDate: "2026-12-31", occupancyEffective: true }, { startDate: "2026-09-01" }, "occupancy_reconciliation_required"],
+    ["current to past", { status: "active", startDate: "2026-01-01", endDate: "2026-12-31", occupancyEffective: true }, { endDate: "2026-07-31" }, "occupancy_reconciliation_required"],
+    ["past to current", { status: "active", startDate: "2025-01-01", endDate: "2025-12-31", occupancyEffective: false }, { startDate: "2026-01-01", endDate: "2026-12-31" }, "restore_active_workflow_required"],
+    ["terminal current", { status: "active", startDate: "2026-01-01", endDate: "2026-12-31", occupancyEffective: true }, { status: "ended" }, "end_lease_workflow_required"],
+  ])("rejects generic %s lifecycle mutation", async (_label, lease, patch, error) => {
+    seedDoc("leases", "lease-edit", { landlordId: "landlord-1", propertyId: "prop-1", unitId: "unit-1", tenantId: "tenant-1", executionStatus: "fully_executed", ...lease });
+    const app = await makeApp();
+    const res = await request(app).put("/lease-edit").send(patch);
+    expect(res.status).toBe(409);
+    expect(res.body?.error).toBe(error);
+    expect((await fakeDb.collection("leases").doc("lease-edit").get()).data()).toMatchObject(lease);
   });
 
   it("lists only active occupied reconciliation candidates from non-archived properties", async () => {

--- a/rentchain-api/src/routes/__tests__/leaseRoutes.integrity.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.integrity.test.ts
@@ -942,6 +942,41 @@ describe("leaseRoutes integrity repairs", () => {
       phone: "9025553333",
     });
     expect(res.body?.tenant?.phone).toBe("90255511119");
+    const tenanciesAfterFirst = (await fakeDb.collection("tenancies").get()).docs.map((doc: any) => doc.data());
+    expect(tenanciesAfterFirst).toHaveLength(1);
+    expect(tenanciesAfterFirst[0].moveInAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(tenanciesAfterFirst[0].moveInAt).not.toBe("2026-04-01");
+
+    const replay = await request(app)
+      .post("/reconciliation-candidates/unit-1/convert")
+      .set("Idempotency-Key", "convert-unit-1")
+      .send({ occupantName: "Recovered Tenant", startDate: "2026-04-01", endDate: "2027-03-31", monthlyRent: 1850, tenantPhone: "(902) 555-1111 ext 9", coApplicantEmail: "coapplicant@example.com", coApplicantPhone: "902-555-3333" });
+    expect(replay.status).toBe(201);
+    expect(replay.body?.lease?.id).toBe(res.body?.lease?.id);
+    expect((await fakeDb.collection("leases").get()).docs).toHaveLength(1);
+    expect((await fakeDb.collection("tenancies").get()).docs).toHaveLength(1);
+    expect((await fakeDb.collection("canonicalEvents").get()).docs).toHaveLength(2);
+  });
+
+  it("fails closed for contradictory occupied-unit tenant evidence", async () => {
+    seedDoc("properties", "prop-1", { landlordId: "landlord-1", units: [{ id: "unit-1", unitId: "unit-1", unitNumber: "101", status: "occupied", occupancyStatus: "occupied", tenantId: "tenant-2" }] });
+    seedDoc("units", "unit-1", { landlordId: "landlord-1", propertyId: "prop-1", unitNumber: "101", status: "occupied", occupancyStatus: "occupied", tenantId: "tenant-1", occupantName: "Tenant One", rent: 1800, executionStatus: "fully_executed" });
+    seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", fullName: "Tenant One", currentLeaseId: null });
+    const app = await makeApp();
+    const res = await request(app).post("/reconciliation-candidates/unit-1/convert").set("Idempotency-Key", "contradictory-conversion").send({ occupantName: "Tenant One", startDate: "2026-01-01", endDate: "2026-12-31", monthlyRent: 1800 });
+    expect(res.status).toBe(409);
+    expect((await fakeDb.collection("leases").get()).docs).toHaveLength(0);
+  });
+
+  it("fails closed for cross-tenant active tenancy during conversion", async () => {
+    seedDoc("properties", "prop-1", { landlordId: "landlord-1", units: [{ id: "unit-1", unitId: "unit-1", unitNumber: "101", status: "occupied", occupancyStatus: "occupied", tenantId: "tenant-1" }] });
+    seedDoc("units", "unit-1", { landlordId: "landlord-1", propertyId: "prop-1", unitNumber: "101", status: "occupied", occupancyStatus: "occupied", tenantId: "tenant-1", occupantName: "Tenant One", rent: 1800, executionStatus: "fully_executed" });
+    seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", fullName: "Tenant One", currentLeaseId: null });
+    seedDoc("tenancies", "foreign", { landlordId: "landlord-1", propertyId: "prop-1", unitId: "unit-1", tenantId: "tenant-2", leaseId: "foreign-lease", status: "active" });
+    const app = await makeApp();
+    const res = await request(app).post("/reconciliation-candidates/unit-1/convert").set("Idempotency-Key", "cross-tenant-conversion").send({ occupantName: "Tenant One", startDate: "2026-01-01", endDate: "2026-12-31", monthlyRent: 1800 });
+    expect(res.status).toBe(409);
+    expect((await fakeDb.collection("leases").get()).docs).toHaveLength(0);
   });
 
   it("rejects occupied unit conversion when the start date is after the end date", async () => {

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -2756,7 +2756,8 @@ router.post("/drafts/:draftId/activate", requireLandlord, async (req: any, res: 
       });
     }
     // Keep in-memory lease service in sync for existing automation/toggle flows.
-    if (!leaseService.getById(leaseId)) leaseService.getAll().push({
+    const compatibilityStatus = result.canonicalOutcome === "occupancy_effective" ? "active" : "pending";
+    if (result.canonicalOutcome === "occupancy_effective" && !leaseService.getById(leaseId)) leaseService.getAll().push({
       id: leaseId,
       tenantId,
       tenantIds,
@@ -2783,7 +2784,7 @@ router.post("/drafts/:draftId/activate", requireLandlord, async (req: any, res: 
     return res.status(200).json({
       ok: true,
       leaseId,
-      lease: { id: leaseId, ...leaseRecord, occupancyEffective: result.occupancyEffective },
+      lease: { id: leaseId, ...leaseRecord, status: compatibilityStatus, occupancyEffective: result.occupancyEffective },
       leaseNotification,
       leaseStart: result,
       occupancyOutcome: result.canonicalOutcome,

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -77,9 +77,12 @@ import {
   toCanonicalLeaseStateInput,
 } from "../lib/leases/canonicalLeaseOccupancyProjection";
 import { deriveCanonicalLeaseTermState } from "../lib/leases/canonicalLeaseOccupancyState";
+import { readMutationIdempotencyKey } from "../lib/http/mutationIdempotency";
+import { createCanonicalLease } from "../services/leaseStart/leaseCreationService";
+import { leaseStartDeterministicId } from "../services/leaseStart/leaseStartExpectedState";
+import { getCanonicalLeaseStartContext, LeaseStartServiceError, startCanonicalLeaseOccupancy } from "../services/leaseStart/leaseStartService";
 import { evaluateJurisdictionPolicy } from "../lib/jurisdiction/operationalPolicyEvaluator";
 import { formatInternalReference, slugifyOperationalReference } from "../lib/identityReferences";
-import { syncPropertyUnitOccupancyForTenantContext } from "../services/tenantPortal/tenantOccupancySyncService";
 import { computeLeaseState } from "../services/stateMachines/stateComputation";
 import { leaseStateMachine } from "../services/stateMachines/leaseStateMachine";
 import { appendProvenanceEvent } from "../services/stateMachines/provenanceStorage";
@@ -107,6 +110,34 @@ const LEDGER_COLLECTION = "ledgerEntries";
 const LEASE_NOTES_COLLECTION = "leaseNotes";
 const PAYMENT_METHODS = new Set(["cash", "etransfer", "cheque", "bank", "card", "other"]);
 const CHARGE_CATEGORIES = new Set(["rent", "fee", "adjustment"]);
+
+function mutationIdempotencyKeyOrReject(req: Request, res: Response): string | null {
+  const validation = readMutationIdempotencyKey(req);
+  if (validation.ok) return validation.key;
+  res.status(400).json({ ok: false, error: validation.error });
+  return null;
+}
+
+function leaseStartErrorResponse(error: unknown, res: Response) {
+  if (!(error instanceof LeaseStartServiceError)) return false;
+  const status = error.code === "lease_start_state_stale" || error.code === "lease_start_idempotency_key_reused" || error.code === "lease_start_context_ambiguous" ? 409 : 500;
+  res.status(status).json({ ok: false, error: error.code, freshContext: error.freshContext || undefined });
+  return true;
+}
+
+function canonicalLeaseStartRejection(res: Response, result: any) {
+  if (Array.isArray(result?.reasons) && result.reasons.includes("MULTIPLE_CURRENT_LEASES")) {
+    return res.status(409).json({
+      ok: false,
+      error: "conflicting_active_lease_agreement",
+      message: "A conflicting active lease agreement already exists for this unit and term",
+      conflictLeaseIds: result?.stateSummary?.eligibleCurrentLeaseIds || [],
+      reasons: result.reasons,
+      leaseStart: result,
+    });
+  }
+  return res.status(409).json({ ok: false, error: "lease_start_context_ambiguous", reasons: result?.reasons || [], leaseStart: result });
+}
 
 type LedgerEntryType = "charge" | "payment" | "adjustment";
 type ReconciliationPropertyState = {
@@ -530,33 +561,6 @@ async function resolveStandaloneUnitDocIdForLeaseEnd(lease: any): Promise<string
   const byLabel = resolveUnitReference(canonicalUnits, leaseUnitNumber);
   if (byLabel.ambiguous) return null;
   return byLabel.unit?.id || null;
-}
-
-async function syncOccupancyAfterActiveLeaseWrite(
-  input: {
-    tenantId: string;
-    leaseId: string;
-    landlordId: string;
-    propertyId: string;
-    unitId: string;
-  },
-  logPrefix: string
-) {
-  try {
-    const result = await syncPropertyUnitOccupancyForTenantContext(input);
-    if (!result.updated) {
-      console.warn(`${logPrefix} occupancy sync skipped`, {
-        leaseId: input.leaseId,
-        tenantId: input.tenantId,
-        landlordId: input.landlordId,
-        propertyId: input.propertyId,
-        unitId: input.unitId,
-        reason: result.reason,
-      });
-    }
-  } catch (syncErr) {
-    console.warn(`${logPrefix} occupancy sync failed`, syncErr);
-  }
 }
 
 async function reconcilePropertyUnitOccupancyForLeaseRestore(lease: any) {
@@ -2242,6 +2246,8 @@ router.get("/reconciliation-candidates", requireLandlord, async (req: any, res: 
         const blockingReasons: string[] = [];
         if (!occupantName) blockingReasons.push("occupant_name_required");
         if (!Number.isFinite(rent) || rent <= 0) blockingReasons.push("rent_required");
+        if (!String(raw?.tenantId || raw?.currentTenantId || "").trim()) blockingReasons.push("canonical_tenant_identity_required");
+        if (String(raw?.executionStatus || raw?.leaseExecutionStatus || "").trim() !== "fully_executed") blockingReasons.push("lease_execution_evidence_required");
 
         return {
           id: unitId,
@@ -2276,6 +2282,8 @@ router.get("/reconciliation-candidates", requireLandlord, async (req: any, res: 
 router.post("/reconciliation-candidates/:unitId/convert", requireLandlord, async (req: any, res: Response) => {
   try {
     if (!(await enforceLeaseCapability(req, res))) return;
+    const idempotencyKey = mutationIdempotencyKeyOrReject(req, res);
+    if (!idempotencyKey) return;
     const landlordId = String(req.user?.landlordId || req.user?.id || "").trim();
     if (!landlordId) return res.status(401).json({ ok: false, error: "Unauthorized" });
 
@@ -2298,17 +2306,11 @@ router.post("/reconciliation-candidates/:unitId/convert", requireLandlord, async
       return res.status(400).json({ ok: false, error: "unit_not_occupied" });
     }
 
-    const conflictingLeases = await db.collection("leases").where("landlordId", "==", landlordId).where("propertyId", "==", propertyId).get();
-    const hasCurrentLease = (conflictingLeases.docs || []).some((doc: any) => {
-      const raw = doc.data() as any;
-      if (!isCurrentLeaseStatus(raw?.status)) return false;
-      return (
-        String(raw?.unitId || "").trim() === unitId ||
-        String(raw?.unitNumber || raw?.unit || "").trim() === unitNumber
-      );
-    });
-    if (hasCurrentLease) {
-      return res.status(409).json({ ok: false, error: "current_lease_already_exists" });
+    const tenantId = String(unit?.tenantId || unit?.currentTenantId || "").trim();
+    if (!tenantId) return res.status(409).json({ ok: false, error: "anonymous_occupied_unit" });
+    const tenantSnap = await db.collection("tenants").doc(tenantId).get();
+    if (!tenantSnap.exists || String(tenantSnap.data()?.landlordId || "").trim() !== landlordId) {
+      return res.status(409).json({ ok: false, error: "occupied_tenant_identity_incoherent" });
     }
 
     const occupantName = String(req.body?.occupantName || unit?.occupantName || "").trim();
@@ -2335,40 +2337,20 @@ router.post("/reconciliation-candidates/:unitId/convert", requireLandlord, async
     if (!Number.isFinite(monthlyRent) || monthlyRent <= 0) {
       return res.status(400).json({ ok: false, error: "monthly_rent_required" });
     }
+    const executionStatus = String(unit?.executionStatus || unit?.leaseExecutionStatus || "").trim();
+    if (executionStatus !== "fully_executed") {
+      return res.status(400).json({ ok: false, error: "lease_execution_evidence_required" });
+    }
 
     const propertySnap = await db.collection("properties").doc(propertyId).get();
     const property = propertySnap.data() as any;
     const propertyName = String(property?.name || property?.addressLine1 || "Property").trim() || "Property";
-    const tenantRef = db.collection("tenants").doc();
     const nowIso = new Date().toISOString();
-    await tenantRef.set(
-      {
-        landlordId,
-        fullName: occupantName,
-        email: tenantEmail,
-        phone: tenantPhone,
-        propertyId,
-        propertyName,
-        unitId,
-        unit: unitNumber,
-        currentLeaseId: null,
-        leaseStart: startDate,
-        leaseEnd: endDate || null,
-        monthlyRent,
-        coApplicant,
-        status: "Current",
-        createdAt: nowIso,
-        updatedAt: nowIso,
-        source: "occupied_unit_reconciliation",
-      },
-      { merge: false }
-    );
-
     const riskSnapshot = await computeLeaseRiskSnapshot({
       landlordId,
       propertyId,
       unitId,
-      tenantIds: [tenantRef.id],
+      tenantIds: [tenantId],
       monthlyRent,
     });
     const riskFields = buildLeaseRiskPersistenceFields({}, riskSnapshot, {
@@ -2376,57 +2358,66 @@ router.post("/reconciliation-candidates/:unitId/convert", requireLandlord, async
       source: "occupied_unit_reconciliation",
     });
 
-    const lease = leaseService.create({
-      tenantId: tenantRef.id,
-      tenantIds: [tenantRef.id],
-      primaryTenantId: tenantRef.id,
-      propertyId,
-      unitNumber,
-      monthlyRent,
-      startDate,
-      endDate,
-      risk: riskFields.risk,
-      riskTimeline: riskFields.riskTimeline,
-    });
-
+    const leaseId = leaseStartDeterministicId("lease", [landlordId, "conversion", idempotencyKey]);
     const firestoreLeaseRecord = {
       landlordId,
-      tenantId: tenantRef.id,
-      tenantIds: [tenantRef.id],
-      primaryTenantId: tenantRef.id,
+      tenantId,
+      tenantIds: [tenantId],
+      primaryTenantId: tenantId,
       propertyId,
       unitId,
       unitNumber,
       monthlyRent,
       startDate,
       endDate: endDate || null,
-      automationEnabled: lease.automationEnabled ?? true,
-      renewalStatus: lease.renewalStatus ?? "unknown",
-      status: lease.status,
-      risk: lease.risk ?? null,
-      riskScore: lease.riskScore ?? lease.risk?.score ?? null,
-      riskGrade: lease.riskGrade ?? lease.risk?.grade ?? null,
-      riskConfidence: lease.riskConfidence ?? lease.risk?.confidence ?? null,
-      riskTimeline: Array.isArray((lease as any).riskTimeline) ? (lease as any).riskTimeline : [],
-      createdAt: lease.createdAt,
-      updatedAt: lease.updatedAt,
+      automationEnabled: true,
+      renewalStatus: "unknown",
+      status: "active",
+      executionStatus: "fully_executed",
+      executionState: "fully_executed",
+      risk: riskFields.risk ?? null,
+      riskScore: riskFields.riskScore ?? null,
+      riskGrade: riskFields.riskGrade ?? null,
+      riskConfidence: riskFields.riskConfidence ?? null,
+      riskTimeline: riskFields.riskTimeline ?? [],
+      createdAt: nowIso,
+      updatedAt: nowIso,
       source: "occupied_unit_reconciliation",
       sourceUnitId: unitId,
       referenceDocument: unit?.leaseDocument || null,
       coApplicant,
     };
-    await db.collection("leases").doc(lease.id).set(firestoreLeaseRecord, { merge: false });
-    await tenantRef.set({ currentLeaseId: lease.id, updatedAt: new Date().toISOString() }, { merge: true });
+    const result = await createCanonicalLease({
+      landlordId,
+      propertyId,
+      unitId,
+      tenantId,
+      leaseId,
+      leaseRecord: firestoreLeaseRecord,
+      operationKind: "conversion",
+      idempotencyKey,
+      evaluationInstant: nowIso,
+      actorId: String(req.user?.id || req.user?.email || landlordId).trim() || landlordId,
+      source: "occupied_unit_reconciliation",
+    });
+    if (result.canonicalOutcome === "rejected") {
+      return canonicalLeaseStartRejection(res, result);
+    }
+    if (!result.occupancyEffective) {
+      return res.status(409).json({ ok: false, error: "lease_start_not_occupancy_effective", reasons: result.reasons, leaseStart: result });
+    }
 
-    const enrichedLease = await enrichLeaseRow({ id: lease.id, ...firestoreLeaseRecord });
+    const enrichedLease = await enrichLeaseRow({ id: leaseId, ...firestoreLeaseRecord, occupancyEffective: true });
     const leaseNotification = internalLeaseRecordNotificationSuppressed();
     return res.status(201).json({
       ok: true,
       lease: enrichedLease,
-      tenant: { id: tenantRef.id, fullName: occupantName, email: tenantEmail, phone: tenantPhone },
+      tenant: { id: tenantId, fullName: occupantName, email: tenantEmail, phone: tenantPhone },
       leaseNotification,
+      leaseStart: result,
     });
   } catch (err) {
+    if (leaseStartErrorResponse(err, res)) return;
     console.error("[POST /api/leases/reconciliation-candidates/:unitId/convert] error", err);
     return res.status(500).json({ ok: false, error: "Failed to convert occupied unit to lease" });
   }
@@ -2604,6 +2595,8 @@ router.post("/drafts/:id/generate", requireLandlord, async (req: any, res: Respo
 
 router.post("/drafts/:draftId/activate", requireLandlord, async (req: any, res: Response) => {
   try {
+    const idempotencyKey = mutationIdempotencyKeyOrReject(req, res);
+    if (!idempotencyKey) return;
     const landlordId = String(req.user?.landlordId || req.user?.id || "").trim();
     if (!landlordId) return res.status(401).json({ ok: false, error: "Unauthorized" });
 
@@ -2656,6 +2649,9 @@ router.post("/drafts/:draftId/activate", requireLandlord, async (req: any, res: 
 
     const generatedLeaseDocument = await loadGeneratedLeaseDocumentForDraft(draftId, draft);
 
+    // Compatibility repair for drafts activated before D3 introduced durable
+    // mutation requests. This is not a new activation and never creates a
+    // second lease; new D3 activations flow through the canonical transaction.
     if (String(draft?.leaseId || "").trim()) {
       const existingLeaseId = String(draft.leaseId).trim();
       const existingLeaseSnap = await db.collection("leases").doc(existingLeaseId).get();
@@ -2669,37 +2665,15 @@ router.post("/drafts/:draftId/activate", requireLandlord, async (req: any, res: 
             file: generatedLeaseDocument.file,
             actorId: String(req.user?.id || req.user?.email || landlordId).trim() || null,
           });
-          const repairedLeaseSnap = await db.collection("leases").doc(existingLeaseId).get();
-          return res.status(200).json({
-            ok: true,
-            leaseId: existingLeaseId,
-            lease: { id: existingLeaseId, ...(repairedLeaseSnap.data() as any) },
-          });
         }
-        return res.status(200).json({
-          ok: true,
-          leaseId: existingLeaseId,
-          lease: { id: existingLeaseId, ...(existingLeaseSnap.data() as any) },
-        });
+        const refreshed = await db.collection("leases").doc(existingLeaseId).get();
+        return res.status(200).json({ ok: true, leaseId: existingLeaseId, lease: { id: existingLeaseId, ...(refreshed.data() as any) }, leaseNotification: internalLeaseRecordNotificationSuppressed(), occupancyOutcome: (refreshed.data() as any)?.occupancyEffective ? "occupancy_effective" : "created_without_occupancy" });
       }
     }
 
-    const conflicts = await assertNoConflictingActiveAgreement({
-      landlordId,
-      propertyId,
-      unitId,
-      tenantIds,
-      startDate,
-      endDate,
-      monthlyRent: Math.round(baseRentCents / 100),
-    });
-    if (conflicts.length) {
-      return res.status(409).json({ ok: false, error: "conflicting_active_lease_agreement", conflictLeaseIds: conflicts.map((entry: any) => entry.lease.id) });
-    }
-
-    const now = Date.now();
+    const now = new Date().toISOString();
     const tenantId = tenantIds[0];
-    const leaseRef = db.collection("leases").doc();
+    const leaseId = leaseStartDeterministicId("lease", [landlordId, "draft_activation", idempotencyKey]);
     const riskSnapshot = await computeLeaseRiskSnapshot({
       landlordId,
       propertyId,
@@ -2739,7 +2713,9 @@ router.post("/drafts/:draftId/activate", requireLandlord, async (req: any, res: 
       riskTimeline: riskFields.riskTimeline,
       automationEnabled: true,
       renewalStatus: "unknown",
-      status: "active",
+      status: String(draft?.status || (String(draft?.executionStatus || draft?.executionState || "") === "fully_executed" ? "active" : "draft")),
+      executionStatus: String(draft?.executionStatus || draft?.executionState || "draft"),
+      executionState: String(draft?.executionState || draft?.executionStatus || "draft"),
       sourceDraftId: draftId,
       createdAt: now,
       updatedAt: now,
@@ -2752,31 +2728,36 @@ router.post("/drafts/:draftId/activate", requireLandlord, async (req: any, res: 
       leaseRecord.leaseDocumentGeneratedAt = now;
       leaseRecord.latestLeaseSnapshotId = generatedLeaseDocument.snapshotId;
     }
-    await leaseRef.set(leaseRecord, { merge: false });
+    const result = await createCanonicalLease({
+      landlordId,
+      propertyId,
+      unitId,
+      tenantId,
+      leaseId,
+      leaseRecord,
+      operationKind: "draft_activation",
+      idempotencyKey,
+      evaluationInstant: now,
+      actorId: String(req.user?.id || req.user?.email || landlordId).trim() || landlordId,
+      source: "lease_draft_activation",
+      draftActivation: { draftId },
+    });
+    if (result.canonicalOutcome === "rejected") {
+      return canonicalLeaseStartRejection(res, result);
+    }
     if (generatedLeaseDocument) {
       await linkGeneratedLeasePdfToTenantWorkspace({
-        draft: { ...draft, leaseId: leaseRef.id },
+        draft: { ...draft, leaseId },
         draftId,
         landlordId,
-        snapshotId: generatedLeaseDocument.snapshotId || `activated_${leaseRef.id}`,
+        snapshotId: generatedLeaseDocument.snapshotId || `activated_${leaseId}`,
         file: generatedLeaseDocument.file,
         actorId: String(req.user?.id || req.user?.email || landlordId).trim() || null,
       });
     }
-    await syncOccupancyAfterActiveLeaseWrite(
-      {
-        tenantId,
-        leaseId: leaseRef.id,
-        landlordId,
-        propertyId,
-        unitId,
-      },
-      "[POST /api/leases/drafts/:draftId/activate]"
-    );
-
     // Keep in-memory lease service in sync for existing automation/toggle flows.
-    leaseService.getAll().push({
-      id: leaseRef.id,
+    if (!leaseService.getById(leaseId)) leaseService.getAll().push({
+      id: leaseId,
       tenantId,
       tenantIds,
       primaryTenantId: tenantId,
@@ -2793,78 +2774,22 @@ router.post("/drafts/:draftId/activate", requireLandlord, async (req: any, res: 
       riskGrade: riskFields.riskGrade,
       riskConfidence: riskFields.riskConfidence,
       riskTimeline: riskFields.riskTimeline,
-      createdAt: new Date(now).toISOString(),
-      updatedAt: new Date(now).toISOString(),
-    });
-
-    await draftRef.set(
-      {
-        ...draft,
-        status: "activated",
-        leaseId: leaseRef.id,
-        activatedAt: now,
-        updatedAt: now,
-      },
-      { merge: false }
-    );
-    await writeCanonicalEvent({
-      domain: "lease",
-      action: "created",
-      status: "active",
-      actor: {
-        type: "landlord",
-        role: "landlord",
-        id: landlordId,
-      },
-      resource: {
-        type: "lease",
-        id: leaseRef.id,
-        parentType: "lease_draft",
-        parentId: draftId,
-      },
-      occurredAt: now,
-      visibility: "landlord",
-      summary: "Lease record created from draft",
-      metadata: {
-        propertyId,
-        unitId,
-        tenantIds,
-      },
-    });
-    await writeCanonicalEvent({
-      domain: "lease",
-      action: "activated",
-      status: "active",
-      actor: {
-        type: "landlord",
-        role: "landlord",
-        id: landlordId,
-      },
-      resource: {
-        type: "lease",
-        id: leaseRef.id,
-        parentType: "lease_draft",
-        parentId: draftId,
-      },
-      occurredAt: now,
-      visibility: "landlord",
-      summary: "Lease activated",
-      metadata: {
-        propertyId,
-        unitId,
-        tenantIds,
-      },
+      createdAt: now,
+      updatedAt: now,
     });
 
     const leaseNotification = internalLeaseRecordNotificationSuppressed();
 
     return res.status(200).json({
       ok: true,
-      leaseId: leaseRef.id,
-      lease: { id: leaseRef.id, ...leaseRecord },
+      leaseId,
+      lease: { id: leaseId, ...leaseRecord, occupancyEffective: result.occupancyEffective },
       leaseNotification,
+      leaseStart: result,
+      occupancyOutcome: result.canonicalOutcome,
     });
   } catch (err: any) {
+    if (leaseStartErrorResponse(err, res)) return;
     console.error("[POST /api/leases/drafts/:draftId/activate] error", err);
     return res.status(500).json({ ok: false, error: "Failed to activate lease draft" });
   }
@@ -3654,6 +3579,8 @@ router.get("/property/:propertyId", requireLandlord, async (req: any, res: Respo
 router.post("/", requireLandlord, async (req: Request, res: Response) => {
   try {
     if (!(await enforceLeaseCapability(req, res))) return;
+    const idempotencyKey = mutationIdempotencyKeyOrReject(req, res);
+    if (!idempotencyKey) return;
     const body = req.body as Partial<CreateLeasePayload>;
     if (!body.tenantId || !body.propertyId || !body.unitNumber) {
       return res.status(400).json({
@@ -3683,23 +3610,6 @@ router.post("/", requireLandlord, async (req: Request, res: Response) => {
       unitReference: String(body.unitNumber || "").trim(),
     });
 
-    const conflicts = await assertNoConflictingActiveAgreement({
-      landlordId,
-      propertyId: body.propertyId,
-      unitId: unitSelection.unitId,
-      tenantIds,
-      startDate: body.startDate,
-      endDate: body.endDate,
-      monthlyRent: Number(body.monthlyRent),
-    });
-    if (conflicts.length) {
-      return res.status(409).json({
-        error: "conflicting_active_lease_agreement",
-        message: "A conflicting active lease agreement already exists for this unit and term",
-        conflictLeaseIds: conflicts.map((entry: any) => entry.lease.id),
-      });
-    }
-
     const riskSnapshot = await computeLeaseRiskSnapshot({
       landlordId,
       propertyId: body.propertyId,
@@ -3712,77 +3622,66 @@ router.post("/", requireLandlord, async (req: Request, res: Response) => {
       source: "lease_create_route",
     });
 
-    const payload: CreateLeasePayload = {
-      tenantId: body.tenantId,
-      tenantIds,
-      primaryTenantId: tenantIds[0] || body.tenantId,
-      propertyId: body.propertyId,
-      unitNumber: unitSelection.unitLabel,
-      monthlyRent: Number(body.monthlyRent),
-      startDate: body.startDate,
-      endDate: body.endDate,
-      risk: riskFields.risk,
-      riskTimeline: riskFields.riskTimeline,
-    };
-
-    const lease = leaseService.create(payload);
-    let firestoreLeaseWritten = false;
-    if (landlordId) {
-      const firestoreLeaseRecord = {
+    const evaluationInstant = new Date().toISOString();
+    const actorId = String((req as any)?.user?.id || (req as any)?.user?.email || landlordId).trim() || landlordId;
+    const leaseId = leaseStartDeterministicId("lease", [landlordId, "direct_create", idempotencyKey]);
+    const executionStatus = String((body as any)?.executionStatus || (body as any)?.executionState || "").trim();
+    const firestoreLeaseRecord = {
         landlordId,
-        tenantId: lease.tenantId,
+        tenantId: String(body.tenantId || "").trim(),
         tenantIds,
         primaryTenantId: tenantIds[0] || body.tenantId,
-        propertyId: lease.propertyId,
+        propertyId: body.propertyId,
         unitId: unitSelection.unitId,
         unitNumber: unitSelection.unitLabel,
         unitLabel: unitSelection.unitLabel,
-        monthlyRent: lease.monthlyRent,
-        startDate: lease.startDate,
-        endDate: lease.endDate ?? null,
-        automationEnabled: lease.automationEnabled ?? true,
-        renewalStatus: lease.renewalStatus ?? "unknown",
-        status: lease.status,
-        risk: lease.risk ?? null,
-        riskScore: lease.riskScore ?? lease.risk?.score ?? null,
-        riskGrade: lease.riskGrade ?? lease.risk?.grade ?? null,
-        riskConfidence: lease.riskConfidence ?? lease.risk?.confidence ?? null,
-        riskTimeline: Array.isArray((lease as any).riskTimeline) ? (lease as any).riskTimeline : [],
-        createdAt: lease.createdAt,
-        updatedAt: lease.updatedAt,
+        monthlyRent: Number(body.monthlyRent),
+        startDate: body.startDate,
+        endDate: body.endDate ?? null,
+        automationEnabled: body.automationEnabled ?? true,
+        renewalStatus: body.renewalStatus ?? "unknown",
+        status: String((body as any)?.status || (executionStatus === "fully_executed" ? "active" : "draft")).trim(),
+        executionStatus: executionStatus || "draft",
+        executionState: executionStatus || "draft",
+        risk: riskFields.risk ?? null,
+        riskScore: riskFields.risk?.score ?? null,
+        riskGrade: riskFields.risk?.grade ?? null,
+        riskConfidence: riskFields.risk?.confidence ?? null,
+        riskTimeline: Array.isArray(riskFields.riskTimeline) ? riskFields.riskTimeline : [],
+        createdAt: evaluationInstant,
+        updatedAt: evaluationInstant,
       };
-      try {
-        await db.collection("leases").doc(lease.id).set(firestoreLeaseRecord, { merge: false });
-        firestoreLeaseWritten = true;
-      } catch (error: any) {
-        console.warn("[POST /api/leases] firestore lease write failed", error);
-      }
-      if (firestoreLeaseWritten) {
-        await syncOccupancyAfterActiveLeaseWrite(
-          {
-            tenantId: String(lease.tenantId || body.tenantId || "").trim(),
-            leaseId: lease.id,
-            landlordId,
-            propertyId: String(lease.propertyId || body.propertyId || "").trim(),
-            unitId: unitSelection.unitId,
-          },
-          "[POST /api/leases]"
-        );
-      }
+    const result = await createCanonicalLease({
+      landlordId,
+      propertyId: String(body.propertyId),
+      unitId: unitSelection.unitId,
+      tenantId: String(body.tenantId),
+      leaseId,
+      leaseRecord: firestoreLeaseRecord,
+      operationKind: "direct_create",
+      idempotencyKey,
+      evaluationInstant,
+      actorId,
+      source: "lease_create_route",
+    });
+    if (result.canonicalOutcome === "rejected") {
+      return canonicalLeaseStartRejection(res, result);
     }
-    const leaseNotification = landlordId && firestoreLeaseWritten
-      ? internalLeaseRecordNotificationSuppressed()
-      : { attempted: false, sent: false, reason: "lease_not_persisted" };
-    res.status(201).json({
+    const persistedLease = await db.collection("leases").doc(leaseId).get();
+    const lease = { id: leaseId, ...(persistedLease.data() || firestoreLeaseRecord) } as any;
+    return res.status(201).json({
       lease: {
         ...lease,
         unitId: unitSelection.unitId,
         unitNumber: unitSelection.unitLabel,
         unitLabel: unitSelection.unitLabel,
       },
-      leaseNotification,
+      leaseNotification: internalLeaseRecordNotificationSuppressed(),
+      leaseStart: result,
+      occupancyOutcome: result.canonicalOutcome,
     });
   } catch (err) {
+    if (leaseStartErrorResponse(err, res)) return;
     console.error("[POST /api/leases] error", err);
     res.status(500).json({ error: "Failed to process lease" });
   }
@@ -3799,6 +3698,7 @@ router.put("/:id", requireLandlord, async (req: any, res: Response) => {
     }
 
     if (leaseResult.source === "firestore") {
+      const evaluationInstant = new Date().toISOString();
       const next = {
         ...(payload.monthlyRent !== undefined ? { monthlyRent: payload.monthlyRent } : {}),
         ...(payload.startDate !== undefined ? { startDate: payload.startDate } : {}),
@@ -3806,9 +3706,54 @@ router.put("/:id", requireLandlord, async (req: any, res: Response) => {
         ...(payload.automationEnabled !== undefined ? { automationEnabled: payload.automationEnabled } : {}),
         ...(payload.renewalStatus !== undefined ? { renewalStatus: payload.renewalStatus } : {}),
         ...(payload.status !== undefined ? { status: payload.status } : {}),
-        updatedAt: new Date().toISOString(),
+        updatedAt: evaluationInstant,
       };
-      await db.collection("leases").doc(String(req.params?.id || "").trim()).set(next, { merge: true });
+      const currentLease = { id: String(req.params?.id || "").trim(), ...(leaseResult.lease as any) };
+      const proposedLease = { ...currentLease, ...next };
+      const before = deriveCanonicalLeaseTermState(currentLease, evaluationInstant);
+      const after = deriveCanonicalLeaseTermState(proposedLease, evaluationInstant);
+      const currentlyOccupancyEffective = (currentLease as any).occupancyEffective === true;
+      const terminalStatus = ["ended", "expired", "archived", "terminated", "cancelled", "canceled", "void"].includes(String((proposedLease as any).status || "").trim().toLowerCase());
+
+      if (currentlyOccupancyEffective && before.state === "active" && (after.state === "upcoming" || after.state === "past" || terminalStatus)) {
+        return res.status(409).json({ ok: false, error: terminalStatus ? "end_lease_workflow_required" : "occupancy_reconciliation_required" });
+      }
+      if (before.state === "past" && after.state === "active") {
+        return res.status(409).json({ ok: false, error: "restore_active_workflow_required" });
+      }
+
+      const executionStatus = String((proposedLease as any).executionStatus || (proposedLease as any).executionState || (proposedLease as any).leaseExecutionState || "").trim();
+      const startsCurrentOccupancy = before.state === "upcoming" && after.state === "active" && executionStatus === "fully_executed";
+      if (startsCurrentOccupancy) {
+        const idempotencyKey = mutationIdempotencyKeyOrReject(req, res);
+        if (!idempotencyKey) return;
+        const propertyId = String((proposedLease as any).propertyId || "").trim();
+        const unitId = String((proposedLease as any).unitId || "").trim();
+        const tenantId = String((proposedLease as any).tenantId || (proposedLease as any).primaryTenantId || "").trim();
+        if (!propertyId || !unitId || !tenantId) return res.status(409).json({ ok: false, error: "lease_start_context_ambiguous" });
+        const context = await getCanonicalLeaseStartContext({ landlordId, propertyId, unitId, tenantId, leaseId: currentLease.id, evaluationInstant, leasePatch: next });
+        const result = await startCanonicalLeaseOccupancy({
+          landlordId,
+          propertyId,
+          unitId,
+          tenantId,
+          leaseId: currentLease.id,
+          operationKind: "date_transition",
+          idempotencyKey,
+          expectedStateToken: context.expectedStateToken,
+          evaluationInstant,
+          trigger: "date_transition",
+          actorId: String(req.user?.id || req.user?.email || landlordId).trim() || landlordId,
+          source: "lease_update_route",
+          leasePatch: next,
+          persistRejectedAttempt: true,
+        });
+        if (result.canonicalOutcome === "rejected" || !result.occupancyEffective) {
+          return canonicalLeaseStartRejection(res, result);
+        }
+      } else {
+        await db.collection("leases").doc(currentLease.id).set(next, { merge: true });
+      }
       const refreshed = await getLeaseEntityForLandlord(String(req.params?.id || "").trim(), landlordId);
       if (!refreshed.ok) return res.status(refreshed.status).json({ error: refreshed.error });
       return res.json({ lease: await enrichLeaseRow({ id: String(req.params?.id || "").trim(), ...(refreshed.lease as any) }) });
@@ -3820,6 +3765,7 @@ router.put("/:id", requireLandlord, async (req: any, res: Response) => {
     }
     return res.json({ lease });
   } catch (err) {
+    if (leaseStartErrorResponse(err, res)) return;
     console.error("[PUT /api/leases/:id] error", err);
     return res.status(500).json({ error: "Failed to process lease" });
   }

--- a/rentchain-api/src/services/__tests__/leaseSigningService.test.ts
+++ b/rentchain-api/src/services/__tests__/leaseSigningService.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const collections = new Map<string, Map<string, any>>();
 const writeCanonicalEventMock = vi.fn(async () => undefined);
+const getCanonicalLeaseStartContextMock = vi.fn(async () => ({ expectedStateToken: "state-1" }));
+const startCanonicalLeaseOccupancyMock = vi.fn(async () => ({ canonicalOutcome: "occupancy_effective", occupancyEffective: true, reasons: [] }));
 
 function ensureCollection(name: string) {
   if (!collections.has(name)) collections.set(name, new Map());
@@ -58,6 +60,11 @@ vi.mock("../../lib/events/buildEvent", () => ({
   writeCanonicalEvent: writeCanonicalEventMock,
 }));
 
+vi.mock("../leaseStart/leaseStartService", () => ({
+  getCanonicalLeaseStartContext: getCanonicalLeaseStartContextMock,
+  startCanonicalLeaseOccupancy: startCanonicalLeaseOccupancyMock,
+}));
+
 vi.mock("../../lib/gcs", () => ({
   uploadBufferToGcs: vi.fn(async ({ path }: { path: string }) => ({ bucket: "bucket", path })),
 }));
@@ -70,11 +77,82 @@ describe("leaseSigningService", () => {
   beforeEach(() => {
     collections.clear();
     writeCanonicalEventMock.mockClear();
+    getCanonicalLeaseStartContextMock.mockClear();
+    startCanonicalLeaseOccupancyMock.mockClear();
     process.env.SIGNING_PROVIDER = "mock";
     process.env.PUBLIC_APP_URL = "http://localhost:5173";
     delete process.env.SIGNING_PROVIDER_API_KEY;
     delete process.env.SIGNING_PROVIDER_WEBHOOK_SECRET;
     delete process.env.SIGNING_PROVIDER_TEST_MODE;
+  });
+
+  it("uses stable provider event identity for canonical occupancy completion", async () => {
+    const { processSigningWebhook, sendLeaseForSignature } = await import("../signing/leaseSigningService");
+    ensureCollection("leases").set("lease-1", {
+      landlordId: "landlord-1",
+      propertyId: "property-1",
+      unitId: "unit-1",
+      tenantId: "tenant-1",
+      status: "active",
+      startDate: "2026-01-01",
+      endDate: "2026-12-31",
+    });
+    const sent = await sendLeaseForSignature({
+      leaseId: "lease-1",
+      landlordId: "landlord-1",
+      lease: { startDate: "2026-01-01" },
+      tenantEmails: ["tenant@example.com"],
+    });
+    const request = ensureCollection("leaseSigningRequests").get(String(sent.signingRequestId));
+    const body = {
+      providerRequestId: request.providerRequestId,
+      eventId: "provider-event-stable-1",
+      type: "signed",
+      occurredAt: "2026-08-19T12:00:00.000Z",
+    };
+    await processSigningWebhook({ providerId: "mock", headers: {}, body });
+    await processSigningWebhook({ providerId: "mock", headers: {}, body });
+
+    expect(startCanonicalLeaseOccupancyMock).toHaveBeenCalledTimes(2);
+    expect(startCanonicalLeaseOccupancyMock).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      operationKind: "signing_completion",
+      idempotencyKey: "mock:provider-event-stable-1",
+      trigger: "signing_completion",
+    }));
+    expect(startCanonicalLeaseOccupancyMock).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      idempotencyKey: "mock:provider-event-stable-1",
+    }));
+    expect(ensureCollection("leases").get("lease-1")).toEqual(expect.objectContaining({ executionStatus: "fully_executed" }));
+  });
+
+  it("keeps signing completion durable while marking rejected occupancy for review", async () => {
+    const { processSigningWebhook, sendLeaseForSignature } = await import("../signing/leaseSigningService");
+    startCanonicalLeaseOccupancyMock.mockResolvedValueOnce({ canonicalOutcome: "rejected", occupancyEffective: false, reasons: ["MULTIPLE_CURRENT_LEASES"] });
+    ensureCollection("leases").set("lease-conflict", {
+      landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-1",
+      status: "active", startDate: "2026-01-01", endDate: "2026-12-31",
+    });
+    const sent = await sendLeaseForSignature({ leaseId: "lease-conflict", landlordId: "landlord-1", lease: { startDate: "2026-01-01" }, tenantEmails: ["tenant@example.com"] });
+    const signingRequest = ensureCollection("leaseSigningRequests").get(String(sent.signingRequestId));
+    await processSigningWebhook({ providerId: "mock", headers: {}, body: { providerRequestId: signingRequest.providerRequestId, eventId: "provider-conflict-1", type: "signed", occurredAt: "2026-08-19T12:00:00.000Z" } });
+    expect(ensureCollection("leases").get("lease-conflict")).toEqual(expect.objectContaining({
+      executionStatus: "fully_executed",
+      occupancyStartReview: expect.objectContaining({ status: "review_needed", reasons: ["MULTIPLE_CURRENT_LEASES"] }),
+    }));
+  });
+
+  it("keeps a fully signed future lease deferred without an occupancy rejection", async () => {
+    const { processSigningWebhook, sendLeaseForSignature } = await import("../signing/leaseSigningService");
+    startCanonicalLeaseOccupancyMock.mockResolvedValueOnce({ canonicalOutcome: "created_without_occupancy", occupancyEffective: false, reasons: ["UPCOMING_LEASE_CANNOT_SUPPORT_OCCUPANCY"] });
+    ensureCollection("leases").set("lease-future", {
+      landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-1",
+      status: "active", startDate: "2027-01-01", endDate: "2027-12-31",
+    });
+    const sent = await sendLeaseForSignature({ leaseId: "lease-future", landlordId: "landlord-1", lease: { startDate: "2027-01-01" }, tenantEmails: ["tenant@example.com"] });
+    const signingRequest = ensureCollection("leaseSigningRequests").get(String(sent.signingRequestId));
+    await processSigningWebhook({ providerId: "mock", headers: {}, body: { providerRequestId: signingRequest.providerRequestId, eventId: "provider-future-1", type: "signed", occurredAt: "2026-08-19T12:00:00.000Z" } });
+    expect(ensureCollection("leases").get("lease-future")).toEqual(expect.objectContaining({ executionStatus: "fully_executed" }));
+    expect(ensureCollection("leases").get("lease-future")).not.toHaveProperty("occupancyStartReview");
   });
 
   it("creates a pending signing request without exposing raw provider references in projected snapshot", async () => {

--- a/rentchain-api/src/services/__tests__/leaseSigningService.test.ts
+++ b/rentchain-api/src/services/__tests__/leaseSigningService.test.ts
@@ -113,16 +113,16 @@ describe("leaseSigningService", () => {
     await processSigningWebhook({ providerId: "mock", headers: {}, body });
     await processSigningWebhook({ providerId: "mock", headers: {}, body });
 
-    expect(startCanonicalLeaseOccupancyMock).toHaveBeenCalledTimes(2);
+    expect(startCanonicalLeaseOccupancyMock).toHaveBeenCalledTimes(1);
     expect(startCanonicalLeaseOccupancyMock).toHaveBeenNthCalledWith(1, expect.objectContaining({
       operationKind: "signing_completion",
       idempotencyKey: "mock:provider-event-stable-1",
       trigger: "signing_completion",
     }));
-    expect(startCanonicalLeaseOccupancyMock).toHaveBeenNthCalledWith(2, expect.objectContaining({
-      idempotencyKey: "mock:provider-event-stable-1",
-    }));
     expect(ensureCollection("leases").get("lease-1")).toEqual(expect.objectContaining({ executionStatus: "fully_executed" }));
+    expect(ensureCollection("leases").get("lease-1")).not.toHaveProperty("occupancyStartReview");
+    expect(ensureCollection("leaseSigningCompletionOperations").size).toBe(1);
+    expect(ensureCollection("leaseSigningEvents").size).toBe(2);
   });
 
   it("keeps signing completion durable while marking rejected occupancy for review", async () => {
@@ -151,8 +151,11 @@ describe("leaseSigningService", () => {
     const sent = await sendLeaseForSignature({ leaseId: "lease-future", landlordId: "landlord-1", lease: { startDate: "2027-01-01" }, tenantEmails: ["tenant@example.com"] });
     const signingRequest = ensureCollection("leaseSigningRequests").get(String(sent.signingRequestId));
     await processSigningWebhook({ providerId: "mock", headers: {}, body: { providerRequestId: signingRequest.providerRequestId, eventId: "provider-future-1", type: "signed", occurredAt: "2026-08-19T12:00:00.000Z" } });
+    await processSigningWebhook({ providerId: "mock", headers: {}, body: { providerRequestId: signingRequest.providerRequestId, eventId: "provider-future-1", type: "signed", occurredAt: "2026-08-19T12:00:00.000Z" } });
     expect(ensureCollection("leases").get("lease-future")).toEqual(expect.objectContaining({ executionStatus: "fully_executed" }));
     expect(ensureCollection("leases").get("lease-future")).not.toHaveProperty("occupancyStartReview");
+    expect(startCanonicalLeaseOccupancyMock).toHaveBeenCalledTimes(1);
+    expect(ensureCollection("leaseSigningCompletionOperations").size).toBe(1);
   });
 
   it("creates a pending signing request without exposing raw provider references in projected snapshot", async () => {

--- a/rentchain-api/src/services/leaseStart/__tests__/leaseCreationService.test.ts
+++ b/rentchain-api/src/services/leaseStart/__tests__/leaseCreationService.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { createCanonicalLease, type CreateCanonicalLeaseInput } from "../leaseCreationService";
+
+function fakeFirestore() {
+  const store = new Map<string, Map<string, any>>();
+  let failCollection: string | null = null;
+  const values = (name: string) => {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  };
+  const ref = (name: string, id: string): any => ({
+    kind: "doc", collectionName: name, id,
+    get: async () => {
+      const value = values(name).get(id);
+      return { id, exists: value !== undefined, data: () => value, ref: ref(name, id) };
+    },
+  });
+  const query = (name: string, filters: any[] = []): any => ({
+    kind: "query", collectionName: name,
+    where: (field: string, op: string, value: any) => query(name, [...filters, { field, op, value }]),
+    get: async () => ({
+      docs: [...values(name)].filter(([, value]) => filters.every((filter) => filter.op === "==" && value[filter.field] === filter.value))
+        .map(([id, value]) => ({ id, exists: true, data: () => value, ref: ref(name, id) })),
+    }),
+  });
+  const firestore: any = {
+    collection: (name: string) => ({ ...query(name), doc: (id: string) => ref(name, id) }),
+    runTransaction: async (callback: any) => {
+      const writes: any[] = [];
+      const result = await callback({
+        get: (target: any) => target.get(),
+        set: (target: any, value: any, options?: any) => writes.push({ kind: "set", target, value, options }),
+        create: (target: any, value: any) => writes.push({ kind: "create", target, value }),
+      });
+      const snapshot = structuredClone([...store].map(([name, entries]) => [name, [...entries]]));
+      try {
+        for (const write of writes) {
+          const name = write.target.collectionName;
+          if (name === failCollection) throw new Error("forced_transaction_failure");
+          const collection = values(name);
+          if (write.kind === "create" && collection.has(write.target.id)) throw new Error("already_exists");
+          const current = collection.get(write.target.id) || {};
+          collection.set(write.target.id, structuredClone(write.options?.merge ? { ...current, ...write.value } : write.value));
+        }
+      } catch (error) {
+        store.clear();
+        for (const [name, entries] of snapshot) store.set(name, new Map(entries));
+        throw error;
+      }
+      return result;
+    },
+  };
+  return {
+    firestore,
+    seed: (name: string, id: string, value: any) => values(name).set(id, structuredClone(value)),
+    read: (name: string, id: string) => structuredClone(values(name).get(id)),
+    list: (name: string) => [...values(name).values()].map((value) => structuredClone(value)),
+    fail: (name: string | null) => { failCollection = name; },
+  };
+}
+
+const at = "2026-08-19T12:00:00.000Z";
+let fake: ReturnType<typeof fakeFirestore>;
+
+function seedContext(overrides: { unit?: any; embedded?: any; tenant?: any } = {}) {
+  fake.seed("properties", "property-1", {
+    landlordId: "landlord-1",
+    units: [{ id: "unit-1", unitId: "unit-1", unitNumber: "1A", status: "vacant", occupancyStatus: "vacant", ...(overrides.embedded || {}) }],
+  });
+  fake.seed("units", "unit-1", { landlordId: "landlord-1", propertyId: "property-1", unitNumber: "1A", status: "vacant", occupancyStatus: "vacant", ...(overrides.unit || {}) });
+  fake.seed("tenants", "tenant-1", { landlordId: "landlord-1", status: "applicant", currentLeaseId: null, ...(overrides.tenant || {}) });
+}
+
+function input(overrides: Partial<CreateCanonicalLeaseInput> = {}): CreateCanonicalLeaseInput {
+  const idempotencyKey = overrides.idempotencyKey || "create-1";
+  const leaseId = overrides.leaseId || `lease-${idempotencyKey}`;
+  const result: CreateCanonicalLeaseInput = {
+    landlordId: "landlord-1",
+    propertyId: "property-1",
+    unitId: "unit-1",
+    tenantId: "tenant-1",
+    leaseId,
+    leaseRecord: {
+      landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-1", tenantIds: ["tenant-1"],
+      status: "active", executionStatus: "fully_executed", startDate: "2026-01-01", endDate: "2026-12-31", monthlyRent: 1800,
+      createdAt: at, updatedAt: at,
+      ...(overrides.leaseRecord || {}),
+    },
+    operationKind: "direct_create",
+    idempotencyKey,
+    evaluationInstant: at,
+    actorId: "landlord-1",
+    source: "test",
+    firestore: fake.firestore,
+  };
+  return { ...result, ...overrides, leaseRecord: { ...result.leaseRecord, ...(overrides.leaseRecord || {}) } };
+}
+
+describe("createCanonicalLease", () => {
+  beforeEach(() => {
+    fake = fakeFirestore();
+    seedContext();
+  });
+
+  it("creates a fully executed current lease and complete occupancy atomically", async () => {
+    const result = await createCanonicalLease(input());
+    expect(result).toMatchObject({ canonicalOutcome: "occupancy_effective", occupancyEffective: true });
+    expect(fake.read("leases", "lease-create-1")).toMatchObject({ occupancyEffective: true });
+    expect(fake.read("units", "unit-1")).toMatchObject({ status: "occupied", currentLeaseId: "lease-create-1", currentTenantId: "tenant-1" });
+    expect(fake.read("properties", "property-1").units[0]).toMatchObject({ status: "occupied", currentLeaseId: "lease-create-1" });
+    expect(fake.read("tenants", "tenant-1")).toMatchObject({ currentLeaseId: "lease-create-1" });
+    expect(fake.list("tenancies")).toHaveLength(1);
+    expect(fake.list("canonicalEvents").map((event) => event.type).sort()).toEqual(["lease.created", "lease.occupancy_started"]);
+    expect(fake.list("leaseStartRequests")).toHaveLength(1);
+  });
+
+  it.each([
+    ["future", { startDate: "2026-09-01", endDate: "2027-08-31" }],
+    ["incomplete", { executionStatus: "draft", executionState: "draft", status: "draft" }],
+    ["missing execution", { executionStatus: undefined, executionState: undefined, status: "active" }],
+  ])("creates %s lease without current occupancy", async (_label, leasePatch) => {
+    const result = await createCanonicalLease(input({ leaseRecord: leasePatch }));
+    expect(result).toMatchObject({ canonicalOutcome: "created_without_occupancy", occupancyEffective: false });
+    expect(fake.read("leases", "lease-create-1")).toBeTruthy();
+    expect(fake.read("units", "unit-1")).toMatchObject({ status: "vacant" });
+    expect(fake.read("tenants", "tenant-1")).toMatchObject({ currentLeaseId: null });
+    expect(fake.list("tenancies")).toEqual([]);
+    expect(fake.list("canonicalEvents").map((event) => event.type)).toEqual(["lease.created_without_occupancy"]);
+  });
+
+  it("returns the durable result for an identical retry without duplicates", async () => {
+    const request = input();
+    const first = await createCanonicalLease(request);
+    const replay = await createCanonicalLease({ ...request, evaluationInstant: "2026-08-19T12:00:05.000Z" });
+    expect(first.leaseId).toBe(replay.leaseId);
+    expect(replay.outcome).toBe("idempotent_replay");
+    expect(fake.list("leases")).toHaveLength(1);
+    expect(fake.list("tenancies")).toHaveLength(1);
+    expect(fake.list("canonicalEvents")).toHaveLength(2);
+    expect(fake.list("leaseStartRequests")).toHaveLength(1);
+  });
+
+  it("rejects the same key with changed semantic payload", async () => {
+    await createCanonicalLease(input());
+    await expect(createCanonicalLease(input({ leaseRecord: { monthlyRent: 1900 } }))).rejects.toMatchObject({ code: "lease_start_idempotency_key_reused" });
+  });
+
+  it("does not collapse a new key with an identical payload", async () => {
+    await createCanonicalLease(input());
+    const second = await createCanonicalLease(input({ idempotencyKey: "create-2", leaseId: "lease-create-2" }));
+    expect(second.canonicalOutcome).toBe("rejected");
+    expect(second.reasons).toContain("MULTIPLE_CURRENT_LEASES");
+    expect(fake.list("leaseStartRequests")).toHaveLength(2);
+  });
+
+  it("fails closed for cross-tenant active tenancy without creating a lease", async () => {
+    fake.seed("tenancies", "foreign", { landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-2", leaseId: "foreign-lease", status: "active" });
+    const result = await createCanonicalLease(input());
+    expect(result.canonicalOutcome).toBe("rejected");
+    expect(fake.list("leases")).toEqual([]);
+    expect(fake.read("units", "unit-1")).toMatchObject({ status: "vacant" });
+    expect(fake.list("canonicalEvents").map((event) => event.type)).toEqual(["lease.occupancy_start_rejected"]);
+  });
+
+  it("rolls back every domain write when the atomic transaction fails", async () => {
+    fake.fail("canonicalEvents");
+    await expect(createCanonicalLease(input())).rejects.toThrow("forced_transaction_failure");
+    expect(fake.list("leases")).toEqual([]);
+    expect(fake.read("units", "unit-1")).toMatchObject({ status: "vacant" });
+    expect(fake.read("tenants", "tenant-1")).toMatchObject({ currentLeaseId: null });
+    expect(fake.list("tenancies")).toEqual([]);
+    expect(fake.list("leaseStartRequests")).toEqual([]);
+  });
+
+  it("consumes a draft in the same transaction as lease creation", async () => {
+    fake.seed("leaseDrafts", "draft-1", { landlordId: "landlord-1", status: "generated", leaseId: null });
+    const result = await createCanonicalLease(input({ operationKind: "draft_activation", draftActivation: { draftId: "draft-1" } }));
+    expect(result.occupancyEffective).toBe(true);
+    expect(fake.read("leaseDrafts", "draft-1")).toMatchObject({ status: "activated", leaseId: "lease-create-1" });
+  });
+});

--- a/rentchain-api/src/services/leaseStart/__tests__/leaseCreationService.test.ts
+++ b/rentchain-api/src/services/leaseStart/__tests__/leaseCreationService.test.ts
@@ -105,7 +105,7 @@ describe("createCanonicalLease", () => {
   it("creates a fully executed current lease and complete occupancy atomically", async () => {
     const result = await createCanonicalLease(input());
     expect(result).toMatchObject({ canonicalOutcome: "occupancy_effective", occupancyEffective: true });
-    expect(fake.read("leases", "lease-create-1")).toMatchObject({ occupancyEffective: true });
+    expect(fake.read("leases", "lease-create-1")).toMatchObject({ status: "active", occupancyEffective: true });
     expect(fake.read("units", "unit-1")).toMatchObject({ status: "occupied", currentLeaseId: "lease-create-1", currentTenantId: "tenant-1" });
     expect(fake.read("properties", "property-1").units[0]).toMatchObject({ status: "occupied", currentLeaseId: "lease-create-1" });
     expect(fake.read("tenants", "tenant-1")).toMatchObject({ currentLeaseId: "lease-create-1" });
@@ -121,7 +121,7 @@ describe("createCanonicalLease", () => {
   ])("creates %s lease without current occupancy", async (_label, leasePatch) => {
     const result = await createCanonicalLease(input({ leaseRecord: leasePatch }));
     expect(result).toMatchObject({ canonicalOutcome: "created_without_occupancy", occupancyEffective: false });
-    expect(fake.read("leases", "lease-create-1")).toBeTruthy();
+    expect(fake.read("leases", "lease-create-1")).toMatchObject({ status: "pending", occupancyEffective: false });
     expect(fake.read("units", "unit-1")).toMatchObject({ status: "vacant" });
     expect(fake.read("tenants", "tenant-1")).toMatchObject({ currentLeaseId: null });
     expect(fake.list("tenancies")).toEqual([]);

--- a/rentchain-api/src/services/leaseStart/__tests__/leaseStartService.test.ts
+++ b/rentchain-api/src/services/leaseStart/__tests__/leaseStartService.test.ts
@@ -296,6 +296,18 @@ describe("leaseStartService", () => {
     expect(fake.list("leaseStartRequests")).toEqual([]);
   });
 
+  it("durably audits an authorized route-level domain rejection exactly once", async () => {
+    fake.seed("leases", "lease-2", { ...fake.read("leases", "lease-1"), tenantId: "tenant-1" });
+    const request = await mutationInput({ operationKind: "date_transition", trigger: "date_transition", idempotencyKey: "rejected-route-1", persistRejectedAttempt: true });
+    const first = await startCanonicalLeaseOccupancy(request);
+    const replay = await startCanonicalLeaseOccupancy(request);
+    expect(first).toMatchObject({ canonicalOutcome: "rejected", reasons: ["MULTIPLE_CURRENT_LEASES"] });
+    expect(replay.outcome).toBe("idempotent_replay");
+    expect(fake.list("canonicalEvents").filter((event) => event.type === "lease.occupancy_start_rejected")).toHaveLength(1);
+    expect(fake.list("leaseStartRequests")).toHaveLength(1);
+    expect(fake.read("leases", "lease-1")).not.toHaveProperty("occupancyEffective", true);
+  });
+
   it("cannot bypass D1 anonymous legacy occupancy rejection", async () => {
     fake = createFakeFirestore();
     seedBase({ unit: { status: "occupied", occupancyStatus: "occupied" }, embedded: { status: "occupied", occupancyStatus: "occupied" } });

--- a/rentchain-api/src/services/leaseStart/__tests__/leaseStartService.test.ts
+++ b/rentchain-api/src/services/leaseStart/__tests__/leaseStartService.test.ts
@@ -5,6 +5,7 @@ import {
   startCanonicalLeaseOccupancy,
   type StartCanonicalLeaseOccupancyInput,
 } from "../leaseStartService";
+import { startSigningCompletionOccupancy } from "../../signing/leaseSigningService";
 
 function createFakeFirestore() {
   const store = new Map<string, Map<string, any>>();
@@ -495,5 +496,54 @@ describe("leaseStartService", () => {
   it("requires a nonempty expected-state token for an occupancy-effective mutation", async () => {
     await expect(startCanonicalLeaseOccupancy({ ...await mutationInput(), expectedStateToken: "" })).rejects.toMatchObject({ code: "lease_start_state_stale" });
     expect(fake.list("canonicalEvents")).toEqual([]);
+  });
+
+  it("replays a real D2 signing completion without recomputing changed expected state", async () => {
+    const request = {
+      firestore: fake.firestore,
+      providerId: "mock",
+      providerEventId: "provider-current-1",
+      occurredAt: evaluationInstant,
+      landlordId: "landlord-1",
+      leaseId: "lease-1",
+      propertyId: "property-1",
+      unitId: "unit-1",
+      tenantId: "tenant-1",
+    };
+    const first = await startSigningCompletionOccupancy(request);
+    const replay = await startSigningCompletionOccupancy(request);
+
+    expect(first).toMatchObject({ replay: false, result: { canonicalOutcome: "occupancy_effective" } });
+    expect(replay).toMatchObject({ replay: true, result: { canonicalOutcome: "occupancy_effective" } });
+    expect(fake.list("canonicalEvents")).toHaveLength(1);
+    expect(fake.list("tenancies")).toHaveLength(1);
+    expect(fake.list("leaseStartRequests")).toHaveLength(1);
+    expect(fake.list("leaseSigningCompletionOperations")).toHaveLength(1);
+  });
+
+  it("replays a deferred future signing completion without occupancy or review evidence", async () => {
+    fake = createFakeFirestore();
+    seedBase({ lease: { startDate: "2027-01-01", endDate: "2027-12-31" } });
+    const request = {
+      firestore: fake.firestore,
+      providerId: "mock",
+      providerEventId: "provider-future-1",
+      occurredAt: evaluationInstant,
+      landlordId: "landlord-1",
+      leaseId: "lease-1",
+      propertyId: "property-1",
+      unitId: "unit-1",
+      tenantId: "tenant-1",
+    };
+    const first = await startSigningCompletionOccupancy(request);
+    const replay = await startSigningCompletionOccupancy(request);
+
+    expect(first).toMatchObject({ replay: false, result: { canonicalOutcome: "created_without_occupancy" } });
+    expect(replay).toMatchObject({ replay: true, result: { canonicalOutcome: "created_without_occupancy" } });
+    expect(fake.list("canonicalEvents")).toEqual([]);
+    expect(fake.list("tenancies")).toEqual([]);
+    expect(fake.list("leaseStartRequests")).toEqual([]);
+    expect(fake.list("leaseSigningCompletionOperations")).toHaveLength(1);
+    expect(fake.read("leases", "lease-1")).not.toHaveProperty("occupancyStartReview");
   });
 });

--- a/rentchain-api/src/services/leaseStart/leaseCreationService.ts
+++ b/rentchain-api/src/services/leaseStart/leaseCreationService.ts
@@ -216,7 +216,8 @@ export async function createCanonicalLease(input: CreateCanonicalLeaseInput): Pr
 
     const eventIds = decision.outcome === "occupancy_effective" ? [creationEventId, occupancyEventId] : [creationEventId];
     const result = { ...baseResult(input, decision, expectedStateToken, requestId, eventIds), leaseId: input.leaseId };
-    transaction.create(leaseRef, { ...input.leaseRecord, id: input.leaseId, occupancyEffective: decision.occupancyEffective, occupancyEffectiveAt: decision.occupancyEffective ? instant : null });
+    const compatibilityStatus = decision.outcome === "occupancy_effective" ? "active" : "pending";
+    transaction.create(leaseRef, { ...input.leaseRecord, id: input.leaseId, status: compatibilityStatus, occupancyEffective: decision.occupancyEffective, occupancyEffectiveAt: decision.occupancyEffective ? instant : null });
     if (input.tenantRecord) transaction.create(tenantRef, { ...input.tenantRecord, id: input.tenantId });
     if (draftRef) transaction.set(draftRef, { status: "activated", leaseId: input.leaseId, activatedAt: instant, updatedAt: instant }, { merge: true });
     transaction.create(firestore.collection("canonicalEvents").doc(creationEventId), canonicalEvent(input, creationEventId, creationType, instant, requestId));

--- a/rentchain-api/src/services/leaseStart/leaseCreationService.ts
+++ b/rentchain-api/src/services/leaseStart/leaseCreationService.ts
@@ -1,0 +1,254 @@
+import { db } from "../../firebase";
+import { evaluateCanonicalLeaseStart, type CanonicalLeaseStartInput } from "../../lib/leases/canonicalLeaseStart";
+import { buildLeaseStartExpectedStateToken, leaseStartDeterministicId, leaseStartHash } from "./leaseStartExpectedState";
+import { LeaseStartServiceError, type LeaseStartOperationKind, type LeaseStartServiceResult } from "./leaseStartService";
+
+export type CreateCanonicalLeaseInput = {
+  landlordId: string;
+  propertyId: string;
+  unitId: string;
+  tenantId: string;
+  leaseId: string;
+  leaseRecord: Record<string, any>;
+  operationKind: Extract<LeaseStartOperationKind, "direct_create" | "draft_activation" | "conversion">;
+  idempotencyKey: string;
+  evaluationInstant: string;
+  actorId: string;
+  source: string;
+  tenantRecord?: Record<string, any> | null;
+  draftActivation?: { draftId: string; expectedLeaseId?: string | null } | null;
+  firestore?: any;
+};
+
+function text(value: unknown): string {
+  return String(value ?? "").trim();
+}
+
+function normalizedInstant(value: unknown): string | null {
+  const parsed = new Date(String(value || ""));
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+}
+
+function data(snapshot: any): any {
+  return snapshot?.exists ? { id: snapshot.id, ...(snapshot.data() || {}) } : null;
+}
+
+function canonicalLease(lease: any) {
+  return {
+    ...lease,
+    id: text(lease?.id),
+    tenantId: lease?.tenantId || lease?.primaryTenantId || lease?.tenantIds?.[0] || null,
+    executionState: lease?.executionState || lease?.executionStatus || lease?.leaseExecutionState || lease?.leaseExecution?.executionStatus,
+    executionStatus: lease?.executionStatus || lease?.executionState || lease?.leaseExecutionState || lease?.leaseExecution?.executionStatus,
+  };
+}
+
+function matchesEmbeddedUnit(unit: any, unitId: string, unitNumber: string): boolean {
+  return [unit?.id, unit?.unitId, unit?.unitNumber].map(text).includes(unitId) || (Boolean(unitNumber) && text(unit?.unitNumber) === unitNumber);
+}
+
+function baseResult(input: CreateCanonicalLeaseInput, decision: any, expectedStateToken: string, requestId: string, eventIds: string[], replay = false): LeaseStartServiceResult {
+  return {
+    outcome: replay ? "idempotent_replay" : decision.outcome,
+    canonicalOutcome: decision.outcome,
+    occupancyEffective: decision.occupancyEffective,
+    reasons: [...decision.reasons],
+    expectedStateToken,
+    auditEventIds: eventIds,
+    idempotency: { key: input.idempotencyKey, replay, resultId: requestId },
+    stateSummary: {
+      leaseId: input.leaseId,
+      propertyId: input.propertyId,
+      unitId: input.unitId,
+      tenantId: input.tenantId,
+      eligibleCurrentLeaseIds: [...decision.context.eligibleCurrentLeaseIds],
+      tenancyIds: [...decision.context.tenancyIds],
+    },
+  };
+}
+
+function canonicalEvent(input: CreateCanonicalLeaseInput, eventId: string, type: "lease.created" | "lease.created_without_occupancy" | "lease.occupancy_started" | "lease.occupancy_start_rejected", occurredAt: string, requestId: string, reasons: string[] = []) {
+  const action = type.replace(/^lease\./, "");
+  return {
+    id: eventId,
+    version: "v1",
+    type,
+    domain: "lease",
+    action,
+    status: type === "lease.occupancy_start_rejected" ? "rejected" : "succeeded",
+    actor: { type: "landlord", id: leaseStartDeterministicId("actor", [input.actorId]), role: "landlord", displayName: null },
+    resource: { type: "lease", id: leaseStartDeterministicId("lease", [input.leaseId]), parentType: "property", parentId: leaseStartDeterministicId("property", [input.propertyId]) },
+    occurredAt,
+    recordedAt: occurredAt,
+    visibility: "internal",
+    summary: type === "lease.occupancy_start_rejected" ? "Canonical lease occupancy start rejected." : type === "lease.occupancy_started" ? "Canonical lease occupancy started." : "Lease created through the canonical lease-start workflow.",
+    metadata: {
+      landlordRef: leaseStartDeterministicId("landlord", [input.landlordId]),
+      tenantRef: leaseStartDeterministicId("tenant", [input.tenantId]),
+      unitRef: leaseStartDeterministicId("unit", [input.unitId]),
+      requestRef: leaseStartDeterministicId("request", [requestId]),
+      operationKind: input.operationKind,
+      trigger: input.operationKind,
+      source: input.source,
+      reasons,
+      legalDetermination: false,
+    },
+    tags: ["lease_start", input.operationKind],
+    appendOnly: true,
+    immutable: true,
+  };
+}
+
+export async function createCanonicalLease(input: CreateCanonicalLeaseInput): Promise<LeaseStartServiceResult & { leaseId: string }> {
+  const firestore = input.firestore || db;
+  const instant = normalizedInstant(input.evaluationInstant);
+  if (!instant || !text(input.idempotencyKey) || input.idempotencyKey.length > 128) {
+    throw new LeaseStartServiceError("lease_start_state_stale");
+  }
+  const requestId = leaseStartDeterministicId("lease_start", [input.landlordId, input.operationKind, input.idempotencyKey]);
+  const requestRef = firestore.collection("leaseStartRequests").doc(requestId);
+  const leaseRef = firestore.collection("leases").doc(input.leaseId);
+  const propertyRef = firestore.collection("properties").doc(input.propertyId);
+  const unitRef = firestore.collection("units").doc(input.unitId);
+  const tenantRef = firestore.collection("tenants").doc(input.tenantId);
+  const draftRef = input.draftActivation ? firestore.collection("leaseDrafts").doc(input.draftActivation.draftId) : null;
+  const {
+    risk: _risk,
+    riskScore: _riskScore,
+    riskGrade: _riskGrade,
+    riskConfidence: _riskConfidence,
+    riskTimeline: _riskTimeline,
+    createdAt: _createdAt,
+    updatedAt: _updatedAt,
+    ...semanticLeaseRecord
+  } = input.leaseRecord;
+  const payloadHash = leaseStartHash({
+    landlordId: input.landlordId,
+    propertyId: input.propertyId,
+    unitId: input.unitId,
+    tenantId: input.tenantId,
+    leaseId: input.leaseId,
+    leaseRecord: semanticLeaseRecord,
+    tenantRecord: input.tenantRecord || null,
+    draftActivation: input.draftActivation || null,
+    operationKind: input.operationKind,
+    idempotencyKey: input.idempotencyKey,
+    actorId: input.actorId,
+    source: input.source,
+  });
+
+  return firestore.runTransaction(async (transaction: any) => {
+    const prior = await transaction.get(requestRef);
+    if (prior.exists) {
+      const priorData = prior.data() || {};
+      if (priorData.payloadHash !== payloadHash) throw new LeaseStartServiceError("lease_start_idempotency_key_reused");
+      return { ...priorData.result, leaseId: input.leaseId, outcome: "idempotent_replay", idempotency: { ...priorData.result.idempotency, replay: true } };
+    }
+
+    const unitsQuery = firestore.collection("units").where("landlordId", "==", input.landlordId).where("propertyId", "==", input.propertyId);
+    const leasesQuery = firestore.collection("leases").where("landlordId", "==", input.landlordId).where("propertyId", "==", input.propertyId);
+    const tenanciesQuery = firestore.collection("tenancies").where("propertyId", "==", input.propertyId);
+    const [leaseSnap, propertySnap, unitSnap, tenantSnap, unitsSnap, leasesSnap, tenanciesSnap, draftSnap] = await Promise.all([
+      transaction.get(leaseRef),
+      transaction.get(propertyRef),
+      transaction.get(unitRef),
+      transaction.get(tenantRef),
+      transaction.get(unitsQuery),
+      transaction.get(leasesQuery),
+      transaction.get(tenanciesQuery),
+      draftRef ? transaction.get(draftRef) : Promise.resolve(null),
+    ]);
+    if (leaseSnap.exists) throw new LeaseStartServiceError("lease_start_idempotency_key_reused");
+    const property = data(propertySnap);
+    const unit = data(unitSnap);
+    const persistedTenant = data(tenantSnap);
+    const tenant = persistedTenant || (input.tenantRecord ? { id: input.tenantId, ...input.tenantRecord } : null);
+    if (!property || !unit || !tenant || text(property.landlordId || property.ownerId || property.owner) !== input.landlordId ||
+        text(unit.landlordId) !== input.landlordId || text(unit.propertyId) !== input.propertyId || text(tenant.landlordId) !== input.landlordId) {
+      throw new LeaseStartServiceError("lease_start_context_ambiguous");
+    }
+    if (input.tenantRecord && persistedTenant) throw new LeaseStartServiceError("lease_start_context_ambiguous");
+    if (draftRef && (!draftSnap?.exists || text(draftSnap.data()?.landlordId) !== input.landlordId)) {
+      throw new LeaseStartServiceError("lease_start_context_ambiguous");
+    }
+    if (draftRef && text(draftSnap.data()?.leaseId) && text(draftSnap.data()?.leaseId) !== input.leaseId) {
+      throw new LeaseStartServiceError("lease_start_idempotency_key_reused");
+    }
+
+    const embeddedUnits = Array.isArray(property.units) ? property.units : [];
+    const unitNumber = text(unit.unitNumber);
+    const matchingUnits = (unitsSnap.docs || []).map(data).filter((entry: any) => entry && (entry.id === input.unitId || (unitNumber && text(entry.unitNumber) === unitNumber)));
+    const embeddedMatches = embeddedUnits.map((entry: any, index: number) => ({ entry, index })).filter(({ entry }: any) => matchesEmbeddedUnit(entry, input.unitId, unitNumber));
+    if (matchingUnits.length !== 1 || matchingUnits[0].id !== input.unitId || embeddedMatches.length !== 1) {
+      throw new LeaseStartServiceError("lease_start_context_ambiguous");
+    }
+
+    const candidateLease = canonicalLease({ ...input.leaseRecord, id: input.leaseId });
+    const contextLeases = (leasesSnap.docs || []).map(data).filter((lease: any) => lease && text(lease.unitId) === input.unitId).map(canonicalLease);
+    const tenancies = (tenanciesSnap.docs || []).map(data).filter((tenancy: any) => tenancy && (text(tenancy.unitId) === input.unitId || (unitNumber && [tenancy.unitNumber, tenancy.unitLabel].map(text).includes(unitNumber))));
+    const embedded = { ...embeddedMatches[0].entry, id: text(embeddedMatches[0].entry.id || embeddedMatches[0].entry.unitId || input.unitId), landlordId: input.landlordId, propertyId: input.propertyId };
+    const canonicalInput: CanonicalLeaseStartInput = {
+      landlordId: input.landlordId,
+      propertyId: input.propertyId,
+      unitId: input.unitId,
+      tenantId: input.tenantId,
+      evaluationInstant: instant,
+      candidateLease,
+      contextLeases,
+      standaloneUnits: [unit],
+      embeddedUnits: [embedded],
+      tenant,
+      tenancies,
+    };
+    const decision = evaluateCanonicalLeaseStart(canonicalInput);
+    const expectedStateToken = buildLeaseStartExpectedStateToken(canonicalInput, decision, { propertyUpdatedAt: property.updatedAt });
+    const creationType = decision.outcome === "created_without_occupancy" ? "lease.created_without_occupancy" : "lease.created";
+    const creationEventId = leaseStartDeterministicId(creationType.replace(/\./g, "_"), [input.landlordId, input.operationKind, input.idempotencyKey, input.leaseId]);
+    const occupancyEventId = leaseStartDeterministicId("lease_occupancy_started", [input.landlordId, input.operationKind, input.idempotencyKey, input.leaseId]);
+    const rejectionEventId = leaseStartDeterministicId("lease_occupancy_start_rejected", [input.landlordId, input.operationKind, input.idempotencyKey, input.leaseId]);
+
+    if (decision.outcome === "rejected") {
+      const result = { ...baseResult(input, decision, expectedStateToken, requestId, [rejectionEventId]), leaseId: input.leaseId };
+      transaction.create(firestore.collection("canonicalEvents").doc(rejectionEventId), canonicalEvent(input, rejectionEventId, "lease.occupancy_start_rejected", instant, requestId, result.reasons));
+      transaction.create(requestRef, { landlordId: input.landlordId, operationKind: input.operationKind, idempotencyKey: input.idempotencyKey, payloadHash, leaseId: input.leaseId, canonicalOutcome: decision.outcome, reasons: result.reasons, occupancyEffective: false, canonicalEventIds: [rejectionEventId], committedAt: instant, result });
+      return result;
+    }
+
+    const eventIds = decision.outcome === "occupancy_effective" ? [creationEventId, occupancyEventId] : [creationEventId];
+    const result = { ...baseResult(input, decision, expectedStateToken, requestId, eventIds), leaseId: input.leaseId };
+    transaction.create(leaseRef, { ...input.leaseRecord, id: input.leaseId, occupancyEffective: decision.occupancyEffective, occupancyEffectiveAt: decision.occupancyEffective ? instant : null });
+    if (input.tenantRecord) transaction.create(tenantRef, { ...input.tenantRecord, id: input.tenantId });
+    if (draftRef) transaction.set(draftRef, { status: "activated", leaseId: input.leaseId, activatedAt: instant, updatedAt: instant }, { merge: true });
+    transaction.create(firestore.collection("canonicalEvents").doc(creationEventId), canonicalEvent(input, creationEventId, creationType, instant, requestId));
+
+    if (decision.outcome === "occupancy_effective") {
+      const postcondition = decision.postcondition;
+      if (!postcondition) throw new LeaseStartServiceError("lease_start_postcondition_failed");
+      const nextUnit = { ...unit, ...postcondition.standaloneUnit };
+      const nextEmbedded = { ...embeddedMatches[0].entry, ...postcondition.embeddedPropertyUnit };
+      const nextEmbeddedUnits = embeddedUnits.map((entry: any, index: number) => index === embeddedMatches[0].index ? nextEmbedded : entry);
+      const tenancyId = postcondition.tenancy.id || leaseStartDeterministicId("tenancy", [input.landlordId, input.propertyId, input.unitId, input.tenantId, input.leaseId]);
+      const tenancyRef = firestore.collection("tenancies").doc(tenancyId);
+      const existingTenancy = tenancies.find((entry: any) => entry.id === tenancyId);
+      const nextTenancy = postcondition.tenancy.action === "reuse" ? { ...existingTenancy } : { ...existingTenancy, ...postcondition.tenancy, id: tenancyId, updatedAt: instant, moveOutAt: null };
+      const nextTenant = { ...tenant, currentLeaseId: input.leaseId, status: "current", updatedAt: instant };
+      const nextTenancies = postcondition.tenancy.action === "create" ? [...tenancies, nextTenancy] : tenancies.map((entry: any) => entry.id === tenancyId ? nextTenancy : entry);
+      const verified = evaluateCanonicalLeaseStart({ ...canonicalInput, candidateLease: { ...candidateLease, occupancyEffective: true, occupancyEffectiveAt: instant }, standaloneUnits: [nextUnit], embeddedUnits: [{ ...nextEmbedded, landlordId: input.landlordId, propertyId: input.propertyId }], tenant: nextTenant, tenancies: nextTenancies });
+      if (verified.outcome !== "already_coherent" || verified.postcondition !== null) throw new LeaseStartServiceError("lease_start_postcondition_failed");
+      result.expectedStateToken = buildLeaseStartExpectedStateToken(
+        { ...canonicalInput, candidateLease: { ...candidateLease, occupancyEffective: true, occupancyEffectiveAt: instant }, standaloneUnits: [nextUnit], embeddedUnits: [{ ...nextEmbedded, landlordId: input.landlordId, propertyId: input.propertyId }], tenant: nextTenant, tenancies: nextTenancies },
+        verified,
+        { propertyUpdatedAt: instant }
+      );
+      transaction.set(propertyRef, { units: nextEmbeddedUnits, updatedAt: instant }, { merge: true });
+      transaction.set(unitRef, nextUnit, { merge: true });
+      transaction.set(tenantRef, { currentLeaseId: input.leaseId, status: "current", updatedAt: instant }, { merge: true });
+      if (postcondition.tenancy.action === "create") transaction.create(tenancyRef, nextTenancy);
+      else if (postcondition.tenancy.action === "reconcile") transaction.set(tenancyRef, nextTenancy, { merge: true });
+      transaction.create(firestore.collection("canonicalEvents").doc(occupancyEventId), canonicalEvent(input, occupancyEventId, "lease.occupancy_started", instant, requestId));
+    }
+
+    transaction.create(requestRef, { landlordId: input.landlordId, operationKind: input.operationKind, idempotencyKey: input.idempotencyKey, payloadHash, leaseId: input.leaseId, canonicalOutcome: decision.outcome, reasons: result.reasons, occupancyEffective: result.occupancyEffective, canonicalEventIds: eventIds, committedAt: instant, result });
+    return result;
+  });
+}

--- a/rentchain-api/src/services/leaseStart/leaseStartService.ts
+++ b/rentchain-api/src/services/leaseStart/leaseStartService.ts
@@ -62,10 +62,12 @@ export type StartCanonicalLeaseOccupancyInput = {
   trigger: LeaseStartTrigger;
   actorId?: string | null;
   source?: string | null;
+  leasePatch?: Record<string, unknown> | null;
+  persistRejectedAttempt?: boolean;
   firestore?: any;
 };
 
-type ContextInput = Pick<StartCanonicalLeaseOccupancyInput, "landlordId" | "propertyId" | "unitId" | "tenantId" | "leaseId" | "evaluationInstant"> & { firestore?: any };
+type ContextInput = Pick<StartCanonicalLeaseOccupancyInput, "landlordId" | "propertyId" | "unitId" | "tenantId" | "leaseId" | "evaluationInstant" | "leasePatch"> & { firestore?: any };
 
 export class LeaseStartServiceError extends Error {
   constructor(public code: LeaseStartErrorCode, public freshContext?: LeaseStartContext) {
@@ -118,7 +120,8 @@ async function readContext(reader: any, input: ContextInput): Promise<{ context:
   ]);
   const property = docData(propertySnap);
   const unit = docData(unitSnap);
-  const candidateLease = docData(leaseSnap);
+  const persistedCandidateLease = docData(leaseSnap);
+  const candidateLease = persistedCandidateLease ? { ...persistedCandidateLease, ...(input.leasePatch || {}) } : null;
   const tenant = docData(tenantSnap);
   if (!property || !unit || !candidateLease || !tenant) throw new LeaseStartServiceError("lease_start_context_ambiguous");
   if (text(property.landlordId || property.ownerId || property.owner) !== input.landlordId ||
@@ -233,6 +236,8 @@ export async function startCanonicalLeaseOccupancy(input: StartCanonicalLeaseOcc
     landlordId: input.landlordId, propertyId: input.propertyId, unitId: input.unitId, tenantId: input.tenantId,
     leaseId: input.leaseId, operationKind: input.operationKind, expectedStateToken: input.expectedStateToken,
     actorId: input.actorId || null, trigger: input.trigger, source: input.source || null,
+    leasePatch: input.leasePatch || null,
+    persistRejectedAttempt: input.persistRejectedAttempt === true,
     evaluationInstant: normalizedInstant,
   });
 
@@ -250,6 +255,35 @@ export async function startCanonicalLeaseOccupancy(input: StartCanonicalLeaseOcc
     // D2 has no live route caller. Canonical rejected and deferred decisions
     // therefore return deterministically with no durable audit or idempotency
     // record. D3 must define authenticated route-attempt persistence policy.
+    if (loaded.context.decision.outcome === "rejected" && input.persistRejectedAttempt === true) {
+      const eventId = leaseStartDeterministicId("lease_occupancy_start_rejected", [input.landlordId, input.operationKind, input.idempotencyKey, input.leaseId]);
+      const rejectedResult: LeaseStartServiceResult = {
+        ...resultFrom(loaded.context, input, requestId),
+        auditEventIds: [eventId],
+        idempotency: { key: input.idempotencyKey, replay: false, resultId: requestId },
+      };
+      transaction.create(firestore.collection("canonicalEvents").doc(eventId), {
+        id: eventId, version: "v1", type: "lease.occupancy_start_rejected", domain: "lease", action: "occupancy_start_rejected", status: "rejected",
+        actor: { type: "landlord", id: leaseStartDeterministicId("actor", [input.actorId || input.landlordId]), role: "landlord", displayName: null },
+        resource: { type: "lease", id: leaseStartDeterministicId("lease", [input.leaseId]), parentType: "property", parentId: leaseStartDeterministicId("property", [input.propertyId]) },
+        occurredAt: normalizedInstant, recordedAt: normalizedInstant, visibility: "internal",
+        summary: "Canonical lease occupancy start rejected.",
+        metadata: {
+          landlordRef: leaseStartDeterministicId("landlord", [input.landlordId]), tenantRef: leaseStartDeterministicId("tenant", [input.tenantId]),
+          unitRef: leaseStartDeterministicId("unit", [input.unitId]), requestRef: leaseStartDeterministicId("request", [requestId]),
+          operationKind: input.operationKind, trigger: input.trigger, source: input.source || null, reasons: rejectedResult.reasons, legalDetermination: false,
+        },
+        tags: ["lease_start", input.trigger, "rejected"], appendOnly: true, immutable: true,
+      });
+      transaction.create(requestRef, {
+        landlordId: input.landlordId, operationKind: input.operationKind, idempotencyKey: input.idempotencyKey,
+        payloadHash, leaseId: input.leaseId, canonicalOutcome: rejectedResult.canonicalOutcome,
+        reasons: rejectedResult.reasons, occupancyEffective: false,
+        resultingExpectedStateToken: rejectedResult.expectedStateToken, canonicalEventIds: [eventId], committedAt: normalizedInstant,
+        result: rejectedResult,
+      });
+      return rejectedResult;
+    }
     if (loaded.context.decision.outcome === "rejected" || loaded.context.decision.outcome === "created_without_occupancy") {
       return resultFrom(loaded.context, input, null);
     }
@@ -287,7 +321,7 @@ export async function startCanonicalLeaseOccupancy(input: StartCanonicalLeaseOcc
       : loaded.records.tenancies.map((tenancy: any) => tenancy.id === tenancyId ? nextTenancy : tenancy);
     const nextCanonicalInput: CanonicalLeaseStartInput = {
       ...loaded.records.canonicalInput,
-      candidateLease: { ...loaded.records.canonicalInput.candidateLease, occupancyEffective: true, occupancyEffectiveAt: normalizedInstant, updatedAt: normalizedInstant },
+      candidateLease: { ...loaded.records.canonicalInput.candidateLease, ...(input.leasePatch || {}), occupancyEffective: true, occupancyEffectiveAt: normalizedInstant, updatedAt: normalizedInstant },
       standaloneUnits: [nextUnit],
       embeddedUnits: [{ ...nextEmbedded, landlordId: input.landlordId, propertyId: input.propertyId }],
       tenant: nextTenant,
@@ -311,7 +345,7 @@ export async function startCanonicalLeaseOccupancy(input: StartCanonicalLeaseOcc
       expectedStateToken: resultingExpectedStateToken,
     };
 
-    transaction.set(loaded.records.leaseRef, { occupancyEffective: true, occupancyEffectiveAt: normalizedInstant, updatedAt: normalizedInstant }, { merge: true });
+    transaction.set(loaded.records.leaseRef, { ...(input.leasePatch || {}), occupancyEffective: true, occupancyEffectiveAt: normalizedInstant, updatedAt: normalizedInstant }, { merge: true });
     transaction.set(loaded.records.propertyRef, { units: nextEmbeddedUnits, updatedAt: normalizedInstant }, { merge: true });
     transaction.set(loaded.records.unitRef, nextUnit, { merge: true });
     transaction.set(loaded.records.tenantRef, { currentLeaseId: input.leaseId, status: "current", updatedAt: normalizedInstant }, { merge: true });

--- a/rentchain-api/src/services/signing/leaseSigningService.ts
+++ b/rentchain-api/src/services/signing/leaseSigningService.ts
@@ -7,6 +7,7 @@ import { deriveLeaseSigningState, type DerivedLeaseSigningState } from "../lease
 import { getConfiguredSigningProvider, signingProviderRegistry } from "./providers";
 import type { ISigningProvider, SigningProviderEventType, SigningProviderFieldPlacement } from "./providers/types";
 import { getCanonicalLeaseStartContext, startCanonicalLeaseOccupancy } from "../leaseStart/leaseStartService";
+import { leaseStartDeterministicId } from "../leaseStart/leaseStartExpectedState";
 
 export type LeaseSigningStatus =
   | "not_started"
@@ -54,6 +55,7 @@ export type SignedLeaseDocumentDownload = {
 
 const REQUESTS = "leaseSigningRequests";
 const EVENTS = "leaseSigningEvents";
+const COMPLETION_OPERATIONS = "leaseSigningCompletionOperations";
 const DEAD_LETTERS = "leaseSigningWebhookDeadLetters";
 let lastGeneratedTimestampMs = 0;
 
@@ -638,6 +640,59 @@ export type SigningWebhookProcessResult = {
   providerResponseText?: string;
 };
 
+export async function startSigningCompletionOccupancy(input: {
+  firestore?: any;
+  providerId: string;
+  providerEventId: string;
+  occurredAt: string;
+  landlordId: string;
+  leaseId: string;
+  propertyId: string;
+  unitId: string;
+  tenantId: string;
+}) {
+  const firestore = input.firestore || db;
+  const idempotencyKey = `${input.providerId}:${input.providerEventId}`;
+  const completionOperationRef = firestore.collection(COMPLETION_OPERATIONS).doc(`lsco_${digest(idempotencyKey, 28)}`);
+  const priorCompletion = await completionOperationRef.get();
+  if (priorCompletion.exists) return { replay: true, result: priorCompletion.data()?.result || null };
+
+  const operationId = leaseStartDeterministicId("lease_start", [input.landlordId, "signing_completion", idempotencyKey]);
+  const priorOperation = await firestore.collection("leaseStartRequests").doc(operationId).get();
+  const occupancyResult = priorOperation.exists
+    ? priorOperation.data()?.result
+    : await (async () => {
+        const context = await getCanonicalLeaseStartContext({ ...input, evaluationInstant: input.occurredAt, firestore });
+        return startCanonicalLeaseOccupancy({
+          landlordId: input.landlordId, propertyId: input.propertyId, unitId: input.unitId, tenantId: input.tenantId,
+          leaseId: input.leaseId, operationKind: "signing_completion", idempotencyKey,
+          expectedStateToken: context.expectedStateToken, evaluationInstant: input.occurredAt,
+          trigger: "signing_completion", actorId: `provider:${input.providerId}`, source: "signing_provider_webhook", firestore,
+        });
+      })();
+  const completionResult = occupancyResult ? {
+    outcome: occupancyResult.outcome || occupancyResult.canonicalOutcome || null,
+    canonicalOutcome: occupancyResult.canonicalOutcome || null,
+    occupancyEffective: occupancyResult.occupancyEffective === true,
+    reasons: Array.isArray(occupancyResult.reasons) ? occupancyResult.reasons : [],
+    auditEventIds: Array.isArray(occupancyResult.auditEventIds) ? occupancyResult.auditEventIds : [],
+  } : null;
+  await completionOperationRef.set({
+    providerId: input.providerId,
+    providerEventRef: `${input.providerId}_evt_${digest(input.providerEventId, 18)}`,
+    leaseId: input.leaseId,
+    landlordId: input.landlordId,
+    canonicalOutcome: occupancyResult?.canonicalOutcome || null,
+    occupancyEffective: occupancyResult?.occupancyEffective === true,
+    canonicalEventIds: Array.isArray(occupancyResult?.auditEventIds) ? occupancyResult.auditEventIds : [],
+    completedAt: input.occurredAt,
+    result: completionResult,
+    rawIdsIncluded: false,
+    payloadIncluded: false,
+  });
+  return { replay: priorOperation.exists, result: completionResult };
+}
+
 export async function processSigningWebhook(input: { providerId: string; headers: any; body: any; rawBody?: Buffer }): Promise<SigningWebhookProcessResult> {
   const provider = signingProviderRegistry.getProvider(input.providerId);
   if (!provider?.isConfigured()) {
@@ -732,21 +787,11 @@ export async function processSigningWebhook(input: { providerId: string; headers
       const tenantId = String(lease.tenantId || lease.primaryTenantId || lease.tenantIds?.[0] || "").trim();
       if (propertyId && unitId && tenantId) {
         try {
-          const context = await getCanonicalLeaseStartContext({ landlordId, propertyId, unitId, tenantId, leaseId, evaluationInstant: occurredAt });
-          const occupancyResult = await startCanonicalLeaseOccupancy({
-            landlordId,
-            propertyId,
-            unitId,
-            tenantId,
-            leaseId,
-            operationKind: "signing_completion",
-            idempotencyKey: `${provider.getProviderId()}:${eventIdentity}`,
-            expectedStateToken: context.expectedStateToken,
-            evaluationInstant: occurredAt,
-            trigger: "signing_completion",
-            actorId: `provider:${provider.getProviderId()}`,
-            source: "signing_provider_webhook",
+          const completion = await startSigningCompletionOccupancy({
+            providerId: provider.getProviderId(), providerEventId: eventIdentity, occurredAt,
+            landlordId, leaseId, propertyId, unitId, tenantId,
           });
+          const occupancyResult = completion.result;
           if (occupancyResult.canonicalOutcome === "rejected") {
             await leaseRef.set({
               occupancyStartReview: {

--- a/rentchain-api/src/services/signing/leaseSigningService.ts
+++ b/rentchain-api/src/services/signing/leaseSigningService.ts
@@ -6,6 +6,7 @@ import { writeCanonicalEvent } from "../../lib/events/buildEvent";
 import { deriveLeaseSigningState, type DerivedLeaseSigningState } from "../leaseStateHelper";
 import { getConfiguredSigningProvider, signingProviderRegistry } from "./providers";
 import type { ISigningProvider, SigningProviderEventType, SigningProviderFieldPlacement } from "./providers/types";
+import { getCanonicalLeaseStartContext, startCanonicalLeaseOccupancy } from "../leaseStart/leaseStartService";
 
 export type LeaseSigningStatus =
   | "not_started"
@@ -708,6 +709,67 @@ export async function processSigningWebhook(input: { providerId: string; headers
     ...safeProviderMetadataFromRequest(data),
     documentMetadata: safeDocumentMetadataFromRequest(data),
   });
+  if (parsed.type === "signed") {
+    const leaseId = String(data?.leaseId || "").trim();
+    const landlordId = String(data?.landlordId || "").trim();
+    const occurredAt = String(parsed.occurredAt || "").trim();
+    const eventIdentity = String(parsed.providerEventId || "").trim();
+    if (!leaseId || !landlordId || !occurredAt || !eventIdentity) {
+      throw Object.assign(new Error("signing_completion_identity_incomplete"), { status: 409 });
+    }
+    const leaseRef = db.collection("leases").doc(leaseId);
+    const leaseSnap = await leaseRef.get();
+    const lease = leaseSnap.exists ? leaseSnap.data() as any : null;
+    if (lease && String(lease.landlordId || "").trim() === landlordId) {
+      await leaseRef.set({
+        executionStatus: "fully_executed",
+        executionState: "fully_executed",
+        fullyExecutedAt: occurredAt,
+        updatedAt: occurredAt,
+      }, { merge: true });
+      const propertyId = String(lease.propertyId || "").trim();
+      const unitId = String(lease.unitId || "").trim();
+      const tenantId = String(lease.tenantId || lease.primaryTenantId || lease.tenantIds?.[0] || "").trim();
+      if (propertyId && unitId && tenantId) {
+        try {
+          const context = await getCanonicalLeaseStartContext({ landlordId, propertyId, unitId, tenantId, leaseId, evaluationInstant: occurredAt });
+          const occupancyResult = await startCanonicalLeaseOccupancy({
+            landlordId,
+            propertyId,
+            unitId,
+            tenantId,
+            leaseId,
+            operationKind: "signing_completion",
+            idempotencyKey: `${provider.getProviderId()}:${eventIdentity}`,
+            expectedStateToken: context.expectedStateToken,
+            evaluationInstant: occurredAt,
+            trigger: "signing_completion",
+            actorId: `provider:${provider.getProviderId()}`,
+            source: "signing_provider_webhook",
+          });
+          if (occupancyResult.canonicalOutcome === "rejected") {
+            await leaseRef.set({
+              occupancyStartReview: {
+                status: "review_needed",
+                reasons: occupancyResult.reasons,
+                evaluatedAt: occurredAt,
+              },
+            }, { merge: true });
+          }
+        } catch (occupancyError: any) {
+          // Signing evidence is independently durable. Canonical occupancy must
+          // fail closed without rolling back a legitimate provider completion.
+          await leaseRef.set({
+            occupancyStartReview: {
+              status: "review_needed",
+              code: String(occupancyError?.code || occupancyError?.message || "lease_start_failed"),
+              evaluatedAt: occurredAt,
+            },
+          }, { merge: true });
+        }
+      }
+    }
+  }
   return {};
 }
 

--- a/rentchain-api/src/services/signing/providers/__tests__/mockSigningProvider.test.ts
+++ b/rentchain-api/src/services/signing/providers/__tests__/mockSigningProvider.test.ts
@@ -41,4 +41,15 @@ describe("MockSigningProvider", () => {
       occurredAt: "2026-01-01T00:00:00.000Z",
     });
   });
+
+  it("fails closed when a webhook has no stable provider event identity", async () => {
+    const provider = new MockSigningProvider();
+
+    await expect(
+      provider.parseWebhookPayload({
+        providerRequestId: "mock_request",
+        type: "signed",
+      })
+    ).rejects.toThrow("signing_webhook_event_identity_missing");
+  });
 });

--- a/rentchain-api/src/services/signing/providers/mockSigningProvider.ts
+++ b/rentchain-api/src/services/signing/providers/mockSigningProvider.ts
@@ -71,9 +71,11 @@ export class MockSigningProvider implements ISigningProvider {
     const type = String(body?.type || body?.eventType || "signed").trim().toLowerCase();
     const allowed = new Set(["sent", "viewed", "signed", "rejected", "expired", "cancelled", "failed", "downloaded"]);
     if (!allowed.has(type)) throw new Error("signing_webhook_type_invalid");
+    const providerEventId = String(body?.eventId || "").trim();
+    if (!providerEventId) throw new Error("signing_webhook_event_identity_missing");
     return {
       providerRequestId,
-      providerEventId: String(body?.eventId || `mock_evt_${digest(`${providerRequestId}:${type}:${nowIso()}`)}`).trim(),
+      providerEventId,
       type: type as any,
       signerEmail: String(body?.signerEmail || "").trim().toLowerCase() || null,
       occurredAt: String(body?.occurredAt || nowIso()),

--- a/rentchain-frontend/server/previewBackendProxy.ts
+++ b/rentchain-frontend/server/previewBackendProxy.ts
@@ -19,6 +19,7 @@ export const PREVIEW_PROXY_CONFIG = {
 export const PREVIEW_BACKEND_TARGET_KEYS = {
   permanent: "permanent",
   pr1555: "pr1555-c99145e5",
+  pr1561: "pr1561-d3-cert",
 } as const;
 
 export type PreviewBackendTarget = {
@@ -41,6 +42,14 @@ const PREVIEW_BACKEND_TARGETS: Record<string, PreviewBackendTarget> = {
       "https://rentchain-pr1555-qa-c99145e5-glistw4pya-nn.a.run.app",
     cloudRunIdTokenAudience:
       "https://rentchain-pr1555-qa-c99145e5-glistw4pya-nn.a.run.app",
+    temporary: true,
+  },
+  [PREVIEW_BACKEND_TARGET_KEYS.pr1561]: {
+    key: PREVIEW_BACKEND_TARGET_KEYS.pr1561,
+    cloudRunServiceUrl:
+      "https://rentchain-pr1561-qa-6256460c-glistw4pya-nn.a.run.app",
+    cloudRunIdTokenAudience:
+      "https://rentchain-pr1561-qa-6256460c-glistw4pya-nn.a.run.app",
     temporary: true,
   },
 };

--- a/rentchain-frontend/server/previewBackendProxy.ts
+++ b/rentchain-frontend/server/previewBackendProxy.ts
@@ -271,7 +271,7 @@ function upstreamHeaders(req: any, googleIdToken: string): Record<string, string
     "X-Serverless-Authorization": `Bearer ${googleIdToken}`,
   };
 
-  for (const name of ["accept", "authorization", "content-type", "x-request-id"]) {
+  for (const name of ["accept", "authorization", "content-type", "idempotency-key", "x-request-id"]) {
     const value = req?.headers?.[name];
     if (typeof value === "string" && value) headers[name] = value;
   }

--- a/rentchain-frontend/src/api/leaseMutationIdempotency.test.ts
+++ b/rentchain-frontend/src/api/leaseMutationIdempotency.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const apiJsonMock = vi.fn(async () => ({ ok: true }));
+
+vi.mock("@/api/http", () => ({ apiJson: apiJsonMock }));
+
+describe("lease mutation idempotency transport", () => {
+  beforeEach(() => apiJsonMock.mockClear());
+
+  it("sends the caller-owned key for direct create and preserves it across retries", async () => {
+    const { createLease } = await import("./leasesApi");
+    const payload = { tenantId: "tenant-1", propertyId: "property-1", unitNumber: "1A", monthlyRent: 1800, startDate: "2026-09-01" };
+    await createLease(payload, "stable-create-key");
+    await createLease(payload, "stable-create-key");
+    expect(apiJsonMock).toHaveBeenCalledTimes(2);
+    expect(apiJsonMock).toHaveBeenNthCalledWith(1, "/leases", expect.objectContaining({ headers: expect.objectContaining({ "Idempotency-Key": "stable-create-key" }) }));
+    expect(apiJsonMock).toHaveBeenNthCalledWith(2, "/leases", expect.objectContaining({ headers: expect.objectContaining({ "Idempotency-Key": "stable-create-key" }) }));
+  });
+
+  it("sends stable keys for draft activation and occupied-unit conversion", async () => {
+    const { activateLeaseDraft } = await import("./leasePacksApi");
+    const { convertUnitReferenceToLease } = await import("./leasesApi");
+    await activateLeaseDraft("draft-1", "draft-key");
+    await convertUnitReferenceToLease("unit-1", "conversion-key", { startDate: "2026-01-01", endDate: "2026-12-31" });
+    expect(apiJsonMock).toHaveBeenCalledWith(
+      "/leases/drafts/draft-1/activate",
+      expect.objectContaining({ headers: expect.objectContaining({ "Idempotency-Key": "draft-key" }) })
+    );
+    expect(apiJsonMock).toHaveBeenCalledWith(
+      "/leases/reconciliation-candidates/unit-1/convert",
+      expect.objectContaining({ headers: expect.objectContaining({ "Idempotency-Key": "conversion-key" }) })
+    );
+  });
+});

--- a/rentchain-frontend/src/api/leasePacksApi.ts
+++ b/rentchain-frontend/src/api/leasePacksApi.ts
@@ -82,12 +82,12 @@ export async function getLeaseSnapshot(snapshotId: string) {
   );
 }
 
-export async function activateLeaseDraft(draftId: string) {
+export async function activateLeaseDraft(draftId: string, idempotencyKey: string) {
   return apiJson<{ ok: true; leaseId: string; lease: Lease }>(
     `/leases/drafts/${encodeURIComponent(draftId)}/activate`,
     {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", "Idempotency-Key": idempotencyKey },
       body: JSON.stringify({}),
     }
   );

--- a/rentchain-frontend/src/api/leasesApi.ts
+++ b/rentchain-frontend/src/api/leasesApi.ts
@@ -446,6 +446,8 @@ export interface CreateLeasePayload {
   endDate?: string | null;
   automationEnabled?: boolean;
   renewalStatus?: LeaseRenewalStatus;
+  executionStatus?: string;
+  status?: LeaseStatus;
 }
 
 export interface UpdateLeasePayload {
@@ -487,6 +489,7 @@ export async function getLeaseReconciliationCandidates(): Promise<{ candidates: 
 
 export async function convertUnitReferenceToLease(
   unitId: string,
+  idempotencyKey: string,
   payload: {
     occupantName?: string;
     tenantEmail?: string;
@@ -500,7 +503,7 @@ export async function convertUnitReferenceToLease(
 ): Promise<{ ok: true; lease: LandlordActiveLease; tenant: { id: string; fullName: string; email?: string | null; phone?: string | null } }> {
   return apiJson(`/leases/reconciliation-candidates/${encodeURIComponent(unitId)}/convert`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", "Idempotency-Key": idempotencyKey },
     body: JSON.stringify(payload),
   });
 }
@@ -598,22 +601,24 @@ export async function getLeasePaymentStatus(id: string): Promise<{
 }
 
 export async function createLease(
-  payload: CreateLeasePayload
-): Promise<{ lease: Lease }> {
-  return apiJson<{ lease: Lease }>("/leases", {
+  payload: CreateLeasePayload,
+  idempotencyKey: string
+): Promise<{ lease: Lease; occupancyOutcome: "created_without_occupancy" | "occupancy_effective" | "already_coherent" }> {
+  return apiJson("/leases", {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", "Idempotency-Key": idempotencyKey },
     body: JSON.stringify(payload),
   });
 }
 
 export async function updateLease(
   id: string,
-  payload: UpdateLeasePayload
+  payload: UpdateLeasePayload,
+  idempotencyKey?: string
 ): Promise<{ lease: Lease }> {
   return apiJson<{ lease: Lease }>(`/leases/${encodeURIComponent(id)}`, {
     method: "PUT",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...(idempotencyKey ? { "Idempotency-Key": idempotencyKey } : {}) },
     body: JSON.stringify(payload),
   });
 }

--- a/rentchain-frontend/src/components/tenants/LeasePackWizardModal.test.tsx
+++ b/rentchain-frontend/src/components/tenants/LeasePackWizardModal.test.tsx
@@ -1,6 +1,6 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createLeaseDraft } from "@/api/leasePacksApi";
+import { activateLeaseDraft, createLeaseDraft, generateLeaseDraftPdf } from "@/api/leasePacksApi";
 import { LeasePackWizardModal } from "./LeasePackWizardModal";
 
 vi.mock("@/api/leasePacksApi", () => ({
@@ -100,5 +100,37 @@ describe("LeasePackWizardModal jurisdiction workflow guidance", () => {
 
     expect(screen.getByText("Lease start date must be on or before the end date.")).toBeInTheDocument();
     expect(createLeaseDraft).not.toHaveBeenCalled();
+  });
+
+  it("reuses an activation key after uncertain transport failure and rotates after a terminal response", async () => {
+    vi.mocked(createLeaseDraft).mockResolvedValue({ ok: true, draftId: "draft-1", draft: {} as any });
+    vi.mocked(generateLeaseDraftPdf).mockResolvedValue({ ok: true, snapshotId: "snapshot-1", scheduleAUrl: "https://example.invalid/schedule-a.pdf" } as any);
+    vi.mocked(activateLeaseDraft)
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockRejectedValueOnce(Object.assign(new Error("conflict"), { status: 409 }))
+      .mockResolvedValueOnce({ ok: true, leaseId: "lease-1", lease: {} as any });
+    render(
+      <LeasePackWizardModal
+        open
+        onClose={vi.fn()}
+        landlordName="Landlord"
+        tenant={{ id: "tenant-1", fullName: "Tenant One", propertyId: "property-1", propertyName: "Harbour Place", unitId: "unit-1", unit: "1", province: "NS" }}
+        lease={{ startDate: "2026-09-01", endDate: "2027-08-31", monthlyRent: 2000 }}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Generate Schedule A PDF/i }));
+    const activate = await screen.findByRole("button", { name: "Activate Lease" });
+    fireEvent.click(activate);
+    expect(await screen.findByText("Failed to fetch")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Activate Lease" }));
+    expect(await screen.findByText("conflict")).toBeInTheDocument();
+
+    const firstKey = vi.mocked(activateLeaseDraft).mock.calls[0][1];
+    expect(vi.mocked(activateLeaseDraft).mock.calls[1][1]).toBe(firstKey);
+    fireEvent.change(screen.getByLabelText("Base rent (CAD)"), { target: { value: "2100" } });
+    fireEvent.click(screen.getByRole("button", { name: "Activate Lease" }));
+    await waitFor(() => expect(activateLeaseDraft).toHaveBeenCalledTimes(3));
+    expect(vi.mocked(activateLeaseDraft).mock.calls[2][1]).not.toBe(firstKey);
   });
 });

--- a/rentchain-frontend/src/components/tenants/LeasePackWizardModal.tsx
+++ b/rentchain-frontend/src/components/tenants/LeasePackWizardModal.tsx
@@ -16,7 +16,7 @@ import { createPdfExportTimer, errorCodeFromUnknown, recordPdfExportEvent } from
 import { normalizeProvinceCode, provinceLabelFromCode, type ProvinceCode } from "@/lib/provinces";
 import { getJurisdictionWorkflow } from "@/lib/jurisdictionLeaseWorkflow";
 import { LeaseRiskCard } from "@/components/leases/LeaseRiskCard";
-import { createMutationIdempotencyKey } from "@/lib/mutationIdempotency";
+import { createMutationIdempotencyKey, isDeterministicMutationFailure } from "@/lib/mutationIdempotency";
 
 interface Props {
   open: boolean;
@@ -335,6 +335,7 @@ export const LeasePackWizardModal: React.FC<Props> = ({
         })
       );
     } catch (err: any) {
+      if (isDeterministicMutationFailure(err)) activationMutationKeyRef.current = null;
       setError(err?.message || "Failed to activate lease.");
     } finally {
       setActivating(false);

--- a/rentchain-frontend/src/components/tenants/LeasePackWizardModal.tsx
+++ b/rentchain-frontend/src/components/tenants/LeasePackWizardModal.tsx
@@ -16,6 +16,7 @@ import { createPdfExportTimer, errorCodeFromUnknown, recordPdfExportEvent } from
 import { normalizeProvinceCode, provinceLabelFromCode, type ProvinceCode } from "@/lib/provinces";
 import { getJurisdictionWorkflow } from "@/lib/jurisdictionLeaseWorkflow";
 import { LeaseRiskCard } from "@/components/leases/LeaseRiskCard";
+import { createMutationIdempotencyKey } from "@/lib/mutationIdempotency";
 
 interface Props {
   open: boolean;
@@ -75,6 +76,10 @@ export const LeasePackWizardModal: React.FC<Props> = ({
   const [activating, setActivating] = React.useState(false);
   const [activatedLeaseId, setActivatedLeaseId] = React.useState<string>("");
   const [activatedLease, setActivatedLease] = React.useState<Lease | null>(null);
+  const activationMutationKeyRef = React.useRef<string | null>(null);
+  React.useEffect(() => {
+    activationMutationKeyRef.current = null;
+  }, [draftId]);
   const [provinceCode, setProvinceCode] = React.useState<ProvinceCode | null>(null);
   const [provinceLoading, setProvinceLoading] = React.useState(false);
   const [state, setState] = React.useState<FormState>({
@@ -313,7 +318,10 @@ export const LeasePackWizardModal: React.FC<Props> = ({
     setActivating(true);
     setError("");
     try {
-      const result = await activateLeaseDraft(draftId);
+      const mutationKey = activationMutationKeyRef.current || createMutationIdempotencyKey("lease-draft-activation");
+      activationMutationKeyRef.current = mutationKey;
+      const result = await activateLeaseDraft(draftId, mutationKey);
+      activationMutationKeyRef.current = null;
       setActivatedLeaseId(result.leaseId);
       setActivatedLease(result.lease);
       showToast({

--- a/rentchain-frontend/src/lib/mutationIdempotency.test.ts
+++ b/rentchain-frontend/src/lib/mutationIdempotency.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it, vi } from "vitest";
+import { createMutationIdempotencyKey } from "./mutationIdempotency";
+
+describe("createMutationIdempotencyKey", () => {
+  it("creates a new caller-owned identity only when invoked for new intent", () => {
+    const randomUUID = vi.spyOn(crypto, "randomUUID")
+      .mockReturnValueOnce("00000000-0000-4000-8000-000000000001")
+      .mockReturnValueOnce("00000000-0000-4000-8000-000000000002");
+    expect(createMutationIdempotencyKey("lease-create")).toBe("lease-create:00000000-0000-4000-8000-000000000001");
+    expect(createMutationIdempotencyKey("lease-create")).toBe("lease-create:00000000-0000-4000-8000-000000000002");
+    randomUUID.mockRestore();
+  });
+});

--- a/rentchain-frontend/src/lib/mutationIdempotency.test.ts
+++ b/rentchain-frontend/src/lib/mutationIdempotency.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { createMutationIdempotencyKey } from "./mutationIdempotency";
+import { createMutationIdempotencyKey, isDeterministicMutationFailure } from "./mutationIdempotency";
 
 describe("createMutationIdempotencyKey", () => {
   it("creates a new caller-owned identity only when invoked for new intent", () => {
@@ -9,5 +9,12 @@ describe("createMutationIdempotencyKey", () => {
     expect(createMutationIdempotencyKey("lease-create")).toBe("lease-create:00000000-0000-4000-8000-000000000001");
     expect(createMutationIdempotencyKey("lease-create")).toBe("lease-create:00000000-0000-4000-8000-000000000002");
     randomUUID.mockRestore();
+  });
+
+  it("distinguishes terminal HTTP responses from uncertain transport outcomes", () => {
+    expect(isDeterministicMutationFailure(Object.assign(new Error("invalid"), { status: 400 }))).toBe(true);
+    expect(isDeterministicMutationFailure(Object.assign(new Error("conflict"), { status: 409 }))).toBe(true);
+    expect(isDeterministicMutationFailure(new TypeError("Failed to fetch"))).toBe(false);
+    expect(isDeterministicMutationFailure(Object.assign(new Error("server unavailable"), { status: 503 }))).toBe(false);
   });
 });

--- a/rentchain-frontend/src/lib/mutationIdempotency.ts
+++ b/rentchain-frontend/src/lib/mutationIdempotency.ts
@@ -1,0 +1,4 @@
+export function createMutationIdempotencyKey(scope: string): string {
+  const normalizedScope = String(scope || "mutation").trim().replace(/[^a-zA-Z0-9:_-]/g, "_").slice(0, 48) || "mutation";
+  return `${normalizedScope}:${crypto.randomUUID()}`;
+}

--- a/rentchain-frontend/src/lib/mutationIdempotency.ts
+++ b/rentchain-frontend/src/lib/mutationIdempotency.ts
@@ -2,3 +2,8 @@ export function createMutationIdempotencyKey(scope: string): string {
   const normalizedScope = String(scope || "mutation").trim().replace(/[^a-zA-Z0-9:_-]/g, "_").slice(0, 48) || "mutation";
   return `${normalizedScope}:${crypto.randomUUID()}`;
 }
+
+export function isDeterministicMutationFailure(error: unknown): boolean {
+  const status = Number((error as { status?: unknown } | null)?.status);
+  return Number.isInteger(status) && status >= 400 && status < 500;
+}

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
@@ -1013,6 +1013,7 @@ describe("LandlordActiveLeasesPage", () => {
     await waitFor(() =>
       expect(mocks.convertUnitReferenceToLease).toHaveBeenCalledWith(
         "unit-9",
+        expect.stringMatching(/^lease-conversion:/),
         expect.objectContaining({
           tenantPhone: "90255511119",
           coApplicantEmail: "coapplicant@example.com",

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
@@ -1025,6 +1025,34 @@ describe("LandlordActiveLeasesPage", () => {
     );
   });
 
+  it("reuses a conversion key after an uncertain failure and rotates it after a terminal conflict", async () => {
+    mocks.convertUnitReferenceToLease
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockRejectedValueOnce(Object.assign(new Error("conflict"), { status: 409 }))
+      .mockResolvedValueOnce({ ok: true, lease: { id: "lease-9" }, tenant: { id: "tenant-9", fullName: "Recovered Tenant" } });
+    render(
+      <MemoryRouter>
+        <LandlordActiveLeasesPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Occupied units missing lease records/i)).toBeInTheDocument();
+    fireEvent.click(screen.getAllByRole("button", { name: "Convert unit 9 to lease" })[0]);
+    fireEvent.click(screen.getByRole("button", { name: "Create lease" }));
+    expect(await screen.findByText("Failed to fetch")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Create lease" }));
+    expect(await screen.findByText("conflict")).toBeInTheDocument();
+
+    const firstKey = mocks.convertUnitReferenceToLease.mock.calls[0][1];
+    const retryKey = mocks.convertUnitReferenceToLease.mock.calls[1][1];
+    expect(retryKey).toBe(firstKey);
+
+    fireEvent.change(screen.getByLabelText("Tenant phone (optional)"), { target: { value: "9025559999" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create lease" }));
+    await waitFor(() => expect(mocks.convertUnitReferenceToLease).toHaveBeenCalledTimes(3));
+    expect(mocks.convertUnitReferenceToLease.mock.calls[2][1]).not.toBe(firstKey);
+  });
+
   it("blocks conversion when the start date is after the end date", async () => {
     render(
       <MemoryRouter>

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
@@ -29,6 +29,7 @@ import { isUpgradeRequiredError } from "@/lib/gatedFeatureErrors";
 import "./LandlordActiveLeasesPage.css";
 import { canonicalLeaseTermLabel, canonicalOccupancyLabel } from "@/lib/leases/canonicalStatePresentation";
 import { ResolveOccupancyDrawer } from "@/components/occupancy/ResolveOccupancyDrawer";
+import { createMutationIdempotencyKey } from "@/lib/mutationIdempotency";
 
 function formatCurrency(value: number | null | undefined) {
   const amount = typeof value === "number" ? value : 0;
@@ -456,6 +457,10 @@ export default function LandlordActiveLeasesPage() {
   const [startDate, setStartDate] = React.useState(todayIso());
   const [endDate, setEndDate] = React.useState("");
   const [monthlyRent, setMonthlyRent] = React.useState("");
+  const convertMutationKeyRef = React.useRef<string | null>(null);
+  React.useEffect(() => {
+    convertMutationKeyRef.current = null;
+  }, [selectedCandidate?.unitId, occupantName, tenantEmail, tenantPhone, coApplicantEmail, coApplicantPhone, startDate, endDate, monthlyRent]);
   const [isNarrowLayout, setIsNarrowLayout] = React.useState(() => {
     if (typeof window === "undefined" || typeof window.matchMedia !== "function") return false;
     return window.matchMedia("(max-width: 768px)").matches;
@@ -599,7 +604,9 @@ export default function LandlordActiveLeasesPage() {
     }
     setConvertSaving(true);
     try {
-      await convertUnitReferenceToLease(selectedCandidate.unitId, {
+      const mutationKey = convertMutationKeyRef.current || createMutationIdempotencyKey("lease-conversion");
+      convertMutationKeyRef.current = mutationKey;
+      await convertUnitReferenceToLease(selectedCandidate.unitId, mutationKey, {
         occupantName,
         tenantEmail: tenantEmail.trim() || undefined,
         tenantPhone: tenantPhone.trim() || undefined,
@@ -609,6 +616,7 @@ export default function LandlordActiveLeasesPage() {
         endDate: endDate || null,
         monthlyRent: Number(monthlyRent || 0),
       });
+      convertMutationKeyRef.current = null;
       setSelectedCandidate(null);
       setConvertError(null);
       await load();

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
@@ -29,7 +29,7 @@ import { isUpgradeRequiredError } from "@/lib/gatedFeatureErrors";
 import "./LandlordActiveLeasesPage.css";
 import { canonicalLeaseTermLabel, canonicalOccupancyLabel } from "@/lib/leases/canonicalStatePresentation";
 import { ResolveOccupancyDrawer } from "@/components/occupancy/ResolveOccupancyDrawer";
-import { createMutationIdempotencyKey } from "@/lib/mutationIdempotency";
+import { createMutationIdempotencyKey, isDeterministicMutationFailure } from "@/lib/mutationIdempotency";
 
 function formatCurrency(value: number | null | undefined) {
   const amount = typeof value === "number" ? value : 0;
@@ -621,6 +621,7 @@ export default function LandlordActiveLeasesPage() {
       setConvertError(null);
       await load();
     } catch (err: unknown) {
+      if (isDeterministicMutationFailure(err)) convertMutationKeyRef.current = null;
       setConvertError(errorMessage(err, "Failed to convert reference to lease."));
     } finally {
       setConvertSaving(false);

--- a/rentchain-frontend/src/platform/leasePreviewProxy.integration.test.ts
+++ b/rentchain-frontend/src/platform/leasePreviewProxy.integration.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   handlePreviewBackendProxy,
+  PREVIEW_BACKEND_TARGET_KEYS,
   PREVIEW_PROXY_CONFIG,
   type PreviewBackendProxyDependencies,
 } from "../../server/previewBackendProxy";
@@ -63,7 +64,7 @@ describe("first-party lease mutation through the Preview proxy", () => {
 
   beforeEach(() => {
     process.env.VERCEL_ENV = "preview";
-    delete process.env.PREVIEW_BACKEND_TARGET;
+    process.env.PREVIEW_BACKEND_TARGET = PREVIEW_BACKEND_TARGET_KEYS.pr1561;
     vi.stubEnv("VITE_DEPLOY_ENV", "preview");
     vi.stubEnv("VITE_API_BASE_URL", "/api/preview-backend");
     authMocks.getAuthToken.mockClear();
@@ -138,7 +139,10 @@ describe("first-party lease mutation through the Preview proxy", () => {
 
     expect(sameOriginRequests).toEqual(["/api/preview-backend/api/leases"]);
     expect(cloudRunRequests).toHaveLength(1);
-    expect(cloudRunRequests[0].url).toBe(`${PREVIEW_PROXY_CONFIG.cloudRunServiceUrl}/api/leases`);
+    expect(cloudRunRequests[0].url).toBe(
+      "https://rentchain-pr1561-qa-6256460c-glistw4pya-nn.a.run.app/api/leases",
+    );
+    expect(cloudRunRequests[0].url).not.toContain(PREVIEW_PROXY_CONFIG.cloudRunServiceUrl);
     const outgoingHeaders = new Headers(cloudRunRequests[0].init?.headers);
     expect(outgoingHeaders.get("idempotency-key")).toBe("d3-end-to-end-key-001");
     expect(outgoingHeaders.get("authorization")).toBe("Bearer application-session-token");

--- a/rentchain-frontend/src/platform/leasePreviewProxy.integration.test.ts
+++ b/rentchain-frontend/src/platform/leasePreviewProxy.integration.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  handlePreviewBackendProxy,
+  PREVIEW_PROXY_CONFIG,
+  type PreviewBackendProxyDependencies,
+} from "../../server/previewBackendProxy";
+
+const authMocks = vi.hoisted(() => ({
+  getAuthToken: vi.fn(() => "application-session-token"),
+  getFirebaseIdToken: vi.fn(async () => null),
+}));
+
+vi.mock("@/lib/authToken", () => ({
+  getAuthToken: authMocks.getAuthToken,
+  getTenantToken: vi.fn(() => null),
+}));
+
+vi.mock("@/lib/firebaseAuthToken", () => ({
+  getFirebaseIdToken: authMocks.getFirebaseIdToken,
+  warnIfFirebaseDomainMismatch: vi.fn(),
+}));
+
+function token(payload: string) {
+  return `header.${payload}.signature`;
+}
+
+function jsonResponse(payload: unknown, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function proxyResponseRecorder() {
+  const headers = new Headers();
+  return {
+    statusCode: 200,
+    body: undefined as unknown,
+    headers,
+    setHeader(name: string, value: string | string[]) {
+      headers.set(name, Array.isArray(value) ? value.join(", ") : value);
+    },
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body: unknown) {
+      this.body = body;
+      return this;
+    },
+    send(body: unknown) {
+      this.body = body;
+      return this;
+    },
+  };
+}
+
+describe("first-party lease mutation through the Preview proxy", () => {
+  const originalVercelEnv = process.env.VERCEL_ENV;
+  const originalPreviewBackendTarget = process.env.PREVIEW_BACKEND_TARGET;
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    process.env.VERCEL_ENV = "preview";
+    delete process.env.PREVIEW_BACKEND_TARGET;
+    vi.stubEnv("VITE_DEPLOY_ENV", "preview");
+    vi.stubEnv("VITE_API_BASE_URL", "/api/preview-backend");
+    authMocks.getAuthToken.mockClear();
+    authMocks.getFirebaseIdToken.mockClear();
+  });
+
+  afterEach(() => {
+    if (originalVercelEnv == null) delete process.env.VERCEL_ENV;
+    else process.env.VERCEL_ENV = originalVercelEnv;
+    if (originalPreviewBackendTarget == null) delete process.env.PREVIEW_BACKEND_TARGET;
+    else process.env.PREVIEW_BACKEND_TARGET = originalPreviewBackendTarget;
+    global.fetch = originalFetch;
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("preserves createLease's caller-owned key through same-origin resolution to Cloud Run", async () => {
+    const cloudRunRequests: Array<{ url: string; init?: RequestInit }> = [];
+    const infrastructureFetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "https://sts.googleapis.com/v1/token") {
+        return jsonResponse({
+          access_token: "federated-access-token",
+          token_type: "Bearer",
+          expires_in: 3600,
+        });
+      }
+      if (url.startsWith("https://iamcredentials.googleapis.com/")) {
+        return jsonResponse({ token: token("google-id-token") });
+      }
+      cloudRunRequests.push({ url, init });
+      return jsonResponse({ lease: { id: "synthetic-lease" }, leaseStart: { canonicalOutcome: "occupancy_effective" } }, 201);
+    });
+    const dependencies: PreviewBackendProxyDependencies = {
+      fetchImpl: infrastructureFetch as typeof fetch,
+      getVercelOidcToken: vi.fn(async () => token("vercel-oidc")),
+    };
+    const sameOriginRequests: string[] = [];
+
+    global.fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      sameOriginRequests.push(url);
+      const incomingHeaders = Object.fromEntries(new Headers(init?.headers).entries());
+      const req = {
+        url,
+        method: init?.method || "GET",
+        headers: incomingHeaders,
+        body: init?.body,
+        query: { path: url.split("?")[0].split("/").slice(3) },
+      };
+      const res = proxyResponseRecorder();
+
+      await handlePreviewBackendProxy(req, res, dependencies);
+
+      const body = Buffer.isBuffer(res.body)
+        ? res.body
+        : JSON.stringify(res.body ?? null);
+      return new Response(body, { status: res.statusCode, headers: res.headers });
+    }) as typeof fetch;
+
+    const { createLease } = await import("../api/leasesApi");
+    await createLease(
+      {
+        tenantId: "synthetic-tenant",
+        propertyId: "synthetic-property",
+        unitNumber: "101",
+        monthlyRent: 1800,
+        startDate: "2026-09-01",
+      },
+      "d3-end-to-end-key-001",
+    );
+
+    expect(sameOriginRequests).toEqual(["/api/preview-backend/api/leases"]);
+    expect(cloudRunRequests).toHaveLength(1);
+    expect(cloudRunRequests[0].url).toBe(`${PREVIEW_PROXY_CONFIG.cloudRunServiceUrl}/api/leases`);
+    const outgoingHeaders = new Headers(cloudRunRequests[0].init?.headers);
+    expect(outgoingHeaders.get("idempotency-key")).toBe("d3-end-to-end-key-001");
+    expect(outgoingHeaders.get("authorization")).toBe("Bearer application-session-token");
+    expect(outgoingHeaders.get("x-serverless-authorization")).toBe(
+      `Bearer ${token("google-id-token")}`,
+    );
+    expect(outgoingHeaders.get("x-request-id")).toBeNull();
+  });
+});

--- a/rentchain-frontend/src/platform/previewBackendProxy.test.ts
+++ b/rentchain-frontend/src/platform/previewBackendProxy.test.ts
@@ -132,12 +132,31 @@ describe("Preview backend proxy", () => {
     });
   });
 
+  it("couples the authorized PR #1561 service URL and audience internally", () => {
+    const target = resolvePreviewBackendTarget({
+      vercelEnvironment: "preview",
+      targetKey: PREVIEW_BACKEND_TARGET_KEYS.pr1561,
+    });
+    expect(target).toEqual({
+      key: "pr1561-d3-cert",
+      cloudRunServiceUrl: "https://rentchain-pr1561-qa-6256460c-glistw4pya-nn.a.run.app",
+      cloudRunIdTokenAudience: "https://rentchain-pr1561-qa-6256460c-glistw4pya-nn.a.run.app",
+      temporary: true,
+    });
+  });
+
   it.each([
     ["production", PREVIEW_BACKEND_TARGET_KEYS.pr1555],
     ["development", PREVIEW_BACKEND_TARGET_KEYS.pr1555],
+    ["production", PREVIEW_BACKEND_TARGET_KEYS.pr1561],
+    ["development", PREVIEW_BACKEND_TARGET_KEYS.pr1561],
     ["preview", ""],
     ["preview", "unknown"],
+    ["preview", "pr1562"],
+    ["preview", "arbitrary"],
+    ["preview", "https://attacker.example"],
     ["preview", "https://metadata.google.internal"],
+    ["preview", "https://arbitrary.a.run.app"],
     ["preview", "https://rentchain-landlord-api-cyaabkl54a-uc.a.run.app"],
     ["preview", "rentchain-pr1555-qa-wrong-region"],
     ["preview", "rentchain-pr1555-qa-cross-project"],
@@ -178,6 +197,31 @@ describe("Preview backend proxy", () => {
     );
   });
 
+  it.each([
+    ["service URL", {
+      key: PREVIEW_BACKEND_TARGET_KEYS.pr1561,
+      cloudRunServiceUrl: "https://arbitrary.a.run.app",
+      cloudRunIdTokenAudience: "https://rentchain-pr1561-qa-6256460c-glistw4pya-nn.a.run.app",
+      temporary: true,
+    }],
+    ["ID-token audience", {
+      key: PREVIEW_BACKEND_TARGET_KEYS.pr1561,
+      cloudRunServiceUrl: "https://rentchain-pr1561-qa-6256460c-glistw4pya-nn.a.run.app",
+      cloudRunIdTokenAudience: "https://arbitrary.a.run.app",
+      temporary: true,
+    }],
+    ["temporary flag", {
+      key: PREVIEW_BACKEND_TARGET_KEYS.pr1561,
+      cloudRunServiceUrl: "https://rentchain-pr1561-qa-6256460c-glistw4pya-nn.a.run.app",
+      cloudRunIdTokenAudience: "https://rentchain-pr1561-qa-6256460c-glistw4pya-nn.a.run.app",
+      temporary: false,
+    }],
+  ])("rejects a tampered PR #1561 mapping: %s", (_label, target) => {
+    expect(() => assertPreviewBackendTarget(target, "preview")).toThrow(
+      "PREVIEW_PROXY_TARGET_REJECTED",
+    );
+  });
+
   it("routes the authorized target using the same URL for ID-token audience and upstream", async () => {
     process.env.PREVIEW_BACKEND_TARGET = PREVIEW_BACKEND_TARGET_KEYS.pr1555;
     const { requests, dependencies } = successfulDependencies();
@@ -199,6 +243,34 @@ describe("Preview backend proxy", () => {
     expect(requests[1].init?.body).toBe(JSON.stringify({ audience: expected, includeEmail: false }));
     expect(requests[2].url).toBe(`${expected}/api/me`);
     expect(requests.every(({ url }) => !url.includes("attacker.invalid"))).toBe(true);
+  });
+
+  it("routes the PR #1561 target only to its exact registered backend", async () => {
+    process.env.PREVIEW_BACKEND_TARGET = PREVIEW_BACKEND_TARGET_KEYS.pr1561;
+    const { requests, dependencies } = successfulDependencies();
+    const res = responseRecorder();
+
+    await handlePreviewBackendProxy(
+      request("/api/preview-backend/api/leases", "POST", {
+        headers: {
+          authorization: "Bearer application-session-token",
+          "content-type": "application/json",
+          "idempotency-key": "pr1561-target-key",
+        },
+        body: { synthetic: true },
+      }),
+      res,
+      dependencies,
+    );
+
+    const expected = "https://rentchain-pr1561-qa-6256460c-glistw4pya-nn.a.run.app";
+    expect(requests[1].init?.body).toBe(JSON.stringify({ audience: expected, includeEmail: false }));
+    expect(requests[2].url).toBe(`${expected}/api/leases`);
+    expect(requests[2].init?.headers).toMatchObject({
+      authorization: "Bearer application-session-token",
+      "idempotency-key": "pr1561-target-key",
+      "X-Serverless-Authorization": `Bearer ${token("google-id-token")}`,
+    });
   });
 
   it("accepts only Preview and rejects Production or Development", async () => {

--- a/rentchain-frontend/src/platform/previewBackendProxy.test.ts
+++ b/rentchain-frontend/src/platform/previewBackendProxy.test.ts
@@ -363,6 +363,79 @@ describe("Preview backend proxy", () => {
     expect(JSON.stringify(requests[2].init?.headers)).not.toContain("must-not-forward");
   });
 
+  it.each([
+    "d3-runtime-cert-key-123",
+    "mutation_ABC-123.xyz",
+  ])("forwards an opaque Idempotency-Key unchanged to the backend request: %s", async (idempotencyKey) => {
+    const { requests, dependencies } = successfulDependencies();
+    const res = responseRecorder();
+
+    await handlePreviewBackendProxy(
+      request("/api/preview-backend/api/leases", "POST", {
+        headers: {
+          authorization: "Bearer application-session-token",
+          "content-type": "application/json",
+          "idempotency-key": idempotencyKey,
+          "x-request-id": "trace-only-request-id",
+        },
+        body: { synthetic: true },
+      }),
+      res,
+      dependencies,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(requests[2].url).toBe(`${PREVIEW_PROXY_CONFIG.cloudRunServiceUrl}/api/leases`);
+    expect(requests[2].init?.headers).toMatchObject({
+      authorization: "Bearer application-session-token",
+      "content-type": "application/json",
+      "idempotency-key": idempotencyKey,
+      "x-request-id": "trace-only-request-id",
+      "X-Serverless-Authorization": `Bearer ${token("google-id-token")}`,
+    });
+  });
+
+  it("does not synthesize Idempotency-Key from x-request-id", async () => {
+    const { requests, dependencies } = successfulDependencies();
+    const res = responseRecorder();
+
+    await handlePreviewBackendProxy(
+      request("/api/preview-backend/api/leases", "POST", {
+        headers: {
+          "content-type": "application/json",
+          "x-request-id": "trace-only-request-id",
+        },
+        body: { synthetic: true },
+      }),
+      res,
+      dependencies,
+    );
+
+    expect(requests[2].init?.headers).toMatchObject({
+      "x-request-id": "trace-only-request-id",
+    });
+    expect(requests[2].init?.headers).not.toHaveProperty("idempotency-key");
+  });
+
+  it("fails closed instead of concatenating duplicate Idempotency-Key values", async () => {
+    const { requests, dependencies } = successfulDependencies();
+    const res = responseRecorder();
+
+    await handlePreviewBackendProxy(
+      request("/api/preview-backend/api/leases", "POST", {
+        headers: {
+          "content-type": "application/json",
+          "idempotency-key": ["first-key", "second-key"],
+        },
+        body: { synthetic: true },
+      }),
+      res,
+      dependencies,
+    );
+
+    expect(requests[2].init?.headers).not.toHaveProperty("idempotency-key");
+  });
+
   it("returns sanitized token-boundary errors", async () => {
     const res = responseRecorder();
     await handlePreviewBackendProxy(


### PR DESCRIPTION
## Summary
- migrates direct lease creation, draft activation, occupied-unit conversion, signing completion, and eligibility-changing lease edits onto the canonical D1/D2 lease-start boundary
- requires stable caller-owned `Idempotency-Key` values for synchronous first-party mutations; `x-request-id` remains tracing only
- forwards caller-supplied `Idempotency-Key` values unchanged through the same-origin Preview proxy while preserving separate application and Cloud Run authorization
- adds the closed, explicit, Preview-only `pr1561-d3-cert` target for the fixed PR #1561 certification service slot
- removes legacy lease-start occupancy synchronization from the migrated workflows while preserving deferred-valid lease creation

## Runtime certification status
- the second exact-head runtime attempt reached the exact-head Vercel Preview and temporary Cloud Run backend, then stopped before domain mutation because the closed proxy registry lacked the PR #1561 target
- the PR #1561 certification target is now explicitly registered without accepting arbitrary URLs, wildcard hosts, or environment-derived service names
- deterministic coverage exercises real `createLease` → real Preview same-origin URL resolution → real proxy handler → mocked PR #1561 Cloud Run and proves the caller key arrives unchanged
- runtime certification has not passed and must be rerun on this new exact head after source review and a new exact-whole-head backend image build

## Safety boundaries
- runtime integration phase only
- no Preview or Production deployment in this source correction
- no Firestore indexes or data migration
- End Lease unchanged
- restore-active unchanged
- future-start scheduler not implemented
- D4/runtime certification remains separately gated

## Validation
- backend canonical/transaction/route/signing/occupancy suites: 196 passed
- frontend PR-changed suites: 94 passed, including 61 Preview proxy tests and the caller-to-PR-1561-Cloud-Run integration regression
- backend TypeScript build: passed on Node 24.19.0
- frontend production build: passed on Node 24.19.0
- `git diff --check`: passed

Draft only. Do not merge, deploy, or treat runtime certification as complete.
