### PR TITLE
Correct lease pack signing handoff semantics

### DIFF
--- a/rentchain-api/src/routes/__tests__/leaseConflictResponses.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseConflictResponses.test.ts
@@ -3,7 +3,7 @@ import request from "supertest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { leaseService } from "../../services/leaseService";
 
-const { fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
+const { fakeDb, getSeededDoc, resetFakeDb, seedDoc } = vi.hoisted(() => {
   const store = new Map<string, Map<string, any>>();
   let idSeq = 0;
 
@@ -61,6 +61,7 @@ const { fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
       store.clear();
       idSeq = 0;
     },
+    getSeededDoc: (name: string, id: string) => ensureCollection(name).get(id)?.data,
     seedDoc: (name: string, id: string, data: any) => ensureCollection(name).set(id, { id, data }),
     fakeDb: {
       runTransaction: async (callback: any) => callback({
@@ -168,7 +169,7 @@ describe("lease conflict responses", () => {
     expect(res.body?.reasons).toContain("MULTIPLE_CURRENT_LEASES");
   });
 
-  it("keeps the same machine-readable conflict code for draft activation overlaps", async () => {
+  it("creates a pending-signing lease without resolving an occupied-unit conflict", async () => {
     seedUnit("unit-1", { unitNumber: "A", status: "occupied" });
     seedDoc("properties", "prop-1", { landlordId: "landlord-1", units: [{ id: "unit-1", unitId: "unit-1", unitNumber: "A", status: "occupied", tenantId: "tenant-1" }] });
     seedDoc("tenants", "tenant-2", { landlordId: "landlord-1", currentLeaseId: null });
@@ -192,8 +193,19 @@ describe("lease conflict responses", () => {
 
     const res = await request(app).post("/drafts/draft-1/activate").set("Idempotency-Key", "conflict-draft").send({});
 
-    expect(res.status).toBe(409);
-    expect(res.body?.error).toBe("conflicting_active_lease_agreement");
-    expect(res.body?.reasons).toContain("MULTIPLE_CURRENT_LEASES");
+    expect(res.status).toBe(200);
+    expect(res.body?.lease).toMatchObject({
+      status: "pending",
+      executionStatus: "draft",
+      executionState: "draft",
+      signingStatus: "not_started",
+    });
+    expect(res.body?.occupancyOutcome).toBe("created_without_occupancy");
+    expect(getSeededDoc("units", "unit-1")).toMatchObject({
+      status: "occupied",
+    });
+    expect(getSeededDoc("tenants", "tenant-2")).toMatchObject({
+      currentLeaseId: null,
+    });
   });
 });

--- a/rentchain-api/src/routes/__tests__/leaseDraftRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseDraftRoutes.test.ts
@@ -562,9 +562,25 @@ describe("lease draft routes", () => {
       email: "tenant@example.com",
     });
 
-    const createRes = await request(app).post("/drafts").set(auth).send(payload);
+    const createRes = await request(app).post("/drafts").set(auth).send({
+      ...payload,
+      executionStatus: "fully_executed",
+      executionState: "fully_executed",
+      fullyExecutedAt: "2026-03-01T00:00:00.000Z",
+      status: "active",
+    });
     expect(createRes.status).toBe(201);
     const draftId = String(createRes.body?.draftId || "");
+    expect(createRes.body?.draft).toEqual(expect.objectContaining({ status: "draft" }));
+    expect(createRes.body?.draft).not.toHaveProperty("executionStatus");
+    expect(createRes.body?.draft).not.toHaveProperty("executionState");
+    expect(createRes.body?.draft).not.toHaveProperty("fullyExecutedAt");
+
+    const generateRes = await request(app)
+      .post(`/drafts/${encodeURIComponent(draftId)}/generate`)
+      .set(auth)
+      .send({ tenantNames: ["Tenant One"], propertyAddress: "1 Test Street", unitLabel: "unit-1" });
+    expect(generateRes.status).toBe(201);
 
     const activateRes = await request(app)
       .post(`/drafts/${encodeURIComponent(draftId)}/activate`)
@@ -573,7 +589,13 @@ describe("lease draft routes", () => {
       .send({});
     expect(activateRes.status).toBe(200);
     expect(activateRes.body?.ok).toBe(true);
-    expect(activateRes.body?.lease).toEqual(expect.objectContaining({ status: "pending", occupancyEffective: false }));
+    expect(activateRes.body?.lease).toEqual(expect.objectContaining({
+      status: "pending",
+      executionStatus: "draft",
+      executionState: "draft",
+      signingStatus: "not_started",
+      occupancyEffective: false,
+    }));
     const leaseId = String(activateRes.body?.leaseId || "");
     expect(leaseId).toBeTruthy();
     expect(activateRes.body?.leaseNotification).toEqual(
@@ -604,31 +626,85 @@ describe("lease draft routes", () => {
       })
     );
     const persistedLease = await fakeDb.collection("leases").doc(leaseId).get();
-    expect(persistedLease.data()).toEqual(expect.objectContaining({ status: "pending", occupancyEffective: false }));
+    expect(persistedLease.data()).toEqual(expect.objectContaining({
+      status: "pending",
+      executionStatus: "draft",
+      executionState: "draft",
+      signingStatus: "not_started",
+      occupancyEffective: false,
+    }));
     expect(leaseService.getById(leaseId)).toBeUndefined();
   });
 
-  it.each([
-    ["future", { startDate: "2027-01-01", endDate: "2027-12-31", executionStatus: "fully_executed" }, "pending", false],
-    ["eligible current", { startDate: "2026-01-01", endDate: "2026-12-31", executionStatus: "fully_executed" }, "active", true],
-  ])("activates a %s draft with canonical compatibility status", async (_label, overrides, expectedStatus, occupancyEffective) => {
-    const draftId = `draft-${String(_label).replace(/\s/g, "-")}`;
-    await fakeDb.collection("leaseDrafts").doc(draftId).set({ ...payload, ...overrides, landlordId: "landlord-1", status: "generated" });
+  it("creates a future generated lease pending signing without occupancy", async () => {
     const router = (await import("../leaseRoutes")).default;
     const app = express();
     app.use(express.json());
     app.use(router);
 
+    const created = await request(app).post("/drafts").set(auth).send({
+      ...payload,
+      startDate: "2027-01-01",
+      endDate: "2027-12-31",
+    });
+    const draftId = String(created.body?.draftId || "");
+    expect((await request(app).post(`/drafts/${draftId}/generate`).set(auth).send({})).status).toBe(201);
+
     const first = await request(app).post(`/drafts/${draftId}/activate`).set(auth).set("Idempotency-Key", `activate-${draftId}`).send({});
     expect(first.status).toBe(200);
-    expect(first.body?.lease).toEqual(expect.objectContaining({ status: expectedStatus, occupancyEffective }));
-    expect((await fakeDb.collection("leases").doc(first.body.leaseId).get()).data()).toEqual(expect.objectContaining({ status: expectedStatus, occupancyEffective }));
-    expect(leaseService.getById(first.body.leaseId) !== undefined).toBe(occupancyEffective);
+    expect(first.body?.lease).toEqual(expect.objectContaining({
+      status: "pending",
+      executionStatus: "draft",
+      signingStatus: "not_started",
+      occupancyEffective: false,
+    }));
+    expect((await fakeDb.collection("leases").doc(first.body.leaseId).get()).data()).toEqual(expect.objectContaining({ status: "pending", occupancyEffective: false }));
+    expect(leaseService.getById(first.body.leaseId)).toBeUndefined();
 
     const replay = await request(app).post(`/drafts/${draftId}/activate`).set(auth).set("Idempotency-Key", `activate-${draftId}`).send({});
     expect(replay.status).toBe(200);
     expect(replay.body?.leaseId).toBe(first.body?.leaseId);
     expect((await fakeDb.collection("leases").get()).docs).toHaveLength(1);
+  });
+
+  it("creates an ambiguous occupied-unit lease pending signing without occupancy mutation", async () => {
+    seedDoc("units", "unit-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitNumber: "unit-1",
+      status: "occupied",
+      occupancyStatus: "occupied",
+      occupantName: "Anonymous Occupant",
+    });
+    const router = (await import("../leaseRoutes")).default;
+    const app = express();
+    app.use(express.json());
+    app.use(router);
+
+    const created = await request(app).post("/drafts").set(auth).send(payload);
+    const draftId = String(created.body?.draftId || "");
+    expect((await request(app).post(`/drafts/${draftId}/generate`).set(auth).send({})).status).toBe(201);
+    const response = await request(app)
+      .post(`/drafts/${draftId}/activate`)
+      .set(auth)
+      .set("Idempotency-Key", "activate-ambiguous-pending")
+      .send({ executionStatus: "fully_executed" });
+
+    expect(response.status).toBe(200);
+    expect(response.body?.lease).toEqual(expect.objectContaining({
+      status: "pending",
+      executionStatus: "draft",
+      occupancyEffective: false,
+    }));
+    expect((await fakeDb.collection("units").doc("unit-1").get()).data()).toEqual(expect.objectContaining({
+      status: "occupied",
+      occupancyStatus: "occupied",
+      occupantName: "Anonymous Occupant",
+    }));
+    expect((await fakeDb.collection("tenants").doc("tenant-1").get()).data()).toEqual(expect.objectContaining({
+      status: "applicant",
+      currentLeaseId: null,
+    }));
   });
 
   it("returns 401 for activate when unauthorized", async () => {

--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -355,6 +355,80 @@ describe("leaseRoutes GET /active", () => {
     expect(res.body?.leases?.[0]?.paymentMethod).toBeUndefined();
   });
 
+  it("keeps pending-signing leases out of current leases while making them discoverable for signing", async () => {
+    seedDoc("properties", "prop-1", { landlordId: "landlord-1", name: "Harbour View", province: "NS" });
+    seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", fullName: "Pending Tenant", email: "pending@example.invalid" });
+    seedDoc("leases", "lease-current-pending", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      tenantId: "tenant-1",
+      tenantIds: ["tenant-1"],
+      primaryTenantId: "tenant-1",
+      unitId: "unit-1",
+      unitNumber: "101",
+      monthlyRent: 1850,
+      startDate: "2026-01-01",
+      endDate: "2099-12-31",
+      status: "pending",
+      executionStatus: "draft",
+      signingStatus: "not_started",
+    });
+    seedDoc("leases", "lease-future-pending", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      tenantId: "tenant-1",
+      tenantIds: ["tenant-1"],
+      primaryTenantId: "tenant-1",
+      unitId: "unit-future",
+      unitNumber: "103",
+      monthlyRent: 1950,
+      startDate: "2099-01-01",
+      endDate: "2099-12-31",
+      status: "pending",
+      executionStatus: "draft",
+      signingStatus: "not_started",
+    });
+    seedDoc("leases", "lease-active", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      tenantId: "tenant-2",
+      unitId: "unit-2",
+      unitNumber: "102",
+      monthlyRent: 1750,
+      startDate: "2026-01-01",
+      endDate: "2026-12-31",
+      status: "active",
+    });
+    seedDoc("leases", "lease-other-landlord-pending", {
+      landlordId: "landlord-2",
+      propertyId: "prop-2",
+      status: "pending",
+    });
+
+    const router = (await import("../leaseRoutes")).default;
+    const pendingRes = await invokeRouter(router, { method: "GET", url: "/pending-signing" });
+    const activeRes = await invokeRouter(router, { method: "GET", url: "/active" });
+
+    expect(pendingRes.status).toBe(200);
+    expect(pendingRes.body?.leases).toHaveLength(2);
+    expect(pendingRes.body?.leases).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: "lease-current-pending",
+        status: "pending",
+        tenantName: "Pending Tenant",
+        leaseExecution: expect.objectContaining({ executionStatus: "draft" }),
+      }),
+      expect.objectContaining({
+        id: "lease-future-pending",
+        status: "pending",
+        startDate: "2099-01-01",
+        leaseExecution: expect.objectContaining({ executionStatus: "draft" }),
+      }),
+    ]));
+    expect(activeRes.status).toBe(200);
+    expect(activeRes.body?.leases.map((lease: any) => lease.id)).toEqual(["lease-active"]);
+  });
+
   it("returns lifecycle summary on landlord-scoped single lease detail responses", async () => {
     seedDoc("properties", "prop-1", { landlordId: "landlord-1", name: "Harbour View", province: "NS" });
     seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", fullName: "Jane Tenant", email: "jane@example.com" });

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -2713,9 +2713,14 @@ router.post("/drafts/:draftId/activate", requireLandlord, async (req: any, res: 
       riskTimeline: riskFields.riskTimeline,
       automationEnabled: true,
       renewalStatus: "unknown",
-      status: String(draft?.status || (String(draft?.executionStatus || draft?.executionState || "") === "fully_executed" ? "active" : "draft")),
-      executionStatus: String(draft?.executionStatus || draft?.executionState || "draft"),
-      executionState: String(draft?.executionState || draft?.executionStatus || "draft"),
+      // Draft activation creates the durable lease record for the signing
+      // workflow. Draft fields are never authoritative execution evidence:
+      // only verified server-side signing completion may establish
+      // fully_executed and invoke occupancy-effective canonical start.
+      status: "pending",
+      executionStatus: "draft",
+      executionState: "draft",
+      signingStatus: "not_started",
       sourceDraftId: draftId,
       createdAt: now,
       updatedAt: now,

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -1617,7 +1617,10 @@ async function loadLatestLeaseNoticeForProjection(leaseId: string, landlordId: s
     .sort((a: any, b: any) => Number(b.updatedAt || b.createdAt || 0) - Number(a.updatedAt || a.createdAt || 0))[0] || null;
 }
 
-async function listLandlordLeaseRows(landlordId: string, opts?: { archived?: boolean | null }) {
+async function listLandlordLeaseRows(
+  landlordId: string,
+  opts?: { archived?: boolean | null; pendingSigning?: boolean }
+) {
   const collectionRef: any = (db as any).collection("leases");
   if (!collectionRef || typeof collectionRef.where !== "function") {
     return [];
@@ -1629,6 +1632,9 @@ async function listLandlordLeaseRows(landlordId: string, opts?: { archived?: boo
   const filtered = rows.filter((row: any) => {
     if (isHiddenFromLandlordLeaseLists(row)) return false;
     const isArchived = Boolean(row?.archivedAt);
+    if (opts?.pendingSigning) {
+      return !isArchived && String(row?.status || "").trim().toLowerCase() === "pending";
+    }
     if (archivedFlag === true) return isArchived;
     if (archivedFlag === false) return !isArchived && isCurrentLeaseStatus(row?.status);
     return true;
@@ -2146,6 +2152,19 @@ router.get("/active", requireLandlord, async (req: any, res: Response) => {
   } catch (err) {
     console.error("[GET /api/leases/active] error", err);
     return res.status(500).json({ ok: false, error: "Failed to load active leases" });
+  }
+});
+
+router.get("/pending-signing", requireLandlord, async (req: any, res: Response) => {
+  try {
+    if (!(await enforceLeaseCapability(req, res))) return;
+    const landlordId = String(req.user?.landlordId || req.user?.id || "").trim();
+    if (!landlordId) return res.status(401).json({ ok: false, error: "Unauthorized" });
+    const leases = await listLandlordLeaseRows(landlordId, { pendingSigning: true });
+    return res.status(200).json({ ok: true, leases });
+  } catch (err) {
+    console.error("[GET /api/leases/pending-signing] error", err);
+    return res.status(500).json({ ok: false, error: "Failed to load leases pending signing" });
   }
 });
 

--- a/rentchain-frontend/src/api/leasesApi.ts
+++ b/rentchain-frontend/src/api/leasesApi.ts
@@ -479,6 +479,10 @@ export async function getActiveLeasesForLandlord(): Promise<{ leases: LandlordAc
   return apiJson<{ leases: LandlordActiveLease[] }>("/leases/active");
 }
 
+export async function getPendingSigningLeasesForLandlord(): Promise<{ leases: LandlordActiveLease[] }> {
+  return apiJson<{ leases: LandlordActiveLease[] }>("/leases/pending-signing");
+}
+
 export async function getArchivedLeasesForLandlord(): Promise<{ leases: LandlordActiveLease[] }> {
   return apiJson<{ leases: LandlordActiveLease[] }>("/leases/archived");
 }

--- a/rentchain-frontend/src/components/tenants/LeasePackWizardModal.test.tsx
+++ b/rentchain-frontend/src/components/tenants/LeasePackWizardModal.test.tsx
@@ -163,7 +163,10 @@ describe("LeasePackWizardModal jurisdiction workflow guidance", () => {
 
     expect(await screen.findByText("Pending signing")).toBeInTheDocument();
     expect(screen.getByText("Lease record created. Signing is still required, and occupancy has not begun.")).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Continue to signing" })).toHaveAttribute("href", "/leases");
+    expect(screen.getByRole("link", { name: "Continue to signing" })).toHaveAttribute(
+      "href",
+      "/leases?view=pending-signing&leaseId=lease-pending"
+    );
     expect(screen.queryByText(/fully executed/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/occupancy started/i)).not.toBeInTheDocument();
   });

--- a/rentchain-frontend/src/components/tenants/LeasePackWizardModal.test.tsx
+++ b/rentchain-frontend/src/components/tenants/LeasePackWizardModal.test.tsx
@@ -120,17 +120,51 @@ describe("LeasePackWizardModal jurisdiction workflow guidance", () => {
     );
 
     fireEvent.click(screen.getByRole("button", { name: /Generate Schedule A PDF/i }));
-    const activate = await screen.findByRole("button", { name: "Activate Lease" });
+    const activate = await screen.findByRole("button", { name: "Create Lease and Continue to Signing" });
     fireEvent.click(activate);
     expect(await screen.findByText("Failed to fetch")).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "Activate Lease" }));
+    fireEvent.click(screen.getByRole("button", { name: "Create Lease and Continue to Signing" }));
     expect(await screen.findByText("conflict")).toBeInTheDocument();
 
     const firstKey = vi.mocked(activateLeaseDraft).mock.calls[0][1];
     expect(vi.mocked(activateLeaseDraft).mock.calls[1][1]).toBe(firstKey);
     fireEvent.change(screen.getByLabelText("Base rent (CAD)"), { target: { value: "2100" } });
-    fireEvent.click(screen.getByRole("button", { name: "Activate Lease" }));
+    fireEvent.click(screen.getByRole("button", { name: "Create Lease and Continue to Signing" }));
     await waitFor(() => expect(activateLeaseDraft).toHaveBeenCalledTimes(3));
     expect(vi.mocked(activateLeaseDraft).mock.calls[2][1]).not.toBe(firstKey);
+  });
+
+  it("presents lease creation as pending signing without implying execution or occupancy", async () => {
+    vi.mocked(createLeaseDraft).mockResolvedValue({ ok: true, draftId: "draft-pending", draft: {} as any });
+    vi.mocked(generateLeaseDraftPdf).mockResolvedValue({
+      ok: true,
+      snapshotId: "snapshot-pending",
+      scheduleAUrl: "https://example.invalid/schedule-a.pdf",
+    } as any);
+    vi.mocked(activateLeaseDraft).mockResolvedValue({
+      ok: true,
+      leaseId: "lease-pending",
+      lease: { status: "pending", occupancyEffective: false } as any,
+    });
+
+    render(
+      <LeasePackWizardModal
+        open
+        onClose={vi.fn()}
+        landlordName="Landlord"
+        tenant={{ id: "tenant-1", fullName: "Tenant One", propertyId: "property-1", propertyName: "Harbour Place", unitId: "unit-1", unit: "1", province: "NS" }}
+        lease={{ startDate: "2026-09-01", endDate: "2027-08-31", monthlyRent: 2000 }}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Generate Schedule A PDF/i }));
+    expect(await screen.findByText(/Schedule A is generated and ready for review/i)).toBeInTheDocument();
+    fireEvent.click(await screen.findByRole("button", { name: "Create Lease and Continue to Signing" }));
+
+    expect(await screen.findByText("Pending signing")).toBeInTheDocument();
+    expect(screen.getByText("Lease record created. Signing is still required, and occupancy has not begun.")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Continue to signing" })).toHaveAttribute("href", "/leases");
+    expect(screen.queryByText(/fully executed/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/occupancy started/i)).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/components/tenants/LeasePackWizardModal.tsx
+++ b/rentchain-frontend/src/components/tenants/LeasePackWizardModal.tsx
@@ -304,11 +304,11 @@ export const LeasePackWizardModal: React.FC<Props> = ({
 
   const handleActivateLease = async () => {
     if (!isNsProvince) {
-      setError("Lease activation from this modal is available for Nova Scotia Schedule A flow only.");
+      setError("Lease creation from this modal is available for Nova Scotia Schedule A flow only.");
       return;
     }
     if (!draftId) {
-      setError("Generate Schedule A PDF first, then activate the lease.");
+      setError("Generate Schedule A PDF first, then create the lease record.");
       return;
     }
     if (isInvalidLeaseDateRange(state.startDate, state.endDate)) {
@@ -325,8 +325,8 @@ export const LeasePackWizardModal: React.FC<Props> = ({
       setActivatedLeaseId(result.leaseId);
       setActivatedLease(result.lease);
       showToast({
-        message: "Lease activated",
-        description: "Lifecycle automation is now enabled for this tenant lease.",
+        message: "Lease record created",
+        description: "Signing is still required, and occupancy has not begun.",
         variant: "success",
       });
       window.dispatchEvent(
@@ -336,7 +336,7 @@ export const LeasePackWizardModal: React.FC<Props> = ({
       );
     } catch (err: any) {
       if (isDeterministicMutationFailure(err)) activationMutationKeyRef.current = null;
-      setError(err?.message || "Failed to activate lease.");
+      setError(err?.message || "Failed to create lease record.");
     } finally {
       setActivating(false);
     }
@@ -612,10 +612,14 @@ export const LeasePackWizardModal: React.FC<Props> = ({
               <Button
                 type="button"
                 onClick={handleActivateLease}
-                disabled={activating}
+                disabled={activating || Boolean(activatedLeaseId)}
                 style={{ padding: "8px 12px" }}
               >
-                {activating ? "Activating..." : "Activate Lease"}
+                {activating
+                  ? "Creating lease..."
+                  : activatedLeaseId
+                    ? "Lease Created"
+                    : "Create Lease and Continue to Signing"}
               </Button>
             ) : null}
           </div>
@@ -623,12 +627,26 @@ export const LeasePackWizardModal: React.FC<Props> = ({
         ) : null}
         {isNsProvince && snapshotId ? (
           <div style={{ color: "#4b5563", fontSize: 12 }}>
-            Activating creates the official lease record and enables lifecycle automation.
+            Schedule A is generated and ready for review. Creating the lease record does not execute the lease or begin occupancy.
           </div>
         ) : null}
 
         {activatedLeaseId ? (
-          <LeaseRiskCard risk={activatedLease?.risk ?? null} />
+          <>
+            <div
+              role="status"
+              style={{ border: "1px solid #bfdbfe", background: "#eff6ff", color: "#1e3a8a", padding: 10, borderRadius: 8 }}
+            >
+              <div style={{ fontWeight: 700 }}>Pending signing</div>
+              <div style={{ fontSize: 13 }}>
+                Lease record created. Signing is still required, and occupancy has not begun.
+              </div>
+              <a href="/leases" style={{ display: "inline-block", marginTop: 6, color: "#1d4ed8", textDecoration: "underline" }}>
+                Continue to signing
+              </a>
+            </div>
+            <LeaseRiskCard risk={activatedLease?.risk ?? null} />
+          </>
         ) : null}
       </div>
     </div>

--- a/rentchain-frontend/src/components/tenants/LeasePackWizardModal.tsx
+++ b/rentchain-frontend/src/components/tenants/LeasePackWizardModal.tsx
@@ -641,7 +641,10 @@ export const LeasePackWizardModal: React.FC<Props> = ({
               <div style={{ fontSize: 13 }}>
                 Lease record created. Signing is still required, and occupancy has not begun.
               </div>
-              <a href="/leases" style={{ display: "inline-block", marginTop: 6, color: "#1d4ed8", textDecoration: "underline" }}>
+              <a
+                href={`/leases?view=pending-signing&leaseId=${encodeURIComponent(activatedLeaseId)}`}
+                style={{ display: "inline-block", marginTop: 6, color: "#1d4ed8", textDecoration: "underline" }}
+              >
                 Continue to signing
               </a>
             </div>

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
@@ -5,6 +5,7 @@ import LandlordActiveLeasesPage from "./LandlordActiveLeasesPage";
 
 const mocks = vi.hoisted(() => ({
   getActiveLeasesForLandlord: vi.fn(),
+  getPendingSigningLeasesForLandlord: vi.fn(),
   getArchivedLeasesForLandlord: vi.fn(),
   enableLeasePaymentRail: vi.fn(),
   getLeaseReconciliationCandidates: vi.fn(),
@@ -19,6 +20,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("@/api/leasesApi", () => ({
   getActiveLeasesForLandlord: mocks.getActiveLeasesForLandlord,
+  getPendingSigningLeasesForLandlord: mocks.getPendingSigningLeasesForLandlord,
   getArchivedLeasesForLandlord: mocks.getArchivedLeasesForLandlord,
   enableLeasePaymentRail: mocks.enableLeasePaymentRail,
   getLeaseReconciliationCandidates: mocks.getLeaseReconciliationCandidates,
@@ -206,6 +208,7 @@ describe("LandlordActiveLeasesPage", () => {
       ],
     });
     mocks.getArchivedLeasesForLandlord.mockResolvedValue({ leases: [] });
+    mocks.getPendingSigningLeasesForLandlord.mockResolvedValue({ leases: [] });
     mocks.getLeaseReconciliationCandidates.mockResolvedValue({
       candidates: [
         {
@@ -1131,6 +1134,62 @@ describe("LandlordActiveLeasesPage", () => {
     expect((await screen.findAllByText("Archived Place")).length).toBeGreaterThan(0);
     fireEvent.click(screen.getByRole("button", { name: "Restore" }));
     await waitFor(() => expect(mocks.restoreLeaseRecord).toHaveBeenCalledWith("lease-2"));
+  });
+
+  it("loads the targeted pending lease into a distinct signing workspace", async () => {
+    mocks.getActiveLeasesForLandlord.mockClear();
+    mocks.getPendingSigningLeasesForLandlord.mockResolvedValue({
+      leases: [
+        {
+          id: "lease-pending",
+          propertyId: "prop-2",
+          propertyName: "Signing Place",
+          unitNumber: "2B",
+          monthlyRent: 1200,
+          startDate: "2026-09-01",
+          endDate: "2027-08-31",
+          status: "pending",
+          tenantName: "Pending Tenant",
+          tenantEmail: "pending@example.invalid",
+          leaseExecution: {
+            executionStatus: "draft",
+            executionLabel: "Lease draft",
+            executionDescription: "Signing is required before execution.",
+            requiredNextAction: "generate_primary_lease",
+            tenantSignatureStatus: "not_started",
+            landlordSignatureStatus: "not_started",
+            pdfStatus: "not_generated",
+            completedAt: null,
+          },
+        },
+        {
+          id: "lease-other-pending",
+          propertyId: "prop-3",
+          propertyName: "Other Signing Place",
+          unitNumber: "3C",
+          monthlyRent: 1300,
+          startDate: "2026-10-01",
+          endDate: "2027-09-30",
+          status: "pending",
+          tenantName: "Other Tenant",
+        },
+      ],
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/leases?view=pending-signing&leaseId=lease-pending"]}>
+        <LandlordActiveLeasesPage />
+      </MemoryRouter>
+    );
+
+    expect((await screen.findAllByText("Pending signing")).length).toBeGreaterThan(0);
+    expect(mocks.getPendingSigningLeasesForLandlord).toHaveBeenCalledTimes(1);
+    expect(mocks.getActiveLeasesForLandlord).not.toHaveBeenCalled();
+    expect((await screen.findAllByText("Signing Place")).length).toBeGreaterThan(0);
+    expect(screen.queryByText("Other Signing Place")).not.toBeInTheDocument();
+    expect(screen.getAllByText("Pending").length).toBeGreaterThan(0);
+    expect(screen.getByText("Lease signing")).toBeInTheDocument();
+    expect(screen.getByText(/not active and do not establish occupancy/i)).toBeInTheDocument();
   });
 
   it("filters the current lease list by tenant, unit, and property with a no-match state", async () => {

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
@@ -6,6 +6,7 @@ import {
   enableLeasePaymentRail,
   getActiveLeasesForLandlord,
   getArchivedLeasesForLandlord,
+  getPendingSigningLeasesForLandlord,
   getLeaseReconciliationCandidates,
   downloadSignedLease,
   refreshLeaseDocumentUrl,
@@ -435,7 +436,9 @@ function renderJurisdictionPolicyGuidance(lease: LandlordActiveLease) {
 
 export default function LandlordActiveLeasesPage() {
   const [searchParams, setSearchParams] = useSearchParams();
-  const view = searchParams.get("view") === "archived" ? "archived" : "active";
+  const requestedView = searchParams.get("view");
+  const view = requestedView === "archived" || requestedView === "pending-signing" ? requestedView : "active";
+  const targetedLeaseId = view === "pending-signing" ? String(searchParams.get("leaseId") || "").trim() : "";
   const entitlements = useEntitlements();
   const leasesEnabled = entitlements.hasCapability("leases");
   const [leases, setLeases] = React.useState<LandlordActiveLease[]>([]);
@@ -494,7 +497,11 @@ export default function LandlordActiveLeasesPage() {
       setLoading(true);
       setError(null);
       const [leaseResponse, candidateResponse] = await Promise.all([
-        view === "archived" ? getArchivedLeasesForLandlord() : getActiveLeasesForLandlord(),
+        view === "archived"
+          ? getArchivedLeasesForLandlord()
+          : view === "pending-signing"
+            ? getPendingSigningLeasesForLandlord()
+            : getActiveLeasesForLandlord(),
         view === "active" ? getLeaseReconciliationCandidates() : Promise.resolve({ candidates: [] }),
       ]);
       const nextLeases = Array.isArray(leaseResponse?.leases)
@@ -630,8 +637,10 @@ export default function LandlordActiveLeasesPage() {
 
   const normalizedSearchQuery = searchQuery.trim().toLowerCase();
   const filteredLeases = React.useMemo(
-    () => leases.filter((lease) => matchesLeaseSearch(lease, normalizedSearchQuery)),
-    [leases, normalizedSearchQuery]
+    () => leases.filter((lease) =>
+      (!targetedLeaseId || lease.id === targetedLeaseId) && matchesLeaseSearch(lease, normalizedSearchQuery)
+    ),
+    [leases, normalizedSearchQuery, targetedLeaseId]
   );
 
   function buildLeaseActionMeta(lease: LandlordActiveLease) {
@@ -836,7 +845,7 @@ export default function LandlordActiveLeasesPage() {
         <div className="printHeader">
           <div className="printTitle">Lease operations summary</div>
           <div className="printMeta">
-            <div>View: {view === "archived" ? "Archived leases" : "Active leases"}</div>
+            <div>View: {view === "archived" ? "Archived leases" : view === "pending-signing" ? "Pending signing" : "Active leases"}</div>
             <div>Visible leases: {filteredLeases.length}</div>
           </div>
         </div>
@@ -882,6 +891,19 @@ export default function LandlordActiveLeasesPage() {
         </button>
         <button
           type="button"
+          onClick={() => setSearchParams({ view: "pending-signing" })}
+          style={{
+            padding: "8px 12px",
+            borderRadius: 10,
+            border: `1px solid ${view === "pending-signing" ? leaseWorkspaceTheme.charcoal : leaseWorkspaceTheme.borderStrong}`,
+            background: view === "pending-signing" ? leaseWorkspaceTheme.charcoal : leaseWorkspaceTheme.card,
+            color: view === "pending-signing" ? "#fffaf1" : leaseWorkspaceTheme.charcoal,
+          }}
+        >
+          Pending signing
+        </button>
+        <button
+          type="button"
           onClick={() => setSearchParams({ view: "archived" })}
           style={{
             padding: "8px 12px",
@@ -920,6 +942,15 @@ export default function LandlordActiveLeasesPage() {
         />
       ) : null}
       {error ? <div style={{ color: "#b91c1c" }}>{error}</div> : null}
+
+      {!entitlements.loading && leasesEnabled && !loading && !error && view === "pending-signing" ? (
+        <div style={{ padding: 16, borderRadius: 12, border: `1px solid ${leaseWorkspaceTheme.border}`, background: leaseWorkspaceTheme.card }}>
+          <div style={{ fontWeight: 800, color: leaseWorkspaceTheme.charcoal }}>Pending signing</div>
+          <div style={{ color: leaseWorkspaceTheme.neutralText, fontSize: 13 }}>
+            These lease records are not active and do not establish occupancy. Complete the signing workflow before activation.
+          </div>
+        </div>
+      ) : null}
 
       {!entitlements.loading && leasesEnabled && !loading && view === "active" && candidates.length > 0 ? (
         <div style={{ display: "grid", gap: 10, border: `1px solid ${leaseWorkspaceTheme.border}`, borderRadius: 12, background: leaseWorkspaceTheme.card, padding: 16 }}>
@@ -1007,7 +1038,11 @@ export default function LandlordActiveLeasesPage() {
             color: leaseWorkspaceTheme.neutralText,
           }}
         >
-          {view === "archived" ? "No archived leases yet." : "No active leases were found for this landlord yet."}
+          {view === "archived"
+            ? "No archived leases yet."
+            : view === "pending-signing"
+              ? "No leases are pending signing."
+              : "No active leases were found for this landlord yet."}
         </div>
       ) : null}
 


### PR DESCRIPTION
## Summary
- make draft activation create a non-executed, pending-signing lease record
- prevent draft or client execution fields from establishing occupancy authority
- hand landlords off to the existing signing workspace with explicit pending-signing copy
- preserve verified server-side signing completion as the sole execution authority

## Validation
- focused backend lease draft/signing/D1/D2/D3 matrix: 108 passed
- frontend suite: 1,831 passed
- backend build: passed
- frontend build: passed
- git diff --check: passed

## Known baseline limitation
- the complete backend suite currently reports 29 unrelated time-sensitive analytics/state failures across 12 files; the focused lease workflow matrix and both builds pass

## Dependency
PR #1562 remains blocked and must not merge until this correction is independently reviewed, exact-head Preview certified, and merged.