### PR TITLE
Guard unit occupancy edits and complete End Lease authority

### DIFF
--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -2324,6 +2324,39 @@ describe("leaseRoutes GET /active", () => {
     expect(listDocs("canonicalEvents")).toHaveLength(0);
   });
 
+  it("ends every participating tenancy and clears every matching tenant pointer for a multi-party lease", async () => {
+    seedDoc("properties", "prop-multi-party", { landlordId: "landlord-1", units: [{ id: "unit-multi-party", unitNumber: "501", status: "occupied", tenantId: "tenant-a", currentLeaseId: "lease-multi-party" }] });
+    seedDoc("units", "unit-multi-party", { landlordId: "landlord-1", propertyId: "prop-multi-party", unitNumber: "501", status: "occupied", occupancyStatus: "occupied", tenantId: "tenant-a", currentTenantId: "tenant-a", leaseId: "lease-multi-party", currentLeaseId: "lease-multi-party" });
+    seedDoc("tenants", "tenant-a", { landlordId: "landlord-1", currentLeaseId: "lease-multi-party" });
+    seedDoc("tenants", "tenant-b", { landlordId: "landlord-1", currentLeaseId: "lease-multi-party" });
+    seedDoc("leases", "lease-multi-party", { landlordId: "landlord-1", propertyId: "prop-multi-party", unitId: "unit-multi-party", unitNumber: "501", tenantId: "tenant-a", tenantIds: ["tenant-a", "tenant-b", "tenant-a", ""], status: "active" });
+    seedDoc("tenancies", "tenancy-a", { landlordId: "landlord-1", propertyId: "prop-multi-party", unitId: "unit-multi-party", tenantId: "tenant-a", leaseId: "lease-multi-party", status: "active" });
+    seedDoc("tenancies", "tenancy-b", { landlordId: "landlord-1", propertyId: "prop-multi-party", unitId: "unit-multi-party", tenantId: "tenant-b", leaseId: "lease-multi-party", status: "active" });
+    seedDoc("tenancies", "unrelated-tenancy", { landlordId: "landlord-1", propertyId: "prop-multi-party", unitId: "unit-multi-party", tenantId: "tenant-a", leaseId: "lease-other", status: "active" });
+    const router = (await import("../leaseRoutes")).default;
+
+    const res = await invokeRouter(router, { method: "POST", url: "/lease-multi-party/end", body: {} });
+
+    expect(res.status).toBe(200);
+    expect((await fakeDb.collection("leases").doc("lease-multi-party").get()).data()).toMatchObject({ status: "ended" });
+    expect((await fakeDb.collection("units").doc("unit-multi-party").get()).data()).toMatchObject({ status: "vacant", currentLeaseId: null });
+    expect((await fakeDb.collection("properties").doc("prop-multi-party").get()).data()?.units[0]).toMatchObject({ status: "vacant", currentLeaseId: null });
+    expect((await fakeDb.collection("tenants").doc("tenant-a").get()).data()).toMatchObject({ currentLeaseId: null });
+    expect((await fakeDb.collection("tenants").doc("tenant-b").get()).data()).toMatchObject({ currentLeaseId: null });
+    expect((await fakeDb.collection("tenancies").doc("tenancy-a").get()).data()).toMatchObject({ status: "inactive" });
+    expect((await fakeDb.collection("tenancies").doc("tenancy-b").get()).data()).toMatchObject({ status: "inactive" });
+    expect((await fakeDb.collection("tenancies").doc("unrelated-tenancy").get()).data()).toMatchObject({ status: "active" });
+    expect(listDocs("canonicalEvents")).toHaveLength(1);
+    expect(listDocs("canonicalEvents")[0].data?.metadata?.tenantRefs).toHaveLength(2);
+
+    const replay = await invokeRouter(router, { method: "POST", url: "/lease-multi-party/end", body: {} });
+    expect(replay.status).toBe(200);
+    expect(listDocs("canonicalEvents")).toHaveLength(1);
+    expect((await fakeDb.collection("tenancies").doc("tenancy-a").get()).data()).toMatchObject({ status: "inactive" });
+    expect((await fakeDb.collection("tenancies").doc("tenancy-b").get()).data()).toMatchObject({ status: "inactive" });
+    expect((await fakeDb.collection("tenancies").doc("unrelated-tenancy").get()).data()).toMatchObject({ status: "active" });
+  });
+
   it("does not commit End Lease domain writes when canonical audit creation fails", async () => {
     seedDoc("properties", "prop-audit-failure", { landlordId: "landlord-1", units: [{ id: "unit-audit-failure", unitNumber: "402", status: "occupied", tenantId: "tenant-audit-failure", currentLeaseId: "lease-audit-failure" }] });
     seedDoc("units", "unit-audit-failure", { landlordId: "landlord-1", propertyId: "prop-audit-failure", unitNumber: "402", status: "occupied", tenantId: "tenant-audit-failure", currentLeaseId: "lease-audit-failure" });

--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -2325,11 +2325,11 @@ describe("leaseRoutes GET /active", () => {
   });
 
   it("ends every participating tenancy and clears every matching tenant pointer for a multi-party lease", async () => {
-    seedDoc("properties", "prop-multi-party", { landlordId: "landlord-1", units: [{ id: "unit-multi-party", unitNumber: "501", status: "occupied", tenantId: "tenant-a", currentLeaseId: "lease-multi-party" }] });
-    seedDoc("units", "unit-multi-party", { landlordId: "landlord-1", propertyId: "prop-multi-party", unitNumber: "501", status: "occupied", occupancyStatus: "occupied", tenantId: "tenant-a", currentTenantId: "tenant-a", leaseId: "lease-multi-party", currentLeaseId: "lease-multi-party" });
+    seedDoc("properties", "prop-multi-party", { landlordId: "landlord-1", units: [{ id: "unit-multi-party", unitNumber: "501", status: "occupied", tenantId: "tenant-b", currentTenantId: "tenant-b", currentLeaseId: "lease-multi-party" }] });
+    seedDoc("units", "unit-multi-party", { landlordId: "landlord-1", propertyId: "prop-multi-party", unitNumber: "501", status: "occupied", occupancyStatus: "occupied", tenantId: "tenant-b", currentTenantId: "tenant-b", leaseId: "lease-multi-party", currentLeaseId: "lease-multi-party" });
     seedDoc("tenants", "tenant-a", { landlordId: "landlord-1", currentLeaseId: "lease-multi-party" });
     seedDoc("tenants", "tenant-b", { landlordId: "landlord-1", currentLeaseId: "lease-multi-party" });
-    seedDoc("leases", "lease-multi-party", { landlordId: "landlord-1", propertyId: "prop-multi-party", unitId: "unit-multi-party", unitNumber: "501", tenantId: "tenant-a", tenantIds: ["tenant-a", "tenant-b", "tenant-a", ""], status: "active" });
+    seedDoc("leases", "lease-multi-party", { landlordId: "landlord-1", propertyId: "prop-multi-party", unitId: "unit-multi-party", unitNumber: "501", tenantId: "tenant-a", primaryTenantId: "tenant-a", tenantIds: ["tenant-a", "tenant-b", "tenant-a", ""], status: "active" });
     seedDoc("tenancies", "tenancy-a", { landlordId: "landlord-1", propertyId: "prop-multi-party", unitId: "unit-multi-party", tenantId: "tenant-a", leaseId: "lease-multi-party", status: "active" });
     seedDoc("tenancies", "tenancy-b", { landlordId: "landlord-1", propertyId: "prop-multi-party", unitId: "unit-multi-party", tenantId: "tenant-b", leaseId: "lease-multi-party", status: "active" });
     seedDoc("tenancies", "unrelated-tenancy", { landlordId: "landlord-1", propertyId: "prop-multi-party", unitId: "unit-multi-party", tenantId: "tenant-a", leaseId: "lease-other", status: "active" });
@@ -2355,6 +2355,29 @@ describe("leaseRoutes GET /active", () => {
     expect((await fakeDb.collection("tenancies").doc("tenancy-a").get()).data()).toMatchObject({ status: "inactive" });
     expect((await fakeDb.collection("tenancies").doc("tenancy-b").get()).data()).toMatchObject({ status: "inactive" });
     expect((await fakeDb.collection("tenancies").doc("unrelated-tenancy").get()).data()).toMatchObject({ status: "active" });
+  });
+
+  it.each([
+    ["foreign tenant pointer", "tenant-c", "tenant-c"],
+    ["mixed participant pointers", "tenant-a", "tenant-b"],
+  ])("fails closed for %s without ending a multi-party lease", async (_label, standaloneTenantId, embeddedTenantId) => {
+    seedDoc("properties", "prop-multi-pointer-conflict", { landlordId: "landlord-1", units: [{ id: "unit-multi-pointer-conflict", unitNumber: "502", status: "occupied", tenantId: embeddedTenantId, currentTenantId: embeddedTenantId, currentLeaseId: "lease-multi-pointer-conflict" }] });
+    seedDoc("units", "unit-multi-pointer-conflict", { landlordId: "landlord-1", propertyId: "prop-multi-pointer-conflict", unitNumber: "502", status: "occupied", occupancyStatus: "occupied", tenantId: standaloneTenantId, currentTenantId: standaloneTenantId, leaseId: "lease-multi-pointer-conflict", currentLeaseId: "lease-multi-pointer-conflict" });
+    seedDoc("tenants", "tenant-a", { landlordId: "landlord-1", currentLeaseId: "lease-multi-pointer-conflict" });
+    seedDoc("tenants", "tenant-b", { landlordId: "landlord-1", currentLeaseId: "lease-multi-pointer-conflict" });
+    seedDoc("leases", "lease-multi-pointer-conflict", { landlordId: "landlord-1", propertyId: "prop-multi-pointer-conflict", unitId: "unit-multi-pointer-conflict", unitNumber: "502", tenantId: "tenant-a", primaryTenantId: "tenant-a", tenantIds: ["tenant-a", "tenant-b"], status: "active" });
+    seedDoc("tenancies", "tenancy-pointer-a", { landlordId: "landlord-1", propertyId: "prop-multi-pointer-conflict", unitId: "unit-multi-pointer-conflict", tenantId: "tenant-a", leaseId: "lease-multi-pointer-conflict", status: "active" });
+    seedDoc("tenancies", "tenancy-pointer-b", { landlordId: "landlord-1", propertyId: "prop-multi-pointer-conflict", unitId: "unit-multi-pointer-conflict", tenantId: "tenant-b", leaseId: "lease-multi-pointer-conflict", status: "active" });
+    const router = (await import("../leaseRoutes")).default;
+
+    const res = await invokeRouter(router, { method: "POST", url: "/lease-multi-pointer-conflict/end", body: {} });
+
+    expect(res.status).toBe(409);
+    expect((await fakeDb.collection("leases").doc("lease-multi-pointer-conflict").get()).data()).toMatchObject({ status: "active" });
+    expect((await fakeDb.collection("units").doc("unit-multi-pointer-conflict").get()).data()).toMatchObject({ status: "occupied" });
+    expect((await fakeDb.collection("tenancies").doc("tenancy-pointer-a").get()).data()).toMatchObject({ status: "active" });
+    expect((await fakeDb.collection("tenancies").doc("tenancy-pointer-b").get()).data()).toMatchObject({ status: "active" });
+    expect(listDocs("canonicalEvents")).toHaveLength(0);
   });
 
   it("does not commit End Lease domain writes when canonical audit creation fails", async () => {

--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -2267,6 +2267,8 @@ describe("leaseRoutes GET /active", () => {
       leaseId: "lease-1",
       currentLeaseId: "lease-1",
     });
+    seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", currentLeaseId: "lease-1" });
+    seedDoc("tenancies", "tenancy-1", { landlordId: "landlord-1", propertyId: "prop-1", unitId: "unit-1", tenantId: "tenant-1", leaseId: "lease-1", status: "active" });
 
     const router = (await import("../leaseRoutes")).default;
     const res = await invokeRouter(router, { method: "POST", url: "/lease-1/end", body: {} });
@@ -2289,6 +2291,60 @@ describe("leaseRoutes GET /active", () => {
         occupancySource: "lease_end",
       })
     );
+    expect((await fakeDb.collection("leases").doc("lease-1").get()).data()).toMatchObject({ status: "ended" });
+    expect((await fakeDb.collection("tenants").doc("tenant-1").get()).data()).toMatchObject({ currentLeaseId: null });
+    expect((await fakeDb.collection("tenancies").doc("tenancy-1").get()).data()).toMatchObject({ status: "inactive" });
+    expect(listDocs("canonicalEvents")).toHaveLength(1);
+    expect(listDocs("canonicalEvents")[0].data).toMatchObject({
+      type: "lease.occupancy_ended",
+      action: "occupancy_ended",
+      appendOnly: true,
+      immutable: true,
+    });
+
+    const replay = await invokeRouter(router, { method: "POST", url: "/lease-1/end", body: {} });
+    expect(replay.status).toBe(200);
+    expect(listDocs("canonicalEvents")).toHaveLength(1);
+    expect((await fakeDb.collection("tenancies").doc("tenancy-1").get()).data()).toMatchObject({ status: "inactive" });
+  });
+
+  it("fails closed when multiple active tenancies claim the lease being ended", async () => {
+    seedDoc("properties", "prop-tenancy-conflict", { landlordId: "landlord-1", units: [{ id: "unit-tenancy-conflict", unitNumber: "401", status: "occupied", tenantId: "tenant-conflict", currentLeaseId: "lease-tenancy-conflict" }] });
+    seedDoc("units", "unit-tenancy-conflict", { landlordId: "landlord-1", propertyId: "prop-tenancy-conflict", unitNumber: "401", status: "occupied", tenantId: "tenant-conflict", currentLeaseId: "lease-tenancy-conflict" });
+    seedDoc("tenants", "tenant-conflict", { landlordId: "landlord-1", currentLeaseId: "lease-tenancy-conflict" });
+    seedDoc("leases", "lease-tenancy-conflict", { landlordId: "landlord-1", propertyId: "prop-tenancy-conflict", unitId: "unit-tenancy-conflict", unitNumber: "401", tenantId: "tenant-conflict", status: "active" });
+    for (const id of ["tenancy-a", "tenancy-b"]) seedDoc("tenancies", id, { landlordId: "landlord-1", propertyId: "prop-tenancy-conflict", unitId: "unit-tenancy-conflict", tenantId: "tenant-conflict", leaseId: "lease-tenancy-conflict", status: "active" });
+    const router = (await import("../leaseRoutes")).default;
+
+    const res = await invokeRouter(router, { method: "POST", url: "/lease-tenancy-conflict/end", body: {} });
+
+    expect(res.status).toBe(409);
+    expect((await fakeDb.collection("leases").doc("lease-tenancy-conflict").get()).data()).toMatchObject({ status: "active" });
+    expect((await fakeDb.collection("units").doc("unit-tenancy-conflict").get()).data()).toMatchObject({ status: "occupied" });
+    expect(listDocs("canonicalEvents")).toHaveLength(0);
+  });
+
+  it("does not commit End Lease domain writes when canonical audit creation fails", async () => {
+    seedDoc("properties", "prop-audit-failure", { landlordId: "landlord-1", units: [{ id: "unit-audit-failure", unitNumber: "402", status: "occupied", tenantId: "tenant-audit-failure", currentLeaseId: "lease-audit-failure" }] });
+    seedDoc("units", "unit-audit-failure", { landlordId: "landlord-1", propertyId: "prop-audit-failure", unitNumber: "402", status: "occupied", tenantId: "tenant-audit-failure", currentLeaseId: "lease-audit-failure" });
+    seedDoc("tenants", "tenant-audit-failure", { landlordId: "landlord-1", currentLeaseId: "lease-audit-failure" });
+    seedDoc("tenancies", "tenancy-audit-failure", { landlordId: "landlord-1", propertyId: "prop-audit-failure", unitId: "unit-audit-failure", tenantId: "tenant-audit-failure", leaseId: "lease-audit-failure", status: "active" });
+    seedDoc("leases", "lease-audit-failure", { landlordId: "landlord-1", propertyId: "prop-audit-failure", unitId: "unit-audit-failure", unitNumber: "402", tenantId: "tenant-audit-failure", status: "active" });
+    vi.spyOn(fakeDb, "runTransaction").mockImplementationOnce(async (callback: any) => callback({
+      get: async (ref: any) => ref.get(),
+      create: () => { throw new Error("synthetic audit failure"); },
+      set: async (ref: any, value: any, options?: any) => ref.set(value, options),
+    }));
+    const router = (await import("../leaseRoutes")).default;
+
+    const res = await invokeRouter(router, { method: "POST", url: "/lease-audit-failure/end", body: {} });
+
+    expect(res.status).toBe(409);
+    expect((await fakeDb.collection("leases").doc("lease-audit-failure").get()).data()).toMatchObject({ status: "active" });
+    expect((await fakeDb.collection("units").doc("unit-audit-failure").get()).data()).toMatchObject({ status: "occupied" });
+    expect((await fakeDb.collection("tenants").doc("tenant-audit-failure").get()).data()).toMatchObject({ currentLeaseId: "lease-audit-failure" });
+    expect((await fakeDb.collection("tenancies").doc("tenancy-audit-failure").get()).data()).toMatchObject({ status: "active" });
+    expect(listDocs("canonicalEvents")).toHaveLength(0);
   });
 
   it("treats an already-ended lease as an idempotent no-op when no replacement linkage exists", async () => {

--- a/rentchain-api/src/routes/__tests__/unitsRoutes.patch.test.ts
+++ b/rentchain-api/src/routes/__tests__/unitsRoutes.patch.test.ts
@@ -125,6 +125,15 @@ describe("unitsRoutes PATCH aliases", () => {
     resetDb();
   });
 
+  function seedCoherentCurrentOccupancy(options: { contradictoryTenantPointer?: boolean } = {}) {
+    const embedded = { id: "unit-1", unitId: "unit-1", unitNumber: "101", status: "occupied", occupancyStatus: "occupied", occupantName: "Tenant One", tenantId: "tenant-1", currentTenantId: "tenant-1", leaseId: "lease-1", currentLeaseId: "lease-1", leaseEndDate: "2026-12-31" };
+    seedDoc("properties", "prop-1", { landlordId: "landlord-1", units: [embedded] });
+    seedDoc("units", "unit-1", { landlordId: "landlord-1", propertyId: "prop-1", ...embedded, rent: 1800 });
+    seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", currentLeaseId: options.contradictoryTenantPointer ? "lease-other" : "lease-1" });
+    seedDoc("leases", "lease-1", { landlordId: "landlord-1", propertyId: "prop-1", unitId: "unit-1", tenantId: "tenant-1", tenantIds: ["tenant-1"], status: "active", executionStatus: "fully_executed", occupancyEffective: true, startDate: "2026-01-01", endDate: "2026-12-31" });
+    seedDoc("tenancies", "tenancy-1", { landlordId: "landlord-1", propertyId: "prop-1", unitId: "unit-1", tenantId: "tenant-1", leaseId: "lease-1", status: "active" });
+  }
+
   it("accepts name + marketRent aliases for unit updates", async () => {
     seedDoc("properties", "prop-1", { landlordId: "landlord-1" });
     seedDoc("units", "unit-1", {
@@ -191,6 +200,54 @@ describe("unitsRoutes PATCH aliases", () => {
     expect(getDoc("canonicalEvents", "anything")).toBeUndefined();
   });
 
+  it.each([
+    ["occupantName clear", { occupantName: null }],
+    ["occupantName case rewrite", { occupantName: "TENANT ONE" }],
+    ["tenantName rewrite", { tenantName: "Other Tenant" }],
+    ["leaseEndDate clear", { leaseEndDate: null }],
+    ["leaseEndDate rewrite", { leaseEndDate: "2026-11-30" }],
+    ["tenantId rewrite", { tenantId: "tenant-other" }],
+    ["currentTenantId clear", { currentTenantId: null }],
+    ["leaseId rewrite", { leaseId: "lease-other" }],
+    ["currentLeaseId clear", { currentLeaseId: null }],
+    ["status vacancy", { status: "vacant" }],
+    ["occupancyStatus vacancy", { occupancyStatus: "vacant" }],
+  ])("rejects coherent current occupancy-bearing bypass: %s", async (_label, body) => {
+    seedCoherentCurrentOccupancy();
+    const before = JSON.parse(JSON.stringify({ unit: getDoc("units", "unit-1"), property: getDoc("properties", "prop-1") }));
+    const app = await createApp();
+
+    const res = await request(app).patch("/api/units/unit-1").send(body);
+
+    expect(res.status).toBe(409);
+    expect(res.body?.error).toBe("end_lease_workflow_required");
+    expect({ unit: getDoc("units", "unit-1"), property: getDoc("properties", "prop-1") }).toEqual(before);
+  });
+
+  it.each([
+    ["occupantName clear", { occupantName: null }],
+    ["occupantName case rewrite", { occupantName: "TENANT ONE" }],
+    ["tenantName rewrite", { tenantName: "Other Tenant" }],
+    ["leaseEndDate clear", { leaseEndDate: null }],
+    ["leaseEndDate rewrite", { leaseEndDate: "2026-11-30" }],
+    ["tenantId rewrite", { tenantId: "tenant-other" }],
+    ["currentTenantId clear", { currentTenantId: null }],
+    ["leaseId rewrite", { leaseId: "lease-other" }],
+    ["currentLeaseId clear", { currentLeaseId: null }],
+    ["status vacancy", { status: "vacant" }],
+    ["occupancyStatus vacancy", { occupancyStatus: "vacant" }],
+  ])("routes contradictory single-current occupancy-bearing bypass to reconciliation: %s", async (_label, body) => {
+    seedCoherentCurrentOccupancy({ contradictoryTenantPointer: true });
+    const before = JSON.parse(JSON.stringify({ unit: getDoc("units", "unit-1"), property: getDoc("properties", "prop-1") }));
+    const app = await createApp();
+
+    const res = await request(app).patch("/api/units/unit-1").send(body);
+
+    expect(res.status).toBe(409);
+    expect(res.body?.error).toBe("occupancy_reconciliation_required");
+    expect({ unit: getDoc("units", "unit-1"), property: getDoc("properties", "prop-1") }).toEqual(before);
+  });
+
   it("rejects ambiguous occupied-to-vacant updates with occupancy reconciliation guidance", async () => {
     seedDoc("properties", "prop-1", { landlordId: "landlord-1", units: [{ id: "unit-1", unitNumber: "101", status: "occupied", occupancyStatus: "occupied" }] });
     seedDoc("units", "unit-1", { landlordId: "landlord-1", propertyId: "prop-1", unitNumber: "101", status: "occupied", occupancyStatus: "occupied" });
@@ -212,7 +269,7 @@ describe("unitsRoutes PATCH aliases", () => {
     seedDoc("leases", "lease-1", { landlordId: "landlord-1", propertyId: "prop-1", unitId: "unit-1", tenantId: "tenant-1", status: "active", executionStatus: "fully_executed", occupancyEffective: true, startDate: "2026-01-01", endDate: "2026-12-31" });
     const app = await createApp();
 
-    const res = await request(app).patch("/api/units/unit-1").send({ name: "101A", marketRent: 1900, status: "occupied", occupantName: "Changed Name" });
+    const res = await request(app).patch("/api/units/unit-1").send({ name: "101A", marketRent: 1900, status: "occupied", occupantName: "Tenant One" });
 
     expect(res.status).toBe(200);
     expect(getDoc("units", "unit-1")).toMatchObject({ unitNumber: "101A", rent: 1900, status: "occupied", occupancyStatus: "occupied", occupantName: "Tenant One", tenantId: "tenant-1", currentLeaseId: "lease-1" });

--- a/rentchain-api/src/routes/__tests__/unitsRoutes.patch.test.ts
+++ b/rentchain-api/src/routes/__tests__/unitsRoutes.patch.test.ts
@@ -62,6 +62,10 @@ const { dbMock, resetDb, seedDoc, getDoc } = vi.hoisted(() => {
   }
 
   const dbMock = {
+    runTransaction: async (callback: any) => callback({
+      get: (target: any) => target.get(),
+      set: (ref: any, payload: any, options?: any) => ref.set(payload, options),
+    }),
     collection: (name: string) => collectionApi(name),
     batch: () => {
       const writes: Array<() => Promise<void>> = [];
@@ -167,6 +171,52 @@ describe("unitsRoutes PATCH aliases", () => {
       occupantName: "Jane Tenant",
       leaseEndDate: "2027-06-10",
     });
+  });
+
+  it("rejects a direct occupied-to-vacant update when a current occupancy-effective lease exists", async () => {
+    const embedded = { id: "unit-1", unitId: "unit-1", unitNumber: "101", status: "occupied", occupancyStatus: "occupied", tenantId: "tenant-1", currentLeaseId: "lease-1" };
+    seedDoc("properties", "prop-1", { landlordId: "landlord-1", units: [embedded] });
+    seedDoc("units", "unit-1", { landlordId: "landlord-1", propertyId: "prop-1", unitNumber: "101", status: "occupied", occupancyStatus: "occupied", tenantId: "tenant-1", currentLeaseId: "lease-1", rent: 1800 });
+    seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", currentLeaseId: "lease-1" });
+    seedDoc("leases", "lease-1", { landlordId: "landlord-1", propertyId: "prop-1", unitId: "unit-1", tenantId: "tenant-1", status: "active", executionStatus: "fully_executed", occupancyEffective: true, startDate: "2026-01-01", endDate: "2026-12-31" });
+    seedDoc("tenancies", "tenancy-1", { landlordId: "landlord-1", propertyId: "prop-1", unitId: "unit-1", tenantId: "tenant-1", leaseId: "lease-1", status: "active" });
+    const before = JSON.parse(JSON.stringify({ unit: getDoc("units", "unit-1"), property: getDoc("properties", "prop-1"), lease: getDoc("leases", "lease-1"), tenant: getDoc("tenants", "tenant-1"), tenancy: getDoc("tenancies", "tenancy-1") }));
+    const app = await createApp();
+
+    const res = await request(app).patch("/api/units/unit-1").send({ status: "vacant", occupantName: null, leaseEndDate: null });
+
+    expect(res.status).toBe(409);
+    expect(res.body?.error).toBe("end_lease_workflow_required");
+    expect({ unit: getDoc("units", "unit-1"), property: getDoc("properties", "prop-1"), lease: getDoc("leases", "lease-1"), tenant: getDoc("tenants", "tenant-1"), tenancy: getDoc("tenancies", "tenancy-1") }).toEqual(before);
+    expect(getDoc("canonicalEvents", "anything")).toBeUndefined();
+  });
+
+  it("rejects ambiguous occupied-to-vacant updates with occupancy reconciliation guidance", async () => {
+    seedDoc("properties", "prop-1", { landlordId: "landlord-1", units: [{ id: "unit-1", unitNumber: "101", status: "occupied", occupancyStatus: "occupied" }] });
+    seedDoc("units", "unit-1", { landlordId: "landlord-1", propertyId: "prop-1", unitNumber: "101", status: "occupied", occupancyStatus: "occupied" });
+    for (const id of ["lease-a", "lease-b"]) seedDoc("leases", id, { landlordId: "landlord-1", propertyId: "prop-1", unitId: "unit-1", status: "active", executionStatus: "fully_executed", occupancyEffective: true, startDate: "2026-01-01", endDate: "2026-12-31" });
+    const app = await createApp();
+
+    const res = await request(app).patch("/api/units/unit-1").send({ status: "vacant" });
+
+    expect(res.status).toBe(409);
+    expect(res.body?.error).toBe("occupancy_reconciliation_required");
+    expect(getDoc("units", "unit-1")).toMatchObject({ status: "occupied", occupancyStatus: "occupied" });
+    expect(getDoc("properties", "prop-1").units[0]).toMatchObject({ status: "occupied", occupancyStatus: "occupied" });
+  });
+
+  it("allows safe metadata edits for current occupancy and preserves occupancy fields in both projections", async () => {
+    seedDoc("properties", "prop-1", { landlordId: "landlord-1", units: [{ id: "unit-1", unitNumber: "101", rent: 1800, status: "occupied", occupancyStatus: "occupied", tenantId: "tenant-1", currentLeaseId: "lease-1" }] });
+    seedDoc("units", "unit-1", { landlordId: "landlord-1", propertyId: "prop-1", unitNumber: "101", rent: 1800, status: "occupied", occupancyStatus: "occupied", occupantName: "Tenant One", tenantId: "tenant-1", currentLeaseId: "lease-1" });
+    seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", currentLeaseId: "lease-1" });
+    seedDoc("leases", "lease-1", { landlordId: "landlord-1", propertyId: "prop-1", unitId: "unit-1", tenantId: "tenant-1", status: "active", executionStatus: "fully_executed", occupancyEffective: true, startDate: "2026-01-01", endDate: "2026-12-31" });
+    const app = await createApp();
+
+    const res = await request(app).patch("/api/units/unit-1").send({ name: "101A", marketRent: 1900, status: "occupied", occupantName: "Changed Name" });
+
+    expect(res.status).toBe(200);
+    expect(getDoc("units", "unit-1")).toMatchObject({ unitNumber: "101A", rent: 1900, status: "occupied", occupancyStatus: "occupied", occupantName: "Tenant One", tenantId: "tenant-1", currentLeaseId: "lease-1" });
+    expect(getDoc("properties", "prop-1").units[0]).toMatchObject({ unitNumber: "101A", rent: 1900, status: "occupied", occupancyStatus: "occupied", tenantId: "tenant-1", currentLeaseId: "lease-1" });
   });
 
   it("returns UNIT_ID_UNRESOLVED when updating a placeholder unit", async () => {

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -439,6 +439,7 @@ async function endFirestoreLeaseAtomically(
       persistedLease.primaryTenantId,
       ...(Array.isArray(persistedLease.tenantIds) ? persistedLease.tenantIds : []),
     ].map((value) => String(value || "").trim()).filter(Boolean)));
+    const participantSet = new Set(participantTenantIds);
     const tenantRefs = participantTenantIds.map((id) => db.collection("tenants").doc(id));
     const tenantSnaps = await Promise.all(tenantRefs.map((ref) => transaction.get(ref)));
     const tenantId = String(persistedLease.tenantId || persistedLease.primaryTenantId || participantTenantIds[0] || "").trim();
@@ -468,12 +469,12 @@ async function endFirestoreLeaseAtomically(
         return Boolean(currentLeaseId) && currentLeaseId !== leaseId;
       })
     );
-    const hasConflictingTenantLink = currentUnitRecords.some((unit: any) =>
-      [unit.tenantId, unit.currentTenantId].some((value) => {
-        const currentTenantId = String(value || "").trim();
-        return Boolean(currentTenantId) && (!tenantId || currentTenantId !== tenantId);
-      })
-    );
+    const unitTenantPointers = currentUnitRecords
+      .flatMap((unit: any) => [unit.tenantId, unit.currentTenantId])
+      .map((value) => String(value || "").trim())
+      .filter(Boolean);
+    const hasConflictingTenantLink = unitTenantPointers.some((currentTenantId) => !participantSet.has(currentTenantId)) ||
+      new Set(unitTenantPointers).size > 1;
     const tenantCurrentLeaseIds = tenantSnaps
       .filter((snap: any) => snap?.exists)
       .map((snap: any) => String((snap.data() || {}).currentLeaseId || "").trim())
@@ -481,7 +482,6 @@ async function endFirestoreLeaseAtomically(
     const queriedActiveTenancies = (tenanciesSnap?.docs || [])
       .map((doc: any) => ({ id: doc.id, ref: doc.ref, ...(doc.data() || {}) }))
       .filter((tenancy: any) => normalizeStatus(tenancy.status) === "active");
-    const participantSet = new Set(participantTenantIds);
     const invalidActiveTenancy = queriedActiveTenancies.some((tenancy: any) =>
       String(tenancy.landlordId || "").trim() !== authority.landlordId ||
       String(tenancy.propertyId || "").trim() !== propertyId ||

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -402,70 +402,36 @@ async function resolvePropertyUnitForLease(lease: any, errorPrefix: string) {
   };
 }
 
-async function reconcilePropertyUnitVacancyForLeaseEnd(lease: any) {
-  const { propertyRef, units, unitIndex } = await resolvePropertyUnitForLease(lease, "lease_end");
-  const nowIso = new Date().toISOString();
-  const nextUnits = units.map((unit: any, index: number) =>
-    index === unitIndex ? { ...unit, status: "vacant" } : unit
-  );
-  await propertyRef.set(
-    {
-      units: nextUnits,
-      updatedAt: nowIso,
-    },
-    { merge: true }
-  );
-
-  const unitDocId = await resolveStandaloneUnitDocIdForLeaseEnd(lease);
-  if (unitDocId) {
-    await db.collection("units").doc(unitDocId).set(
-      {
-        status: "vacant",
-        occupancyStatus: "vacant",
-        tenantId: null,
-        currentTenantId: null,
-        leaseId: null,
-        currentLeaseId: null,
-        occupancySource: "lease_end",
-        occupancyUpdatedAt: nowIso,
-        updatedAt: nowIso,
-      },
-      { merge: true }
-    );
-  }
-}
-
 /**
  * Ends a Firestore lease and reconciles every denormalized occupancy projection
  * in one transaction.  The previous implementation committed the lease first
  * and reconciled the property/unit projections afterwards, leaving a durable
  * ended lease when the second write failed.
  */
-async function endFirestoreLeaseAtomically(leaseId: string, lease: any, endDate: string) {
+async function endFirestoreLeaseAtomically(
+  leaseId: string,
+  lease: any,
+  endDate: string,
+  authority: { landlordId: string; actorId: string }
+) {
   const propertyId = String(lease?.propertyId || "").trim();
   const unitReference = String(lease?.unitId || lease?.unitNumber || lease?.unit || "").trim();
   const tenantId = String(lease?.tenantId || lease?.primaryTenantId || "").trim();
   if (!propertyId || !unitReference) throw new Error("lease_end_missing_property_or_unit");
 
-  // Lightweight route fakes used by unit tests do not implement transactions;
-  // retain their existing reconciliation path while real Firestore always uses
-  // the atomic branch below.
-  if (typeof (db as any).runTransaction !== "function") {
-    await db.collection("leases").doc(leaseId).set({ status: "ended", endDate, updatedAt: new Date().toISOString() }, { merge: true });
-    await reconcilePropertyUnitVacancyForLeaseEnd({ id: leaseId, ...lease });
-    return;
-  }
+  if (typeof (db as any).runTransaction !== "function") throw new Error("lease_end_transaction_unavailable");
 
-  try {
-    await (db as any).runTransaction(async (transaction: any) => {
+  await (db as any).runTransaction(async (transaction: any) => {
     const leaseRef = db.collection("leases").doc(leaseId);
     const propertyRef = db.collection("properties").doc(propertyId);
     const tenantRef = tenantId ? db.collection("tenants").doc(tenantId) : null;
-    const [leaseSnap, propertySnap, tenantSnap, unitSnap] = await Promise.all([
+    const tenanciesQuery = tenantId ? db.collection("tenancies").where("tenantId", "==", tenantId) : null;
+    const [leaseSnap, propertySnap, tenantSnap, unitSnap, tenanciesSnap] = await Promise.all([
       transaction.get(leaseRef),
       transaction.get(propertyRef),
       tenantRef ? transaction.get(tenantRef) : Promise.resolve(null),
       transaction.get(db.collection("units").where("propertyId", "==", propertyId)),
+      tenanciesQuery ? transaction.get(tenanciesQuery) : Promise.resolve({ docs: [] }),
     ]);
     if (!leaseSnap.exists) throw new Error("lease_end_lease_not_found");
     if (!propertySnap.exists) throw new Error("lease_end_property_not_found");
@@ -482,9 +448,7 @@ async function endFirestoreLeaseAtomically(leaseId: string, lease: any, endDate:
       const data = doc.data() || {};
       return matchesUnitReference(data, unitReference, doc.id);
     });
-    // Test doubles may return plain documents without transaction references.
-    // Fall back before issuing any transaction writes in that case.
-    if (unitDocs.length === 1 && !unitDocs[0].ref) throw new Error("lease_end_transaction_double_unsupported");
+    if (unitDocs.length === 1 && !unitDocs[0].ref) throw new Error("lease_end_transaction_unavailable");
 
     if (unitDocs.length > 1) throw new Error("lease_end_standalone_unit_ambiguous");
 
@@ -506,6 +470,17 @@ async function endFirestoreLeaseAtomically(leaseId: string, lease: any, endDate:
     const tenantCurrentLeaseId = tenantSnap?.exists
       ? String((tenantSnap.data() || {}).currentLeaseId || "").trim()
       : "";
+    const activeTenancies = (tenanciesSnap?.docs || [])
+      .map((doc: any) => ({ id: doc.id, ref: doc.ref, ...(doc.data() || {}) }))
+      .filter((tenancy: any) => normalizeStatus(tenancy.status) === "active")
+      .filter((tenancy: any) => !tenancy.landlordId || String(tenancy.landlordId).trim() === authority.landlordId)
+      .filter((tenancy: any) => !tenancy.propertyId || String(tenancy.propertyId).trim() === propertyId)
+      .filter((tenancy: any) => matchesUnitReference(tenancy, unitReference));
+
+    if (activeTenancies.length > 1) throw new Error("lease_end_active_tenancy_ambiguous");
+    if (activeTenancies.some((tenancy: any) => tenancy.leaseId && String(tenancy.leaseId).trim() !== leaseId)) {
+      throw new Error("lease_end_current_linkage_mismatch");
+    }
 
     if (
       hasConflictingLeaseLink ||
@@ -525,6 +500,38 @@ async function endFirestoreLeaseAtomically(leaseId: string, lease: any, endDate:
         ? { ...unit, status: "vacant", occupancyStatus: "vacant", tenantId: null, currentTenantId: null, leaseId: null, currentLeaseId: null, occupancySource: "lease_end", occupancyUpdatedAt: nowIso, updatedAt: nowIso }
         : unit
     );
+    const auditEventId = leaseStartDeterministicId("lease_occupancy_ended", [authority.landlordId, leaseId]);
+    const auditRef = db.collection("canonicalEvents").doc(auditEventId);
+    transaction.create(auditRef, {
+      id: auditEventId,
+      version: "v1",
+      type: "lease.occupancy_ended",
+      domain: "lease",
+      action: "occupancy_ended",
+      status: "succeeded",
+      actor: { type: "landlord", id: leaseStartDeterministicId("actor", [authority.actorId]), role: "landlord", displayName: null },
+      resource: { type: "lease", id: leaseStartDeterministicId("lease", [leaseId]), parentType: "property", parentId: leaseStartDeterministicId("property", [propertyId]) },
+      occurredAt: nowIso,
+      recordedAt: nowIso,
+      visibility: "internal",
+      summary: "Canonical lease occupancy ended.",
+      metadata: {
+        landlordRef: leaseStartDeterministicId("landlord", [authority.landlordId]),
+        tenantRef: tenantId ? leaseStartDeterministicId("tenant", [tenantId]) : null,
+        unitRef: leaseStartDeterministicId("unit", [unitReference]),
+        leaseRef: leaseStartDeterministicId("lease", [leaseId]),
+        workflow: "end_lease",
+        source: "lease_end_route",
+        previousCanonicalOccupancyState: "occupied",
+        resultingCanonicalOccupancyState: "vacant",
+        effectiveDate: endDate,
+        legalDetermination: false,
+      },
+      tags: ["lease_end", "occupancy_ended"],
+      appendOnly: true,
+      immutable: true,
+    });
+
     transaction.set(propertyRef, { units: nextEmbeddedUnits, updatedAt: nowIso }, { merge: true });
 
     if (unitDocs.length === 1) {
@@ -538,12 +545,10 @@ async function endFirestoreLeaseAtomically(leaseId: string, lease: any, endDate:
         transaction.set(tenantRef, { currentLeaseId: null, updatedAt: nowIso }, { merge: true });
       }
     }
-    });
-  } catch (error: any) {
-    if (error?.message !== "lease_end_transaction_double_unsupported") throw error;
-    await db.collection("leases").doc(leaseId).set({ status: "ended", endDate, updatedAt: new Date().toISOString() }, { merge: true });
-    await reconcilePropertyUnitVacancyForLeaseEnd({ id: leaseId, ...lease });
-  }
+    if (activeTenancies.length === 1) {
+      transaction.set(activeTenancies[0].ref, { status: "inactive", moveOutAt: endDate, updatedAt: nowIso }, { merge: true });
+    }
+  });
 }
 
 async function resolveStandaloneUnitDocIdForLeaseEnd(lease: any): Promise<string | null> {
@@ -3807,7 +3812,15 @@ router.post("/:id/end", requireLandlord, async (req: any, res: Response) => {
     }
     if (leaseResult.source === "firestore") {
       try {
-        await endFirestoreLeaseAtomically(String(req.params?.id || "").trim(), leaseResult.lease as any, endDate);
+        await endFirestoreLeaseAtomically(
+          String(req.params?.id || "").trim(),
+          leaseResult.lease as any,
+          endDate,
+          {
+            landlordId,
+            actorId: String(req.user?.id || req.user?.email || landlordId).trim() || landlordId,
+          }
+        );
       } catch (reconcileErr: any) {
         console.error("[POST /api/leases/:id/end] occupancy reconciliation failed", {
           leaseId: String(req.params?.id || "").trim(),

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -416,7 +416,6 @@ async function endFirestoreLeaseAtomically(
 ) {
   const propertyId = String(lease?.propertyId || "").trim();
   const unitReference = String(lease?.unitId || lease?.unitNumber || lease?.unit || "").trim();
-  const tenantId = String(lease?.tenantId || lease?.primaryTenantId || "").trim();
   if (!propertyId || !unitReference) throw new Error("lease_end_missing_property_or_unit");
 
   if (typeof (db as any).runTransaction !== "function") throw new Error("lease_end_transaction_unavailable");
@@ -424,17 +423,25 @@ async function endFirestoreLeaseAtomically(
   await (db as any).runTransaction(async (transaction: any) => {
     const leaseRef = db.collection("leases").doc(leaseId);
     const propertyRef = db.collection("properties").doc(propertyId);
-    const tenantRef = tenantId ? db.collection("tenants").doc(tenantId) : null;
-    const tenanciesQuery = tenantId ? db.collection("tenancies").where("tenantId", "==", tenantId) : null;
-    const [leaseSnap, propertySnap, tenantSnap, unitSnap, tenanciesSnap] = await Promise.all([
+    const tenanciesQuery = db.collection("tenancies").where("leaseId", "==", leaseId);
+    const [leaseSnap, propertySnap, unitSnap, tenanciesSnap] = await Promise.all([
       transaction.get(leaseRef),
       transaction.get(propertyRef),
-      tenantRef ? transaction.get(tenantRef) : Promise.resolve(null),
       transaction.get(db.collection("units").where("propertyId", "==", propertyId)),
-      tenanciesQuery ? transaction.get(tenanciesQuery) : Promise.resolve({ docs: [] }),
+      transaction.get(tenanciesQuery),
     ]);
     if (!leaseSnap.exists) throw new Error("lease_end_lease_not_found");
     if (!propertySnap.exists) throw new Error("lease_end_property_not_found");
+
+    const persistedLease = leaseSnap.data() || {};
+    const participantTenantIds = Array.from(new Set([
+      persistedLease.tenantId,
+      persistedLease.primaryTenantId,
+      ...(Array.isArray(persistedLease.tenantIds) ? persistedLease.tenantIds : []),
+    ].map((value) => String(value || "").trim()).filter(Boolean)));
+    const tenantRefs = participantTenantIds.map((id) => db.collection("tenants").doc(id));
+    const tenantSnaps = await Promise.all(tenantRefs.map((ref) => transaction.get(ref)));
+    const tenantId = String(persistedLease.tenantId || persistedLease.primaryTenantId || participantTenantIds[0] || "").trim();
 
     const nowIso = new Date().toISOString();
     const propertyData = propertySnap.data() || {};
@@ -467,25 +474,30 @@ async function endFirestoreLeaseAtomically(
         return Boolean(currentTenantId) && (!tenantId || currentTenantId !== tenantId);
       })
     );
-    const tenantCurrentLeaseId = tenantSnap?.exists
-      ? String((tenantSnap.data() || {}).currentLeaseId || "").trim()
-      : "";
-    const activeTenancies = (tenanciesSnap?.docs || [])
+    const tenantCurrentLeaseIds = tenantSnaps
+      .filter((snap: any) => snap?.exists)
+      .map((snap: any) => String((snap.data() || {}).currentLeaseId || "").trim())
+      .filter(Boolean);
+    const queriedActiveTenancies = (tenanciesSnap?.docs || [])
       .map((doc: any) => ({ id: doc.id, ref: doc.ref, ...(doc.data() || {}) }))
-      .filter((tenancy: any) => normalizeStatus(tenancy.status) === "active")
-      .filter((tenancy: any) => !tenancy.landlordId || String(tenancy.landlordId).trim() === authority.landlordId)
-      .filter((tenancy: any) => !tenancy.propertyId || String(tenancy.propertyId).trim() === propertyId)
-      .filter((tenancy: any) => matchesUnitReference(tenancy, unitReference));
-
-    if (activeTenancies.length > 1) throw new Error("lease_end_active_tenancy_ambiguous");
-    if (activeTenancies.some((tenancy: any) => tenancy.leaseId && String(tenancy.leaseId).trim() !== leaseId)) {
-      throw new Error("lease_end_current_linkage_mismatch");
+      .filter((tenancy: any) => normalizeStatus(tenancy.status) === "active");
+    const participantSet = new Set(participantTenantIds);
+    const invalidActiveTenancy = queriedActiveTenancies.some((tenancy: any) =>
+      String(tenancy.landlordId || "").trim() !== authority.landlordId ||
+      String(tenancy.propertyId || "").trim() !== propertyId ||
+      !matchesUnitReference(tenancy, unitReference) ||
+      !participantSet.has(String(tenancy.tenantId || "").trim())
+    );
+    const activeTenancyTenantIds = queriedActiveTenancies.map((tenancy: any) => String(tenancy.tenantId || "").trim());
+    if (invalidActiveTenancy || new Set(activeTenancyTenantIds).size !== activeTenancyTenantIds.length) {
+      throw new Error("lease_end_active_tenancy_ambiguous");
     }
+    const activeTenancies = queriedActiveTenancies;
 
     if (
       hasConflictingLeaseLink ||
       hasConflictingTenantLink ||
-      (tenantCurrentLeaseId && tenantCurrentLeaseId !== leaseId)
+      tenantCurrentLeaseIds.some((currentLeaseId) => currentLeaseId !== leaseId)
     ) {
       throw new Error("lease_end_current_linkage_mismatch");
     }
@@ -518,6 +530,7 @@ async function endFirestoreLeaseAtomically(
       metadata: {
         landlordRef: leaseStartDeterministicId("landlord", [authority.landlordId]),
         tenantRef: tenantId ? leaseStartDeterministicId("tenant", [tenantId]) : null,
+        tenantRefs: participantTenantIds.map((id) => leaseStartDeterministicId("tenant", [id])),
         unitRef: leaseStartDeterministicId("unit", [unitReference]),
         leaseRef: leaseStartDeterministicId("lease", [leaseId]),
         workflow: "end_lease",
@@ -539,15 +552,17 @@ async function endFirestoreLeaseAtomically(
     }
 
     transaction.set(leaseRef, { status: "ended", endDate, updatedAt: nowIso }, { merge: true });
-    if (tenantRef && tenantSnap?.exists) {
-      const tenant = tenantSnap.data() || {};
-      if (String(tenant.currentLeaseId || "").trim() === leaseId) {
-        transaction.set(tenantRef, { currentLeaseId: null, updatedAt: nowIso }, { merge: true });
+    tenantSnaps.forEach((tenantSnap: any, index: number) => {
+      if (tenantSnap?.exists) {
+        const tenant = tenantSnap.data() || {};
+        if (String(tenant.currentLeaseId || "").trim() === leaseId) {
+          transaction.set(tenantRefs[index], { currentLeaseId: null, updatedAt: nowIso }, { merge: true });
+        }
       }
-    }
-    if (activeTenancies.length === 1) {
-      transaction.set(activeTenancies[0].ref, { status: "inactive", moveOutAt: endDate, updatedAt: nowIso }, { merge: true });
-    }
+    });
+    activeTenancies.forEach((tenancy: any) => {
+      transaction.set(tenancy.ref, { status: "inactive", moveOutAt: endDate, updatedAt: nowIso }, { merge: true });
+    });
   });
 }
 

--- a/rentchain-api/src/routes/unitsRoutes.ts
+++ b/rentchain-api/src/routes/unitsRoutes.ts
@@ -5,6 +5,7 @@ import { authenticateJwt } from "../middleware/authMiddleware";
 import { requireCapability } from "../services/capabilityGuard";
 import { uploadBufferToGcs } from "../lib/gcs";
 import { getSignedDownloadUrl } from "../lib/gcsSignedUrl";
+import { applyGovernedUnitUpdate, GovernedUnitUpdateError } from "../services/governedUnitUpdateService";
 
 const router = Router();
 const leaseDocumentUpload = multer({
@@ -568,12 +569,19 @@ router.patch("/units/:unitId", authenticateJwt, requireLandlord, async (req: any
     updates.leaseEndDate = value || null;
   }
 
-  updates.updatedAt = new Date();
   updates.updatedAtServer = FieldValue.serverTimestamp ? FieldValue.serverTimestamp() : new Date();
 
-  await ref.set(updates, { merge: true });
-  const updated = { id: unitId, ...existing, ...updates };
-  return res.json({ ok: true, unit: updated });
+  try {
+    const updated = await applyGovernedUnitUpdate({ firestore: db, landlordId, unitId, updates });
+    return res.json({ ok: true, unit: updated });
+  } catch (error: any) {
+    if (error instanceof GovernedUnitUpdateError) {
+      return res.status(409).json({ ok: false, error: error.code });
+    }
+    if (error?.message === "UNIT_NOT_FOUND") return res.status(404).json({ ok: false, error: "UNIT_NOT_FOUND" });
+    if (error?.message === "FORBIDDEN") return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    throw error;
+  }
 });
 
 router.post(

--- a/rentchain-api/src/routes/unitsRoutes.ts
+++ b/rentchain-api/src/routes/unitsRoutes.ts
@@ -518,6 +518,11 @@ router.patch("/units/:unitId", authenticateJwt, requireLandlord, async (req: any
     leaseEnd,
   } = req.body || {};
   const updates: any = {};
+  const occupancyAttempts = Object.fromEntries(
+    ["tenantId", "currentTenantId", "leaseId", "currentLeaseId"]
+      .filter((field) => Object.prototype.hasOwnProperty.call(req.body || {}, field))
+      .map((field) => [field, (req.body || {})[field]])
+  );
 
   const nextUnitNumber = unitNumber ?? unit ?? name ?? label;
   if (nextUnitNumber !== undefined) {
@@ -557,13 +562,19 @@ router.patch("/units/:unitId", authenticateJwt, requireLandlord, async (req: any
     updates.status = normalizedStatus;
     updates.occupancyStatus = normalizedStatus;
   }
-  const nextOccupantName = occupantName ?? tenantName;
+  const nextOccupantName = Object.prototype.hasOwnProperty.call(req.body || {}, "occupantName")
+    ? occupantName
+    : tenantName;
   if (nextOccupantName !== undefined) {
     const value = String(nextOccupantName || "").trim();
     updates.occupantName = value || null;
     updates.tenantName = value || null;
   }
-  const nextLeaseEndDate = leaseEndDate ?? endDate ?? leaseEnd;
+  const nextLeaseEndDate = Object.prototype.hasOwnProperty.call(req.body || {}, "leaseEndDate")
+    ? leaseEndDate
+    : Object.prototype.hasOwnProperty.call(req.body || {}, "endDate")
+      ? endDate
+      : leaseEnd;
   if (nextLeaseEndDate !== undefined) {
     const value = String(nextLeaseEndDate || "").trim();
     updates.leaseEndDate = value || null;
@@ -572,7 +583,7 @@ router.patch("/units/:unitId", authenticateJwt, requireLandlord, async (req: any
   updates.updatedAtServer = FieldValue.serverTimestamp ? FieldValue.serverTimestamp() : new Date();
 
   try {
-    const updated = await applyGovernedUnitUpdate({ firestore: db, landlordId, unitId, updates });
+    const updated = await applyGovernedUnitUpdate({ firestore: db, landlordId, unitId, updates, occupancyAttempts });
     return res.json({ ok: true, unit: updated });
   } catch (error: any) {
     if (error instanceof GovernedUnitUpdateError) {

--- a/rentchain-api/src/services/governedUnitUpdateService.ts
+++ b/rentchain-api/src/services/governedUnitUpdateService.ts
@@ -11,6 +11,7 @@ type GovernedUnitUpdateInput = {
   landlordId: string;
   unitId: string;
   updates: Record<string, any>;
+  occupancyAttempts?: Record<string, any>;
 };
 
 const OCCUPANCY_FIELDS = new Set([
@@ -31,6 +32,38 @@ function text(value: unknown): string {
 
 function occupied(value: unknown): boolean {
   return text(value).toLowerCase() === "occupied";
+}
+
+function normalized(value: unknown): string {
+  return text(value).toLowerCase();
+}
+
+function hasOwn(record: Record<string, any>, field: string): boolean {
+  return Object.prototype.hasOwnProperty.call(record, field);
+}
+
+function firstDefined(record: Record<string, any>, fields: string[]): unknown {
+  for (const field of fields) {
+    if (hasOwn(record, field)) return record[field];
+  }
+  return undefined;
+}
+
+function occupancyBearingMutation(existing: any, updates: Record<string, any>, attempts: Record<string, any>): boolean {
+  const requested = { ...updates, ...attempts };
+  const logicalGroups = [
+    { fields: ["status", "occupancyStatus"], current: existing.status ?? existing.occupancyStatus, normalize: normalized },
+    { fields: ["occupantName", "tenantName"], current: existing.occupantName ?? existing.tenantName, normalize: text },
+    { fields: ["leaseEndDate"], current: existing.leaseEndDate, normalize: text },
+  ];
+  if (logicalGroups.some(({ fields, current, normalize }) => {
+    const requestedValue = firstDefined(requested, fields);
+    return requestedValue !== undefined && normalize(requestedValue) !== normalize(current);
+  })) return true;
+
+  return ["tenantId", "currentTenantId", "leaseId", "currentLeaseId"].some((field) =>
+    hasOwn(attempts, field) && text(attempts[field]) !== text(existing[field])
+  );
 }
 
 function matchesEmbeddedUnit(unit: any, unitId: string, unitNumber: string): boolean {
@@ -109,20 +142,47 @@ export async function applyGovernedUnitUpdate(input: GovernedUnitUpdateInput): P
       .filter((tenancy: any) => !propertyId || !text(tenancy.propertyId) || text(tenancy.propertyId) === propertyId)
       .filter((tenancy: any) => tenancyMatchesUnit(tenancy, input.unitId, unitNumber));
     const tenant = tenantSnap?.exists ? tenantSnap.data() || {} : null;
-    const requestsVacancy = input.updates.status === "vacant" || input.updates.occupancyStatus === "vacant";
+    const attempts = input.occupancyAttempts || {};
+    const hasOccupancyMutation = occupancyBearingMutation(existing, input.updates, attempts);
     const hasOccupiedEvidence = occupied(existing.status) || occupied(existing.occupancyStatus) || occupied(embedded?.status) ||
       occupied(embedded?.occupancyStatus) || Boolean(text(existing.currentLeaseId || existing.leaseId)) ||
-      Boolean(text(embedded?.currentLeaseId || embedded?.leaseId)) || Boolean(text(tenant?.currentLeaseId)) || activeTenancies.length > 0;
+      Boolean(text(embedded?.currentLeaseId || embedded?.leaseId)) || Boolean(text(tenant?.currentLeaseId)) ||
+      activeTenancies.length > 0 || currentLeases.length > 0;
 
-    if (requestsVacancy && currentLeases.length === 1) {
+    const selectedLease = currentLeases.length === 1 ? currentLeases[0] : null;
+    const selectedLeaseId = text(selectedLease?.id);
+    const leaseParticipantIds = new Set(
+      [selectedLease?.tenantId, selectedLease?.primaryTenantId, ...(Array.isArray(selectedLease?.tenantIds) ? selectedLease.tenantIds : [])]
+        .map(text)
+        .filter(Boolean)
+    );
+    const unitTenantIds = [existing.currentTenantId, existing.tenantId, embedded?.currentTenantId, embedded?.tenantId]
+      .map(text)
+      .filter(Boolean);
+    const statusValues = [existing.status, existing.occupancyStatus, embedded?.status, embedded?.occupancyStatus]
+      .map(normalized)
+      .filter(Boolean);
+    const leasePointers = [existing.currentLeaseId, existing.leaseId, embedded?.currentLeaseId, embedded?.leaseId, tenant?.currentLeaseId]
+      .map(text)
+      .filter(Boolean);
+    const contradictoryContext = currentLeases.length > 1 || new Set(statusValues).size > 1 ||
+      (selectedLeaseId && leasePointers.some((pointer) => pointer !== selectedLeaseId)) ||
+      (selectedLeaseId && (unitTenantIds.length === 0 || unitTenantIds.some((id) => !leaseParticipantIds.has(id)))) ||
+      activeTenancies.length > 1 ||
+      (selectedLeaseId && activeTenancies.some((tenancy: any) =>
+        (text(tenancy.leaseId) && text(tenancy.leaseId) !== selectedLeaseId) ||
+        (text(tenancy.tenantId) && !leaseParticipantIds.has(text(tenancy.tenantId)))
+      ));
+
+    if (hasOccupancyMutation && hasOccupiedEvidence) {
+      if (contradictoryContext || currentLeases.length !== 1) {
+        throw new GovernedUnitUpdateError("occupancy_reconciliation_required");
+      }
       throw new GovernedUnitUpdateError("end_lease_workflow_required");
     }
-    if (requestsVacancy && (currentLeases.length > 1 || hasOccupiedEvidence)) {
-      throw new GovernedUnitUpdateError("occupancy_reconciliation_required");
-    }
 
-    const canonicalCurrent = currentLeases.length === 1;
-    const governedUpdates = canonicalCurrent ? { ...safeMetadata(input.updates) } : { ...input.updates };
+    const protectedOccupancy = hasOccupiedEvidence || currentLeases.length > 0;
+    const governedUpdates = protectedOccupancy ? { ...safeMetadata(input.updates) } : { ...input.updates };
     const now = new Date();
     governedUpdates.updatedAt = now;
     const nextUnit = { ...existing, ...governedUpdates };

--- a/rentchain-api/src/services/governedUnitUpdateService.ts
+++ b/rentchain-api/src/services/governedUnitUpdateService.ts
@@ -1,0 +1,140 @@
+import { deriveCanonicalLeaseTermState } from "../lib/leases/canonicalLeaseOccupancyState";
+
+export class GovernedUnitUpdateError extends Error {
+  constructor(public code: "end_lease_workflow_required" | "occupancy_reconciliation_required") {
+    super(code);
+  }
+}
+
+type GovernedUnitUpdateInput = {
+  firestore: any;
+  landlordId: string;
+  unitId: string;
+  updates: Record<string, any>;
+};
+
+const OCCUPANCY_FIELDS = new Set([
+  "status",
+  "occupancyStatus",
+  "occupantName",
+  "tenantName",
+  "leaseEndDate",
+  "tenantId",
+  "currentTenantId",
+  "leaseId",
+  "currentLeaseId",
+]);
+
+function text(value: unknown): string {
+  return String(value || "").trim();
+}
+
+function occupied(value: unknown): boolean {
+  return text(value).toLowerCase() === "occupied";
+}
+
+function matchesEmbeddedUnit(unit: any, unitId: string, unitNumber: string): boolean {
+  const candidates = [unit?.id, unit?.unitId, unit?.uid].map(text);
+  if (candidates.includes(unitId)) return true;
+  return Boolean(unitNumber) && [unit?.unitNumber, unit?.label, unit?.unit].map(text).includes(unitNumber);
+}
+
+function leaseMatchesUnit(lease: any, unitId: string, unitNumber: string): boolean {
+  if (text(lease?.unitId) === unitId) return true;
+  return Boolean(unitNumber) && [lease?.unitNumber, lease?.unit, lease?.unitLabel].map(text).includes(unitNumber);
+}
+
+function tenancyMatchesUnit(tenancy: any, unitId: string, unitNumber: string): boolean {
+  if (text(tenancy?.unitId) === unitId) return true;
+  return Boolean(unitNumber) && [tenancy?.unitNumber, tenancy?.unitLabel].map(text).includes(unitNumber);
+}
+
+function safeMetadata(updates: Record<string, any>): Record<string, any> {
+  return Object.fromEntries(Object.entries(updates).filter(([field]) => !OCCUPANCY_FIELDS.has(field)));
+}
+
+function embeddedPatch(updates: Record<string, any>): Record<string, any> {
+  const allowed = new Set([
+    "unitNumber", "rent", "marketRent", "beds", "bedrooms", "baths", "bathrooms", "notes",
+    "status", "occupancyStatus", "occupantName", "tenantName", "leaseEndDate",
+  ]);
+  return Object.fromEntries(Object.entries(updates).filter(([field]) => allowed.has(field)));
+}
+
+export async function applyGovernedUnitUpdate(input: GovernedUnitUpdateInput): Promise<Record<string, any>> {
+  return input.firestore.runTransaction(async (transaction: any) => {
+    const unitRef = input.firestore.collection("units").doc(input.unitId);
+    const unitSnap = await transaction.get(unitRef);
+    if (!unitSnap.exists) throw Object.assign(new Error("UNIT_NOT_FOUND"), { status: 404 });
+    const existing = unitSnap.data() || {};
+    if (text(existing.landlordId) !== input.landlordId) throw Object.assign(new Error("FORBIDDEN"), { status: 403 });
+
+    const propertyId = text(existing.propertyId);
+    const propertyRef = propertyId ? input.firestore.collection("properties").doc(propertyId) : null;
+    const leasesQuery = propertyId
+      ? input.firestore.collection("leases").where("landlordId", "==", input.landlordId).where("propertyId", "==", propertyId)
+      : null;
+    const tenantId = text(existing.currentTenantId || existing.tenantId);
+    const tenantRef = tenantId ? input.firestore.collection("tenants").doc(tenantId) : null;
+    const tenanciesQuery = tenantId ? input.firestore.collection("tenancies").where("tenantId", "==", tenantId) : null;
+    const [propertySnap, leasesSnap, tenantSnap, tenanciesSnap] = await Promise.all([
+      propertyRef ? transaction.get(propertyRef) : Promise.resolve(null),
+      leasesQuery ? transaction.get(leasesQuery) : Promise.resolve({ docs: [] }),
+      tenantRef ? transaction.get(tenantRef) : Promise.resolve(null),
+      tenanciesQuery ? transaction.get(tenanciesQuery) : Promise.resolve({ docs: [] }),
+    ]);
+    if (propertyRef && !propertySnap?.exists) throw Object.assign(new Error("PROPERTY_NOT_FOUND"), { status: 404 });
+    const property = propertySnap?.data?.() || {};
+    const propertyLandlordId = text(property.landlordId || property.ownerId || property.owner);
+    if (propertyRef && propertyLandlordId !== input.landlordId) throw Object.assign(new Error("FORBIDDEN"), { status: 403 });
+
+    const unitNumber = text(existing.unitNumber || existing.label || existing.unit);
+    const embeddedUnits = Array.isArray(property.units) ? property.units : [];
+    const embeddedMatches = embeddedUnits
+      .map((unit: any, index: number) => ({ unit, index }))
+      .filter(({ unit }: any) => matchesEmbeddedUnit(unit, input.unitId, unitNumber));
+    if (embeddedUnits.length > 0 && embeddedMatches.length !== 1) {
+      throw new GovernedUnitUpdateError("occupancy_reconciliation_required");
+    }
+    const embedded = embeddedMatches[0]?.unit || null;
+    const leases = (leasesSnap?.docs || [])
+      .map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) }))
+      .filter((lease: any) => leaseMatchesUnit(lease, input.unitId, unitNumber));
+    const currentLeases = leases.filter((lease: any) =>
+      lease.occupancyEffective === true && deriveCanonicalLeaseTermState({ id: lease.id, ...lease }).supportsCurrentOccupancy
+    );
+    const activeTenancies = (tenanciesSnap?.docs || [])
+      .map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) }))
+      .filter((tenancy: any) => text(tenancy.status).toLowerCase() === "active")
+      .filter((tenancy: any) => !propertyId || !text(tenancy.propertyId) || text(tenancy.propertyId) === propertyId)
+      .filter((tenancy: any) => tenancyMatchesUnit(tenancy, input.unitId, unitNumber));
+    const tenant = tenantSnap?.exists ? tenantSnap.data() || {} : null;
+    const requestsVacancy = input.updates.status === "vacant" || input.updates.occupancyStatus === "vacant";
+    const hasOccupiedEvidence = occupied(existing.status) || occupied(existing.occupancyStatus) || occupied(embedded?.status) ||
+      occupied(embedded?.occupancyStatus) || Boolean(text(existing.currentLeaseId || existing.leaseId)) ||
+      Boolean(text(embedded?.currentLeaseId || embedded?.leaseId)) || Boolean(text(tenant?.currentLeaseId)) || activeTenancies.length > 0;
+
+    if (requestsVacancy && currentLeases.length === 1) {
+      throw new GovernedUnitUpdateError("end_lease_workflow_required");
+    }
+    if (requestsVacancy && (currentLeases.length > 1 || hasOccupiedEvidence)) {
+      throw new GovernedUnitUpdateError("occupancy_reconciliation_required");
+    }
+
+    const canonicalCurrent = currentLeases.length === 1;
+    const governedUpdates = canonicalCurrent ? { ...safeMetadata(input.updates) } : { ...input.updates };
+    const now = new Date();
+    governedUpdates.updatedAt = now;
+    const nextUnit = { ...existing, ...governedUpdates };
+    transaction.set(unitRef, governedUpdates, { merge: true });
+
+    if (propertyRef && embeddedMatches.length === 1) {
+      const projectionPatch = embeddedPatch(governedUpdates);
+      const nextEmbeddedUnits = embeddedUnits.map((unit: any, index: number) =>
+        index === embeddedMatches[0].index ? { ...unit, ...projectionPatch, updatedAt: now } : unit
+      );
+      transaction.set(propertyRef, { units: nextEmbeddedUnits, updatedAt: now }, { merge: true });
+    }
+    return { id: input.unitId, ...nextUnit };
+  });
+}

--- a/rentchain-frontend/src/components/properties/PropertyDetailPanel.test.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyDetailPanel.test.tsx
@@ -101,11 +101,12 @@ vi.mock("./UnitsCsvPreviewModal", () => ({
 }));
 
 vi.mock("./UnitEditModal", () => ({
-  UnitEditModal: ({ open, unit, onSaved }: any) =>
+  UnitEditModal: ({ open, unit, occupancyAuthority, onSaved }: any) =>
     open ? (
       <div data-testid="unit-edit-modal">
         <div>modal tenant: {unit?.occupantName || ""}</div>
         <div>modal lease end: {unit?.leaseEndDate || ""}</div>
+        <div>modal occupancy authority: {occupancyAuthority || "none"}</div>
         <button
           type="button"
           onClick={() =>
@@ -486,6 +487,15 @@ describe("PropertyDetailPanel", () => {
           updatedAt: "2026-01-01T00:00:00.000Z",
         },
       ],
+      canonicalUnitStates: {
+        "unit-1": {
+          leaseTermState: "active",
+          occupancyState: "occupied",
+          tenantRelationshipState: "current_occupant",
+          supportingLeaseId: "lease-1",
+          reasons: [],
+        },
+      },
       credibilitySummary: null,
     });
 
@@ -518,6 +528,9 @@ describe("PropertyDetailPanel", () => {
     expect(leaseLinks.length).toBeGreaterThan(0);
     expect(leaseLinks[0]).toHaveAttribute("href", "/leases/lease-1/summary");
     expect(screen.queryByText("tenant-1")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Edit" }).at(-1)!);
+    expect(await screen.findByText("modal occupancy authority: current")).toBeInTheDocument();
   });
 
   it("prefers canonical review-needed occupancy over a stale saved occupied status", async () => {
@@ -531,6 +544,9 @@ describe("PropertyDetailPanel", () => {
     expect((await screen.findAllByText("Review needed")).length).toBeGreaterThan(0);
     expect(screen.getAllByText("Past lease · Occupancy requires review").length).toBeGreaterThan(0);
     expect(screen.getAllByRole("button", { name: "Resolve occupancy" }).length).toBeGreaterThan(0);
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Edit" }).at(-1)!);
+    expect(await screen.findByText("modal occupancy authority: review")).toBeInTheDocument();
   });
 
   it("hydrates lease risk unit labels from property units instead of showing raw unit ids", async () => {

--- a/rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx
@@ -2162,6 +2162,13 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
       <UnitEditModal
         open={!!editingUnit}
         unit={editingUnit}
+        occupancyAuthority={(() => {
+          const unitId = String(editingUnit?.id || editingUnit?.unitId || "").trim();
+          const canonical = canonicalUnitStates[unitId];
+          if (canonical?.occupancyState === "occupied" && canonical.supportingLeaseId) return "current";
+          if (canonical?.occupancyState === "review_needed") return "review";
+          return "none";
+        })()}
         onClose={() => setEditingUnit(null)}
         onSaved={(updated) => {
           const editingKey = String(editingUnit?.id || editingUnit?.unitId || editingUnit?.uid || "").trim();

--- a/rentchain-frontend/src/components/properties/UnitEditModal.test.tsx
+++ b/rentchain-frontend/src/components/properties/UnitEditModal.test.tsx
@@ -144,6 +144,52 @@ describe("UnitEditModal", () => {
     );
   });
 
+  it("blocks canonical current occupancy from being marked vacant and shows End Lease guidance", async () => {
+    render(
+      <UnitEditModal open unit={{ id: "unit-1", unitNumber: "101", status: "occupied" }} occupancyAuthority="current" onClose={vi.fn()} onSaved={vi.fn()} />
+    );
+    fireEvent.change(screen.getByLabelText("Status"), { target: { value: "vacant" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(await screen.findByText("End the lease before marking this unit vacant.")).toBeInTheDocument();
+    expect(mocks.updateUnit).not.toHaveBeenCalled();
+    expect(screen.getByRole("dialog", { name: "Edit unit" })).toBeInTheDocument();
+  });
+
+  it("blocks review-needed occupancy from being marked vacant and shows Resolve Occupancy guidance", async () => {
+    render(
+      <UnitEditModal open unit={{ id: "unit-1", unitNumber: "101", status: "occupied" }} occupancyAuthority="review" onClose={vi.fn()} onSaved={vi.fn()} />
+    );
+    fireEvent.change(screen.getByLabelText("Status"), { target: { value: "vacant" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(await screen.findByText("Resolve the occupancy records before changing this unit to vacant.")).toBeInTheDocument();
+    expect(mocks.updateUnit).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["end_lease_workflow_required", "End the lease before marking this unit vacant."],
+    ["occupancy_reconciliation_required", "Resolve the occupancy records before changing this unit to vacant."],
+  ])("maps backend %s conflicts to bounded guidance without closing", async (code, copy) => {
+    const onClose = vi.fn();
+    mocks.updateUnit.mockRejectedValue(new Error(code));
+    render(<UnitEditModal open unit={{ id: "unit-1", unitNumber: "101", status: "vacant" }} onClose={onClose} onSaved={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText("Monthly rent"), { target: { value: "1900" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(await screen.findByText(copy)).toBeInTheDocument();
+    expect(screen.queryByText(code)).not.toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("keeps safe metadata edits available for current occupancy", async () => {
+    mocks.updateUnit.mockResolvedValue({ unit: { id: "unit-1", unitNumber: "101A", status: "occupied" } });
+    render(<UnitEditModal open unit={{ id: "unit-1", unitNumber: "101", status: "occupied" }} occupancyAuthority="current" onClose={vi.fn()} onSaved={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText("Unit number"), { target: { value: "101A" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() => expect(mocks.updateUnit).toHaveBeenCalled());
+  });
+
   it("keeps the modal open when the update response omits a persisted ID", async () => {
     const onClose = vi.fn();
     const onSaved = vi.fn();

--- a/rentchain-frontend/src/components/properties/UnitEditModal.test.tsx
+++ b/rentchain-frontend/src/components/properties/UnitEditModal.test.tsx
@@ -144,7 +144,8 @@ describe("UnitEditModal", () => {
     );
   });
 
-  it("blocks canonical current occupancy from being marked vacant and shows End Lease guidance", async () => {
+  it("submits canonical current occupancy for backend authority and shows End Lease guidance", async () => {
+    mocks.updateUnit.mockRejectedValue(new Error("end_lease_workflow_required"));
     render(
       <UnitEditModal open unit={{ id: "unit-1", unitNumber: "101", status: "occupied" }} occupancyAuthority="current" onClose={vi.fn()} onSaved={vi.fn()} />
     );
@@ -152,7 +153,27 @@ describe("UnitEditModal", () => {
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     expect(await screen.findByText("End the lease before marking this unit vacant.")).toBeInTheDocument();
-    expect(mocks.updateUnit).not.toHaveBeenCalled();
+    expect(mocks.updateUnit).toHaveBeenCalledWith(
+      "unit-1",
+      expect.objectContaining({ status: "vacant" })
+    );
+    expect(screen.getByRole("dialog", { name: "Edit unit" })).toBeInTheDocument();
+  });
+
+  it("lets backend reconciliation override incomplete current occupancy context", async () => {
+    mocks.updateUnit.mockRejectedValue(new Error("occupancy_reconciliation_required"));
+    render(
+      <UnitEditModal open unit={{ id: "unit-1", unitNumber: "101", status: "occupied" }} occupancyAuthority="current" onClose={vi.fn()} onSaved={vi.fn()} />
+    );
+    fireEvent.change(screen.getByLabelText("Status"), { target: { value: "vacant" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(await screen.findByText("Resolve the occupancy records before changing this unit to vacant.")).toBeInTheDocument();
+    expect(screen.queryByText("End the lease before marking this unit vacant.")).not.toBeInTheDocument();
+    expect(mocks.updateUnit).toHaveBeenCalledWith(
+      "unit-1",
+      expect.objectContaining({ status: "vacant" })
+    );
     expect(screen.getByRole("dialog", { name: "Edit unit" })).toBeInTheDocument();
   });
 

--- a/rentchain-frontend/src/components/properties/UnitEditModal.tsx
+++ b/rentchain-frontend/src/components/properties/UnitEditModal.tsx
@@ -9,7 +9,11 @@ type Props = {
   unit: any | null;
   onClose: () => void;
   onSaved: (unit: any) => void;
+  occupancyAuthority?: "current" | "review" | "none";
 };
+
+const END_LEASE_GUIDANCE = "End the lease before marking this unit vacant.";
+const RESOLVE_OCCUPANCY_GUIDANCE = "Resolve the occupancy records before changing this unit to vacant.";
 
 function isPersistedUnitId(unit: any) {
   const id = String(unit?.id || unit?.unitId || unit?.uid || "").trim();
@@ -25,7 +29,7 @@ function resolveSavedUnit(response: any, fallbackUnit: any, payload: any) {
   return updated;
 }
 
-export function UnitEditModal({ open, unit, onClose, onSaved }: Props) {
+export function UnitEditModal({ open, unit, onClose, onSaved, occupancyAuthority = "none" }: Props) {
   const [unitNumber, setUnitNumber] = useState("");
   const [rent, setRent] = useState<string>("");
   const [beds, setBeds] = useState<string>("");
@@ -91,6 +95,15 @@ export function UnitEditModal({ open, unit, onClose, onSaved }: Props) {
       setError("This unit is not ready for occupancy updates yet. Refresh the property after saving units, then try again.");
       return;
     }
+    const attemptsVacancy = String(unit?.status || "").toLowerCase() === "occupied" && (status || "vacant").toLowerCase() === "vacant";
+    if (attemptsVacancy && occupancyAuthority === "current") {
+      setError(END_LEASE_GUIDANCE);
+      return;
+    }
+    if (attemptsVacancy && occupancyAuthority === "review") {
+      setError(RESOLVE_OCCUPANCY_GUIDANCE);
+      return;
+    }
     setSaving(true);
     setError(null);
     try {
@@ -123,6 +136,10 @@ export function UnitEditModal({ open, unit, onClose, onSaved }: Props) {
           ? "This unit could not be found. Refresh the property after saving units, then try again."
           : message === "UNIT_ID_UNRESOLVED"
           ? "The unit was saved, but its stable ID was not returned. Keep this modal open and try again, or refresh the property."
+          : message === "end_lease_workflow_required"
+          ? END_LEASE_GUIDANCE
+          : message === "occupancy_reconciliation_required"
+          ? RESOLVE_OCCUPANCY_GUIDANCE
           : message || "Failed to save unit"
       );
     } finally {

--- a/rentchain-frontend/src/components/properties/UnitEditModal.tsx
+++ b/rentchain-frontend/src/components/properties/UnitEditModal.tsx
@@ -96,10 +96,6 @@ export function UnitEditModal({ open, unit, onClose, onSaved, occupancyAuthority
       return;
     }
     const attemptsVacancy = String(unit?.status || "").toLowerCase() === "occupied" && (status || "vacant").toLowerCase() === "vacant";
-    if (attemptsVacancy && occupancyAuthority === "current") {
-      setError(END_LEASE_GUIDANCE);
-      return;
-    }
     if (attemptsVacancy && occupancyAuthority === "review") {
       setError(RESOLVE_OCCUPANCY_GUIDANCE);
       return;


### PR DESCRIPTION
## Summary

- fail closed when generic unit edits attempt to end canonical or ambiguous occupancy
- preserve safe occupied/vacant metadata edits and synchronize duplicated embedded unit metadata
- complete End Lease tenancy reconciliation and append canonical audit evidence atomically
- add backend transaction, replay, failure-atomicity, and bounded frontend guidance regressions

## Validation

- backend unit route/transaction tests: 7 passed
- backend End Lease tests: 53 passed
- backend D1-D3/signing/occupancy/tenancy matrix: 171 passed
- frontend UnitEditModal and PropertyDetailPanel tests: 28 passed
- frontend signing/occupancy matrix: 30 passed
- complete frontend suite: 1,837 passed
- backend build: passed
- frontend build: passed
- `git diff --check`: passed

The complete backend suite also ran: 3,412 passed and 29 unrelated baseline/date-sensitive tests failed (expired delegated-access fixtures, inbox expectation drift, decision snapshots, and timeouts). All mission-specific backend matrices pass.

## Boundaries

- no data migration or Firestore index change
- no D1/D2/lease-start or Resolve Occupancy semantic change
- no Production or Preview mutation
- PR #1562 remains blocked and unchanged

Draft only. Do not merge or deploy without separate Founder authorization.
