### PR TITLE
Restore tenant lease canonical projection for End Lease access

### DIFF
--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -1915,6 +1915,125 @@ describe("leaseRoutes GET /active", () => {
     );
   });
 
+  it("projects canonical current evidence for both participants in a coherent multi-party tenant lease", async () => {
+    const unit = {
+      id: "unit-multi-projection",
+      unitNumber: "501",
+      status: "occupied",
+      occupancyStatus: "occupied",
+      currentTenantId: "tenant-b",
+      tenantId: "tenant-b",
+      currentLeaseId: "lease-multi-projection",
+    };
+    seedDoc("properties", "prop-multi-projection", {
+      landlordId: "landlord-1",
+      name: "Harbour View",
+      address: "123 Harbour Street",
+      units: [unit],
+    });
+    seedDoc("units", "unit-multi-projection", {
+      ...unit,
+      landlordId: "landlord-1",
+      propertyId: "prop-multi-projection",
+    });
+    seedDoc("tenants", "tenant-a", { landlordId: "landlord-1", status: "current", currentLeaseId: "lease-multi-projection" });
+    seedDoc("tenants", "tenant-b", { landlordId: "landlord-1", status: "current", currentLeaseId: "lease-multi-projection" });
+    seedDoc("leases", "lease-multi-projection", {
+      landlordId: "landlord-1",
+      propertyId: "prop-multi-projection",
+      unitId: "unit-multi-projection",
+      unitNumber: "501",
+      tenantId: "tenant-a",
+      primaryTenantId: "tenant-a",
+      tenantIds: ["tenant-a", "tenant-b"],
+      status: "active",
+      executionStatus: "fully_executed",
+      occupancyEffective: true,
+      startDate: "2026-01-01",
+      endDate: "2026-12-31",
+      monthlyRent: 2100,
+    });
+    seedDoc("leases", "lease-cross-landlord", {
+      landlordId: "landlord-2",
+      propertyId: "prop-foreign",
+      unitId: "unit-foreign",
+      tenantId: "tenant-b",
+      tenantIds: ["tenant-b"],
+      status: "active",
+      executionStatus: "fully_executed",
+      occupancyEffective: true,
+      startDate: "2026-01-01",
+      endDate: "2026-12-31",
+    });
+
+    const router = (await import("../leaseRoutes")).default;
+    for (const tenantId of ["tenant-a", "tenant-b"]) {
+      const res = await invokeRouter(router, { method: "GET", url: `/tenant/${tenantId}` });
+      expect(res.status).toBe(200);
+      expect(res.body?.leases).toHaveLength(1);
+      expect(res.body.leases[0]).toEqual(expect.objectContaining({
+        id: "lease-multi-projection",
+        occupancyEffective: true,
+        tenantIds: ["tenant-a", "tenant-b"],
+        canonicalState: expect.objectContaining({
+          leaseTermState: "active",
+          occupancyState: "occupied",
+          tenantRelationshipState: "current_occupant",
+          supportingLeaseId: "lease-multi-projection",
+          reasons: [],
+        }),
+      }));
+    }
+  });
+
+  it("keeps non-current and ambiguous tenant lease projections fail closed", async () => {
+    const units = [
+      { id: "unit-pending", unitNumber: "101", status: "vacant", occupancyStatus: "vacant" },
+      { id: "unit-future", unitNumber: "102", status: "vacant", occupancyStatus: "vacant" },
+      { id: "unit-ended", unitNumber: "103", status: "vacant", occupancyStatus: "vacant" },
+      { id: "unit-review", unitNumber: "104", status: "occupied", occupancyStatus: "occupied", currentLeaseId: "lease-stale", currentTenantId: "tenant-1" },
+      { id: "unit-multiple", unitNumber: "105", status: "occupied", occupancyStatus: "occupied", currentLeaseId: "lease-multiple-a", currentTenantId: "tenant-1" },
+    ];
+    seedDoc("properties", "prop-projection-states", { landlordId: "landlord-1", name: "Projection House", units });
+    for (const unit of units) {
+      seedDoc("units", unit.id, { ...unit, landlordId: "landlord-1", propertyId: "prop-projection-states" });
+    }
+    seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", status: "current", currentLeaseId: "lease-multiple-a" });
+    const lease = (id: string, unitId: string, patch: Record<string, unknown>) => seedDoc("leases", id, {
+      landlordId: "landlord-1",
+      propertyId: "prop-projection-states",
+      unitId,
+      tenantId: "tenant-1",
+      tenantIds: ["tenant-1"],
+      primaryTenantId: "tenant-1",
+      monthlyRent: 1800,
+      ...patch,
+    });
+    lease("lease-pending", "unit-pending", { status: "pending", executionStatus: "not_started", occupancyEffective: false, startDate: "2026-01-01", endDate: "2026-12-31" });
+    lease("lease-future", "unit-future", { status: "active", executionStatus: "fully_executed", occupancyEffective: false, startDate: "2099-01-01", endDate: "2099-12-31" });
+    lease("lease-ended", "unit-ended", { status: "ended", executionStatus: "fully_executed", occupancyEffective: false, startDate: "2025-01-01", endDate: "2025-12-31", endedAt: "2025-12-31T00:00:00.000Z" });
+    lease("lease-review", "unit-review", { status: "active", executionStatus: "fully_executed", occupancyEffective: true, startDate: "2026-01-01", endDate: "2026-12-31" });
+    lease("lease-multiple-a", "unit-multiple", { status: "active", executionStatus: "fully_executed", occupancyEffective: true, startDate: "2026-01-01", endDate: "2026-12-31" });
+    lease("lease-multiple-b", "unit-multiple", { status: "active", executionStatus: "fully_executed", occupancyEffective: true, startDate: "2026-02-01", endDate: "2026-11-30" });
+
+    const router = (await import("../leaseRoutes")).default;
+    const res = await invokeRouter(router, { method: "GET", url: "/tenant/tenant-1" });
+    expect(res.status).toBe(200);
+    const byId = new Map(res.body.leases.map((item: any) => [item.id, item]));
+    expect((byId.get("lease-pending") as any)?.canonicalState).toEqual(expect.objectContaining({ leaseTermState: "draft", occupancyState: "vacant" }));
+    expect((byId.get("lease-future") as any)?.canonicalState).toEqual(expect.objectContaining({ leaseTermState: "upcoming", occupancyState: "vacant" }));
+    expect((byId.get("lease-ended") as any)?.canonicalState).toEqual(expect.objectContaining({ leaseTermState: "ended", occupancyState: "vacant" }));
+    expect((byId.get("lease-review") as any)?.canonicalState).toEqual(expect.objectContaining({ occupancyState: "review_needed", tenantRelationshipState: "occupancy_unresolved" }));
+    for (const id of ["lease-multiple-a", "lease-multiple-b"]) {
+      expect((byId.get(id) as any)?.canonicalState).toEqual(expect.objectContaining({
+        occupancyState: "review_needed",
+        tenantRelationshipState: "occupancy_unresolved",
+        supportingLeaseId: null,
+        reasons: expect.arrayContaining(["MULTIPLE_CURRENT_LEASES"]),
+      }));
+    }
+  });
+
   it("fails closed when direct lease creation cannot resolve canonical unit context", async () => {
     const router = (await import("../leaseRoutes")).default;
     const res = await invokeRouter(router, {

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -270,6 +270,7 @@ function normalizeLeaseRow(id: string, raw: any) {
         ? null
         : String(raw?.endDate || raw?.leaseEndDate || raw?.leaseEnd || "").trim() || null,
     status: String(raw?.status || "active").trim().toLowerCase() || "active",
+    occupancyEffective: raw?.occupancyEffective === true,
     risk,
     riskScore: typeof raw?.riskScore === "number" ? raw.riskScore : typeof risk?.score === "number" ? risk.score : null,
     riskGrade: String(raw?.riskGrade || risk?.grade || "").trim() || null,
@@ -1663,6 +1664,17 @@ async function listLandlordLeaseRows(
 
   const leases = await Promise.all(filtered.map((row: any) => enrichLeaseRow(row)));
   const mergedLeases = mergeLeaseRows(leases);
+  const propertyIds = Array.from(
+    new Set(mergedLeases.map((lease: any) => String(lease?.propertyId || "").trim()).filter(Boolean))
+  );
+  const unitsByPropertyId = new Map<string, any[]>(
+    await Promise.all(
+      propertyIds.map(async (propertyId) => [
+        propertyId,
+        await loadUnitsForProperty(db as any, propertyId, landlordId),
+      ] as [string, any[]])
+    )
+  );
   const leaseIds = mergedLeases.map((lease: any) => String(lease?.id || "").trim()).filter(Boolean);
   const latestNoticeByLeaseId = new Map<string, any>();
   if (leaseIds.length > 0) {
@@ -1683,6 +1695,8 @@ async function listLandlordLeaseRows(
     const latestNotice = latestNoticeByLeaseId.get(String(lease?.id || "").trim()) || null;
     const unitId = String(lease?.unitId || lease?.unitNumber || lease?.unitLabel || "").trim();
     const propertyId = String(lease?.propertyId || "").trim();
+    const unitResolution = resolveUnitReference(unitsByPropertyId.get(propertyId) || [], unitId);
+    const unitInputs = resolveCanonicalUnitProjectionInputs(unitResolution.unit || {});
     const relatedLeases = mergedLeases.filter((candidate: any) =>
       String(candidate?.propertyId || "").trim() === propertyId &&
       String(candidate?.unitId || candidate?.unitNumber || candidate?.unitLabel || "").trim() === unitId
@@ -1690,9 +1704,7 @@ async function listLandlordLeaseRows(
     const canonicalState = buildCanonicalLeaseOccupancyProjection({
       leases: relatedLeases,
       context: { landlordId, propertyId, unitId },
-      persistedUnitOccupancy: lease?.stateCoherence?.sourceFields?.unitStatus,
-      persistedTenancyStatus: lease?.stateCoherence?.sourceFields?.occupancyStatus,
-      currentLeasePointerId: lease?.stateCoherence?.sourceFields?.currentLeaseId,
+      ...unitInputs,
       tenantId: lease?.primaryTenantId || lease?.tenantId || lease?.tenantIds?.[0],
       persistedTenantStatus: lease?.stateCoherence?.sourceFields?.tenantStatus,
     });
@@ -3521,7 +3533,20 @@ router.get("/tenant/:tenantId", requireLandlord, async (req: any, res: Response)
         };
       })
     );
-    return res.status(200).json({ ok: true, leases: mergeLeaseRows([...memoryLeases, ...displayLeases]) });
+    const canonicalLeaseRows = landlordId ? await listLandlordLeaseRows(landlordId) : [];
+    const canonicalLeaseById = new Map(
+      canonicalLeaseRows.map((lease: any) => [String(lease?.id || "").trim(), lease])
+    );
+    const projectedDisplayLeases = displayLeases.map((lease: any) => {
+      const canonicalLease = canonicalLeaseById.get(String(lease?.id || "").trim()) as any;
+      if (!canonicalLease) return lease;
+      return {
+        ...lease,
+        occupancyEffective: canonicalLease.occupancyEffective === true,
+        canonicalState: canonicalLease.canonicalState,
+      };
+    });
+    return res.status(200).json({ ok: true, leases: mergeLeaseRows([...memoryLeases, ...projectedDisplayLeases]) });
   } catch {
     return res.status(200).json({ ok: true, leases: memoryLeases });
   }

--- a/rentchain-frontend/server/previewBackendProxy.ts
+++ b/rentchain-frontend/server/previewBackendProxy.ts
@@ -20,6 +20,7 @@ export const PREVIEW_BACKEND_TARGET_KEYS = {
   permanent: "permanent",
   pr1555: "pr1555-c99145e5",
   pr1561: "pr1561-d3-cert",
+  pr1565: "pr1565-tenant-lease-cert",
 } as const;
 
 export type PreviewBackendTarget = {
@@ -50,6 +51,14 @@ const PREVIEW_BACKEND_TARGETS: Record<string, PreviewBackendTarget> = {
       "https://rentchain-pr1561-qa-6256460c-glistw4pya-nn.a.run.app",
     cloudRunIdTokenAudience:
       "https://rentchain-pr1561-qa-6256460c-glistw4pya-nn.a.run.app",
+    temporary: true,
+  },
+  [PREVIEW_BACKEND_TARGET_KEYS.pr1565]: {
+    key: PREVIEW_BACKEND_TARGET_KEYS.pr1565,
+    cloudRunServiceUrl:
+      "https://rentchain-pr1565-qa-tenantlease-glistw4pya-nn.a.run.app",
+    cloudRunIdTokenAudience:
+      "https://rentchain-pr1565-qa-tenantlease-glistw4pya-nn.a.run.app",
     temporary: true,
   },
 };

--- a/rentchain-frontend/src/components/tenants/TenantLeasePanel.test.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantLeasePanel.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TenantLeasePanel } from "./TenantLeasePanel";
 
 const mocks = vi.hoisted(() => ({
@@ -33,6 +33,8 @@ vi.mock("@/components/leases/LeaseRiskCard", () => ({
 }));
 
 describe("TenantLeasePanel", () => {
+  afterEach(() => cleanup());
+
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.useCapabilities.mockReturnValue({
@@ -92,6 +94,112 @@ describe("TenantLeasePanel", () => {
     fireEvent.click(screen.getByRole("button", { name: "Confirm end lease" }));
 
     await waitFor(() => expect(mocks.endLease).toHaveBeenCalledWith("lease-1", expect.any(String)));
+  });
+
+  it("restores End Lease for the runtime-shaped canonical multi-party response", async () => {
+    mocks.getLeaseAutomationTasks.mockResolvedValue({ tasks: [] });
+    mocks.getLeasesForTenant.mockResolvedValue({
+      leases: [
+        {
+          id: "lease-multi-party",
+          tenantId: "tenant-a",
+          primaryTenantId: "tenant-a",
+          tenantIds: ["tenant-a", "tenant-b"],
+          propertyId: "property-1",
+          propertyName: "Harbour View",
+          unitId: "unit-1",
+          unitNumber: "101",
+          monthlyRent: 1800,
+          startDate: "2026-01-01",
+          endDate: "2026-12-31",
+          status: "active",
+          occupancyEffective: true,
+          canonicalState: {
+            leaseTermState: "active",
+            occupancyState: "occupied",
+            tenantRelationshipState: "current_occupant",
+            supportingLeaseId: "lease-multi-party",
+            reasons: [],
+          },
+        },
+      ],
+    });
+
+    render(<TenantLeasePanel tenantId="tenant-b" />);
+
+    expect(await screen.findByText("Property: Harbour View - Unit 101")).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "End lease" })).toHaveLength(1);
+  });
+
+  it.each([
+    [
+      "pending signing",
+      {
+        id: "lease-pending",
+        status: "pending",
+        canonicalState: { leaseTermState: "draft", occupancyState: "vacant", tenantRelationshipState: "past_tenant", supportingLeaseId: null, reasons: ["DRAFT_LEASE_CANNOT_SUPPORT_OCCUPANCY"] },
+      },
+    ],
+    [
+      "review needed",
+      {
+        id: "lease-review",
+        status: "active",
+        canonicalState: { leaseTermState: "active", occupancyState: "review_needed", tenantRelationshipState: "occupancy_unresolved", supportingLeaseId: "lease-review", reasons: ["STALE_CURRENT_LEASE_POINTER"] },
+      },
+    ],
+    [
+      "future",
+      {
+        id: "lease-future",
+        status: "active",
+        canonicalState: { leaseTermState: "upcoming", occupancyState: "vacant", tenantRelationshipState: "past_tenant", supportingLeaseId: null, reasons: ["UPCOMING_LEASE_CANNOT_SUPPORT_OCCUPANCY"] },
+      },
+    ],
+  ])("does not expose End Lease for %s canonical state", async (_label, lease) => {
+    mocks.getLeasesForTenant.mockResolvedValue({
+      leases: [{
+        propertyId: "property-1",
+        propertyName: "Harbour View",
+        unitNumber: "101",
+        monthlyRent: 1800,
+        startDate: "2026-01-01",
+        endDate: "2026-12-31",
+        ...lease,
+      }],
+    });
+
+    render(<TenantLeasePanel tenantId="tenant-1" />);
+    await waitFor(() => expect(mocks.getLeasesForTenant).toHaveBeenCalled());
+    expect(screen.queryByRole("button", { name: "End lease" })).not.toBeInTheDocument();
+  });
+
+  it("fails closed instead of choosing an arbitrary lease when multiple canonical current leases are returned", async () => {
+    const canonicalState = {
+      leaseTermState: "active",
+      occupancyState: "occupied",
+      tenantRelationshipState: "current_occupant",
+      reasons: [],
+    };
+    mocks.getLeasesForTenant.mockResolvedValue({
+      leases: ["lease-a", "lease-b"].map((id) => ({
+        id,
+        propertyId: "property-1",
+        propertyName: "Harbour View",
+        unitNumber: "101",
+        monthlyRent: 1800,
+        startDate: "2026-01-01",
+        endDate: "2026-12-31",
+        status: "active",
+        occupancyEffective: true,
+        canonicalState: { ...canonicalState, supportingLeaseId: id },
+      })),
+    });
+
+    render(<TenantLeasePanel tenantId="tenant-1" />);
+    await waitFor(() => expect(mocks.getLeasesForTenant).toHaveBeenCalled());
+    expect(screen.queryByRole("button", { name: "End lease" })).not.toBeInTheDocument();
+    expect(mocks.getLeaseAutomationTasks).not.toHaveBeenCalled();
   });
 
   it("does not render raw property ids in lease labels", async () => {

--- a/rentchain-frontend/src/components/tenants/TenantLeasePanel.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantLeasePanel.tsx
@@ -12,7 +12,7 @@ import { useCapabilities } from "@/hooks/useCapabilities";
 import { useUpgrade } from "@/context/UpgradeContext";
 import { upgradeStarterButtonStyle } from "@/lib/upgradeButtonStyles";
 import { LeaseRiskCard } from "@/components/leases/LeaseRiskCard";
-import { deriveLeaseLifecycleStatus, isLeaseCurrentlyActive } from "@/lib/leases/leaseLifecycle";
+import { deriveLeaseLifecycleStatus, selectCanonicalCurrentLease } from "@/lib/leases/leaseLifecycle";
 
 const DATE_ONLY_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
 const DATE_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
@@ -169,7 +169,7 @@ export const TenantLeasePanel: React.FC<TenantLeasePanelProps> = ({ tenantId, on
   }, [loadLeases, tenantId]);
 
   const activeLease = useMemo(
-    () => leases.find((l) => isLeaseCurrentlyActive(l)) ?? null,
+    () => selectCanonicalCurrentLease(leases),
     [leases]
   );
 

--- a/rentchain-frontend/src/lib/leases/leaseLifecycle.test.ts
+++ b/rentchain-frontend/src/lib/leases/leaseLifecycle.test.ts
@@ -5,11 +5,37 @@ import {
   getExpiringSoonLeases,
   isLeaseCurrentlyActive,
   isLeaseExpired,
+  selectCanonicalCurrentLease,
 } from "./leaseLifecycle";
 
 const today = "2026-05-04";
 
 describe("leaseLifecycle", () => {
+  it("selects exactly one canonical current lease and fails closed on ambiguity", () => {
+    const current = {
+      id: "lease-current",
+      canonicalState: {
+        leaseTermState: "active" as const,
+        occupancyState: "occupied" as const,
+        tenantRelationshipState: "current_occupant" as const,
+      },
+    };
+    const secondCurrent = { ...current, id: "lease-current-2" };
+    const pending = {
+      id: "lease-pending",
+      status: "pending",
+      canonicalState: {
+        leaseTermState: "draft" as const,
+        occupancyState: "vacant" as const,
+        tenantRelationshipState: "past_tenant" as const,
+      },
+    };
+
+    expect(selectCanonicalCurrentLease([current, pending], today)).toBe(current);
+    expect(selectCanonicalCurrentLease([current, secondCurrent], today)).toBeNull();
+    expect(selectCanonicalCurrentLease([pending], today)).toBeNull();
+  });
+
   it("prefers backend derived lifecycle state when present", () => {
     const lease = {
       id: "lease-derived",

--- a/rentchain-frontend/src/lib/leases/leaseLifecycle.ts
+++ b/rentchain-frontend/src/lib/leases/leaseLifecycle.ts
@@ -235,6 +235,16 @@ export function isLeaseCurrentlyActive(lease: LeaseLike | null | undefined, toda
   return status === "active" || status === "notice_period";
 }
 
+export function selectCanonicalCurrentLease<T extends LeaseLike>(
+  leases: T[],
+  today: string | number | Date = new Date()
+): T | null {
+  const current = (Array.isArray(leases) ? leases : []).filter((lease) =>
+    isLeaseCurrentlyActive(lease, today)
+  );
+  return current.length === 1 ? current[0] : null;
+}
+
 export function isLeaseExpired(lease: LeaseLike | null | undefined, today: string | number | Date = new Date()) {
   return deriveLeaseLifecycleStatus(lease, today) === "expired";
 }

--- a/rentchain-frontend/src/platform/previewBackendProxy.test.ts
+++ b/rentchain-frontend/src/platform/previewBackendProxy.test.ts
@@ -145,11 +145,28 @@ describe("Preview backend proxy", () => {
     });
   });
 
+  it("couples the authorized PR #1565 service URL and audience internally", () => {
+    const target = resolvePreviewBackendTarget({
+      vercelEnvironment: "preview",
+      targetKey: PREVIEW_BACKEND_TARGET_KEYS.pr1565,
+    });
+    expect(target).toEqual({
+      key: "pr1565-tenant-lease-cert",
+      cloudRunServiceUrl:
+        "https://rentchain-pr1565-qa-tenantlease-glistw4pya-nn.a.run.app",
+      cloudRunIdTokenAudience:
+        "https://rentchain-pr1565-qa-tenantlease-glistw4pya-nn.a.run.app",
+      temporary: true,
+    });
+  });
+
   it.each([
     ["production", PREVIEW_BACKEND_TARGET_KEYS.pr1555],
     ["development", PREVIEW_BACKEND_TARGET_KEYS.pr1555],
     ["production", PREVIEW_BACKEND_TARGET_KEYS.pr1561],
     ["development", PREVIEW_BACKEND_TARGET_KEYS.pr1561],
+    ["production", PREVIEW_BACKEND_TARGET_KEYS.pr1565],
+    ["development", PREVIEW_BACKEND_TARGET_KEYS.pr1565],
     ["preview", ""],
     ["preview", "unknown"],
     ["preview", "pr1562"],
@@ -222,6 +239,60 @@ describe("Preview backend proxy", () => {
     );
   });
 
+  it.each([
+    ["arbitrary host", {
+      key: PREVIEW_BACKEND_TARGET_KEYS.pr1565,
+      cloudRunServiceUrl: "https://arbitrary.a.run.app",
+      cloudRunIdTokenAudience:
+        "https://rentchain-pr1565-qa-tenantlease-glistw4pya-nn.a.run.app",
+      temporary: true,
+    }],
+    ["cross-project host", {
+      key: PREVIEW_BACKEND_TARGET_KEYS.pr1565,
+      cloudRunServiceUrl:
+        "https://rentchain-pr1565-qa-tenantlease-other-project.a.run.app",
+      cloudRunIdTokenAudience:
+        "https://rentchain-pr1565-qa-tenantlease-other-project.a.run.app",
+      temporary: true,
+    }],
+    ["wrong service slot", {
+      key: PREVIEW_BACKEND_TARGET_KEYS.pr1565,
+      cloudRunServiceUrl:
+        "https://rentchain-pr1565-qa-wrongslot-glistw4pya-nn.a.run.app",
+      cloudRunIdTokenAudience:
+        "https://rentchain-pr1565-qa-wrongslot-glistw4pya-nn.a.run.app",
+      temporary: true,
+    }],
+    ["Production Cloud Run host", {
+      key: PREVIEW_BACKEND_TARGET_KEYS.pr1565,
+      cloudRunServiceUrl:
+        "https://rentchain-landlord-api-cyaabkl54a-uc.a.run.app",
+      cloudRunIdTokenAudience:
+        "https://rentchain-landlord-api-cyaabkl54a-uc.a.run.app",
+      temporary: true,
+    }],
+    ["mismatched audience", {
+      key: PREVIEW_BACKEND_TARGET_KEYS.pr1565,
+      cloudRunServiceUrl:
+        "https://rentchain-pr1565-qa-tenantlease-glistw4pya-nn.a.run.app",
+      cloudRunIdTokenAudience:
+        "https://rentchain-preview-backend-glistw4pya-nn.a.run.app",
+      temporary: true,
+    }],
+    ["temporary flag", {
+      key: PREVIEW_BACKEND_TARGET_KEYS.pr1565,
+      cloudRunServiceUrl:
+        "https://rentchain-pr1565-qa-tenantlease-glistw4pya-nn.a.run.app",
+      cloudRunIdTokenAudience:
+        "https://rentchain-pr1565-qa-tenantlease-glistw4pya-nn.a.run.app",
+      temporary: false,
+    }],
+  ])("rejects a tampered PR #1565 mapping: %s", (_label, target) => {
+    expect(() => assertPreviewBackendTarget(target, "preview")).toThrow(
+      "PREVIEW_PROXY_TARGET_REJECTED",
+    );
+  });
+
   it("routes the authorized target using the same URL for ID-token audience and upstream", async () => {
     process.env.PREVIEW_BACKEND_TARGET = PREVIEW_BACKEND_TARGET_KEYS.pr1555;
     const { requests, dependencies } = successfulDependencies();
@@ -271,6 +342,31 @@ describe("Preview backend proxy", () => {
       "idempotency-key": "pr1561-target-key",
       "X-Serverless-Authorization": `Bearer ${token("google-id-token")}`,
     });
+  });
+
+  it("routes the PR #1565 tenant lease read only to its exact registered backend", async () => {
+    process.env.PREVIEW_BACKEND_TARGET = PREVIEW_BACKEND_TARGET_KEYS.pr1565;
+    const { requests, dependencies } = successfulDependencies();
+    const res = responseRecorder();
+
+    await handlePreviewBackendProxy(
+      request(
+        "/api/preview-backend/api/leases/tenant/synthetic-tenant",
+        "GET",
+      ),
+      res,
+      dependencies,
+    );
+
+    const expected =
+      "https://rentchain-pr1565-qa-tenantlease-glistw4pya-nn.a.run.app";
+    expect(requests[1].init?.body).toBe(
+      JSON.stringify({ audience: expected, includeEmail: false }),
+    );
+    expect(requests[2].url).toBe(
+      `${expected}/api/leases/tenant/synthetic-tenant`,
+    );
+    expect(requests[2].init?.method).toBe("GET");
   });
 
   it("accepts only Preview and rejects Production or Development", async () => {


### PR DESCRIPTION
## Summary
- preserve shared backend canonical occupancy evidence on tenant lease responses
- restore coherent active multi-party lease selection in TenantLeasePanel
- fail closed when tenant lease responses contain multiple canonical current candidates

## Validation
- backend focused canonical and authority regressions: 222 passed
- frontend focused lifecycle, panel, occupancy, unit-edit, Lease Pack, and signing regressions: 86 passed
- frontend full suite: 1,858 passed
- backend build: passed on Node 24.19.0
- frontend build: passed on Node 24.19.0
- git diff --check: passed

## Boundaries
- no legacy status/date current-lease fallback
- no End Lease mutation-authority change
- no runtime deployment or Preview/Production mutation
- Draft only; runtime certification and merge remain separately gated

## Known baseline harness issue
- an optional unchanged tenantWorkspaceLeaseLinkageContinuity test file still fails before collection due its existing Vitest hoisted dbMock initialization; the file is byte-for-byte unchanged from the exact base