### PR TITLE
PR G: Renewal Continuity

### DIFF
--- a/rentchain-api/src/lib/leases/__tests__/renewalContinuity.test.ts
+++ b/rentchain-api/src/lib/leases/__tests__/renewalContinuity.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { evaluateRenewalContinuity, type RenewalContinuityLease } from "../renewalContinuity";
+
+const instant = "2027-01-01T12:00:00.000Z";
+
+function lease(id: string, overrides: Partial<RenewalContinuityLease> = {}): RenewalContinuityLease {
+  return {
+    id,
+    landlordId: "landlord-1",
+    propertyId: "property-1",
+    unitId: "unit-1",
+    tenantId: "tenant-1",
+    tenantIds: ["tenant-1"],
+    status: "active",
+    executionStatus: "fully_executed",
+    startDate: id === "predecessor" ? "2026-01-01" : "2027-01-01",
+    endDate: id === "predecessor" ? "2026-12-31" : "2027-12-31",
+    ...(id === "predecessor" ? { renewedByLeaseId: "successor", occupancyEffective: true } : { predecessorLeaseId: "predecessor" }),
+    ...overrides,
+  };
+}
+
+function evaluate(overrides: {
+  predecessor?: Partial<RenewalContinuityLease>;
+  successor?: Partial<RenewalContinuityLease>;
+  contextLeases?: RenewalContinuityLease[];
+  evaluationInstant?: string;
+  unit?: Record<string, unknown>;
+  embedded?: Record<string, unknown>;
+  tenant?: Record<string, unknown>;
+} = {}) {
+  return evaluateRenewalContinuity({
+    predecessor: lease("predecessor", overrides.predecessor),
+    successor: lease("successor", overrides.successor),
+    contextLeases: overrides.contextLeases || [],
+    evaluationInstant: overrides.evaluationInstant || instant,
+    standaloneUnit: { currentLeaseId: "predecessor", leaseId: "predecessor", currentTenantId: "tenant-1", ...(overrides.unit || {}) },
+    embeddedUnit: { currentLeaseId: "predecessor", leaseId: "predecessor", currentTenantId: "tenant-1", ...(overrides.embedded || {}) },
+    tenant: { currentLeaseId: "predecessor", ...(overrides.tenant || {}) },
+  });
+}
+
+describe("renewal continuity contract", () => {
+  it("accepts an effective fully executed contiguous linked renewal", () => {
+    expect(evaluate()).toMatchObject({ eligible: true, reasons: [], contiguous: true, participantIds: ["tenant-1"] });
+  });
+
+  it("keeps a fully executed future renewal ineligible and non-current", () => {
+    const result = evaluate({ evaluationInstant: "2026-12-15T12:00:00.000Z" });
+    expect(result.eligible).toBe(false);
+    expect(result.reasons).toContain("RENEWAL_TOO_EARLY");
+  });
+
+  it.each([
+    ["missing linkage", { predecessor: { renewedByLeaseId: null } }, "RENEWAL_LINK_MISSING"],
+    ["conflicting linkage", { predecessor: { renewalLeaseId: "other" } }, "RENEWAL_LINK_CONFLICT"],
+    ["wrong landlord", { successor: { landlordId: "landlord-2" } }, "RENEWAL_CONTEXT_MISMATCH"],
+    ["wrong property", { successor: { propertyId: "property-2" } }, "RENEWAL_CONTEXT_MISMATCH"],
+    ["wrong unit", { successor: { unitId: "unit-2" } }, "RENEWAL_CONTEXT_MISMATCH"],
+    ["gap", { successor: { startDate: "2027-01-02" } }, "RENEWAL_TERM_NOT_CONTIGUOUS"],
+    ["incomplete execution", { successor: { executionStatus: "tenant_signed" } }, "RENEWAL_EXECUTION_INCOMPLETE"],
+    ["draft successor", { successor: { status: "draft" } }, "RENEWAL_SUCCESSOR_INELIGIBLE"],
+    ["ended successor", { successor: { status: "ended" } }, "RENEWAL_SUCCESSOR_INELIGIBLE"],
+    ["invalid dates", { successor: { startDate: "2027-12-31", endDate: "2027-01-01" } }, "RENEWAL_SUCCESSOR_INELIGIBLE"],
+    ["participant mismatch", { successor: { tenantId: "tenant-2", tenantIds: ["tenant-2"] } }, "RENEWAL_PARTICIPANTS_MISMATCH"],
+    ["superseded successor", { successor: { renewedByLeaseId: "successor-2" } }, "RENEWAL_SUCCESSOR_SUPERSEDED"],
+    ["stale unit pointer", { unit: { currentLeaseId: "other", leaseId: "other" } }, "RENEWAL_PROJECTION_MISMATCH"],
+    ["stale tenant pointer", { tenant: { currentLeaseId: "other" } }, "RENEWAL_PROJECTION_MISMATCH"],
+  ] as const)("fails closed for %s", (_label, input, reason) => {
+    const result = evaluate(input as Parameters<typeof evaluate>[0]);
+    expect(result.eligible).toBe(false);
+    expect(result.reasons).toContain(reason);
+  });
+
+  it("fails closed for overlapping current terms without choosing the linked renewal", () => {
+    const result = evaluate({ predecessor: { endDate: "2027-01-31" } });
+    expect(result.reasons).toContain("MULTIPLE_CURRENT_LEASES");
+    expect(result.eligible).toBe(false);
+  });
+
+  it("fails closed when a predecessor has multiple explicit successors", () => {
+    const result = evaluate({ contextLeases: [lease("successor-2", { predecessorLeaseId: "predecessor" })] });
+    expect(result.reasons).toContain("MULTIPLE_RENEWAL_SUCCESSORS");
+  });
+
+  it("normalizes participant sets by canonical ID rather than ordering", () => {
+    const result = evaluate({
+      predecessor: { tenantId: "tenant-1", tenantIds: ["tenant-2", "tenant-1"] },
+      successor: { tenantId: "tenant-2", tenantIds: ["tenant-1", "tenant-2"] },
+    });
+    expect(result.reasons).not.toContain("RENEWAL_PARTICIPANTS_MISMATCH");
+  });
+});

--- a/rentchain-api/src/lib/leases/__tests__/renewalContinuity.test.ts
+++ b/rentchain-api/src/lib/leases/__tests__/renewalContinuity.test.ts
@@ -64,6 +64,7 @@ describe("renewal continuity contract", () => {
     ["invalid dates", { successor: { startDate: "2027-12-31", endDate: "2027-01-01" } }, "RENEWAL_SUCCESSOR_INELIGIBLE"],
     ["participant mismatch", { successor: { tenantId: "tenant-2", tenantIds: ["tenant-2"] } }, "RENEWAL_PARTICIPANTS_MISMATCH"],
     ["superseded successor", { successor: { renewedByLeaseId: "successor-2" } }, "RENEWAL_SUCCESSOR_SUPERSEDED"],
+    ["occupancy-excluded successor", { successor: { occupancyDisposition: { status: "excluded_from_current_occupancy_by_resolution" } } }, "RENEWAL_SUCCESSOR_INELIGIBLE"],
     ["stale unit pointer", { unit: { currentLeaseId: "other", leaseId: "other" } }, "RENEWAL_PROJECTION_MISMATCH"],
     ["stale tenant pointer", { tenant: { currentLeaseId: "other" } }, "RENEWAL_PROJECTION_MISMATCH"],
   ] as const)("fails closed for %s", (_label, input, reason) => {

--- a/rentchain-api/src/lib/leases/renewalContinuity.ts
+++ b/rentchain-api/src/lib/leases/renewalContinuity.ts
@@ -21,6 +21,7 @@ export type RenewalContinuityLease = CanonicalLeaseStateInput & {
   replacedByLeaseId?: unknown;
   predecessorLeaseId?: unknown;
   occupancyEffective?: unknown;
+  occupancyDisposition?: { status?: unknown } | null;
 };
 
 export type RenewalContinuityEvaluation = {
@@ -128,7 +129,8 @@ export function evaluateRenewalContinuity(input: {
   if (normalized(input.successor.executionState || input.successor.executionStatus) !== "fully_executed") {
     reasons.push("RENEWAL_EXECUTION_INCOMPLETE");
   }
-  if (successorTerm.state !== "active" || TERMINAL.has(normalized(input.successor.status)) || input.successor.occupancyEffective === true) {
+  if (successorTerm.state !== "active" || TERMINAL.has(normalized(input.successor.status)) || input.successor.occupancyEffective === true ||
+      normalized(input.successor.occupancyDisposition?.status) === "excluded_from_current_occupancy_by_resolution") {
     reasons.push("RENEWAL_SUCCESSOR_INELIGIBLE");
   }
   if (successorLinks(input.successor).length > 0) reasons.push("RENEWAL_SUCCESSOR_SUPERSEDED");

--- a/rentchain-api/src/lib/leases/renewalContinuity.ts
+++ b/rentchain-api/src/lib/leases/renewalContinuity.ts
@@ -1,0 +1,171 @@
+import { deriveCanonicalLeaseTermState, type CanonicalLeaseStateInput } from "./canonicalLeaseOccupancyState";
+
+export type RenewalContinuityReason =
+  | "RENEWAL_LINK_MISSING"
+  | "RENEWAL_LINK_CONFLICT"
+  | "RENEWAL_CONTEXT_MISMATCH"
+  | "RENEWAL_TERM_NOT_CONTIGUOUS"
+  | "RENEWAL_TOO_EARLY"
+  | "RENEWAL_EXECUTION_INCOMPLETE"
+  | "RENEWAL_PARTICIPANTS_MISMATCH"
+  | "RENEWAL_PREDECESSOR_NOT_CURRENT"
+  | "RENEWAL_SUCCESSOR_INELIGIBLE"
+  | "RENEWAL_SUCCESSOR_SUPERSEDED"
+  | "MULTIPLE_RENEWAL_SUCCESSORS"
+  | "MULTIPLE_CURRENT_LEASES"
+  | "RENEWAL_PROJECTION_MISMATCH";
+
+export type RenewalContinuityLease = CanonicalLeaseStateInput & {
+  tenantIds?: unknown;
+  renewalLeaseId?: unknown;
+  replacedByLeaseId?: unknown;
+  predecessorLeaseId?: unknown;
+  occupancyEffective?: unknown;
+};
+
+export type RenewalContinuityEvaluation = {
+  eligible: boolean;
+  reasons: RenewalContinuityReason[];
+  predecessorLeaseId: string;
+  successorLeaseId: string;
+  participantIds: string[];
+  effectiveStartDate: string | null;
+  predecessorEndDate: string | null;
+  contiguous: boolean;
+  predecessorCanonicalState: string;
+  successorCanonicalState: string;
+};
+
+const TERMINAL = new Set(["ended", "terminated", "expired", "archived", "cancelled", "canceled", "void", "superseded"]);
+
+function text(value: unknown): string {
+  return String(value ?? "").trim();
+}
+
+function normalized(value: unknown): string {
+  return text(value).toLowerCase().replace(/[\s-]+/g, "_");
+}
+
+function utcDay(value: unknown): number | null {
+  if (value == null || value === "") return null;
+  const parsed = value instanceof Date ? value : new Date(String(value));
+  if (Number.isNaN(parsed.getTime())) return null;
+  return Date.UTC(parsed.getUTCFullYear(), parsed.getUTCMonth(), parsed.getUTCDate());
+}
+
+function isoDay(value: unknown): string | null {
+  const day = utcDay(value);
+  return day == null ? null : new Date(day).toISOString().slice(0, 10);
+}
+
+function participantIds(lease: RenewalContinuityLease): string[] {
+  const values = [
+    ...(Array.isArray(lease.tenantIds) ? lease.tenantIds : []),
+    lease.tenantId,
+    lease.primaryTenantId,
+  ];
+  return [...new Set(values.map(text).filter(Boolean))].sort();
+}
+
+function successorLinks(lease: RenewalContinuityLease): string[] {
+  return [...new Set([
+    lease.renewedByLeaseId,
+    lease.renewalLeaseId,
+    lease.successorLeaseId,
+    lease.replacedByLeaseId,
+  ].map(text).filter(Boolean))].sort();
+}
+
+function sameValues(left: string[], right: string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function orderedReasons(reasons: RenewalContinuityReason[]): RenewalContinuityReason[] {
+  return [...new Set(reasons)];
+}
+
+export function evaluateRenewalContinuity(input: {
+  predecessor: RenewalContinuityLease;
+  successor: RenewalContinuityLease;
+  contextLeases: RenewalContinuityLease[];
+  evaluationInstant: unknown;
+  standaloneUnit: Record<string, unknown>;
+  embeddedUnit: Record<string, unknown>;
+  tenant: Record<string, unknown>;
+}): RenewalContinuityEvaluation {
+  const predecessorId = text(input.predecessor.id);
+  const successorId = text(input.successor.id);
+  const reasons: RenewalContinuityReason[] = [];
+  const links = successorLinks(input.predecessor);
+  const inverse = text(input.successor.predecessorLeaseId);
+  const predecessorParticipants = participantIds(input.predecessor);
+  const successorParticipants = participantIds(input.successor);
+  const predecessorTerm = deriveCanonicalLeaseTermState(input.predecessor, input.evaluationInstant);
+  const successorTerm = deriveCanonicalLeaseTermState(input.successor, input.evaluationInstant);
+  const predecessorEnd = utcDay(input.predecessor.endDate ?? input.predecessor.leaseEndDate ?? input.predecessor.leaseEnd);
+  const successorStart = utcDay(input.successor.startDate ?? input.successor.leaseStartDate ?? input.successor.leaseStart);
+  const contiguous = predecessorEnd != null && successorStart != null && successorStart === predecessorEnd + 86_400_000;
+
+  if (!predecessorId || !successorId || links.length === 0 || !links.includes(successorId) || !inverse) {
+    reasons.push("RENEWAL_LINK_MISSING");
+  }
+  if (links.length > 1 || (inverse && inverse !== predecessorId)) reasons.push("RENEWAL_LINK_CONFLICT");
+  const linkedSuccessors = [input.successor, ...input.contextLeases]
+    .filter((lease) => text(lease.predecessorLeaseId) === predecessorId)
+    .map((lease) => text(lease.id))
+    .filter(Boolean);
+  if (new Set(linkedSuccessors).size > 1) reasons.push("MULTIPLE_RENEWAL_SUCCESSORS");
+  if (
+    text(input.predecessor.landlordId) !== text(input.successor.landlordId) ||
+    text(input.predecessor.propertyId) !== text(input.successor.propertyId) ||
+    text(input.predecessor.unitId) !== text(input.successor.unitId)
+  ) reasons.push("RENEWAL_CONTEXT_MISMATCH");
+  if (!contiguous) reasons.push("RENEWAL_TERM_NOT_CONTIGUOUS");
+  if (!sameValues(predecessorParticipants, successorParticipants) || successorParticipants.length === 0) {
+    reasons.push("RENEWAL_PARTICIPANTS_MISMATCH");
+  }
+  if (successorTerm.state === "upcoming") reasons.push("RENEWAL_TOO_EARLY");
+  if (normalized(input.successor.executionState || input.successor.executionStatus) !== "fully_executed") {
+    reasons.push("RENEWAL_EXECUTION_INCOMPLETE");
+  }
+  if (successorTerm.state !== "active" || TERMINAL.has(normalized(input.successor.status)) || input.successor.occupancyEffective === true) {
+    reasons.push("RENEWAL_SUCCESSOR_INELIGIBLE");
+  }
+  if (successorLinks(input.successor).length > 0) reasons.push("RENEWAL_SUCCESSOR_SUPERSEDED");
+
+  const current = [input.predecessor, input.successor, ...input.contextLeases]
+    .filter((lease, index, leases) => leases.findIndex((candidate) => text(candidate.id) === text(lease.id)) === index)
+    .filter((lease) => deriveCanonicalLeaseTermState(lease, input.evaluationInstant).supportsCurrentOccupancy)
+    .filter((lease) => normalized(lease.executionState || lease.executionStatus) === "fully_executed");
+  if (current.length > 1) reasons.push("MULTIPLE_CURRENT_LEASES");
+  if (!["active", "past"].includes(predecessorTerm.state) || input.predecessor.occupancyEffective !== true) {
+    reasons.push("RENEWAL_PREDECESSOR_NOT_CURRENT");
+  }
+
+  const unitPointers = [input.standaloneUnit, input.embeddedUnit].flatMap((unit) => [text(unit.currentLeaseId), text(unit.leaseId)]).filter(Boolean);
+  const tenantPointer = text(input.tenant.currentLeaseId);
+  if (unitPointers.some((id) => id !== predecessorId) || (tenantPointer && tenantPointer !== predecessorId)) {
+    reasons.push("RENEWAL_PROJECTION_MISMATCH");
+  }
+
+  return {
+    eligible: reasons.length === 0,
+    reasons: orderedReasons(reasons),
+    predecessorLeaseId: predecessorId,
+    successorLeaseId: successorId,
+    participantIds: successorParticipants,
+    effectiveStartDate: isoDay(input.successor.startDate ?? input.successor.leaseStartDate ?? input.successor.leaseStart),
+    predecessorEndDate: isoDay(input.predecessor.endDate ?? input.predecessor.leaseEndDate ?? input.predecessor.leaseEnd),
+    contiguous,
+    predecessorCanonicalState: predecessorTerm.state,
+    successorCanonicalState: successorTerm.state,
+  };
+}
+
+export function renewalParticipantIds(lease: RenewalContinuityLease): string[] {
+  return participantIds(lease);
+}
+
+export function renewalSuccessorLinks(lease: RenewalContinuityLease): string[] {
+  return successorLinks(lease);
+}

--- a/rentchain-api/src/routes/__tests__/leaseConflictResponses.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseConflictResponses.test.ts
@@ -147,6 +147,26 @@ describe("lease conflict responses", () => {
     });
   }
 
+  function seedRenewalContext() {
+    const now = new Date();
+    const today = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+    const isoDay = (day: number) => new Date(day).toISOString().slice(0, 10);
+    const unit = {
+      id: "unit-1", unitNumber: "A", status: "occupied", occupancyStatus: "occupied",
+      tenantId: "tenant-1", currentTenantId: "tenant-1", leaseId: "predecessor", currentLeaseId: "predecessor",
+      updatedAt: "2026-12-31T12:00:00.000Z",
+    };
+    seedDoc("properties", "prop-1", { landlordId: "landlord-1", units: [unit], updatedAt: unit.updatedAt });
+    seedDoc("units", "unit-1", { landlordId: "landlord-1", propertyId: "prop-1", ...unit });
+    seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", status: "current", currentLeaseId: "predecessor", updatedAt: unit.updatedAt });
+    seedLease("predecessor", { executionStatus: "fully_executed", occupancyEffective: true, renewedByLeaseId: "successor", startDate: isoDay(today - 365 * 86_400_000), endDate: isoDay(today - 86_400_000) });
+    seedLease("successor", { executionStatus: "fully_executed", predecessorLeaseId: "predecessor", startDate: isoDay(today), endDate: isoDay(today + 364 * 86_400_000), occupancyEffective: false });
+    seedDoc("tenancies", "predecessor-tenancy", {
+      landlordId: "landlord-1", propertyId: "prop-1", unitId: "unit-1", tenantId: "tenant-1", leaseId: "predecessor",
+      status: "active", moveInAt: "2026-01-01T00:00:00.000Z", moveOutAt: null,
+    });
+  }
+
   it("returns the machine-readable conflict code for direct create overlaps", async () => {
     seedUnit("unit-1", { unitNumber: "A", status: "occupied" });
     seedDoc("properties", "prop-1", { landlordId: "landlord-1", units: [{ id: "unit-1", unitId: "unit-1", unitNumber: "A", status: "occupied", tenantId: "tenant-1" }] });
@@ -207,5 +227,35 @@ describe("lease conflict responses", () => {
     expect(getSeededDoc("tenants", "tenant-2")).toMatchObject({
       currentLeaseId: null,
     });
+  });
+
+  it("serves a read-only renewal context and requires expected state for activation", async () => {
+    seedRenewalContext();
+    const app = await makeApp();
+
+    const contextResponse = await request(app).get("/renewals/successor/context");
+    expect(contextResponse.status).toBe(200);
+    expect(contextResponse.body.context).toMatchObject({ handoffEligible: true, predecessorLeaseId: "predecessor", successorLeaseId: "successor" });
+    expect(getSeededDoc("units", "unit-1")).toMatchObject({ currentLeaseId: "predecessor" });
+
+    const missingState = await request(app).post("/renewals/successor/activate").set("Idempotency-Key", "renewal-route-1").send({});
+    expect(missingState.status).toBe(400);
+    expect(missingState.body.error).toBe("renewal_expected_state_required");
+  });
+
+  it("activates a renewal through the authenticated idempotent route", async () => {
+    seedRenewalContext();
+    const app = await makeApp();
+    const contextResponse = await request(app).get("/renewals/successor/context");
+    const context = contextResponse.body.context;
+
+    const activation = await request(app).post("/renewals/successor/activate").set("Idempotency-Key", "renewal-route-2").send({
+      expectedStateToken: context.expectedStateToken,
+      evaluationInstant: context.evaluationInstant,
+    });
+    expect(activation.status).toBe(200);
+    expect(activation.body.result).toMatchObject({ outcome: "renewal_handoff_completed", predecessorLeaseId: "predecessor", successorLeaseId: "successor" });
+    expect(getSeededDoc("units", "unit-1")).toMatchObject({ status: "occupied", currentLeaseId: "successor" });
+    expect(getSeededDoc("tenancies", "predecessor-tenancy")).toMatchObject({ status: "inactive" });
   });
 });

--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -3221,4 +3221,108 @@ describe("leaseRoutes GET /active", () => {
       expect.objectContaining({ id: "unit-dup", unitNumber: "102", status: "vacant" }),
     ]);
   });
+
+  it("projects one coherent renewal handoff through Properties, Leases, Tenants, tenant detail, and Review Needed", async () => {
+    const futureUnit = {
+      id: "unit-renewal-future", unitNumber: "F1", status: "occupied", occupancyStatus: "occupied",
+      tenantId: "tenant-future", currentTenantId: "tenant-future", leaseId: "lease-future-predecessor", currentLeaseId: "lease-future-predecessor",
+    };
+    const handoffUnit = {
+      id: "unit-renewal", unitNumber: "R1", status: "occupied", occupancyStatus: "occupied",
+      tenantId: "tenant-renewal-a", currentTenantId: "tenant-renewal-a", leaseId: "lease-predecessor", currentLeaseId: "lease-predecessor",
+    };
+    seedDoc("properties", "property-renewal", {
+      landlordId: "landlord-1", ownerUserId: "landlord-1", name: "Renewal House", units: [futureUnit, handoffUnit],
+    });
+    seedDoc("units", futureUnit.id, { ...futureUnit, landlordId: "landlord-1", propertyId: "property-renewal" });
+    seedDoc("units", handoffUnit.id, { ...handoffUnit, landlordId: "landlord-1", propertyId: "property-renewal" });
+    seedDoc("tenants", "tenant-future", { landlordId: "landlord-1", fullName: "Future Tenant", status: "current", currentLeaseId: "lease-future-predecessor", propertyId: "property-renewal", unitId: futureUnit.id });
+    seedDoc("tenants", "tenant-renewal-a", { landlordId: "landlord-1", fullName: "Renewal Tenant A", status: "current", currentLeaseId: "lease-predecessor", propertyId: "property-renewal", unitId: handoffUnit.id });
+    seedDoc("tenants", "tenant-renewal-b", { landlordId: "landlord-1", fullName: "Renewal Tenant B", status: "current", currentLeaseId: "lease-predecessor", propertyId: "property-renewal", unitId: handoffUnit.id });
+    seedDoc("leases", "lease-future-predecessor", {
+      landlordId: "landlord-1", propertyId: "property-renewal", unitId: futureUnit.id,
+      tenantId: "tenant-future", tenantIds: ["tenant-future"], status: "active", executionStatus: "fully_executed",
+      occupancyEffective: true, renewedByLeaseId: "lease-future-successor", startDate: "2026-01-01", endDate: "2026-12-31",
+    });
+    seedDoc("leases", "lease-future-successor", {
+      landlordId: "landlord-1", propertyId: "property-renewal", unitId: futureUnit.id,
+      tenantId: "tenant-future", tenantIds: ["tenant-future"], status: "pending", executionStatus: "fully_executed",
+      occupancyEffective: false, predecessorLeaseId: "lease-future-predecessor", startDate: "2099-01-01", endDate: "2099-12-31",
+    });
+    const participants = ["tenant-renewal-a", "tenant-renewal-b"];
+    seedDoc("leases", "lease-predecessor", {
+      landlordId: "landlord-1", propertyId: "property-renewal", unitId: handoffUnit.id,
+      tenantId: participants[0], primaryTenantId: participants[0], tenantIds: participants,
+      status: "active", executionStatus: "fully_executed", occupancyEffective: true,
+      renewedByLeaseId: "lease-successor", startDate: "2025-08-23", endDate: "2026-08-22", monthlyRent: 1800,
+    });
+    seedDoc("leases", "lease-successor", {
+      landlordId: "landlord-1", propertyId: "property-renewal", unitId: handoffUnit.id,
+      tenantId: participants[0], primaryTenantId: participants[0], tenantIds: participants,
+      status: "active", executionStatus: "fully_executed", occupancyEffective: false,
+      predecessorLeaseId: "lease-predecessor", startDate: "2026-08-23", endDate: "2027-08-22", monthlyRent: 1850,
+    });
+    for (const tenantId of participants) {
+      seedDoc("tenancies", `predecessor-${tenantId}`, {
+        landlordId: "landlord-1", propertyId: "property-renewal", unitId: handoffUnit.id,
+        tenantId, leaseId: "lease-predecessor", status: "active", moveOutAt: null,
+      });
+    }
+
+    const leaseRouter = (await import("../leaseRoutes")).default;
+    const propertiesRouter = (await import("../propertiesRoutes")).default;
+    const tenantsRouter = (await import("../tenantsRoutes")).default;
+    const occupancyReviewRouter = (await import("../occupancyReviewRoutes")).default;
+
+    const futureProperties = await invokeRouter(propertiesRouter, { method: "GET", url: "/" });
+    expect(futureProperties.status).toBe(200);
+    const futureProperty = futureProperties.body.items.find((entry: any) => entry.id === "property-renewal");
+    expect(futureProperty.units.find((entry: any) => entry.id === futureUnit.id)).toMatchObject({ currentLeaseId: "lease-future-predecessor" });
+    const futureLeases = await invokeRouter(leaseRouter, { method: "GET", url: "/tenant/tenant-future" });
+    expect(futureLeases.body.leases.find((entry: any) => entry.id === "lease-future-successor")?.canonicalState?.supportingLeaseId).not.toBe("lease-future-successor");
+    const futureTenant = await invokeRouter(tenantsRouter, { method: "GET", url: "/tenant-future" });
+    expect(futureTenant.body?.tenant?.currentLeaseId).toBe("lease-future-predecessor");
+
+    const { getRenewalContinuityContext, handoffRenewalContinuity } = await import("../../services/leaseStart/renewalContinuityService");
+    const context = await getRenewalContinuityContext({
+      landlordId: "landlord-1", successorLeaseId: "lease-successor",
+      evaluationInstant: "2026-08-23T12:00:00.000Z", firestore: fakeDb,
+    });
+    await handoffRenewalContinuity({
+      landlordId: "landlord-1", successorLeaseId: "lease-successor",
+      evaluationInstant: "2026-08-23T12:00:00.000Z", expectedStateToken: context.expectedStateToken,
+      idempotencyKey: "renewal-cross-surface", actorId: "landlord-1", source: "cross_surface_test", firestore: fakeDb,
+    });
+
+    const properties = await invokeRouter(propertiesRouter, { method: "GET", url: "/" });
+    expect(properties.status).toBe(200);
+    const property = properties.body.items.find((entry: any) => entry.id === "property-renewal");
+    expect(property.units.find((entry: any) => entry.id === handoffUnit.id)).toMatchObject({
+      status: "occupied", occupancyStatus: "occupied", currentLeaseId: "lease-successor", currentTenantId: "tenant-renewal-a",
+    });
+
+    const activeLeases = await invokeRouter(leaseRouter, { method: "GET", url: "/active" });
+    expect(activeLeases.status).toBe(200);
+    expect(activeLeases.body.leases.find((entry: any) => entry.id === "lease-successor")?.canonicalState).toMatchObject({
+      occupancyState: "occupied", supportingLeaseId: "lease-successor", reasons: [],
+    });
+    expect(activeLeases.body.leases.find((entry: any) => entry.id === "lease-predecessor")?.canonicalState?.supportingLeaseId).not.toBe("lease-predecessor");
+
+    const tenants = await invokeRouter(tenantsRouter, { method: "GET", url: "/" });
+    expect(tenants.status).toBe(200);
+    for (const tenantId of participants) {
+      expect(tenants.body.tenants.find((entry: any) => entry.id === tenantId)).toMatchObject({
+        currentLeaseId: "lease-successor", canonicalState: expect.objectContaining({ tenantRelationshipState: "current_occupant", supportingLeaseId: "lease-successor" }),
+      });
+      const detail = await invokeRouter(tenantsRouter, { method: "GET", url: `/${tenantId}` });
+      expect(detail.status).toBe(200);
+      expect(detail.body.tenant).toMatchObject({ currentLeaseId: "lease-successor" });
+      expect(detail.body.canonicalState).toMatchObject({ occupancyState: "occupied", tenantRelationshipState: "current_occupant", supportingLeaseId: "lease-successor" });
+      expect(detail.body.lease).toMatchObject({ id: "lease-successor" });
+    }
+
+    const review = await invokeRouter(occupancyReviewRouter, { method: "GET", url: "/" });
+    expect(review.status).toBe(200);
+    expect(review.body.items.filter((item: any) => item.propertyId === "property-renewal" && item.unitId === handoffUnit.id)).toEqual([]);
+  });
 });

--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -3279,9 +3279,24 @@ describe("leaseRoutes GET /active", () => {
     const futureProperty = futureProperties.body.items.find((entry: any) => entry.id === "property-renewal");
     expect(futureProperty.units.find((entry: any) => entry.id === futureUnit.id)).toMatchObject({ currentLeaseId: "lease-future-predecessor" });
     const futureLeases = await invokeRouter(leaseRouter, { method: "GET", url: "/tenant/tenant-future" });
+    expect(futureLeases.body.leases.find((entry: any) => entry.id === "lease-future-predecessor")?.canonicalState).toMatchObject({
+      occupancyState: "occupied", supportingLeaseId: "lease-future-predecessor",
+    });
     expect(futureLeases.body.leases.find((entry: any) => entry.id === "lease-future-successor")?.canonicalState?.supportingLeaseId).not.toBe("lease-future-successor");
+    const futureTenants = await invokeRouter(tenantsRouter, { method: "GET", url: "/" });
+    expect(futureTenants.status).toBe(200);
+    expect(futureTenants.body.tenants.find((entry: any) => entry.id === "tenant-future")).toMatchObject({
+      currentLeaseId: "lease-future-predecessor",
+      canonicalState: expect.objectContaining({ supportingLeaseId: "lease-future-predecessor" }),
+    });
     const futureTenant = await invokeRouter(tenantsRouter, { method: "GET", url: "/tenant-future" });
     expect(futureTenant.body?.tenant?.currentLeaseId).toBe("lease-future-predecessor");
+    expect(futureTenant.body?.canonicalState).toMatchObject({
+      occupancyState: "occupied", tenantRelationshipState: "current_occupant", supportingLeaseId: "lease-future-predecessor",
+    });
+    const futureReview = await invokeRouter(occupancyReviewRouter, { method: "GET", url: "/" });
+    expect(futureReview.status).toBe(200);
+    expect(futureReview.body.items.filter((item: any) => item.propertyId === "property-renewal" && item.unitId === futureUnit.id)).toEqual([]);
 
     const { getRenewalContinuityContext, handoffRenewalContinuity } = await import("../../services/leaseStart/renewalContinuityService");
     const context = await getRenewalContinuityContext({
@@ -3306,7 +3321,7 @@ describe("leaseRoutes GET /active", () => {
     expect(activeLeases.body.leases.find((entry: any) => entry.id === "lease-successor")?.canonicalState).toMatchObject({
       occupancyState: "occupied", supportingLeaseId: "lease-successor", reasons: [],
     });
-    expect(activeLeases.body.leases.find((entry: any) => entry.id === "lease-predecessor")?.canonicalState?.supportingLeaseId).not.toBe("lease-predecessor");
+    expect(activeLeases.body.leases.find((entry: any) => entry.id === "lease-predecessor")).toBeUndefined();
 
     const tenants = await invokeRouter(tenantsRouter, { method: "GET", url: "/" });
     expect(tenants.status).toBe(200);
@@ -3319,6 +3334,20 @@ describe("leaseRoutes GET /active", () => {
       expect(detail.body.tenant).toMatchObject({ currentLeaseId: "lease-successor" });
       expect(detail.body.canonicalState).toMatchObject({ occupancyState: "occupied", tenantRelationshipState: "current_occupant", supportingLeaseId: "lease-successor" });
       expect(detail.body.lease).toMatchObject({ id: "lease-successor" });
+
+      // TenantLeasePanel consumes this route as the tenant-detail workspace's
+      // current and historical lease source. It must retain the renewed
+      // predecessor while classifying only the successor as current.
+      const leaseHistory = await invokeRouter(leaseRouter, { method: "GET", url: `/tenant/${tenantId}` });
+      expect(leaseHistory.status).toBe(200);
+      expect(leaseHistory.body.leases.find((entry: any) => entry.id === "lease-successor")?.canonicalState).toMatchObject({
+        occupancyState: "occupied", supportingLeaseId: "lease-successor", reasons: [],
+      });
+      expect(leaseHistory.body.leases.find((entry: any) => entry.id === "lease-predecessor")).toMatchObject({
+        id: "lease-predecessor", status: "renewed", startDate: "2025-08-23", endDate: "2026-08-22",
+        monthlyRent: 1800, occupancyEffective: false,
+        canonicalState: expect.objectContaining({ occupancyState: "occupied", supportingLeaseId: "lease-successor" }),
+      });
     }
 
     const review = await invokeRouter(occupancyReviewRouter, { method: "GET", url: "/" });

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -81,6 +81,11 @@ import { readMutationIdempotencyKey } from "../lib/http/mutationIdempotency";
 import { createCanonicalLease } from "../services/leaseStart/leaseCreationService";
 import { leaseStartDeterministicId } from "../services/leaseStart/leaseStartExpectedState";
 import { getCanonicalLeaseStartContext, LeaseStartServiceError, startCanonicalLeaseOccupancy } from "../services/leaseStart/leaseStartService";
+import {
+  getRenewalContinuityContext,
+  handoffRenewalContinuity,
+  RenewalContinuityServiceError,
+} from "../services/leaseStart/renewalContinuityService";
 import { evaluateJurisdictionPolicy } from "../lib/jurisdiction/operationalPolicyEvaluator";
 import { formatInternalReference, slugifyOperationalReference } from "../lib/identityReferences";
 import { computeLeaseState } from "../services/stateMachines/stateComputation";
@@ -122,6 +127,18 @@ function leaseStartErrorResponse(error: unknown, res: Response) {
   if (!(error instanceof LeaseStartServiceError)) return false;
   const status = error.code === "lease_start_state_stale" || error.code === "lease_start_idempotency_key_reused" || error.code === "lease_start_context_ambiguous" ? 409 : 500;
   res.status(status).json({ ok: false, error: error.code, freshContext: error.freshContext || undefined });
+  return true;
+}
+
+function renewalContinuityErrorResponse(error: unknown, res: Response) {
+  if (!(error instanceof RenewalContinuityServiceError)) return false;
+  const status = error.code === "renewal_context_ambiguous" ? 404 : error.code === "renewal_postcondition_failed" ? 500 : 409;
+  res.status(status).json({
+    ok: false,
+    error: error.code,
+    reasons: error.reasons,
+    freshContext: error.freshContext || undefined,
+  });
   return true;
 }
 
@@ -2872,6 +2889,52 @@ router.get("/snapshots/:id", requireLandlord, async (req: any, res: Response) =>
   }
 });
 
+router.get("/renewals/:successorLeaseId/context", requireLandlord, async (req: any, res: Response) => {
+  try {
+    if (!(await enforceLeaseCapability(req, res))) return;
+    const landlordId = String(req.user?.landlordId || req.user?.id || "").trim();
+    const evaluationInstant = new Date().toISOString();
+    const context = await getRenewalContinuityContext({
+      landlordId,
+      successorLeaseId: String(req.params?.successorLeaseId || "").trim(),
+      evaluationInstant,
+    });
+    return res.json({ ok: true, context });
+  } catch (error) {
+    if (renewalContinuityErrorResponse(error, res)) return;
+    console.error("[GET /api/leases/renewals/:successorLeaseId/context] error", error);
+    return res.status(500).json({ ok: false, error: "renewal_context_failed" });
+  }
+});
+
+router.post("/renewals/:successorLeaseId/activate", requireLandlord, async (req: any, res: Response) => {
+  try {
+    if (!(await enforceLeaseCapability(req, res))) return;
+    const idempotencyKey = mutationIdempotencyKeyOrReject(req, res);
+    if (!idempotencyKey) return;
+    const landlordId = String(req.user?.landlordId || req.user?.id || "").trim();
+    const expectedStateToken = String(req.body?.expectedStateToken || "").trim();
+    const evaluationInstant = String(req.body?.evaluationInstant || "").trim();
+    if (!expectedStateToken || !evaluationInstant) {
+      return res.status(400).json({ ok: false, error: "renewal_expected_state_required" });
+    }
+    const result = await handoffRenewalContinuity({
+      landlordId,
+      successorLeaseId: String(req.params?.successorLeaseId || "").trim(),
+      expectedStateToken,
+      evaluationInstant,
+      idempotencyKey,
+      actorId: String(req.user?.id || req.user?.email || landlordId).trim() || landlordId,
+      source: "lease_renewal_route",
+    });
+    return res.json({ ok: true, result });
+  } catch (error) {
+    if (renewalContinuityErrorResponse(error, res)) return;
+    console.error("[POST /api/leases/renewals/:successorLeaseId/activate] error", error);
+    return res.status(500).json({ ok: false, error: "renewal_handoff_failed" });
+  }
+});
+
 router.post("/:id/automation/tasks/regenerate", requireLandlord, async (req: any, res: Response) => {
   const landlordId = String(req.user?.landlordId || req.user?.id || "").trim();
   const leaseResult = await getLeaseEntityForLandlord(String(req.params?.id || "").trim(), landlordId);
@@ -3712,6 +3775,9 @@ router.post("/", requireLandlord, async (req: Request, res: Response) => {
         endDate: body.endDate ?? null,
         automationEnabled: body.automationEnabled ?? true,
         renewalStatus: body.renewalStatus ?? "unknown",
+        ...(String((body as any)?.predecessorLeaseId || "").trim()
+          ? { predecessorLeaseId: String((body as any).predecessorLeaseId).trim() }
+          : {}),
         status: String((body as any)?.status || (executionStatus === "fully_executed" ? "active" : "draft")).trim(),
         executionStatus: executionStatus || "draft",
         executionState: executionStatus || "draft",
@@ -3735,6 +3801,9 @@ router.post("/", requireLandlord, async (req: Request, res: Response) => {
       evaluationInstant,
       actorId,
       source: "lease_create_route",
+      renewalLink: String((body as any)?.predecessorLeaseId || "").trim()
+        ? { predecessorLeaseId: String((body as any).predecessorLeaseId).trim() }
+        : null,
     });
     if (result.canonicalOutcome === "rejected") {
       return canonicalLeaseStartRejection(res, result);

--- a/rentchain-api/src/services/__tests__/leaseSigningService.test.ts
+++ b/rentchain-api/src/services/__tests__/leaseSigningService.test.ts
@@ -146,13 +146,13 @@ describe("leaseSigningService", () => {
     startCanonicalLeaseOccupancyMock.mockResolvedValueOnce({ canonicalOutcome: "created_without_occupancy", occupancyEffective: false, reasons: ["UPCOMING_LEASE_CANNOT_SUPPORT_OCCUPANCY"] });
     ensureCollection("leases").set("lease-future", {
       landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-1",
-      status: "active", startDate: "2027-01-01", endDate: "2027-12-31",
+      status: "pending", predecessorLeaseId: "lease-predecessor", startDate: "2027-01-01", endDate: "2027-12-31",
     });
     const sent = await sendLeaseForSignature({ leaseId: "lease-future", landlordId: "landlord-1", lease: { startDate: "2027-01-01" }, tenantEmails: ["tenant@example.com"] });
     const signingRequest = ensureCollection("leaseSigningRequests").get(String(sent.signingRequestId));
     await processSigningWebhook({ providerId: "mock", headers: {}, body: { providerRequestId: signingRequest.providerRequestId, eventId: "provider-future-1", type: "signed", occurredAt: "2026-08-19T12:00:00.000Z" } });
     await processSigningWebhook({ providerId: "mock", headers: {}, body: { providerRequestId: signingRequest.providerRequestId, eventId: "provider-future-1", type: "signed", occurredAt: "2026-08-19T12:00:00.000Z" } });
-    expect(ensureCollection("leases").get("lease-future")).toEqual(expect.objectContaining({ executionStatus: "fully_executed" }));
+    expect(ensureCollection("leases").get("lease-future")).toEqual(expect.objectContaining({ executionStatus: "fully_executed", status: "active" }));
     expect(ensureCollection("leases").get("lease-future")).not.toHaveProperty("occupancyStartReview");
     expect(startCanonicalLeaseOccupancyMock).toHaveBeenCalledTimes(1);
     expect(ensureCollection("leaseSigningCompletionOperations").size).toBe(1);

--- a/rentchain-api/src/services/__tests__/leaseSigningService.test.ts
+++ b/rentchain-api/src/services/__tests__/leaseSigningService.test.ts
@@ -152,10 +152,27 @@ describe("leaseSigningService", () => {
     const signingRequest = ensureCollection("leaseSigningRequests").get(String(sent.signingRequestId));
     await processSigningWebhook({ providerId: "mock", headers: {}, body: { providerRequestId: signingRequest.providerRequestId, eventId: "provider-future-1", type: "signed", occurredAt: "2026-08-19T12:00:00.000Z" } });
     await processSigningWebhook({ providerId: "mock", headers: {}, body: { providerRequestId: signingRequest.providerRequestId, eventId: "provider-future-1", type: "signed", occurredAt: "2026-08-19T12:00:00.000Z" } });
-    expect(ensureCollection("leases").get("lease-future")).toEqual(expect.objectContaining({ executionStatus: "fully_executed", status: "active" }));
+    expect(ensureCollection("leases").get("lease-future")).toEqual(expect.objectContaining({ executionStatus: "fully_executed", status: "pending" }));
     expect(ensureCollection("leases").get("lease-future")).not.toHaveProperty("occupancyStartReview");
-    expect(startCanonicalLeaseOccupancyMock).toHaveBeenCalledTimes(1);
-    expect(ensureCollection("leaseSigningCompletionOperations").size).toBe(1);
+    expect(startCanonicalLeaseOccupancyMock).not.toHaveBeenCalled();
+    expect(ensureCollection("leaseSigningCompletionOperations").size).toBe(0);
+  });
+
+  it("never hands linked renewal occupancy over when signing completes on its effective date", async () => {
+    const { processSigningWebhook, sendLeaseForSignature } = await import("../signing/leaseSigningService");
+    ensureCollection("leases").set("lease-renewal-effective", {
+      landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-1",
+      status: "pending", predecessorLeaseId: "lease-predecessor", occupancyEffective: false,
+      startDate: "2027-01-01", endDate: "2027-12-31",
+    });
+    const sent = await sendLeaseForSignature({ leaseId: "lease-renewal-effective", landlordId: "landlord-1", lease: { startDate: "2027-01-01" }, tenantEmails: ["tenant@example.com"] });
+    const signingRequest = ensureCollection("leaseSigningRequests").get(String(sent.signingRequestId));
+    await processSigningWebhook({ providerId: "mock", headers: {}, body: { providerRequestId: signingRequest.providerRequestId, eventId: "provider-renewal-effective", type: "signed", occurredAt: "2027-01-01T12:00:00.000Z" } });
+    expect(ensureCollection("leases").get("lease-renewal-effective")).toEqual(expect.objectContaining({
+      executionStatus: "fully_executed", status: "pending", occupancyEffective: false,
+    }));
+    expect(startCanonicalLeaseOccupancyMock).not.toHaveBeenCalled();
+    expect(getCanonicalLeaseStartContextMock).not.toHaveBeenCalled();
   });
 
   it("creates a pending signing request without exposing raw provider references in projected snapshot", async () => {

--- a/rentchain-api/src/services/leaseService.ts
+++ b/rentchain-api/src/services/leaseService.ts
@@ -37,6 +37,7 @@ export interface CreateLeasePayload {
   endDate?: string | null;
   automationEnabled?: boolean;
   renewalStatus?: LeaseRenewalStatus;
+  predecessorLeaseId?: string | null;
   risk?: RiskAssessment | null;
   riskTimeline?: LeaseRiskTimelineEntry[];
 }

--- a/rentchain-api/src/services/leaseStart/__tests__/leaseCreationService.test.ts
+++ b/rentchain-api/src/services/leaseStart/__tests__/leaseCreationService.test.ts
@@ -178,4 +178,31 @@ describe("createCanonicalLease", () => {
     expect(result.occupancyEffective).toBe(true);
     expect(fake.read("leaseDrafts", "draft-1")).toMatchObject({ status: "activated", leaseId: "lease-create-1" });
   });
+
+  it("creates a future renewal and both durable links in the lease-creation transaction", async () => {
+    fake.seed("leases", "predecessor", {
+      landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-1", tenantIds: ["tenant-1"],
+      status: "active", executionStatus: "fully_executed", startDate: "2025-09-01", endDate: "2026-08-31", occupancyEffective: true,
+    });
+    const result = await createCanonicalLease(input({
+      renewalLink: { predecessorLeaseId: "predecessor" },
+      leaseRecord: { startDate: "2026-09-01", endDate: "2027-08-31", executionStatus: "fully_executed" },
+    }));
+    expect(result.canonicalOutcome).toBe("created_without_occupancy");
+    expect(fake.read("leases", "lease-create-1")).toMatchObject({ status: "active", predecessorLeaseId: "predecessor", occupancyEffective: false });
+    expect(fake.read("leases", "predecessor")).toMatchObject({ renewedByLeaseId: "lease-create-1" });
+  });
+
+  it("rejects a renewal link when participant sets differ without changing the predecessor", async () => {
+    fake.seed("leases", "predecessor", {
+      landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-2", tenantIds: ["tenant-2"],
+      status: "active", executionStatus: "fully_executed", startDate: "2025-09-01", endDate: "2026-08-31", occupancyEffective: true,
+    });
+    await expect(createCanonicalLease(input({
+      renewalLink: { predecessorLeaseId: "predecessor" },
+      leaseRecord: { startDate: "2026-09-01", endDate: "2027-08-31" },
+    }))).rejects.toMatchObject({ code: "lease_start_context_ambiguous" });
+    expect(fake.read("leases", "predecessor").renewedByLeaseId).toBeUndefined();
+    expect(fake.read("leases", "lease-create-1")).toBeUndefined();
+  });
 });

--- a/rentchain-api/src/services/leaseStart/__tests__/leaseCreationService.test.ts
+++ b/rentchain-api/src/services/leaseStart/__tests__/leaseCreationService.test.ts
@@ -189,7 +189,7 @@ describe("createCanonicalLease", () => {
       leaseRecord: { startDate: "2026-09-01", endDate: "2027-08-31", executionStatus: "fully_executed" },
     }));
     expect(result.canonicalOutcome).toBe("created_without_occupancy");
-    expect(fake.read("leases", "lease-create-1")).toMatchObject({ status: "active", predecessorLeaseId: "predecessor", occupancyEffective: false });
+    expect(fake.read("leases", "lease-create-1")).toMatchObject({ status: "pending", predecessorLeaseId: "predecessor", occupancyEffective: false });
     expect(fake.read("leases", "predecessor")).toMatchObject({ renewedByLeaseId: "lease-create-1" });
   });
 

--- a/rentchain-api/src/services/leaseStart/__tests__/leaseStartTransaction.test.ts
+++ b/rentchain-api/src/services/leaseStart/__tests__/leaseStartTransaction.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi } from "vitest";
+import { runLeaseStartTransaction } from "../leaseStartTransaction";
+
+type Ref = { collection: string; id: string };
+
+function ref(collection: string, id: string): Ref {
+  return { collection, id };
+}
+
+function createTransactionalStore() {
+  const data = new Map<string, any>();
+  let tail = Promise.resolve();
+  const key = (target: Ref) => `${target.collection}/${target.id}`;
+  const firestore = {
+    runTransaction: vi.fn(async (callback: (transaction: any) => Promise<any>) => {
+      const execute = async () => {
+        const pending: Array<() => void> = [];
+        const transaction = {
+          get: async (target: Ref) => {
+            const value = data.get(key(target));
+            return { exists: value !== undefined, data: () => value };
+          },
+          create: (target: Ref, value: any) => pending.push(() => {
+            if (data.has(key(target))) throw new Error("already_exists");
+            data.set(key(target), structuredClone(value));
+          }),
+          set: (target: Ref, value: any) => pending.push(() => data.set(key(target), structuredClone(value))),
+        };
+        const result = await callback(transaction);
+        pending.forEach((apply) => apply());
+        return result;
+      };
+      const result = tail.then(execute, execute);
+      tail = result.then(() => undefined, () => undefined);
+      return result;
+    }),
+  };
+  return { firestore, data, read: (target: Ref) => data.get(key(target)) };
+}
+
+function adapter(store: ReturnType<typeof createTransactionalStore>, overrides: Record<string, any> = {}) {
+  const requestRef = ref("leaseStartRequests", "request-1");
+  const eventRef = ref("canonicalEvents", "event-1");
+  const domainRef = ref("leases", "lease-1");
+  const apply = vi.fn((transaction: any) => transaction.set(domainRef, { status: "active" }));
+  const load = vi.fn(async () => ({ expectedStateToken: "token-1" }));
+  const postcondition = vi.fn();
+  return {
+    requestRef,
+    eventRef,
+    domainRef,
+    apply,
+    load,
+    postcondition,
+    input: {
+      firestore: store.firestore,
+      requestRef,
+      payloadHash: "fingerprint-1",
+      expectedStateToken: "token-1",
+      error: (kind: string) => Object.assign(new Error(kind), { code: kind }),
+      loadAuthoritativeState: load,
+      getExpectedStateToken: (loaded: any) => loaded.expectedStateToken,
+      buildPlan: vi.fn(async ({ transaction }: any) => ({
+        result: { outcome: "committed", idempotency: { replay: false } },
+        applyMutations: () => apply(transaction),
+        assertPostcondition: postcondition,
+        events: [{ ref: eventRef, record: { type: "lease.started" } }],
+        requestRecord: {
+          payloadHash: "fingerprint-1",
+          result: { outcome: "committed", idempotency: { replay: false } },
+        },
+      })),
+      ...overrides,
+    },
+  };
+}
+
+describe("shared lease-start transaction engine", () => {
+  it("executes the domain callback once and persists domain, audit, and result atomically", async () => {
+    const store = createTransactionalStore();
+    const subject = adapter(store);
+    await runLeaseStartTransaction(subject.input);
+    expect(store.firestore.runTransaction).toHaveBeenCalledTimes(1);
+    expect(subject.input.buildPlan).toHaveBeenCalledTimes(1);
+    expect(subject.apply).toHaveBeenCalledTimes(1);
+    expect(subject.postcondition).toHaveBeenCalledTimes(1);
+    expect(store.read(subject.domainRef)).toEqual({ status: "active" });
+    expect(store.read(subject.eventRef)).toEqual({ type: "lease.started" });
+    expect(store.read(subject.requestRef)).toMatchObject({ payloadHash: "fingerprint-1" });
+  });
+
+  it("returns a stored same-key replay without loading or mutating domain state", async () => {
+    const store = createTransactionalStore();
+    const first = adapter(store);
+    await runLeaseStartTransaction(first.input);
+    const replay = adapter(store);
+    const result = await runLeaseStartTransaction(replay.input);
+    expect(result).toMatchObject({ outcome: "idempotent_replay", idempotency: { replay: true } });
+    expect(replay.load).not.toHaveBeenCalled();
+    expect(replay.apply).not.toHaveBeenCalled();
+  });
+
+  it("rejects a changed fingerprint before load or mutation", async () => {
+    const store = createTransactionalStore();
+    const first = adapter(store);
+    await runLeaseStartTransaction(first.input);
+    const changed = adapter(store, { payloadHash: "fingerprint-2" });
+    await expect(runLeaseStartTransaction(changed.input)).rejects.toMatchObject({ code: "idempotency" });
+    expect(changed.load).not.toHaveBeenCalled();
+    expect(changed.apply).not.toHaveBeenCalled();
+  });
+
+  it("rejects stale expected state before mutation", async () => {
+    const store = createTransactionalStore();
+    const subject = adapter(store, { expectedStateToken: "stale-token" });
+    await expect(runLeaseStartTransaction(subject.input)).rejects.toMatchObject({ code: "stale" });
+    expect(subject.apply).not.toHaveBeenCalled();
+    expect(store.read(subject.requestRef)).toBeUndefined();
+  });
+
+  it("rolls back queued domain writes when the postcondition fails", async () => {
+    const store = createTransactionalStore();
+    const subject = adapter(store);
+    subject.postcondition.mockImplementation(() => { throw new Error("postcondition_failed"); });
+    await expect(runLeaseStartTransaction(subject.input)).rejects.toThrow("postcondition_failed");
+    expect(store.read(subject.domainRef)).toBeUndefined();
+    expect(store.read(subject.eventRef)).toBeUndefined();
+    expect(store.read(subject.requestRef)).toBeUndefined();
+  });
+
+  it("does not persist success state when the domain callback fails", async () => {
+    const store = createTransactionalStore();
+    const subject = adapter(store);
+    subject.input.buildPlan.mockRejectedValueOnce(new Error("domain_failed"));
+    await expect(runLeaseStartTransaction(subject.input)).rejects.toThrow("domain_failed");
+    expect(store.read(subject.eventRef)).toBeUndefined();
+    expect(store.read(subject.requestRef)).toBeUndefined();
+  });
+
+  it("serializes concurrent same-key attempts into one logical mutation and one replay", async () => {
+    const store = createTransactionalStore();
+    const first = adapter(store);
+    const second = adapter(store);
+    const results = await Promise.all([
+      runLeaseStartTransaction(first.input),
+      runLeaseStartTransaction(second.input),
+    ]);
+    expect(results.map((result: any) => result.outcome).sort()).toEqual(["committed", "idempotent_replay"]);
+    expect(first.apply.mock.calls.length + second.apply.mock.calls.length).toBe(1);
+    expect(store.read(first.eventRef)).toEqual({ type: "lease.started" });
+  });
+
+  it("keeps one logical result when Firestore retries a conflicted callback", async () => {
+    const store = createTransactionalStore();
+    const subject = adapter(store);
+    const nativeRunner = store.firestore.runTransaction;
+    subject.input.firestore = {
+      runTransaction: async (callback: any) => {
+        await callback({
+          get: async () => ({ exists: false, data: () => undefined }),
+          create: () => undefined,
+          set: () => undefined,
+        });
+        return nativeRunner(callback);
+      },
+    };
+    const result = await runLeaseStartTransaction(subject.input);
+    expect(result).toMatchObject({ outcome: "committed" });
+    expect(subject.input.buildPlan).toHaveBeenCalledTimes(2);
+    expect(store.read(subject.eventRef)).toEqual({ type: "lease.started" });
+    expect(store.read(subject.requestRef)).toMatchObject({ payloadHash: "fingerprint-1" });
+  });
+});

--- a/rentchain-api/src/services/leaseStart/__tests__/renewalContinuityService.test.ts
+++ b/rentchain-api/src/services/leaseStart/__tests__/renewalContinuityService.test.ts
@@ -4,6 +4,8 @@ import {
   handoffRenewalContinuity,
   RenewalContinuityServiceError,
 } from "../renewalContinuityService";
+import { buildCanonicalLeaseOccupancyProjection } from "../../../lib/leases/canonicalLeaseOccupancyProjection";
+import { deriveLeaseLifecycleReviewQueue } from "../../../lib/leases/leaseLifecycleReviewQueue";
 
 function createFakeFirestore() {
   const store = new Map<string, Map<string, any>>();
@@ -139,8 +141,26 @@ describe("renewal continuity service", () => {
     expect(fake.read("tenancies", "predecessor-tenancy")).toMatchObject({ status: "inactive", moveOutAt: evaluationInstant });
     expect(fake.list("tenancies").filter((entry) => entry.leaseId === "successor" && entry.status === "active")).toHaveLength(1);
     expect(fake.list("canonicalEvents")).toHaveLength(1);
-    expect(fake.read("leases", "predecessor")).toMatchObject({ startDate: predecessorBefore.startDate, endDate: predecessorBefore.endDate, status: predecessorBefore.status, monthlyRent: predecessorBefore.monthlyRent });
-    expect(fake.read("leases", "successor")).toMatchObject({ startDate: successorBefore.startDate, endDate: successorBefore.endDate, executionStatus: successorBefore.executionStatus, monthlyRent: successorBefore.monthlyRent });
+    expect(fake.read("leases", "predecessor")).toMatchObject({ startDate: predecessorBefore.startDate, endDate: predecessorBefore.endDate, status: "renewed", monthlyRent: predecessorBefore.monthlyRent, occupancyEffective: false });
+    expect(fake.read("leases", "successor")).toMatchObject({ startDate: successorBefore.startDate, endDate: successorBefore.endDate, executionStatus: successorBefore.executionStatus, monthlyRent: successorBefore.monthlyRent, status: "active", occupancyEffective: true });
+    const projectedLeases = [
+      { id: "predecessor", ...fake.read("leases", "predecessor") },
+      { id: "successor", ...fake.read("leases", "successor") },
+    ];
+    const projection = buildCanonicalLeaseOccupancyProjection({
+      leases: projectedLeases,
+      context: { asOfDate: evaluationInstant },
+      persistedUnitOccupancy: fake.read("units", "unit-1").occupancyStatus,
+      persistedTenancyStatus: "active",
+      persistedTenantStatus: fake.read("tenants", "tenant-1").status,
+      currentLeasePointerId: fake.read("units", "unit-1").currentLeaseId,
+      tenantId: "tenant-1",
+    });
+    expect(projection).toMatchObject({
+      occupancyState: "occupied", tenantRelationshipState: "current_occupant", supportingLeaseId: "successor", reasons: [],
+    });
+    const review = deriveLeaseLifecycleReviewQueue({ leases: projectedLeases, units: [{ id: "unit-1", ...fake.read("units", "unit-1") }], today: evaluationInstant, detectedAt: evaluationInstant });
+    expect(review.items.filter((item) => ["predecessor", "successor"].includes(item.leaseId))).toHaveLength(0);
   });
 
   it("replays the same logical request without duplicate tenancy or audit", async () => {
@@ -187,5 +207,42 @@ describe("renewal continuity service", () => {
     expect(attempts.filter((attempt) => attempt.status === "fulfilled")).toHaveLength(1);
     expect(fake.list("canonicalEvents")).toHaveLength(1);
     expect(fake.list("tenancies").filter((entry) => entry.leaseId === "successor" && entry.status === "active")).toHaveLength(1);
+  });
+
+  it("reconciles every participant tenancy, reuses a successor row, and preserves unrelated rows", async () => {
+    fake.seed("tenants", "tenant-2", { landlordId: "landlord-1", status: "current", currentLeaseId: "predecessor" });
+    fake.seed("leases", "predecessor", { ...fake.read("leases", "predecessor"), tenantIds: ["tenant-1", "tenant-2"] });
+    fake.seed("leases", "successor", { ...fake.read("leases", "successor"), tenantIds: ["tenant-1", "tenant-2"] });
+    fake.seed("tenancies", "predecessor-tenancy-2", {
+      landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-2", leaseId: "predecessor",
+      status: "active", moveInAt: "2026-01-01T00:00:00.000Z", moveOutAt: null,
+    });
+    fake.seed("tenancies", "successor-tenancy-2", {
+      landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-2", leaseId: "successor",
+      status: "pending", moveInAt: "2027-01-01T00:00:00.000Z", moveOutAt: null, source: "existing",
+    });
+    fake.seed("tenancies", "unrelated", {
+      landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-foreign", leaseId: "historical",
+      status: "inactive", moveOutAt: "2025-01-01T00:00:00.000Z", marker: "unchanged",
+    });
+    await handoffRenewalContinuity(await request());
+    expect(fake.list("tenancies").filter((entry) => entry.leaseId === "predecessor" && entry.status === "active")).toHaveLength(0);
+    const successors = fake.list("tenancies").filter((entry) => entry.leaseId === "successor" && entry.status === "active");
+    expect(successors).toHaveLength(2);
+    expect(new Set(successors.map((entry) => entry.tenantId))).toEqual(new Set(["tenant-1", "tenant-2"]));
+    expect(fake.read("tenancies", "successor-tenancy-2")).toMatchObject({ status: "active", source: "existing" });
+    expect(fake.read("tenancies", "unrelated")).toMatchObject({ status: "inactive", marker: "unchanged" });
+    expect(fake.read("tenants", "tenant-2")).toMatchObject({ currentLeaseId: "successor" });
+  });
+
+  it("rejects an occupancy-excluded successor before writes", async () => {
+    fake.seed("leases", "successor", {
+      ...fake.read("leases", "successor"),
+      occupancyDisposition: { status: "excluded_from_current_occupancy_by_resolution" },
+    });
+    const input = await request();
+    await expect(handoffRenewalContinuity(input)).rejects.toMatchObject({ code: "renewal_handoff_ineligible" });
+    expect(fake.list("canonicalEvents")).toHaveLength(0);
+    expect(fake.read("units", "unit-1")).toMatchObject({ currentLeaseId: "predecessor" });
   });
 });

--- a/rentchain-api/src/services/leaseStart/__tests__/renewalContinuityService.test.ts
+++ b/rentchain-api/src/services/leaseStart/__tests__/renewalContinuityService.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  getRenewalContinuityContext,
+  handoffRenewalContinuity,
+  RenewalContinuityServiceError,
+} from "../renewalContinuityService";
+
+function createFakeFirestore() {
+  const store = new Map<string, Map<string, any>>();
+  let transactionQueue = Promise.resolve();
+  const collectionData = (name: string) => {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  };
+  const ref = (name: string, id: string): any => ({
+    kind: "doc", collectionName: name, id,
+    get: async () => {
+      const value = collectionData(name).get(id);
+      return { id, exists: value !== undefined, data: () => value };
+    },
+    set: async (value: any, options?: any) => {
+      const prior = collectionData(name).get(id);
+      collectionData(name).set(id, options?.merge ? { ...(prior || {}), ...structuredClone(value) } : structuredClone(value));
+    },
+    create: async (value: any) => {
+      if (collectionData(name).has(id)) throw new Error("already_exists");
+      collectionData(name).set(id, structuredClone(value));
+    },
+  });
+  const query = (name: string, filters: any[] = []): any => ({
+    kind: "query", collectionName: name, filters,
+    where: (field: string, op: string, value: any) => query(name, [...filters, { field, op, value }]),
+    get: async () => ({
+      docs: [...collectionData(name).entries()]
+        .filter(([, value]) => filters.every((filter) => filter.op === "==" && value[filter.field] === filter.value))
+        .map(([id, value]) => ({ id, exists: true, data: () => value })),
+    }),
+  });
+  const firestore: any = {
+    collection: (name: string) => ({ ...query(name), doc: (id: string) => ref(name, id) }),
+    runTransaction: async (callback: any) => {
+      const execute = async () => {
+      const writes: Array<{ kind: "set" | "create"; target: any; value: any; options?: any }> = [];
+      const result = await callback({
+        get: (target: any) => target.get(),
+        set: (target: any, value: any, options?: any) => writes.push({ kind: "set", target, value, options }),
+        create: (target: any, value: any) => writes.push({ kind: "create", target, value }),
+      });
+      const snapshot = structuredClone([...store.entries()].map(([name, values]) => [name, [...values.entries()]]));
+      try {
+        for (const write of writes) {
+          if (write.kind === "create") await write.target.create(write.value);
+          else await write.target.set(write.value, write.options);
+        }
+      } catch (error) {
+        store.clear();
+        for (const [name, values] of snapshot) store.set(name, new Map(values));
+        throw error;
+      }
+      return result;
+      };
+      const pending = transactionQueue.then(execute, execute);
+      transactionQueue = pending.then(() => undefined, () => undefined);
+      return pending;
+    },
+  };
+  return {
+    firestore,
+    seed: (name: string, id: string, value: any) => collectionData(name).set(id, structuredClone(value)),
+    read: (name: string, id: string) => structuredClone(collectionData(name).get(id)),
+    list: (name: string) => [...collectionData(name).values()].map((value) => structuredClone(value)),
+  };
+}
+
+const evaluationInstant = "2027-01-01T12:00:00.000Z";
+let fake: ReturnType<typeof createFakeFirestore>;
+
+function seed(overrides: { predecessor?: any; successor?: any; extraTenancy?: any } = {}) {
+  const unit = {
+    id: "unit-1", landlordId: "landlord-1", propertyId: "property-1", unitNumber: "1A",
+    status: "occupied", occupancyStatus: "occupied", occupied: true,
+    tenantId: "tenant-1", currentTenantId: "tenant-1", leaseId: "predecessor", currentLeaseId: "predecessor",
+    updatedAt: "2026-12-31T12:00:00.000Z",
+  };
+  fake.seed("properties", "property-1", { landlordId: "landlord-1", units: [{ ...unit }], updatedAt: unit.updatedAt });
+  fake.seed("units", "unit-1", unit);
+  fake.seed("tenants", "tenant-1", { landlordId: "landlord-1", status: "current", currentLeaseId: "predecessor", updatedAt: unit.updatedAt });
+  fake.seed("leases", "predecessor", {
+    landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-1", tenantIds: ["tenant-1"],
+    status: "active", executionStatus: "fully_executed", startDate: "2026-01-01", endDate: "2026-12-31",
+    renewedByLeaseId: "successor", occupancyEffective: true, monthlyRent: 1200, updatedAt: unit.updatedAt,
+    ...(overrides.predecessor || {}),
+  });
+  fake.seed("leases", "successor", {
+    landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-1", tenantIds: ["tenant-1"],
+    status: "active", executionStatus: "fully_executed", startDate: "2027-01-01", endDate: "2027-12-31",
+    predecessorLeaseId: "predecessor", occupancyEffective: false, monthlyRent: 1250, updatedAt: unit.updatedAt,
+    ...(overrides.successor || {}),
+  });
+  fake.seed("tenancies", "predecessor-tenancy", {
+    landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-1", leaseId: "predecessor",
+    status: "active", moveInAt: "2026-01-01T00:00:00.000Z", moveOutAt: null, updatedAt: unit.updatedAt,
+  });
+  if (overrides.extraTenancy) fake.seed("tenancies", "other-tenancy", overrides.extraTenancy);
+}
+
+async function request(overrides: Record<string, unknown> = {}) {
+  const context = await getRenewalContinuityContext({ landlordId: "landlord-1", successorLeaseId: "successor", evaluationInstant, firestore: fake.firestore });
+  return {
+    landlordId: "landlord-1", successorLeaseId: "successor", evaluationInstant,
+    expectedStateToken: context.expectedStateToken, idempotencyKey: "renewal-request-1",
+    actorId: "landlord-1", source: "test", firestore: fake.firestore,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  fake = createFakeFirestore();
+  seed();
+});
+
+describe("renewal continuity service", () => {
+  it("returns a read-only eligible context", async () => {
+    const before = JSON.stringify(fake.list("tenancies"));
+    const context = await getRenewalContinuityContext({ landlordId: "landlord-1", successorLeaseId: "successor", evaluationInstant, firestore: fake.firestore });
+    expect(context).toMatchObject({ handoffEligible: true, termContinuity: true, executionReady: true, blockingReasons: [] });
+    expect(JSON.stringify(fake.list("tenancies"))).toBe(before);
+    expect(fake.list("canonicalEvents")).toHaveLength(0);
+  });
+
+  it("atomically hands occupancy to the successor without mutating contract fields", async () => {
+    const predecessorBefore = fake.read("leases", "predecessor");
+    const successorBefore = fake.read("leases", "successor");
+    const result = await handoffRenewalContinuity(await request());
+    expect(result.outcome).toBe("renewal_handoff_completed");
+    expect(fake.read("units", "unit-1")).toMatchObject({ status: "occupied", currentLeaseId: "successor", currentTenantId: "tenant-1" });
+    expect(fake.read("properties", "property-1").units[0]).toMatchObject({ status: "occupied", currentLeaseId: "successor", currentTenantId: "tenant-1" });
+    expect(fake.read("tenants", "tenant-1")).toMatchObject({ status: "current", currentLeaseId: "successor" });
+    expect(fake.read("tenancies", "predecessor-tenancy")).toMatchObject({ status: "inactive", moveOutAt: evaluationInstant });
+    expect(fake.list("tenancies").filter((entry) => entry.leaseId === "successor" && entry.status === "active")).toHaveLength(1);
+    expect(fake.list("canonicalEvents")).toHaveLength(1);
+    expect(fake.read("leases", "predecessor")).toMatchObject({ startDate: predecessorBefore.startDate, endDate: predecessorBefore.endDate, status: predecessorBefore.status, monthlyRent: predecessorBefore.monthlyRent });
+    expect(fake.read("leases", "successor")).toMatchObject({ startDate: successorBefore.startDate, endDate: successorBefore.endDate, executionStatus: successorBefore.executionStatus, monthlyRent: successorBefore.monthlyRent });
+  });
+
+  it("replays the same logical request without duplicate tenancy or audit", async () => {
+    const input = await request();
+    await handoffRenewalContinuity(input);
+    const replay = await handoffRenewalContinuity(input);
+    expect(replay.outcome).toBe("idempotent_replay");
+    expect(fake.list("canonicalEvents")).toHaveLength(1);
+    expect(fake.list("tenancies").filter((entry) => entry.leaseId === "successor" && entry.status === "active")).toHaveLength(1);
+  });
+
+  it("rejects stale state before any write", async () => {
+    const input = await request();
+    fake.seed("units", "unit-1", { ...fake.read("units", "unit-1"), updatedAt: "changed", currentLeaseId: "other", leaseId: "other" });
+    await expect(handoffRenewalContinuity(input)).rejects.toMatchObject({ code: "renewal_state_stale" });
+    expect(fake.list("canonicalEvents")).toHaveLength(0);
+  });
+
+  it("rejects a reused idempotency key with changed payload", async () => {
+    const input = await request();
+    await handoffRenewalContinuity(input);
+    await expect(handoffRenewalContinuity({ ...input, source: "changed" })).rejects.toBeInstanceOf(RenewalContinuityServiceError);
+    await expect(handoffRenewalContinuity({ ...input, source: "changed" })).rejects.toMatchObject({ code: "renewal_idempotency_key_reused" });
+  });
+
+  it("rejects an unrelated active same-unit tenancy without broad deactivation", async () => {
+    fake = createFakeFirestore();
+    seed({ extraTenancy: { landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-2", leaseId: "other", status: "active", moveOutAt: null } });
+    const input = await request();
+    await expect(handoffRenewalContinuity(input)).rejects.toMatchObject({ code: "renewal_handoff_ineligible" });
+    expect(fake.read("tenancies", "other-tenancy")).toMatchObject({ status: "active", moveOutAt: null });
+  });
+
+  it("allows only one winner for concurrent handoff identities", async () => {
+    const context = await getRenewalContinuityContext({ landlordId: "landlord-1", successorLeaseId: "successor", evaluationInstant, firestore: fake.firestore });
+    const base = {
+      landlordId: "landlord-1", successorLeaseId: "successor", evaluationInstant,
+      expectedStateToken: context.expectedStateToken, actorId: "landlord-1", source: "test", firestore: fake.firestore,
+    };
+    const attempts = await Promise.allSettled([
+      handoffRenewalContinuity({ ...base, idempotencyKey: "concurrent-a" }),
+      handoffRenewalContinuity({ ...base, idempotencyKey: "concurrent-b" }),
+    ]);
+    expect(attempts.filter((attempt) => attempt.status === "fulfilled")).toHaveLength(1);
+    expect(fake.list("canonicalEvents")).toHaveLength(1);
+    expect(fake.list("tenancies").filter((entry) => entry.leaseId === "successor" && entry.status === "active")).toHaveLength(1);
+  });
+});

--- a/rentchain-api/src/services/leaseStart/leaseCreationService.ts
+++ b/rentchain-api/src/services/leaseStart/leaseCreationService.ts
@@ -2,6 +2,7 @@ import { db } from "../../firebase";
 import { evaluateCanonicalLeaseStart, type CanonicalLeaseStartInput } from "../../lib/leases/canonicalLeaseStart";
 import { buildLeaseStartExpectedStateToken, leaseStartDeterministicId, leaseStartHash } from "./leaseStartExpectedState";
 import { LeaseStartServiceError, type LeaseStartOperationKind, type LeaseStartServiceResult } from "./leaseStartService";
+import { runLeaseStartTransaction } from "./leaseStartTransaction";
 
 export type CreateCanonicalLeaseInput = {
   landlordId: string;
@@ -140,14 +141,17 @@ export async function createCanonicalLease(input: CreateCanonicalLeaseInput): Pr
     source: input.source,
   });
 
-  return firestore.runTransaction(async (transaction: any) => {
-    const prior = await transaction.get(requestRef);
-    if (prior.exists) {
-      const priorData = prior.data() || {};
-      if (priorData.payloadHash !== payloadHash) throw new LeaseStartServiceError("lease_start_idempotency_key_reused");
-      return { ...priorData.result, leaseId: input.leaseId, outcome: "idempotent_replay", idempotency: { ...priorData.result.idempotency, replay: true } };
-    }
-
+  return runLeaseStartTransaction<{ expectedStateToken: string }, LeaseStartServiceResult & { leaseId: string }>({
+    firestore,
+    requestRef,
+    payloadHash,
+    error: (kind) => new LeaseStartServiceError(kind === "idempotency" ? "lease_start_idempotency_key_reused" : "lease_start_state_stale"),
+    loadAuthoritativeState: async () => ({ expectedStateToken: "creation_state_is_transaction_authoritative" }),
+    getExpectedStateToken: (loaded) => loaded.expectedStateToken,
+    buildPlan: async ({ transaction }) => {
+    const mutations: Array<() => void> = [];
+    const events: Array<{ ref: any; record: Record<string, unknown> }> = [];
+    let assertPostcondition: (() => void) | undefined;
     const unitsQuery = firestore.collection("units").where("landlordId", "==", input.landlordId).where("propertyId", "==", input.propertyId);
     const leasesQuery = firestore.collection("leases").where("landlordId", "==", input.landlordId).where("propertyId", "==", input.propertyId);
     const tenanciesQuery = firestore.collection("tenancies").where("propertyId", "==", input.propertyId);
@@ -226,26 +230,28 @@ export async function createCanonicalLease(input: CreateCanonicalLeaseInput): Pr
 
     if (decision.outcome === "rejected") {
       const result = { ...baseResult(input, decision, expectedStateToken, requestId, [rejectionEventId]), leaseId: input.leaseId };
-      transaction.create(firestore.collection("canonicalEvents").doc(rejectionEventId), canonicalEvent(input, rejectionEventId, "lease.occupancy_start_rejected", instant, requestId, result.reasons));
-      transaction.create(requestRef, { landlordId: input.landlordId, operationKind: input.operationKind, idempotencyKey: input.idempotencyKey, payloadHash, leaseId: input.leaseId, canonicalOutcome: decision.outcome, reasons: result.reasons, occupancyEffective: false, canonicalEventIds: [rejectionEventId], committedAt: instant, result });
-      return result;
+      return {
+        result,
+        events: [{ ref: firestore.collection("canonicalEvents").doc(rejectionEventId), record: canonicalEvent(input, rejectionEventId, "lease.occupancy_start_rejected", instant, requestId, result.reasons) }],
+        requestRecord: { landlordId: input.landlordId, operationKind: input.operationKind, idempotencyKey: input.idempotencyKey, payloadHash, leaseId: input.leaseId, canonicalOutcome: decision.outcome, reasons: result.reasons, occupancyEffective: false, canonicalEventIds: [rejectionEventId], committedAt: instant, result },
+      };
     }
 
     const eventIds = decision.outcome === "occupancy_effective" ? [creationEventId, occupancyEventId] : [creationEventId];
     const result = { ...baseResult(input, decision, expectedStateToken, requestId, eventIds), leaseId: input.leaseId };
     const compatibilityStatus = decision.outcome === "occupancy_effective" ? "active" : "pending";
-    transaction.create(leaseRef, {
+    mutations.push(() => transaction.create(leaseRef, {
       ...input.leaseRecord,
       ...(input.renewalLink ? { predecessorLeaseId: input.renewalLink.predecessorLeaseId } : {}),
       id: input.leaseId,
       status: compatibilityStatus,
       occupancyEffective: decision.occupancyEffective,
       occupancyEffectiveAt: decision.occupancyEffective ? instant : null,
-    });
-    if (predecessorRef) transaction.set(predecessorRef, { renewedByLeaseId: input.leaseId, updatedAt: instant }, { merge: true });
-    if (input.tenantRecord) transaction.create(tenantRef, { ...input.tenantRecord, id: input.tenantId });
-    if (draftRef) transaction.set(draftRef, { status: "activated", leaseId: input.leaseId, activatedAt: instant, updatedAt: instant }, { merge: true });
-    transaction.create(firestore.collection("canonicalEvents").doc(creationEventId), canonicalEvent(input, creationEventId, creationType, instant, requestId));
+    }));
+    if (predecessorRef) mutations.push(() => transaction.set(predecessorRef, { renewedByLeaseId: input.leaseId, updatedAt: instant }, { merge: true }));
+    if (input.tenantRecord) mutations.push(() => transaction.create(tenantRef, { ...input.tenantRecord, id: input.tenantId }));
+    if (draftRef) mutations.push(() => transaction.set(draftRef, { status: "activated", leaseId: input.leaseId, activatedAt: instant, updatedAt: instant }, { merge: true }));
+    events.push({ ref: firestore.collection("canonicalEvents").doc(creationEventId), record: canonicalEvent(input, creationEventId, creationType, instant, requestId) });
 
     if (decision.outcome === "occupancy_effective") {
       const postcondition = decision.postcondition;
@@ -260,21 +266,29 @@ export async function createCanonicalLease(input: CreateCanonicalLeaseInput): Pr
       const nextTenant = { ...tenant, currentLeaseId: input.leaseId, status: "current", updatedAt: instant };
       const nextTenancies = postcondition.tenancy.action === "create" ? [...tenancies, nextTenancy] : tenancies.map((entry: any) => entry.id === tenancyId ? nextTenancy : entry);
       const verified = evaluateCanonicalLeaseStart({ ...canonicalInput, candidateLease: { ...candidateLease, occupancyEffective: true, occupancyEffectiveAt: instant }, standaloneUnits: [nextUnit], embeddedUnits: [{ ...nextEmbedded, landlordId: input.landlordId, propertyId: input.propertyId }], tenant: nextTenant, tenancies: nextTenancies });
-      if (verified.outcome !== "already_coherent" || verified.postcondition !== null) throw new LeaseStartServiceError("lease_start_postcondition_failed");
+      assertPostcondition = () => {
+        if (verified.outcome !== "already_coherent" || verified.postcondition !== null) throw new LeaseStartServiceError("lease_start_postcondition_failed");
+      };
       result.expectedStateToken = buildLeaseStartExpectedStateToken(
         { ...canonicalInput, candidateLease: { ...candidateLease, occupancyEffective: true, occupancyEffectiveAt: instant }, standaloneUnits: [nextUnit], embeddedUnits: [{ ...nextEmbedded, landlordId: input.landlordId, propertyId: input.propertyId }], tenant: nextTenant, tenancies: nextTenancies },
         verified,
         { propertyUpdatedAt: instant }
       );
-      transaction.set(propertyRef, { units: nextEmbeddedUnits, updatedAt: instant }, { merge: true });
-      transaction.set(unitRef, nextUnit, { merge: true });
-      transaction.set(tenantRef, { currentLeaseId: input.leaseId, status: "current", updatedAt: instant }, { merge: true });
-      if (postcondition.tenancy.action === "create") transaction.create(tenancyRef, nextTenancy);
-      else if (postcondition.tenancy.action === "reconcile") transaction.set(tenancyRef, nextTenancy, { merge: true });
-      transaction.create(firestore.collection("canonicalEvents").doc(occupancyEventId), canonicalEvent(input, occupancyEventId, "lease.occupancy_started", instant, requestId));
+      mutations.push(() => transaction.set(propertyRef, { units: nextEmbeddedUnits, updatedAt: instant }, { merge: true }));
+      mutations.push(() => transaction.set(unitRef, nextUnit, { merge: true }));
+      mutations.push(() => transaction.set(tenantRef, { currentLeaseId: input.leaseId, status: "current", updatedAt: instant }, { merge: true }));
+      if (postcondition.tenancy.action === "create") mutations.push(() => transaction.create(tenancyRef, nextTenancy));
+      else if (postcondition.tenancy.action === "reconcile") mutations.push(() => transaction.set(tenancyRef, nextTenancy, { merge: true }));
+      events.push({ ref: firestore.collection("canonicalEvents").doc(occupancyEventId), record: canonicalEvent(input, occupancyEventId, "lease.occupancy_started", instant, requestId) });
     }
 
-    transaction.create(requestRef, { landlordId: input.landlordId, operationKind: input.operationKind, idempotencyKey: input.idempotencyKey, payloadHash, leaseId: input.leaseId, canonicalOutcome: decision.outcome, reasons: result.reasons, occupancyEffective: result.occupancyEffective, canonicalEventIds: eventIds, committedAt: instant, result });
-    return result;
+    return {
+      result,
+      applyMutations: () => mutations.forEach((mutation) => mutation()),
+      assertPostcondition,
+      events,
+      requestRecord: { landlordId: input.landlordId, operationKind: input.operationKind, idempotencyKey: input.idempotencyKey, payloadHash, leaseId: input.leaseId, canonicalOutcome: decision.outcome, reasons: result.reasons, occupancyEffective: result.occupancyEffective, canonicalEventIds: eventIds, committedAt: instant, result },
+    };
+    },
   });
 }

--- a/rentchain-api/src/services/leaseStart/leaseCreationService.ts
+++ b/rentchain-api/src/services/leaseStart/leaseCreationService.ts
@@ -233,9 +233,7 @@ export async function createCanonicalLease(input: CreateCanonicalLeaseInput): Pr
 
     const eventIds = decision.outcome === "occupancy_effective" ? [creationEventId, occupancyEventId] : [creationEventId];
     const result = { ...baseResult(input, decision, expectedStateToken, requestId, eventIds), leaseId: input.leaseId };
-    const renewalFullyExecuted = Boolean(input.renewalLink) &&
-      text(input.leaseRecord.executionStatus || input.leaseRecord.executionState) === "fully_executed";
-    const compatibilityStatus = decision.outcome === "occupancy_effective" || renewalFullyExecuted ? "active" : "pending";
+    const compatibilityStatus = decision.outcome === "occupancy_effective" ? "active" : "pending";
     transaction.create(leaseRef, {
       ...input.leaseRecord,
       ...(input.renewalLink ? { predecessorLeaseId: input.renewalLink.predecessorLeaseId } : {}),

--- a/rentchain-api/src/services/leaseStart/leaseCreationService.ts
+++ b/rentchain-api/src/services/leaseStart/leaseCreationService.ts
@@ -17,6 +17,7 @@ export type CreateCanonicalLeaseInput = {
   source: string;
   tenantRecord?: Record<string, any> | null;
   draftActivation?: { draftId: string; expectedLeaseId?: string | null } | null;
+  renewalLink?: { predecessorLeaseId: string } | null;
   firestore?: any;
 };
 
@@ -112,6 +113,7 @@ export async function createCanonicalLease(input: CreateCanonicalLeaseInput): Pr
   const unitRef = firestore.collection("units").doc(input.unitId);
   const tenantRef = firestore.collection("tenants").doc(input.tenantId);
   const draftRef = input.draftActivation ? firestore.collection("leaseDrafts").doc(input.draftActivation.draftId) : null;
+  const predecessorRef = input.renewalLink ? firestore.collection("leases").doc(input.renewalLink.predecessorLeaseId) : null;
   const {
     risk: _risk,
     riskScore: _riskScore,
@@ -131,6 +133,7 @@ export async function createCanonicalLease(input: CreateCanonicalLeaseInput): Pr
     leaseRecord: semanticLeaseRecord,
     tenantRecord: input.tenantRecord || null,
     draftActivation: input.draftActivation || null,
+    renewalLink: input.renewalLink || null,
     operationKind: input.operationKind,
     idempotencyKey: input.idempotencyKey,
     actorId: input.actorId,
@@ -148,7 +151,7 @@ export async function createCanonicalLease(input: CreateCanonicalLeaseInput): Pr
     const unitsQuery = firestore.collection("units").where("landlordId", "==", input.landlordId).where("propertyId", "==", input.propertyId);
     const leasesQuery = firestore.collection("leases").where("landlordId", "==", input.landlordId).where("propertyId", "==", input.propertyId);
     const tenanciesQuery = firestore.collection("tenancies").where("propertyId", "==", input.propertyId);
-    const [leaseSnap, propertySnap, unitSnap, tenantSnap, unitsSnap, leasesSnap, tenanciesSnap, draftSnap] = await Promise.all([
+    const [leaseSnap, propertySnap, unitSnap, tenantSnap, unitsSnap, leasesSnap, tenanciesSnap, draftSnap, predecessorSnap] = await Promise.all([
       transaction.get(leaseRef),
       transaction.get(propertyRef),
       transaction.get(unitRef),
@@ -157,6 +160,7 @@ export async function createCanonicalLease(input: CreateCanonicalLeaseInput): Pr
       transaction.get(leasesQuery),
       transaction.get(tenanciesQuery),
       draftRef ? transaction.get(draftRef) : Promise.resolve(null),
+      predecessorRef ? transaction.get(predecessorRef) : Promise.resolve(null),
     ]);
     if (leaseSnap.exists) throw new LeaseStartServiceError("lease_start_idempotency_key_reused");
     const property = data(propertySnap);
@@ -173,6 +177,19 @@ export async function createCanonicalLease(input: CreateCanonicalLeaseInput): Pr
     }
     if (draftRef && text(draftSnap.data()?.leaseId) && text(draftSnap.data()?.leaseId) !== input.leaseId) {
       throw new LeaseStartServiceError("lease_start_idempotency_key_reused");
+    }
+    if (predecessorRef) {
+      const predecessor = data(predecessorSnap);
+      const existingLinks = [predecessor?.renewedByLeaseId, predecessor?.renewalLeaseId, predecessor?.successorLeaseId, predecessor?.replacedByLeaseId]
+        .map(text).filter(Boolean);
+      const predecessorParticipants = [...new Set([...(Array.isArray(predecessor?.tenantIds) ? predecessor.tenantIds : []), predecessor?.tenantId, predecessor?.primaryTenantId].map(text).filter(Boolean))].sort();
+      const successorParticipants = [...new Set([...(Array.isArray(input.leaseRecord?.tenantIds) ? input.leaseRecord.tenantIds : []), input.leaseRecord?.tenantId, input.leaseRecord?.primaryTenantId].map(text).filter(Boolean))].sort();
+      if (!predecessor || text(predecessor.landlordId) !== input.landlordId || text(predecessor.propertyId) !== input.propertyId ||
+          text(predecessor.unitId) !== input.unitId || existingLinks.some((link) => link !== input.leaseId) ||
+          predecessorParticipants.length === 0 || predecessorParticipants.length !== successorParticipants.length ||
+          predecessorParticipants.some((participant, index) => participant !== successorParticipants[index])) {
+        throw new LeaseStartServiceError("lease_start_context_ambiguous");
+      }
     }
 
     const embeddedUnits = Array.isArray(property.units) ? property.units : [];
@@ -216,8 +233,18 @@ export async function createCanonicalLease(input: CreateCanonicalLeaseInput): Pr
 
     const eventIds = decision.outcome === "occupancy_effective" ? [creationEventId, occupancyEventId] : [creationEventId];
     const result = { ...baseResult(input, decision, expectedStateToken, requestId, eventIds), leaseId: input.leaseId };
-    const compatibilityStatus = decision.outcome === "occupancy_effective" ? "active" : "pending";
-    transaction.create(leaseRef, { ...input.leaseRecord, id: input.leaseId, status: compatibilityStatus, occupancyEffective: decision.occupancyEffective, occupancyEffectiveAt: decision.occupancyEffective ? instant : null });
+    const renewalFullyExecuted = Boolean(input.renewalLink) &&
+      text(input.leaseRecord.executionStatus || input.leaseRecord.executionState) === "fully_executed";
+    const compatibilityStatus = decision.outcome === "occupancy_effective" || renewalFullyExecuted ? "active" : "pending";
+    transaction.create(leaseRef, {
+      ...input.leaseRecord,
+      ...(input.renewalLink ? { predecessorLeaseId: input.renewalLink.predecessorLeaseId } : {}),
+      id: input.leaseId,
+      status: compatibilityStatus,
+      occupancyEffective: decision.occupancyEffective,
+      occupancyEffectiveAt: decision.occupancyEffective ? instant : null,
+    });
+    if (predecessorRef) transaction.set(predecessorRef, { renewedByLeaseId: input.leaseId, updatedAt: instant }, { merge: true });
     if (input.tenantRecord) transaction.create(tenantRef, { ...input.tenantRecord, id: input.tenantId });
     if (draftRef) transaction.set(draftRef, { status: "activated", leaseId: input.leaseId, activatedAt: instant, updatedAt: instant }, { merge: true });
     transaction.create(firestore.collection("canonicalEvents").doc(creationEventId), canonicalEvent(input, creationEventId, creationType, instant, requestId));

--- a/rentchain-api/src/services/leaseStart/leaseStartExpectedState.ts
+++ b/rentchain-api/src/services/leaseStart/leaseStartExpectedState.ts
@@ -17,6 +17,13 @@ export function leaseStartHash(value: unknown): string {
   return crypto.createHash("sha256").update(stable(value)).digest("hex");
 }
 
+export function buildLeaseStartExpectedStateMaterialToken(
+  version: string,
+  material: Record<string, unknown>
+): string {
+  return leaseStartHash({ version, ...material });
+}
+
 function leaseMaterial(lease: CanonicalLeaseStartInput["candidateLease"]) {
   return {
     id: lease.id,
@@ -59,8 +66,7 @@ export function buildLeaseStartExpectedStateToken(
   decision: CanonicalLeaseStartResult,
   versionMarkers: { propertyUpdatedAt?: unknown } = {}
 ): string {
-  return leaseStartHash({
-    version: "lease_start_expected_state_v1",
+  return buildLeaseStartExpectedStateMaterialToken("lease_start_expected_state_v1", {
     landlordId: input.landlordId,
     propertyId: input.propertyId,
     unitId: input.unitId,

--- a/rentchain-api/src/services/leaseStart/leaseStartService.ts
+++ b/rentchain-api/src/services/leaseStart/leaseStartService.ts
@@ -7,6 +7,12 @@ import {
 } from "../../lib/leases/canonicalLeaseStart";
 import type { CanonicalLeaseConflictReason, CanonicalLeaseStateInput } from "../../lib/leases/canonicalLeaseOccupancyState";
 import { buildLeaseStartExpectedStateToken, leaseStartDeterministicId, leaseStartHash } from "./leaseStartExpectedState";
+import {
+  assertLeaseStartExpectedState,
+  persistLeaseStartAtomicResult,
+  readLeaseStartReplay,
+  runLeaseStartTransaction,
+} from "./leaseStartTransaction";
 
 export type LeaseStartOperationKind =
   | "direct_create"
@@ -241,17 +247,15 @@ export async function startCanonicalLeaseOccupancy(input: StartCanonicalLeaseOcc
     evaluationInstant: normalizedInstant,
   });
 
-  return firestore.runTransaction(async (transaction: any) => {
-    const prior = await transaction.get(requestRef);
-    if (prior.exists) {
-      const data = prior.data() || {};
-      if (data.payloadHash !== payloadHash) throw new LeaseStartServiceError("lease_start_idempotency_key_reused");
-      return { ...data.result, outcome: "idempotent_replay", idempotency: { ...data.result.idempotency, replay: true } };
-    }
+  return runLeaseStartTransaction(firestore, async (transaction: any) => {
+    const replay = await readLeaseStartReplay<LeaseStartServiceResult>({
+      transaction, requestRef, payloadHash,
+      error: (kind) => new LeaseStartServiceError(kind === "idempotency" ? "lease_start_idempotency_key_reused" : "lease_start_state_stale"),
+    });
+    if (replay) return replay;
     const loaded = await readContext(transaction, { ...input, evaluationInstant: normalizedInstant, firestore });
-    if (loaded.context.expectedStateToken !== input.expectedStateToken) {
-      throw new LeaseStartServiceError("lease_start_state_stale", loaded.context);
-    }
+    assertLeaseStartExpectedState(loaded.context.expectedStateToken, input.expectedStateToken, () =>
+      new LeaseStartServiceError("lease_start_state_stale", loaded.context));
     // D2 has no live route caller. Canonical rejected and deferred decisions
     // therefore return deterministically with no durable audit or idempotency
     // record. D3 must define authenticated route-attempt persistence policy.
@@ -262,7 +266,8 @@ export async function startCanonicalLeaseOccupancy(input: StartCanonicalLeaseOcc
         auditEventIds: [eventId],
         idempotency: { key: input.idempotencyKey, replay: false, resultId: requestId },
       };
-      transaction.create(firestore.collection("canonicalEvents").doc(eventId), {
+      const eventRef = firestore.collection("canonicalEvents").doc(eventId);
+      const eventRecord = {
         id: eventId, version: "v1", type: "lease.occupancy_start_rejected", domain: "lease", action: "occupancy_start_rejected", status: "rejected",
         actor: { type: "landlord", id: leaseStartDeterministicId("actor", [input.actorId || input.landlordId]), role: "landlord", displayName: null },
         resource: { type: "lease", id: leaseStartDeterministicId("lease", [input.leaseId]), parentType: "property", parentId: leaseStartDeterministicId("property", [input.propertyId]) },
@@ -274,14 +279,14 @@ export async function startCanonicalLeaseOccupancy(input: StartCanonicalLeaseOcc
           operationKind: input.operationKind, trigger: input.trigger, source: input.source || null, reasons: rejectedResult.reasons, legalDetermination: false,
         },
         tags: ["lease_start", input.trigger, "rejected"], appendOnly: true, immutable: true,
-      });
-      transaction.create(requestRef, {
+      };
+      persistLeaseStartAtomicResult({ transaction, requestRef, events: [{ ref: eventRef, record: eventRecord }], requestRecord: {
         landlordId: input.landlordId, operationKind: input.operationKind, idempotencyKey: input.idempotencyKey,
         payloadHash, leaseId: input.leaseId, canonicalOutcome: rejectedResult.canonicalOutcome,
         reasons: rejectedResult.reasons, occupancyEffective: false,
         resultingExpectedStateToken: rejectedResult.expectedStateToken, canonicalEventIds: [eventId], committedAt: normalizedInstant,
         result: rejectedResult,
-      });
+      }});
       return rejectedResult;
     }
     if (loaded.context.decision.outcome === "rejected" || loaded.context.decision.outcome === "created_without_occupancy") {
@@ -291,13 +296,13 @@ export async function startCanonicalLeaseOccupancy(input: StartCanonicalLeaseOcc
     const baseResult = resultFrom(loaded.context, input, requestId);
     if (loaded.context.decision.outcome === "already_coherent") {
       const committedResult = { ...baseResult, idempotency: { ...baseResult.idempotency, resultId: requestId } };
-      transaction.create(requestRef, {
+      persistLeaseStartAtomicResult({ transaction, requestRef, requestRecord: {
         landlordId: input.landlordId, operationKind: input.operationKind, idempotencyKey: input.idempotencyKey,
         payloadHash, leaseId: input.leaseId, canonicalOutcome: committedResult.canonicalOutcome,
         reasons: committedResult.reasons, occupancyEffective: committedResult.occupancyEffective,
         resultingExpectedStateToken: committedResult.expectedStateToken, canonicalEventIds: [], committedAt: normalizedInstant,
         result: committedResult,
-      });
+      }});
       return committedResult;
     }
 
@@ -351,7 +356,7 @@ export async function startCanonicalLeaseOccupancy(input: StartCanonicalLeaseOcc
     transaction.set(loaded.records.tenantRef, { currentLeaseId: input.leaseId, status: "current", updatedAt: normalizedInstant }, { merge: true });
     if (postcondition.tenancy.action === "create") transaction.create(tenancyRef, nextTenancy);
     else if (postcondition.tenancy.action === "reconcile") transaction.set(tenancyRef, nextTenancy, { merge: true });
-    transaction.create(eventRef, {
+    const eventRecord = {
       id: eventId, version: "v1", type: "lease.occupancy_started", domain: "lease", action: "occupancy_started", status: "succeeded",
       actor: { type: "landlord", id: leaseStartDeterministicId("actor", [input.actorId || input.landlordId]), role: "landlord", displayName: null },
       resource: { type: "lease", id: leaseStartDeterministicId("lease", [input.leaseId]), parentType: "property", parentId: leaseStartDeterministicId("property", [input.propertyId]) },
@@ -363,14 +368,14 @@ export async function startCanonicalLeaseOccupancy(input: StartCanonicalLeaseOcc
         operationKind: input.operationKind, trigger: input.trigger, source: input.source || null, legalDetermination: false,
       },
       tags: ["lease_start", input.trigger], appendOnly: true, immutable: true,
-    });
-    transaction.create(requestRef, {
+    };
+    persistLeaseStartAtomicResult({ transaction, requestRef, events: [{ ref: eventRef, record: eventRecord }], requestRecord: {
       landlordId: input.landlordId, operationKind: input.operationKind, idempotencyKey: input.idempotencyKey,
       payloadHash, leaseId: input.leaseId, canonicalOutcome: committedResult.canonicalOutcome,
       reasons: committedResult.reasons, occupancyEffective: committedResult.occupancyEffective,
       resultingExpectedStateToken: committedResult.expectedStateToken, canonicalEventIds: [eventId], committedAt: normalizedInstant,
       result: committedResult,
-    });
+    }});
     return committedResult;
   });
 }

--- a/rentchain-api/src/services/leaseStart/leaseStartService.ts
+++ b/rentchain-api/src/services/leaseStart/leaseStartService.ts
@@ -8,9 +8,6 @@ import {
 import type { CanonicalLeaseConflictReason, CanonicalLeaseStateInput } from "../../lib/leases/canonicalLeaseOccupancyState";
 import { buildLeaseStartExpectedStateToken, leaseStartDeterministicId, leaseStartHash } from "./leaseStartExpectedState";
 import {
-  assertLeaseStartExpectedState,
-  persistLeaseStartAtomicResult,
-  readLeaseStartReplay,
   runLeaseStartTransaction,
 } from "./leaseStartTransaction";
 
@@ -247,15 +244,18 @@ export async function startCanonicalLeaseOccupancy(input: StartCanonicalLeaseOcc
     evaluationInstant: normalizedInstant,
   });
 
-  return runLeaseStartTransaction(firestore, async (transaction: any) => {
-    const replay = await readLeaseStartReplay<LeaseStartServiceResult>({
-      transaction, requestRef, payloadHash,
-      error: (kind) => new LeaseStartServiceError(kind === "idempotency" ? "lease_start_idempotency_key_reused" : "lease_start_state_stale"),
-    });
-    if (replay) return replay;
-    const loaded = await readContext(transaction, { ...input, evaluationInstant: normalizedInstant, firestore });
-    assertLeaseStartExpectedState(loaded.context.expectedStateToken, input.expectedStateToken, () =>
-      new LeaseStartServiceError("lease_start_state_stale", loaded.context));
+  return runLeaseStartTransaction<Awaited<ReturnType<typeof readContext>>, LeaseStartServiceResult>({
+    firestore,
+    requestRef,
+    payloadHash,
+    expectedStateToken: input.expectedStateToken,
+    error: (kind, loaded) => new LeaseStartServiceError(
+      kind === "idempotency" ? "lease_start_idempotency_key_reused" : "lease_start_state_stale",
+      loaded?.context
+    ),
+    loadAuthoritativeState: (transaction) => readContext(transaction, { ...input, evaluationInstant: normalizedInstant, firestore }),
+    getExpectedStateToken: (loaded) => loaded.context.expectedStateToken,
+    buildPlan: async ({ transaction, loaded }) => {
     // D2 has no live route caller. Canonical rejected and deferred decisions
     // therefore return deterministically with no durable audit or idempotency
     // record. D3 must define authenticated route-attempt persistence policy.
@@ -280,30 +280,28 @@ export async function startCanonicalLeaseOccupancy(input: StartCanonicalLeaseOcc
         },
         tags: ["lease_start", input.trigger, "rejected"], appendOnly: true, immutable: true,
       };
-      persistLeaseStartAtomicResult({ transaction, requestRef, events: [{ ref: eventRef, record: eventRecord }], requestRecord: {
-        landlordId: input.landlordId, operationKind: input.operationKind, idempotencyKey: input.idempotencyKey,
-        payloadHash, leaseId: input.leaseId, canonicalOutcome: rejectedResult.canonicalOutcome,
-        reasons: rejectedResult.reasons, occupancyEffective: false,
-        resultingExpectedStateToken: rejectedResult.expectedStateToken, canonicalEventIds: [eventId], committedAt: normalizedInstant,
-        result: rejectedResult,
-      }});
-      return rejectedResult;
+      return { result: rejectedResult, events: [{ ref: eventRef, record: eventRecord }], requestRecord: {
+          landlordId: input.landlordId, operationKind: input.operationKind, idempotencyKey: input.idempotencyKey,
+          payloadHash, leaseId: input.leaseId, canonicalOutcome: rejectedResult.canonicalOutcome,
+          reasons: rejectedResult.reasons, occupancyEffective: false,
+          resultingExpectedStateToken: rejectedResult.expectedStateToken, canonicalEventIds: [eventId], committedAt: normalizedInstant,
+          result: rejectedResult,
+        } };
     }
     if (loaded.context.decision.outcome === "rejected" || loaded.context.decision.outcome === "created_without_occupancy") {
-      return resultFrom(loaded.context, input, null);
+      return { result: resultFrom(loaded.context, input, null) };
     }
 
     const baseResult = resultFrom(loaded.context, input, requestId);
     if (loaded.context.decision.outcome === "already_coherent") {
       const committedResult = { ...baseResult, idempotency: { ...baseResult.idempotency, resultId: requestId } };
-      persistLeaseStartAtomicResult({ transaction, requestRef, requestRecord: {
-        landlordId: input.landlordId, operationKind: input.operationKind, idempotencyKey: input.idempotencyKey,
-        payloadHash, leaseId: input.leaseId, canonicalOutcome: committedResult.canonicalOutcome,
-        reasons: committedResult.reasons, occupancyEffective: committedResult.occupancyEffective,
-        resultingExpectedStateToken: committedResult.expectedStateToken, canonicalEventIds: [], committedAt: normalizedInstant,
-        result: committedResult,
-      }});
-      return committedResult;
+      return { result: committedResult, requestRecord: {
+          landlordId: input.landlordId, operationKind: input.operationKind, idempotencyKey: input.idempotencyKey,
+          payloadHash, leaseId: input.leaseId, canonicalOutcome: committedResult.canonicalOutcome,
+          reasons: committedResult.reasons, occupancyEffective: committedResult.occupancyEffective,
+          resultingExpectedStateToken: committedResult.expectedStateToken, canonicalEventIds: [], committedAt: normalizedInstant,
+          result: committedResult,
+        } };
     }
 
     const postcondition = loaded.context.decision.postcondition;
@@ -318,8 +316,6 @@ export async function startCanonicalLeaseOccupancy(input: StartCanonicalLeaseOcc
     const nextTenancy = postcondition.tenancy.action === "reuse"
       ? { ...existingTenancy }
       : { ...existingTenancy, ...postcondition.tenancy, id: tenancyId, updatedAt: normalizedInstant, moveOutAt: null };
-    assertPostcondition(loaded.context, { unit: nextUnit, embedded: nextEmbedded, tenant: nextTenant, tenancy: nextTenancy });
-
     const nextEmbeddedUnits = loaded.records.embeddedUnits.map((entry: any, index: number) => index === loaded.records.embeddedIndex ? nextEmbedded : entry);
     const nextTenancies = postcondition.tenancy.action === "create"
       ? [...loaded.records.tenancies, nextTenancy]
@@ -333,9 +329,6 @@ export async function startCanonicalLeaseOccupancy(input: StartCanonicalLeaseOcc
       tenancies: nextTenancies,
     };
     const verifiedDecision = evaluateCanonicalLeaseStart(nextCanonicalInput);
-    if (verifiedDecision.outcome !== "already_coherent" || verifiedDecision.postcondition !== null) {
-      throw new LeaseStartServiceError("lease_start_postcondition_failed", loaded.context);
-    }
     const resultingExpectedStateToken = buildLeaseStartExpectedStateToken(
       nextCanonicalInput,
       verifiedDecision,
@@ -350,12 +343,6 @@ export async function startCanonicalLeaseOccupancy(input: StartCanonicalLeaseOcc
       expectedStateToken: resultingExpectedStateToken,
     };
 
-    transaction.set(loaded.records.leaseRef, { ...(input.leasePatch || {}), occupancyEffective: true, occupancyEffectiveAt: normalizedInstant, updatedAt: normalizedInstant }, { merge: true });
-    transaction.set(loaded.records.propertyRef, { units: nextEmbeddedUnits, updatedAt: normalizedInstant }, { merge: true });
-    transaction.set(loaded.records.unitRef, nextUnit, { merge: true });
-    transaction.set(loaded.records.tenantRef, { currentLeaseId: input.leaseId, status: "current", updatedAt: normalizedInstant }, { merge: true });
-    if (postcondition.tenancy.action === "create") transaction.create(tenancyRef, nextTenancy);
-    else if (postcondition.tenancy.action === "reconcile") transaction.set(tenancyRef, nextTenancy, { merge: true });
     const eventRecord = {
       id: eventId, version: "v1", type: "lease.occupancy_started", domain: "lease", action: "occupancy_started", status: "succeeded",
       actor: { type: "landlord", id: leaseStartDeterministicId("actor", [input.actorId || input.landlordId]), role: "landlord", displayName: null },
@@ -369,13 +356,31 @@ export async function startCanonicalLeaseOccupancy(input: StartCanonicalLeaseOcc
       },
       tags: ["lease_start", input.trigger], appendOnly: true, immutable: true,
     };
-    persistLeaseStartAtomicResult({ transaction, requestRef, events: [{ ref: eventRef, record: eventRecord }], requestRecord: {
-      landlordId: input.landlordId, operationKind: input.operationKind, idempotencyKey: input.idempotencyKey,
-      payloadHash, leaseId: input.leaseId, canonicalOutcome: committedResult.canonicalOutcome,
-      reasons: committedResult.reasons, occupancyEffective: committedResult.occupancyEffective,
-      resultingExpectedStateToken: committedResult.expectedStateToken, canonicalEventIds: [eventId], committedAt: normalizedInstant,
+    return {
       result: committedResult,
-    }});
-    return committedResult;
+      applyMutations: () => {
+        transaction.set(loaded.records.leaseRef, { ...(input.leasePatch || {}), occupancyEffective: true, occupancyEffectiveAt: normalizedInstant, updatedAt: normalizedInstant }, { merge: true });
+        transaction.set(loaded.records.propertyRef, { units: nextEmbeddedUnits, updatedAt: normalizedInstant }, { merge: true });
+        transaction.set(loaded.records.unitRef, nextUnit, { merge: true });
+        transaction.set(loaded.records.tenantRef, { currentLeaseId: input.leaseId, status: "current", updatedAt: normalizedInstant }, { merge: true });
+        if (postcondition.tenancy.action === "create") transaction.create(tenancyRef, nextTenancy);
+        else if (postcondition.tenancy.action === "reconcile") transaction.set(tenancyRef, nextTenancy, { merge: true });
+      },
+      assertPostcondition: () => {
+        assertPostcondition(loaded.context, { unit: nextUnit, embedded: nextEmbedded, tenant: nextTenant, tenancy: nextTenancy });
+        if (verifiedDecision.outcome !== "already_coherent" || verifiedDecision.postcondition !== null) {
+          throw new LeaseStartServiceError("lease_start_postcondition_failed", loaded.context);
+        }
+      },
+      events: [{ ref: eventRef, record: eventRecord }],
+      requestRecord: {
+        landlordId: input.landlordId, operationKind: input.operationKind, idempotencyKey: input.idempotencyKey,
+        payloadHash, leaseId: input.leaseId, canonicalOutcome: committedResult.canonicalOutcome,
+        reasons: committedResult.reasons, occupancyEffective: committedResult.occupancyEffective,
+        resultingExpectedStateToken: committedResult.expectedStateToken, canonicalEventIds: [eventId], committedAt: normalizedInstant,
+        result: committedResult,
+      },
+    };
+    },
   });
 }

--- a/rentchain-api/src/services/leaseStart/leaseStartTransaction.ts
+++ b/rentchain-api/src/services/leaseStart/leaseStartTransaction.ts
@@ -1,22 +1,74 @@
-export type LeaseStartTransactionErrorFactory = (kind: "idempotency" | "stale") => Error;
+export type LeaseStartTransactionErrorFactory<TLoaded = unknown> = (
+  kind: "idempotency" | "stale",
+  loaded?: TLoaded
+) => Error;
 
 export type LeaseStartAtomicEvent = {
   ref: any;
   record: Record<string, unknown>;
 };
 
-export async function runLeaseStartTransaction<T>(
-  firestore: any,
-  execute: (transaction: any) => Promise<T>
-): Promise<T> {
-  return firestore.runTransaction(execute);
+export type LeaseStartTransactionPlan<T> = {
+  result: T;
+  applyMutations?: () => void;
+  assertPostcondition?: () => void;
+  events?: LeaseStartAtomicEvent[];
+  requestRecord?: Record<string, unknown>;
+};
+
+export type LeaseStartTransactionAdapter<TLoaded, TResult> = {
+  firestore: any;
+  requestRef: any;
+  payloadHash: string;
+  expectedStateToken?: string;
+  error: LeaseStartTransactionErrorFactory<TLoaded>;
+  loadAuthoritativeState: (transaction: any) => Promise<TLoaded>;
+  getExpectedStateToken: (loaded: TLoaded) => string;
+  buildPlan: (input: { transaction: any; loaded: TLoaded }) => Promise<LeaseStartTransactionPlan<TResult>> | LeaseStartTransactionPlan<TResult>;
+};
+
+export async function runLeaseStartTransaction<TLoaded, TResult>(
+  adapter: LeaseStartTransactionAdapter<TLoaded, TResult>
+): Promise<TResult> {
+  return adapter.firestore.runTransaction(async (transaction: any) => {
+    const replay = await readLeaseStartReplay<TResult>({
+      transaction,
+      requestRef: adapter.requestRef,
+      payloadHash: adapter.payloadHash,
+      error: adapter.error,
+    });
+    if (replay) return replay;
+
+    const loaded = await adapter.loadAuthoritativeState(transaction);
+    if (adapter.expectedStateToken !== undefined) {
+      assertLeaseStartExpectedState(
+        adapter.getExpectedStateToken(loaded),
+        adapter.expectedStateToken,
+        (kind) => adapter.error(kind, loaded)
+      );
+    }
+
+    const plan = await adapter.buildPlan({ transaction, loaded });
+    plan.applyMutations?.();
+    plan.assertPostcondition?.();
+
+    if (plan.requestRecord) {
+      persistLeaseStartAtomicResult({
+        transaction,
+        requestRef: adapter.requestRef,
+        requestRecord: plan.requestRecord,
+        events: plan.events,
+      });
+    }
+    return plan.result;
+  });
 }
 
 export async function readLeaseStartReplay<T>(input: {
   transaction: any;
   requestRef: any;
   payloadHash: string;
-  error: LeaseStartTransactionErrorFactory;
+  error: (kind: "idempotency" | "stale") => Error;
 }): Promise<T | null> {
   const prior = await input.transaction.get(input.requestRef);
   if (!prior.exists) return null;

--- a/rentchain-api/src/services/leaseStart/leaseStartTransaction.ts
+++ b/rentchain-api/src/services/leaseStart/leaseStartTransaction.ts
@@ -1,0 +1,50 @@
+export type LeaseStartTransactionErrorFactory = (kind: "idempotency" | "stale") => Error;
+
+export type LeaseStartAtomicEvent = {
+  ref: any;
+  record: Record<string, unknown>;
+};
+
+export async function runLeaseStartTransaction<T>(
+  firestore: any,
+  execute: (transaction: any) => Promise<T>
+): Promise<T> {
+  return firestore.runTransaction(execute);
+}
+
+export async function readLeaseStartReplay<T>(input: {
+  transaction: any;
+  requestRef: any;
+  payloadHash: string;
+  error: LeaseStartTransactionErrorFactory;
+}): Promise<T | null> {
+  const prior = await input.transaction.get(input.requestRef);
+  if (!prior.exists) return null;
+  const data = prior.data() || {};
+  if (data.payloadHash !== input.payloadHash) throw input.error("idempotency");
+  return {
+    ...data.result,
+    outcome: "idempotent_replay",
+    idempotency: { ...data.result.idempotency, replay: true },
+  } as T;
+}
+
+export function assertLeaseStartExpectedState(
+  actual: string,
+  expected: string,
+  error: LeaseStartTransactionErrorFactory
+): void {
+  if (actual !== expected) throw error("stale");
+}
+
+export function persistLeaseStartAtomicResult(input: {
+  transaction: any;
+  requestRef: any;
+  requestRecord: Record<string, unknown>;
+  events?: LeaseStartAtomicEvent[];
+}): void {
+  for (const event of input.events || []) {
+    input.transaction.create(event.ref, event.record);
+  }
+  input.transaction.create(input.requestRef, input.requestRecord);
+}

--- a/rentchain-api/src/services/leaseStart/renewalContinuityService.ts
+++ b/rentchain-api/src/services/leaseStart/renewalContinuityService.ts
@@ -7,6 +7,12 @@ import {
   type RenewalContinuityLease,
 } from "../../lib/leases/renewalContinuity";
 import { leaseStartDeterministicId, leaseStartHash } from "./leaseStartExpectedState";
+import {
+  assertLeaseStartExpectedState,
+  persistLeaseStartAtomicResult,
+  readLeaseStartReplay,
+  runLeaseStartTransaction,
+} from "./leaseStartTransaction";
 
 export type RenewalContinuityContext = {
   expectedStateToken: string;
@@ -116,6 +122,13 @@ function contextToken(records: any, evaluation: RenewalContinuityEvaluation, eva
     unit: records.unit,
     embedded: records.embedded,
     tenant: records.tenant,
+    tenants: records.tenants.map((tenant: any) => ({
+      id: tenant.id,
+      landlordId: tenant.landlordId ?? null,
+      currentLeaseId: tenant.currentLeaseId ?? null,
+      status: tenant.status ?? null,
+      updatedAt: tenant.updatedAt ?? null,
+    })).sort((left: any, right: any) => left.id.localeCompare(right.id)),
     tenancies: tenancyMaterial,
     propertyUpdatedAt: records.property.updatedAt ?? null,
   });
@@ -164,15 +177,23 @@ async function readRenewalContext(reader: any, input: RenewalContextInput) {
   const occupantIds = [...new Set(pointerIds)];
   if (occupantIds.length !== 1 || !participantIds.includes(occupantIds[0])) throw new RenewalContinuityServiceError("renewal_context_ambiguous");
   const tenantId = occupantIds[0];
-  const tenantRef = firestore.collection("tenants").doc(tenantId);
-  const tenantSnap = await get(tenantRef);
-  const tenant = docData(tenantSnap);
-  if (!tenant || text(tenant.landlordId) !== input.landlordId) throw new RenewalContinuityServiceError("renewal_context_ambiguous");
+  const tenantRefs = participantIds.map((participantId) => firestore.collection("tenants").doc(participantId));
+  const tenantSnaps = await Promise.all(tenantRefs.map(get));
+  const tenants = tenantSnaps.map(docData);
+  if (tenants.some((entry: any) => !entry || text(entry.landlordId) !== input.landlordId)) {
+    throw new RenewalContinuityServiceError("renewal_context_ambiguous");
+  }
+  const tenant = tenants.find((entry: any) => entry.id === tenantId);
+  const tenantRef = tenantRefs[participantIds.indexOf(tenantId)];
   const tenancies = (tenanciesSnap.docs || []).map(docData).filter((tenancy: any) => tenancy && text(tenancy.unitId) === unitId);
   const evaluation = evaluateRenewalContinuity({ predecessor, successor, contextLeases, evaluationInstant: input.evaluationInstant, standaloneUnit: unit, embeddedUnit: embedded, tenant });
+  if (tenants.some((entry: any) => text(entry.currentLeaseId) && text(entry.currentLeaseId) !== predecessorId)) {
+    evaluation.reasons = [...new Set([...evaluation.reasons, "RENEWAL_PROJECTION_MISMATCH" as const])];
+    evaluation.eligible = false;
+  }
   const records = {
     predecessorRef, successorRef, propertyRef, unitRef, tenantRef, predecessor, successor, property, unit, embedded,
-    embeddedUnits, embeddedIndex: embeddedMatches[0].index, contextLeases, tenant, tenantId, tenancies,
+    embeddedUnits, embeddedIndex: embeddedMatches[0].index, contextLeases, tenant, tenantId, tenantRefs, tenants, tenancies,
   };
   const context: RenewalContinuityContext = {
     expectedStateToken: contextToken(records, evaluation, input.evaluationInstant),
@@ -216,33 +237,39 @@ export async function handoffRenewalContinuity(input: RenewalHandoffInput): Prom
     evaluationInstant,
   });
 
-  return firestore.runTransaction(async (transaction: any) => {
-    const prior = await transaction.get(requestRef);
-    if (prior.exists) {
-      const data = prior.data() || {};
-      if (data.payloadHash !== payloadHash) throw new RenewalContinuityServiceError("renewal_idempotency_key_reused");
-      return { ...data.result, outcome: "idempotent_replay", idempotency: { ...data.result.idempotency, replay: true } };
-    }
+  return runLeaseStartTransaction(firestore, async (transaction: any) => {
+    const replay = await readLeaseStartReplay<RenewalContinuityResult>({
+      transaction, requestRef, payloadHash,
+      error: (kind) => new RenewalContinuityServiceError(kind === "idempotency" ? "renewal_idempotency_key_reused" : "renewal_state_stale"),
+    });
+    if (replay) return replay;
     const loaded = await readRenewalContext(transaction, { ...input, evaluationInstant, firestore });
-    if (loaded.context.expectedStateToken !== input.expectedStateToken) {
-      throw new RenewalContinuityServiceError("renewal_state_stale", loaded.context);
-    }
+    assertLeaseStartExpectedState(loaded.context.expectedStateToken, input.expectedStateToken, () =>
+      new RenewalContinuityServiceError("renewal_state_stale", loaded.context));
     if (!loaded.evaluation.eligible) {
       throw new RenewalContinuityServiceError("renewal_handoff_ineligible", loaded.context, loaded.evaluation.reasons);
     }
+    const participantIds = new Set(loaded.context.participantIds);
     const predecessorTenancies = loaded.records.tenancies.filter((tenancy: any) =>
+      text(tenancy.landlordId) === input.landlordId && text(tenancy.propertyId) === loaded.context.propertyId && text(tenancy.unitId) === loaded.context.unitId &&
       text(tenancy.leaseId) === loaded.context.predecessorLeaseId &&
-      text(tenancy.tenantId) === loaded.records.tenantId &&
+      participantIds.has(text(tenancy.tenantId)) &&
       ["active", "current", "occupied"].includes(state(tenancy.status)) && !text(tenancy.moveOutAt)
     );
     const successorTenancies = loaded.records.tenancies.filter((tenancy: any) =>
-      text(tenancy.leaseId) === loaded.context.successorLeaseId && ["active", "current", "occupied"].includes(state(tenancy.status)) && !text(tenancy.moveOutAt)
+      text(tenancy.landlordId) === input.landlordId && text(tenancy.propertyId) === loaded.context.propertyId && text(tenancy.unitId) === loaded.context.unitId &&
+      text(tenancy.leaseId) === loaded.context.successorLeaseId && participantIds.has(text(tenancy.tenantId))
     );
     const unrelatedActiveTenancies = loaded.records.tenancies.filter((tenancy: any) =>
+      text(tenancy.landlordId) === input.landlordId &&
       ["active", "current", "occupied"].includes(state(tenancy.status)) && !text(tenancy.moveOutAt) &&
-      text(tenancy.leaseId) !== loaded.context.predecessorLeaseId
+      ![loaded.context.predecessorLeaseId, loaded.context.successorLeaseId].includes(text(tenancy.leaseId))
     );
-    if (predecessorTenancies.length !== 1 || successorTenancies.length !== 0 || unrelatedActiveTenancies.length !== 0) {
+    const predecessorTenantIds = new Set(predecessorTenancies.map((entry: any) => text(entry.tenantId)));
+    const successorCounts = new Map<string, number>();
+    successorTenancies.forEach((entry: any) => successorCounts.set(text(entry.tenantId), (successorCounts.get(text(entry.tenantId)) || 0) + 1));
+    if (predecessorTenancies.length !== participantIds.size || [...participantIds].some((id) => !predecessorTenantIds.has(id)) ||
+        [...successorCounts.values()].some((count) => count > 1) || unrelatedActiveTenancies.length !== 0) {
       throw new RenewalContinuityServiceError("renewal_handoff_ineligible", loaded.context, ["RENEWAL_PROJECTION_MISMATCH"]);
     }
 
@@ -265,24 +292,34 @@ export async function handoffRenewalContinuity(input: RenewalHandoffInput): Prom
     if (Object.prototype.hasOwnProperty.call(loaded.records.embedded, "occupied")) nextEmbedded.occupied = true;
     if (Object.prototype.hasOwnProperty.call(loaded.records.embedded, "isOccupied")) nextEmbedded.isOccupied = true;
     const nextEmbeddedUnits = loaded.records.embeddedUnits.map((entry: any, index: number) => index === loaded.records.embeddedIndex ? nextEmbedded : entry);
-    const predecessorTenancy = predecessorTenancies[0];
-    const predecessorTenancyRef = firestore.collection("tenancies").doc(predecessorTenancy.id);
-    const successorTenancyId = leaseStartDeterministicId("tenancy", [input.landlordId, loaded.context.propertyId, loaded.context.unitId, loaded.records.tenantId, loaded.context.successorLeaseId]);
-    const successorTenancyRef = firestore.collection("tenancies").doc(successorTenancyId);
-    const successorTenancy = {
-      id: successorTenancyId,
-      landlordId: input.landlordId,
-      propertyId: loaded.context.propertyId,
-      unitId: loaded.context.unitId,
-      tenantId: loaded.records.tenantId,
-      leaseId: loaded.context.successorLeaseId,
-      status: "active",
-      moveInAt: evaluationInstant,
-      moveOutAt: null,
-      createdAt: evaluationInstant,
-      updatedAt: evaluationInstant,
-      source: "renewal_handoff",
-    };
+    const successorPlans = loaded.context.participantIds.map((participantId) => {
+      const existing = successorTenancies.find((entry: any) => text(entry.tenantId) === participantId);
+      const id = existing?.id || leaseStartDeterministicId("tenancy", [input.landlordId, loaded.context.propertyId, loaded.context.unitId, participantId, loaded.context.successorLeaseId]);
+      return {
+        existing: Boolean(existing),
+        ref: firestore.collection("tenancies").doc(id),
+        record: {
+          ...(existing || {}), id, landlordId: input.landlordId, propertyId: loaded.context.propertyId,
+          unitId: loaded.context.unitId, tenantId: participantId, leaseId: loaded.context.successorLeaseId,
+          status: "active", moveInAt: existing?.moveInAt || evaluationInstant, moveOutAt: null,
+          createdAt: existing?.createdAt || evaluationInstant, updatedAt: evaluationInstant, source: existing?.source || "renewal_handoff",
+        },
+      };
+    });
+    const finalTenancies = loaded.records.tenancies.map((entry: any) => {
+      if (predecessorTenancies.some((prior: any) => prior.id === entry.id)) {
+        return { ...entry, status: "inactive", moveOutAt: evaluationInstant, updatedAt: evaluationInstant };
+      }
+      const successor = successorPlans.find((plan) => plan.record.id === entry.id);
+      return successor ? successor.record : entry;
+    });
+    for (const plan of successorPlans) if (!plan.existing) finalTenancies.push(plan.record);
+    const finalPredecessorActive = finalTenancies.filter((entry: any) => text(entry.leaseId) === loaded.context.predecessorLeaseId && participantIds.has(text(entry.tenantId)) && ["active", "current", "occupied"].includes(state(entry.status)) && !text(entry.moveOutAt));
+    const finalSuccessors = finalTenancies.filter((entry: any) => text(entry.leaseId) === loaded.context.successorLeaseId && participantIds.has(text(entry.tenantId)) && ["active", "current", "occupied"].includes(state(entry.status)) && !text(entry.moveOutAt));
+    const finalSuccessorIds = new Set(finalSuccessors.map((entry: any) => text(entry.tenantId)));
+    const unrelatedTenanciesUnchanged = loaded.records.tenancies
+      .filter((entry: any) => ![loaded.context.predecessorLeaseId, loaded.context.successorLeaseId].includes(text(entry.leaseId)))
+      .every((entry: any) => leaseStartHash(entry) === leaseStartHash(finalTenancies.find((next: any) => next.id === entry.id)));
     if (
       text(nextUnit.currentLeaseId) !== loaded.context.successorLeaseId ||
       text(nextEmbedded.currentLeaseId) !== loaded.context.successorLeaseId ||
@@ -290,8 +327,8 @@ export async function handoffRenewalContinuity(input: RenewalHandoffInput): Prom
       text(nextEmbedded.currentTenantId) !== loaded.records.tenantId ||
       state(nextUnit.status) !== "occupied" ||
       state(nextEmbedded.status) !== "occupied" ||
-      successorTenancy.leaseId !== loaded.context.successorLeaseId ||
-      successorTenancy.status !== "active"
+      finalPredecessorActive.length !== 0 || finalSuccessors.length !== participantIds.size ||
+      [...participantIds].some((id) => !finalSuccessorIds.has(id)) || !unrelatedTenanciesUnchanged
     ) throw new RenewalContinuityServiceError("renewal_postcondition_failed", loaded.context);
     const eventId = leaseStartDeterministicId("renewal_occupancy_handoff", [input.landlordId, input.idempotencyKey, loaded.context.predecessorLeaseId, loaded.context.successorLeaseId]);
     const result: RenewalContinuityResult = {
@@ -303,13 +340,22 @@ export async function handoffRenewalContinuity(input: RenewalHandoffInput): Prom
       idempotency: { key: input.idempotencyKey, replay: false, resultId: requestId },
     };
 
-    transaction.set(loaded.records.successorRef, { occupancyEffective: true, occupancyEffectiveAt: evaluationInstant, updatedAt: evaluationInstant }, { merge: true });
+    transaction.set(loaded.records.predecessorRef, { status: "renewed", occupancyEffective: false, occupancyEndedAt: evaluationInstant, updatedAt: evaluationInstant }, { merge: true });
+    transaction.set(loaded.records.successorRef, { status: "active", occupancyEffective: true, occupancyEffectiveAt: evaluationInstant, updatedAt: evaluationInstant }, { merge: true });
     transaction.set(loaded.records.propertyRef, { units: nextEmbeddedUnits, updatedAt: evaluationInstant }, { merge: true });
     transaction.set(loaded.records.unitRef, nextUnit, { merge: true });
-    transaction.set(loaded.records.tenantRef, { currentLeaseId: loaded.context.successorLeaseId, status: "current", updatedAt: evaluationInstant }, { merge: true });
-    transaction.set(predecessorTenancyRef, { status: "inactive", moveOutAt: evaluationInstant, updatedAt: evaluationInstant }, { merge: true });
-    transaction.create(successorTenancyRef, successorTenancy);
-    transaction.create(firestore.collection("canonicalEvents").doc(eventId), {
+    for (const tenantRef of loaded.records.tenantRefs) {
+      transaction.set(tenantRef, { currentLeaseId: loaded.context.successorLeaseId, status: "current", updatedAt: evaluationInstant }, { merge: true });
+    }
+    for (const predecessorTenancy of predecessorTenancies) {
+      transaction.set(firestore.collection("tenancies").doc(predecessorTenancy.id), { status: "inactive", moveOutAt: evaluationInstant, updatedAt: evaluationInstant }, { merge: true });
+    }
+    for (const plan of successorPlans) {
+      if (plan.existing) transaction.set(plan.ref, plan.record, { merge: true });
+      else transaction.create(plan.ref, plan.record);
+    }
+    const eventRef = firestore.collection("canonicalEvents").doc(eventId);
+    const eventRecord = {
       id: eventId, version: "v1", type: "lease.renewal_occupancy_handoff", domain: "lease", action: "renewal_occupancy_handoff", status: "succeeded",
       actor: { type: "landlord", id: leaseStartDeterministicId("actor", [input.actorId]), role: "landlord", displayName: null },
       resource: { type: "lease", id: leaseStartDeterministicId("lease", [loaded.context.successorLeaseId]), parentType: "property", parentId: leaseStartDeterministicId("property", [loaded.context.propertyId]) },
@@ -324,12 +370,12 @@ export async function handoffRenewalContinuity(input: RenewalHandoffInput): Prom
         source: input.source, legalDetermination: false,
       },
       tags: ["lease_start", "renewal_handoff"], appendOnly: true, immutable: true,
-    });
-    transaction.create(requestRef, {
+    };
+    persistLeaseStartAtomicResult({ transaction, requestRef, events: [{ ref: eventRef, record: eventRecord }], requestRecord: {
       landlordId: input.landlordId, operationKind: "renewal_handoff", idempotencyKey: input.idempotencyKey,
       payloadHash, leaseId: loaded.context.successorLeaseId, predecessorLeaseId: loaded.context.predecessorLeaseId,
       canonicalEventIds: [eventId], committedAt: evaluationInstant, result,
-    });
+    }});
     return result;
   });
 }

--- a/rentchain-api/src/services/leaseStart/renewalContinuityService.ts
+++ b/rentchain-api/src/services/leaseStart/renewalContinuityService.ts
@@ -1,0 +1,340 @@
+import { db } from "../../firebase";
+import {
+  evaluateRenewalContinuity,
+  renewalParticipantIds,
+  renewalSuccessorLinks,
+  type RenewalContinuityEvaluation,
+  type RenewalContinuityLease,
+} from "../../lib/leases/renewalContinuity";
+import { leaseStartDeterministicId, leaseStartHash } from "./leaseStartExpectedState";
+
+export type RenewalContinuityContext = {
+  expectedStateToken: string;
+  evaluationInstant: string;
+  predecessorLeaseId: string;
+  successorLeaseId: string;
+  propertyId: string;
+  unitId: string;
+  participantIds: string[];
+  predecessorCanonicalState: string;
+  successorCanonicalState: string;
+  termContinuity: boolean;
+  executionReady: boolean;
+  handoffEligible: boolean;
+  blockingReasons: RenewalContinuityEvaluation["reasons"];
+};
+
+export type RenewalContinuityResult = {
+  outcome: "renewal_handoff_completed" | "idempotent_replay";
+  predecessorLeaseId: string;
+  successorLeaseId: string;
+  expectedStateToken: string;
+  auditEventIds: string[];
+  idempotency: { key: string; replay: boolean; resultId: string };
+};
+
+export type RenewalContinuityErrorCode =
+  | "renewal_context_ambiguous"
+  | "renewal_handoff_ineligible"
+  | "renewal_state_stale"
+  | "renewal_idempotency_key_reused"
+  | "renewal_postcondition_failed";
+
+export class RenewalContinuityServiceError extends Error {
+  constructor(
+    public code: RenewalContinuityErrorCode,
+    public freshContext?: RenewalContinuityContext,
+    public reasons: RenewalContinuityEvaluation["reasons"] = []
+  ) {
+    super(code);
+  }
+}
+
+type RenewalContextInput = {
+  landlordId: string;
+  successorLeaseId: string;
+  evaluationInstant: string;
+  firestore?: any;
+};
+
+type RenewalHandoffInput = RenewalContextInput & {
+  expectedStateToken: string;
+  idempotencyKey: string;
+  actorId: string;
+  source: string;
+};
+
+function text(value: unknown): string {
+  return String(value ?? "").trim();
+}
+
+function state(value: unknown): string {
+  return text(value).toLowerCase().replace(/[\s-]+/g, "_");
+}
+
+function instant(value: unknown): string | null {
+  const parsed = new Date(String(value || ""));
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+}
+
+function docData(snapshot: any): any {
+  return snapshot?.exists ? { id: snapshot.id, ...(snapshot.data() || {}) } : null;
+}
+
+function matchesEmbeddedUnit(unit: any, unitId: string, unitNumber: string): boolean {
+  return [unit?.id, unit?.unitId, unit?.unitNumber].map(text).includes(unitId) || (Boolean(unitNumber) && text(unit?.unitNumber) === unitNumber);
+}
+
+function canonicalLease(lease: any): RenewalContinuityLease {
+  return {
+    ...lease,
+    id: text(lease?.id),
+    executionState: lease?.executionState || lease?.executionStatus || lease?.leaseExecutionState || lease?.leaseExecution?.executionStatus,
+    executionStatus: lease?.executionStatus || lease?.executionState || lease?.leaseExecutionState || lease?.leaseExecution?.executionStatus,
+  };
+}
+
+function contextToken(records: any, evaluation: RenewalContinuityEvaluation, evaluationInstant: string): string {
+  const tenancyMaterial = records.tenancies.map((tenancy: any) => ({
+    id: tenancy.id,
+    landlordId: tenancy.landlordId ?? null,
+    propertyId: tenancy.propertyId ?? null,
+    unitId: tenancy.unitId ?? null,
+    tenantId: tenancy.tenantId ?? null,
+    leaseId: tenancy.leaseId ?? null,
+    status: tenancy.status ?? null,
+    moveOutAt: tenancy.moveOutAt ?? null,
+    updatedAt: tenancy.updatedAt ?? null,
+  })).sort((left: any, right: any) => left.id.localeCompare(right.id));
+  return leaseStartHash({
+    version: "renewal_continuity_expected_state_v1",
+    evaluationInstant,
+    evaluation,
+    predecessor: records.predecessor,
+    successor: records.successor,
+    contextLeases: records.contextLeases,
+    unit: records.unit,
+    embedded: records.embedded,
+    tenant: records.tenant,
+    tenancies: tenancyMaterial,
+    propertyUpdatedAt: records.property.updatedAt ?? null,
+  });
+}
+
+async function readRenewalContext(reader: any, input: RenewalContextInput) {
+  const firestore = input.firestore || db;
+  const successorRef = firestore.collection("leases").doc(input.successorLeaseId);
+  const get = (target: any) => reader?.get ? reader.get(target) : target.get();
+  const successorSnap = await get(successorRef);
+  const successor = canonicalLease(docData(successorSnap));
+  if (!successor.id || text(successor.landlordId) !== input.landlordId) throw new RenewalContinuityServiceError("renewal_context_ambiguous");
+  const predecessorId = text(successor.predecessorLeaseId);
+  if (!predecessorId) throw new RenewalContinuityServiceError("renewal_context_ambiguous", undefined, ["RENEWAL_LINK_MISSING"]);
+
+  const propertyId = text(successor.propertyId);
+  const unitId = text(successor.unitId);
+  if (!propertyId || !unitId) throw new RenewalContinuityServiceError("renewal_context_ambiguous");
+  const predecessorRef = firestore.collection("leases").doc(predecessorId);
+  const propertyRef = firestore.collection("properties").doc(propertyId);
+  const unitRef = firestore.collection("units").doc(unitId);
+  const leasesQuery = firestore.collection("leases").where("landlordId", "==", input.landlordId).where("propertyId", "==", propertyId);
+  const tenanciesQuery = firestore.collection("tenancies").where("propertyId", "==", propertyId);
+  const [predecessorSnap, propertySnap, unitSnap, leasesSnap, tenanciesSnap] = await Promise.all([
+    get(predecessorRef), get(propertyRef), get(unitRef), get(leasesQuery), get(tenanciesQuery),
+  ]);
+  const predecessor = canonicalLease(docData(predecessorSnap));
+  const property = docData(propertySnap);
+  const unit = docData(unitSnap);
+  if (!predecessor.id || !property || !unit || text(predecessor.landlordId) !== input.landlordId ||
+      text(property.landlordId || property.ownerId || property.owner) !== input.landlordId ||
+      text(unit.landlordId) !== input.landlordId || text(unit.propertyId) !== propertyId) {
+    throw new RenewalContinuityServiceError("renewal_context_ambiguous");
+  }
+
+  const unitNumber = text(unit.unitNumber);
+  const embeddedUnits = Array.isArray(property.units) ? property.units : [];
+  const embeddedMatches = embeddedUnits.map((entry: any, index: number) => ({ entry, index }))
+    .filter(({ entry }: any) => matchesEmbeddedUnit(entry, unitId, unitNumber));
+  if (embeddedMatches.length !== 1) throw new RenewalContinuityServiceError("renewal_context_ambiguous");
+  const embedded = { ...embeddedMatches[0].entry, id: text(embeddedMatches[0].entry.id || embeddedMatches[0].entry.unitId || unitId) };
+  const contextLeases = (leasesSnap.docs || []).map(docData).filter((lease: any) => lease && text(lease.unitId) === unitId)
+    .map(canonicalLease).filter((lease: RenewalContinuityLease) => lease.id !== predecessorId && lease.id !== input.successorLeaseId);
+  const participantIds = renewalParticipantIds(successor);
+  const pointerIds = [unit.currentTenantId, unit.tenantId, embedded.currentTenantId, embedded.tenantId].map(text).filter(Boolean);
+  const occupantIds = [...new Set(pointerIds)];
+  if (occupantIds.length !== 1 || !participantIds.includes(occupantIds[0])) throw new RenewalContinuityServiceError("renewal_context_ambiguous");
+  const tenantId = occupantIds[0];
+  const tenantRef = firestore.collection("tenants").doc(tenantId);
+  const tenantSnap = await get(tenantRef);
+  const tenant = docData(tenantSnap);
+  if (!tenant || text(tenant.landlordId) !== input.landlordId) throw new RenewalContinuityServiceError("renewal_context_ambiguous");
+  const tenancies = (tenanciesSnap.docs || []).map(docData).filter((tenancy: any) => tenancy && text(tenancy.unitId) === unitId);
+  const evaluation = evaluateRenewalContinuity({ predecessor, successor, contextLeases, evaluationInstant: input.evaluationInstant, standaloneUnit: unit, embeddedUnit: embedded, tenant });
+  const records = {
+    predecessorRef, successorRef, propertyRef, unitRef, tenantRef, predecessor, successor, property, unit, embedded,
+    embeddedUnits, embeddedIndex: embeddedMatches[0].index, contextLeases, tenant, tenantId, tenancies,
+  };
+  const context: RenewalContinuityContext = {
+    expectedStateToken: contextToken(records, evaluation, input.evaluationInstant),
+    evaluationInstant: input.evaluationInstant,
+    predecessorLeaseId: predecessorId,
+    successorLeaseId: input.successorLeaseId,
+    propertyId,
+    unitId,
+    participantIds,
+    predecessorCanonicalState: evaluation.predecessorCanonicalState,
+    successorCanonicalState: evaluation.successorCanonicalState,
+    termContinuity: evaluation.contiguous,
+    executionReady: state(successor.executionState || successor.executionStatus) === "fully_executed",
+    handoffEligible: evaluation.eligible,
+    blockingReasons: evaluation.reasons,
+  };
+  return { context, records, evaluation };
+}
+
+export async function getRenewalContinuityContext(input: RenewalContextInput): Promise<RenewalContinuityContext> {
+  const evaluationInstant = instant(input.evaluationInstant);
+  if (!evaluationInstant) throw new RenewalContinuityServiceError("renewal_context_ambiguous");
+  return (await readRenewalContext(input.firestore || db, { ...input, evaluationInstant })).context;
+}
+
+export async function handoffRenewalContinuity(input: RenewalHandoffInput): Promise<RenewalContinuityResult> {
+  const firestore = input.firestore || db;
+  const evaluationInstant = instant(input.evaluationInstant);
+  if (!evaluationInstant || !text(input.idempotencyKey) || input.idempotencyKey.length > 160 || !text(input.expectedStateToken)) {
+    throw new RenewalContinuityServiceError("renewal_state_stale");
+  }
+  const requestId = leaseStartDeterministicId("renewal_handoff", [input.landlordId, input.idempotencyKey]);
+  const requestRef = firestore.collection("leaseStartRequests").doc(requestId);
+  const payloadHash = leaseStartHash({
+    landlordId: input.landlordId,
+    successorLeaseId: input.successorLeaseId,
+    expectedStateToken: input.expectedStateToken,
+    idempotencyKey: input.idempotencyKey,
+    actorId: input.actorId,
+    source: input.source,
+    evaluationInstant,
+  });
+
+  return firestore.runTransaction(async (transaction: any) => {
+    const prior = await transaction.get(requestRef);
+    if (prior.exists) {
+      const data = prior.data() || {};
+      if (data.payloadHash !== payloadHash) throw new RenewalContinuityServiceError("renewal_idempotency_key_reused");
+      return { ...data.result, outcome: "idempotent_replay", idempotency: { ...data.result.idempotency, replay: true } };
+    }
+    const loaded = await readRenewalContext(transaction, { ...input, evaluationInstant, firestore });
+    if (loaded.context.expectedStateToken !== input.expectedStateToken) {
+      throw new RenewalContinuityServiceError("renewal_state_stale", loaded.context);
+    }
+    if (!loaded.evaluation.eligible) {
+      throw new RenewalContinuityServiceError("renewal_handoff_ineligible", loaded.context, loaded.evaluation.reasons);
+    }
+    const predecessorTenancies = loaded.records.tenancies.filter((tenancy: any) =>
+      text(tenancy.leaseId) === loaded.context.predecessorLeaseId &&
+      text(tenancy.tenantId) === loaded.records.tenantId &&
+      ["active", "current", "occupied"].includes(state(tenancy.status)) && !text(tenancy.moveOutAt)
+    );
+    const successorTenancies = loaded.records.tenancies.filter((tenancy: any) =>
+      text(tenancy.leaseId) === loaded.context.successorLeaseId && ["active", "current", "occupied"].includes(state(tenancy.status)) && !text(tenancy.moveOutAt)
+    );
+    const unrelatedActiveTenancies = loaded.records.tenancies.filter((tenancy: any) =>
+      ["active", "current", "occupied"].includes(state(tenancy.status)) && !text(tenancy.moveOutAt) &&
+      text(tenancy.leaseId) !== loaded.context.predecessorLeaseId
+    );
+    if (predecessorTenancies.length !== 1 || successorTenancies.length !== 0 || unrelatedActiveTenancies.length !== 0) {
+      throw new RenewalContinuityServiceError("renewal_handoff_ineligible", loaded.context, ["RENEWAL_PROJECTION_MISMATCH"]);
+    }
+
+    const nextUnit = {
+      ...loaded.records.unit,
+      status: "occupied", occupancyStatus: "occupied",
+      tenantId: loaded.records.tenantId, currentTenantId: loaded.records.tenantId,
+      leaseId: loaded.context.successorLeaseId, currentLeaseId: loaded.context.successorLeaseId,
+      occupancySource: "canonical_renewal_handoff", occupancyUpdatedAt: evaluationInstant, updatedAt: evaluationInstant,
+    };
+    const nextEmbedded = {
+      ...loaded.records.embedded,
+      status: "occupied", occupancyStatus: "occupied",
+      tenantId: loaded.records.tenantId, currentTenantId: loaded.records.tenantId,
+      leaseId: loaded.context.successorLeaseId, currentLeaseId: loaded.context.successorLeaseId,
+      occupancySource: "canonical_renewal_handoff", occupancyUpdatedAt: evaluationInstant, updatedAt: evaluationInstant,
+    };
+    if (Object.prototype.hasOwnProperty.call(loaded.records.unit, "occupied")) nextUnit.occupied = true;
+    if (Object.prototype.hasOwnProperty.call(loaded.records.unit, "isOccupied")) nextUnit.isOccupied = true;
+    if (Object.prototype.hasOwnProperty.call(loaded.records.embedded, "occupied")) nextEmbedded.occupied = true;
+    if (Object.prototype.hasOwnProperty.call(loaded.records.embedded, "isOccupied")) nextEmbedded.isOccupied = true;
+    const nextEmbeddedUnits = loaded.records.embeddedUnits.map((entry: any, index: number) => index === loaded.records.embeddedIndex ? nextEmbedded : entry);
+    const predecessorTenancy = predecessorTenancies[0];
+    const predecessorTenancyRef = firestore.collection("tenancies").doc(predecessorTenancy.id);
+    const successorTenancyId = leaseStartDeterministicId("tenancy", [input.landlordId, loaded.context.propertyId, loaded.context.unitId, loaded.records.tenantId, loaded.context.successorLeaseId]);
+    const successorTenancyRef = firestore.collection("tenancies").doc(successorTenancyId);
+    const successorTenancy = {
+      id: successorTenancyId,
+      landlordId: input.landlordId,
+      propertyId: loaded.context.propertyId,
+      unitId: loaded.context.unitId,
+      tenantId: loaded.records.tenantId,
+      leaseId: loaded.context.successorLeaseId,
+      status: "active",
+      moveInAt: evaluationInstant,
+      moveOutAt: null,
+      createdAt: evaluationInstant,
+      updatedAt: evaluationInstant,
+      source: "renewal_handoff",
+    };
+    if (
+      text(nextUnit.currentLeaseId) !== loaded.context.successorLeaseId ||
+      text(nextEmbedded.currentLeaseId) !== loaded.context.successorLeaseId ||
+      text(nextUnit.currentTenantId) !== loaded.records.tenantId ||
+      text(nextEmbedded.currentTenantId) !== loaded.records.tenantId ||
+      state(nextUnit.status) !== "occupied" ||
+      state(nextEmbedded.status) !== "occupied" ||
+      successorTenancy.leaseId !== loaded.context.successorLeaseId ||
+      successorTenancy.status !== "active"
+    ) throw new RenewalContinuityServiceError("renewal_postcondition_failed", loaded.context);
+    const eventId = leaseStartDeterministicId("renewal_occupancy_handoff", [input.landlordId, input.idempotencyKey, loaded.context.predecessorLeaseId, loaded.context.successorLeaseId]);
+    const result: RenewalContinuityResult = {
+      outcome: "renewal_handoff_completed",
+      predecessorLeaseId: loaded.context.predecessorLeaseId,
+      successorLeaseId: loaded.context.successorLeaseId,
+      expectedStateToken: leaseStartHash({ prior: loaded.context.expectedStateToken, completedAt: evaluationInstant, successorLeaseId: loaded.context.successorLeaseId }),
+      auditEventIds: [eventId],
+      idempotency: { key: input.idempotencyKey, replay: false, resultId: requestId },
+    };
+
+    transaction.set(loaded.records.successorRef, { occupancyEffective: true, occupancyEffectiveAt: evaluationInstant, updatedAt: evaluationInstant }, { merge: true });
+    transaction.set(loaded.records.propertyRef, { units: nextEmbeddedUnits, updatedAt: evaluationInstant }, { merge: true });
+    transaction.set(loaded.records.unitRef, nextUnit, { merge: true });
+    transaction.set(loaded.records.tenantRef, { currentLeaseId: loaded.context.successorLeaseId, status: "current", updatedAt: evaluationInstant }, { merge: true });
+    transaction.set(predecessorTenancyRef, { status: "inactive", moveOutAt: evaluationInstant, updatedAt: evaluationInstant }, { merge: true });
+    transaction.create(successorTenancyRef, successorTenancy);
+    transaction.create(firestore.collection("canonicalEvents").doc(eventId), {
+      id: eventId, version: "v1", type: "lease.renewal_occupancy_handoff", domain: "lease", action: "renewal_occupancy_handoff", status: "succeeded",
+      actor: { type: "landlord", id: leaseStartDeterministicId("actor", [input.actorId]), role: "landlord", displayName: null },
+      resource: { type: "lease", id: leaseStartDeterministicId("lease", [loaded.context.successorLeaseId]), parentType: "property", parentId: leaseStartDeterministicId("property", [loaded.context.propertyId]) },
+      occurredAt: evaluationInstant, recordedAt: evaluationInstant, visibility: "internal", summary: "Canonical renewal occupancy handoff completed.",
+      metadata: {
+        landlordRef: leaseStartDeterministicId("landlord", [input.landlordId]),
+        tenantRef: leaseStartDeterministicId("tenant", [loaded.records.tenantId]),
+        unitRef: leaseStartDeterministicId("unit", [loaded.context.unitId]),
+        predecessorLeaseRef: leaseStartDeterministicId("lease", [loaded.context.predecessorLeaseId]),
+        successorLeaseRef: leaseStartDeterministicId("lease", [loaded.context.successorLeaseId]),
+        requestRef: leaseStartDeterministicId("request", [requestId]),
+        source: input.source, legalDetermination: false,
+      },
+      tags: ["lease_start", "renewal_handoff"], appendOnly: true, immutable: true,
+    });
+    transaction.create(requestRef, {
+      landlordId: input.landlordId, operationKind: "renewal_handoff", idempotencyKey: input.idempotencyKey,
+      payloadHash, leaseId: loaded.context.successorLeaseId, predecessorLeaseId: loaded.context.predecessorLeaseId,
+      canonicalEventIds: [eventId], committedAt: evaluationInstant, result,
+    });
+    return result;
+  });
+}
+
+export function renewalLinkIsAuthoritative(predecessor: RenewalContinuityLease, successor: RenewalContinuityLease): boolean {
+  const links = renewalSuccessorLinks(predecessor);
+  return links.length === 1 && links[0] === text(successor.id) && text(successor.predecessorLeaseId) === text(predecessor.id);
+}

--- a/rentchain-api/src/services/leaseStart/renewalContinuityService.ts
+++ b/rentchain-api/src/services/leaseStart/renewalContinuityService.ts
@@ -8,9 +8,6 @@ import {
 } from "../../lib/leases/renewalContinuity";
 import { buildLeaseStartExpectedStateMaterialToken, leaseStartDeterministicId, leaseStartHash } from "./leaseStartExpectedState";
 import {
-  assertLeaseStartExpectedState,
-  persistLeaseStartAtomicResult,
-  readLeaseStartReplay,
   runLeaseStartTransaction,
 } from "./leaseStartTransaction";
 
@@ -236,15 +233,18 @@ export async function handoffRenewalContinuity(input: RenewalHandoffInput): Prom
     evaluationInstant,
   });
 
-  return runLeaseStartTransaction(firestore, async (transaction: any) => {
-    const replay = await readLeaseStartReplay<RenewalContinuityResult>({
-      transaction, requestRef, payloadHash,
-      error: (kind) => new RenewalContinuityServiceError(kind === "idempotency" ? "renewal_idempotency_key_reused" : "renewal_state_stale"),
-    });
-    if (replay) return replay;
-    const loaded = await readRenewalContext(transaction, { ...input, evaluationInstant, firestore });
-    assertLeaseStartExpectedState(loaded.context.expectedStateToken, input.expectedStateToken, () =>
-      new RenewalContinuityServiceError("renewal_state_stale", loaded.context));
+  return runLeaseStartTransaction<Awaited<ReturnType<typeof readRenewalContext>>, RenewalContinuityResult>({
+    firestore,
+    requestRef,
+    payloadHash,
+    expectedStateToken: input.expectedStateToken,
+    error: (kind, loaded) => new RenewalContinuityServiceError(
+      kind === "idempotency" ? "renewal_idempotency_key_reused" : "renewal_state_stale",
+      loaded?.context
+    ),
+    loadAuthoritativeState: (transaction) => readRenewalContext(transaction, { ...input, evaluationInstant, firestore }),
+    getExpectedStateToken: (loaded) => loaded.context.expectedStateToken,
+    buildPlan: async ({ transaction, loaded }) => {
     if (!loaded.evaluation.eligible) {
       throw new RenewalContinuityServiceError("renewal_handoff_ineligible", loaded.context, loaded.evaluation.reasons);
     }
@@ -319,16 +319,6 @@ export async function handoffRenewalContinuity(input: RenewalHandoffInput): Prom
     const unrelatedTenanciesUnchanged = loaded.records.tenancies
       .filter((entry: any) => ![loaded.context.predecessorLeaseId, loaded.context.successorLeaseId].includes(text(entry.leaseId)))
       .every((entry: any) => leaseStartHash(entry) === leaseStartHash(finalTenancies.find((next: any) => next.id === entry.id)));
-    if (
-      text(nextUnit.currentLeaseId) !== loaded.context.successorLeaseId ||
-      text(nextEmbedded.currentLeaseId) !== loaded.context.successorLeaseId ||
-      text(nextUnit.currentTenantId) !== loaded.records.tenantId ||
-      text(nextEmbedded.currentTenantId) !== loaded.records.tenantId ||
-      state(nextUnit.status) !== "occupied" ||
-      state(nextEmbedded.status) !== "occupied" ||
-      finalPredecessorActive.length !== 0 || finalSuccessors.length !== participantIds.size ||
-      [...participantIds].some((id) => !finalSuccessorIds.has(id)) || !unrelatedTenanciesUnchanged
-    ) throw new RenewalContinuityServiceError("renewal_postcondition_failed", loaded.context);
     const eventId = leaseStartDeterministicId("renewal_occupancy_handoff", [input.landlordId, input.idempotencyKey, loaded.context.predecessorLeaseId, loaded.context.successorLeaseId]);
     const result: RenewalContinuityResult = {
       outcome: "renewal_handoff_completed",
@@ -339,20 +329,6 @@ export async function handoffRenewalContinuity(input: RenewalHandoffInput): Prom
       idempotency: { key: input.idempotencyKey, replay: false, resultId: requestId },
     };
 
-    transaction.set(loaded.records.predecessorRef, { status: "renewed", occupancyEffective: false, occupancyEndedAt: evaluationInstant, updatedAt: evaluationInstant }, { merge: true });
-    transaction.set(loaded.records.successorRef, { status: "active", occupancyEffective: true, occupancyEffectiveAt: evaluationInstant, updatedAt: evaluationInstant }, { merge: true });
-    transaction.set(loaded.records.propertyRef, { units: nextEmbeddedUnits, updatedAt: evaluationInstant }, { merge: true });
-    transaction.set(loaded.records.unitRef, nextUnit, { merge: true });
-    for (const tenantRef of loaded.records.tenantRefs) {
-      transaction.set(tenantRef, { currentLeaseId: loaded.context.successorLeaseId, status: "current", updatedAt: evaluationInstant }, { merge: true });
-    }
-    for (const predecessorTenancy of predecessorTenancies) {
-      transaction.set(firestore.collection("tenancies").doc(predecessorTenancy.id), { status: "inactive", moveOutAt: evaluationInstant, updatedAt: evaluationInstant }, { merge: true });
-    }
-    for (const plan of successorPlans) {
-      if (plan.existing) transaction.set(plan.ref, plan.record, { merge: true });
-      else transaction.create(plan.ref, plan.record);
-    }
     const eventRef = firestore.collection("canonicalEvents").doc(eventId);
     const eventRecord = {
       id: eventId, version: "v1", type: "lease.renewal_occupancy_handoff", domain: "lease", action: "renewal_occupancy_handoff", status: "succeeded",
@@ -370,12 +346,44 @@ export async function handoffRenewalContinuity(input: RenewalHandoffInput): Prom
       },
       tags: ["lease_start", "renewal_handoff"], appendOnly: true, immutable: true,
     };
-    persistLeaseStartAtomicResult({ transaction, requestRef, events: [{ ref: eventRef, record: eventRecord }], requestRecord: {
-      landlordId: input.landlordId, operationKind: "renewal_handoff", idempotencyKey: input.idempotencyKey,
-      payloadHash, leaseId: loaded.context.successorLeaseId, predecessorLeaseId: loaded.context.predecessorLeaseId,
-      canonicalEventIds: [eventId], committedAt: evaluationInstant, result,
-    }});
-    return result;
+    return {
+      result,
+      applyMutations: () => {
+        transaction.set(loaded.records.predecessorRef, { status: "renewed", occupancyEffective: false, occupancyEndedAt: evaluationInstant, updatedAt: evaluationInstant }, { merge: true });
+        transaction.set(loaded.records.successorRef, { status: "active", occupancyEffective: true, occupancyEffectiveAt: evaluationInstant, updatedAt: evaluationInstant }, { merge: true });
+        transaction.set(loaded.records.propertyRef, { units: nextEmbeddedUnits, updatedAt: evaluationInstant }, { merge: true });
+        transaction.set(loaded.records.unitRef, nextUnit, { merge: true });
+        for (const tenantRef of loaded.records.tenantRefs) {
+          transaction.set(tenantRef, { currentLeaseId: loaded.context.successorLeaseId, status: "current", updatedAt: evaluationInstant }, { merge: true });
+        }
+        for (const predecessorTenancy of predecessorTenancies) {
+          transaction.set(firestore.collection("tenancies").doc(predecessorTenancy.id), { status: "inactive", moveOutAt: evaluationInstant, updatedAt: evaluationInstant }, { merge: true });
+        }
+        for (const successorPlan of successorPlans) {
+          if (successorPlan.existing) transaction.set(successorPlan.ref, successorPlan.record, { merge: true });
+          else transaction.create(successorPlan.ref, successorPlan.record);
+        }
+      },
+      assertPostcondition: () => {
+        if (
+          text(nextUnit.currentLeaseId) !== loaded.context.successorLeaseId ||
+          text(nextEmbedded.currentLeaseId) !== loaded.context.successorLeaseId ||
+          text(nextUnit.currentTenantId) !== loaded.records.tenantId ||
+          text(nextEmbedded.currentTenantId) !== loaded.records.tenantId ||
+          state(nextUnit.status) !== "occupied" ||
+          state(nextEmbedded.status) !== "occupied" ||
+          finalPredecessorActive.length !== 0 || finalSuccessors.length !== participantIds.size ||
+          [...participantIds].some((id) => !finalSuccessorIds.has(id)) || !unrelatedTenanciesUnchanged
+        ) throw new RenewalContinuityServiceError("renewal_postcondition_failed", loaded.context);
+      },
+      events: [{ ref: eventRef, record: eventRecord }],
+      requestRecord: {
+        landlordId: input.landlordId, operationKind: "renewal_handoff", idempotencyKey: input.idempotencyKey,
+        payloadHash, leaseId: loaded.context.successorLeaseId, predecessorLeaseId: loaded.context.predecessorLeaseId,
+        canonicalEventIds: [eventId], committedAt: evaluationInstant, result,
+      },
+    };
+    },
   });
 }
 

--- a/rentchain-api/src/services/leaseStart/renewalContinuityService.ts
+++ b/rentchain-api/src/services/leaseStart/renewalContinuityService.ts
@@ -6,7 +6,7 @@ import {
   type RenewalContinuityEvaluation,
   type RenewalContinuityLease,
 } from "../../lib/leases/renewalContinuity";
-import { leaseStartDeterministicId, leaseStartHash } from "./leaseStartExpectedState";
+import { buildLeaseStartExpectedStateMaterialToken, leaseStartDeterministicId, leaseStartHash } from "./leaseStartExpectedState";
 import {
   assertLeaseStartExpectedState,
   persistLeaseStartAtomicResult,
@@ -112,8 +112,7 @@ function contextToken(records: any, evaluation: RenewalContinuityEvaluation, eva
     moveOutAt: tenancy.moveOutAt ?? null,
     updatedAt: tenancy.updatedAt ?? null,
   })).sort((left: any, right: any) => left.id.localeCompare(right.id));
-  return leaseStartHash({
-    version: "renewal_continuity_expected_state_v1",
+  return buildLeaseStartExpectedStateMaterialToken("renewal_continuity_expected_state_v1", {
     evaluationInstant,
     evaluation,
     predecessor: records.predecessor,

--- a/rentchain-api/src/services/signing/leaseSigningService.ts
+++ b/rentchain-api/src/services/signing/leaseSigningService.ts
@@ -779,6 +779,12 @@ export async function processSigningWebhook(input: { providerId: string; headers
       await leaseRef.set({
         executionStatus: "fully_executed",
         executionState: "fully_executed",
+        ...(
+          String(lease.predecessorLeaseId || "").trim() &&
+          ["draft", "pending", "pending_signature", "sent"].includes(String(lease.status || "").trim().toLowerCase())
+            ? { status: "active" }
+            : {}
+        ),
         fullyExecutedAt: occurredAt,
         updatedAt: occurredAt,
       }, { merge: true });

--- a/rentchain-api/src/services/signing/leaseSigningService.ts
+++ b/rentchain-api/src/services/signing/leaseSigningService.ts
@@ -776,22 +776,20 @@ export async function processSigningWebhook(input: { providerId: string; headers
     const leaseSnap = await leaseRef.get();
     const lease = leaseSnap.exists ? leaseSnap.data() as any : null;
     if (lease && String(lease.landlordId || "").trim() === landlordId) {
+      const isLinkedRenewal = Boolean(String(lease.predecessorLeaseId || "").trim());
       await leaseRef.set({
         executionStatus: "fully_executed",
         executionState: "fully_executed",
-        ...(
-          String(lease.predecessorLeaseId || "").trim() &&
-          ["draft", "pending", "pending_signature", "sent"].includes(String(lease.status || "").trim().toLowerCase())
-            ? { status: "active" }
-            : {}
-        ),
         fullyExecutedAt: occurredAt,
         updatedAt: occurredAt,
       }, { merge: true });
       const propertyId = String(lease.propertyId || "").trim();
       const unitId = String(lease.unitId || "").trim();
       const tenantId = String(lease.tenantId || lease.primaryTenantId || lease.tenantIds?.[0] || "").trim();
-      if (propertyId && unitId && tenantId) {
+      // A linked renewal is execution-complete here, never occupancy-effective.
+      // Its explicit renewal activation route owns the atomic handoff at every
+      // date boundary, including on or after the successor start date.
+      if (!isLinkedRenewal && propertyId && unitId && tenantId) {
         try {
           const completion = await startSigningCompletionOccupancy({
             providerId: provider.getProviderId(), providerEventId: eventIdentity, occurredAt,

--- a/rentchain-frontend/server/previewBackendProxy.ts
+++ b/rentchain-frontend/server/previewBackendProxy.ts
@@ -23,6 +23,7 @@ export const PREVIEW_BACKEND_TARGET_KEYS = {
   pr1565: "pr1565-tenant-lease-cert",
   pr1566: "pr1566-multiple-current-cert",
   pr1567: "pr1567-review-needed-cert",
+  pr1568: "pr1568-renewal-continuity-cert",
 } as const;
 
 export type PreviewBackendTarget = {
@@ -77,6 +78,14 @@ const PREVIEW_BACKEND_TARGETS: Record<string, PreviewBackendTarget> = {
       "https://rentchain-pr1567-qa-reviewneeded-glistw4pya-nn.a.run.app",
     cloudRunIdTokenAudience:
       "https://rentchain-pr1567-qa-reviewneeded-glistw4pya-nn.a.run.app",
+    temporary: true,
+  },
+  [PREVIEW_BACKEND_TARGET_KEYS.pr1568]: {
+    key: PREVIEW_BACKEND_TARGET_KEYS.pr1568,
+    cloudRunServiceUrl:
+      "https://rentchain-pr1568-qa-renewal-glistw4pya-nn.a.run.app",
+    cloudRunIdTokenAudience:
+      "https://rentchain-pr1568-qa-renewal-glistw4pya-nn.a.run.app",
     temporary: true,
   },
 };

--- a/rentchain-frontend/src/api/leasesApi.ts
+++ b/rentchain-frontend/src/api/leasesApi.ts
@@ -447,6 +447,7 @@ export interface CreateLeasePayload {
   endDate?: string | null;
   automationEnabled?: boolean;
   renewalStatus?: LeaseRenewalStatus;
+  predecessorLeaseId?: string | null;
   executionStatus?: string;
   status?: LeaseStatus;
 }

--- a/rentchain-frontend/src/api/renewalContinuityApi.test.ts
+++ b/rentchain-frontend/src/api/renewalContinuityApi.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { apiFetchMock } = vi.hoisted(() => ({ apiFetchMock: vi.fn() }));
+vi.mock("./apiFetch", () => ({ apiFetch: apiFetchMock }));
+
+import { activateRenewalContinuity, getRenewalContinuityContext } from "./renewalContinuityApi";
+
+describe("renewalContinuityApi", () => {
+  beforeEach(() => apiFetchMock.mockReset());
+
+  it("loads the server-authoritative successor context", async () => {
+    apiFetchMock.mockResolvedValue({ ok: true, context: { handoffEligible: false } });
+    await getRenewalContinuityContext("lease successor");
+    expect(apiFetchMock).toHaveBeenCalledWith("/leases/renewals/lease%20successor/context");
+  });
+
+  it("sends expected state and caller-owned idempotency identity", async () => {
+    apiFetchMock.mockResolvedValue({ ok: true, result: { outcome: "renewal_handoff_completed" } });
+    await activateRenewalContinuity("successor", {
+      expectedStateToken: "state-1",
+      evaluationInstant: "2027-01-01T12:00:00.000Z",
+    }, "renewal-request-1");
+    expect(apiFetchMock).toHaveBeenCalledWith("/leases/renewals/successor/activate", {
+      method: "POST",
+      headers: { "Idempotency-Key": "renewal-request-1" },
+      body: { expectedStateToken: "state-1", evaluationInstant: "2027-01-01T12:00:00.000Z" },
+    });
+  });
+});

--- a/rentchain-frontend/src/api/renewalContinuityApi.ts
+++ b/rentchain-frontend/src/api/renewalContinuityApi.ts
@@ -1,0 +1,58 @@
+import { apiFetch } from "./apiFetch";
+
+export type RenewalContinuityReason =
+  | "RENEWAL_LINK_MISSING"
+  | "RENEWAL_LINK_CONFLICT"
+  | "RENEWAL_CONTEXT_MISMATCH"
+  | "RENEWAL_TERM_NOT_CONTIGUOUS"
+  | "RENEWAL_TOO_EARLY"
+  | "RENEWAL_EXECUTION_INCOMPLETE"
+  | "RENEWAL_PARTICIPANTS_MISMATCH"
+  | "RENEWAL_PREDECESSOR_NOT_CURRENT"
+  | "RENEWAL_SUCCESSOR_INELIGIBLE"
+  | "RENEWAL_SUCCESSOR_SUPERSEDED"
+  | "MULTIPLE_RENEWAL_SUCCESSORS"
+  | "MULTIPLE_CURRENT_LEASES"
+  | "RENEWAL_PROJECTION_MISMATCH";
+
+export type RenewalContinuityContext = {
+  expectedStateToken: string;
+  evaluationInstant: string;
+  predecessorLeaseId: string;
+  successorLeaseId: string;
+  propertyId: string;
+  unitId: string;
+  participantIds: string[];
+  predecessorCanonicalState: string;
+  successorCanonicalState: string;
+  termContinuity: boolean;
+  executionReady: boolean;
+  handoffEligible: boolean;
+  blockingReasons: RenewalContinuityReason[];
+};
+
+export function getRenewalContinuityContext(successorLeaseId: string) {
+  return apiFetch<{ ok: true; context: RenewalContinuityContext }>(
+    `/leases/renewals/${encodeURIComponent(successorLeaseId)}/context`
+  );
+}
+
+export function activateRenewalContinuity(
+  successorLeaseId: string,
+  input: Pick<RenewalContinuityContext, "expectedStateToken" | "evaluationInstant">,
+  idempotencyKey: string
+) {
+  return apiFetch<{
+    ok: true;
+    result: {
+      outcome: "renewal_handoff_completed" | "idempotent_replay";
+      predecessorLeaseId: string;
+      successorLeaseId: string;
+      auditEventIds: string[];
+    };
+  }>(`/leases/renewals/${encodeURIComponent(successorLeaseId)}/activate`, {
+    method: "POST",
+    headers: { "Idempotency-Key": idempotencyKey },
+    body: input,
+  });
+}

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.test.tsx
@@ -13,6 +13,8 @@ const mocks = vi.hoisted(() => ({
   createLandlordDecisionQueueItem: vi.fn(),
   updateLandlordDecisionQueueItem: vi.fn(),
   fetchReviewTimeline: vi.fn(),
+  getRenewalContinuityContext: vi.fn(),
+  activateRenewalContinuity: vi.fn(),
 }));
 
 const scrollIntoViewMock = vi.fn();
@@ -38,6 +40,11 @@ vi.mock("@/api/landlordDecisionQueueApi", () => ({
 vi.mock("@/api/reviewTimelineApi", () => ({
   fetchReviewTimeline: mocks.fetchReviewTimeline,
   reviewTimelinePath: ({ scope, scopeId }: { scope: string; scopeId: string }) => `/review-timeline?scope=${scope}&scopeId=${scopeId}`,
+}));
+
+vi.mock("@/api/renewalContinuityApi", () => ({
+  getRenewalContinuityContext: mocks.getRenewalContinuityContext,
+  activateRenewalContinuity: mocks.activateRenewalContinuity,
 }));
 
 function renderWorkflow(path: string) {
@@ -147,6 +154,9 @@ describe("LandlordLeaseWorkflowPage", () => {
     mocks.createLandlordDecisionQueueItem.mockReset();
     mocks.updateLandlordDecisionQueueItem.mockReset();
     mocks.fetchReviewTimeline.mockReset();
+    mocks.getRenewalContinuityContext.mockReset();
+    mocks.activateRenewalContinuity.mockReset();
+    mocks.getRenewalContinuityContext.mockRejectedValue(new Error("renewal_context_ambiguous"));
     mocks.getLeaseById.mockResolvedValue({
       lease: {
         id: "lease-1",
@@ -1473,6 +1483,86 @@ describe("LandlordLeaseWorkflowPage", () => {
     expect(document.body).not.toHaveTextContent(/must respond by|notice has been served|legally valid|automatically compliant/i);
     expect(document.body).not.toHaveTextContent(/evidence saved|notice has been served|email sent/i);
     expect(document.body).not.toHaveTextContent("/portfolio-health?entry=lease-renewals&propertyId=prop-1");
+  });
+
+  it("presents an upcoming fully executed renewal without an early activation action", async () => {
+    mocks.getRenewalContinuityContext.mockResolvedValueOnce({
+      ok: true,
+      context: {
+        expectedStateToken: "state-upcoming",
+        evaluationInstant: "2026-12-15T12:00:00.000Z",
+        predecessorLeaseId: "lease-old",
+        successorLeaseId: "lease-1",
+        propertyId: "prop-1",
+        unitId: "unit-1",
+        participantIds: ["tenant-1"],
+        predecessorCanonicalState: "past",
+        successorCanonicalState: "upcoming",
+        termContinuity: true,
+        executionReady: true,
+        handoffEligible: false,
+        blockingReasons: ["RENEWAL_TOO_EARLY"],
+      },
+    });
+    renderWorkflow("/leases/lease-1/workflows/renewal");
+    const card = await screen.findByLabelText("Renewal continuity");
+    expect(card).toHaveTextContent("Upcoming renewal");
+    expect(card).toHaveTextContent("Fully executed");
+    expect(within(card).queryByRole("button", { name: "Activate renewal" })).not.toBeInTheDocument();
+  });
+
+  it("activates only a server-eligible renewal with expected state and one idempotency key", async () => {
+    const eligibleContext = {
+      expectedStateToken: "state-eligible",
+      evaluationInstant: "2027-01-01T12:00:00.000Z",
+      predecessorLeaseId: "lease-old",
+      successorLeaseId: "lease-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      participantIds: ["tenant-1"],
+      predecessorCanonicalState: "past" as const,
+      successorCanonicalState: "active" as const,
+      termContinuity: true,
+      executionReady: true,
+      handoffEligible: true,
+      blockingReasons: [],
+    };
+    mocks.getRenewalContinuityContext.mockResolvedValue({ ok: true, context: eligibleContext });
+    mocks.activateRenewalContinuity.mockResolvedValue({ ok: true, result: { outcome: "renewal_handoff_completed" } });
+    renderWorkflow("/leases/lease-1/workflows/renewal");
+    fireEvent.click(await screen.findByRole("button", { name: "Activate renewal" }));
+    await waitFor(() => expect(mocks.activateRenewalContinuity).toHaveBeenCalledTimes(1));
+    expect(mocks.activateRenewalContinuity).toHaveBeenCalledWith(
+      "lease-1",
+      { expectedStateToken: "state-eligible", evaluationInstant: "2027-01-01T12:00:00.000Z" },
+      expect.stringMatching(/^renewal-/)
+    );
+    expect(await screen.findByRole("status")).toHaveTextContent("Occupancy remained continuous");
+  });
+
+  it("renders blocked ambiguous renewal guidance without selecting a successor", async () => {
+    mocks.getRenewalContinuityContext.mockResolvedValueOnce({
+      ok: true,
+      context: {
+        expectedStateToken: "state-blocked",
+        evaluationInstant: "2027-01-01T12:00:00.000Z",
+        predecessorLeaseId: "lease-old",
+        successorLeaseId: "lease-1",
+        propertyId: "prop-1",
+        unitId: "unit-1",
+        participantIds: ["tenant-1"],
+        predecessorCanonicalState: "past",
+        successorCanonicalState: "active",
+        termContinuity: true,
+        executionReady: true,
+        handoffEligible: false,
+        blockingReasons: ["MULTIPLE_RENEWAL_SUCCESSORS"],
+      },
+    });
+    renderWorkflow("/leases/lease-1/workflows/renewal");
+    const card = await screen.findByLabelText("Renewal continuity");
+    expect(card).toHaveTextContent("Multiple successor renewals require review.");
+    expect(within(card).queryByRole("button", { name: "Activate renewal" })).not.toBeInTheDocument();
   });
 
   it("uses workflow-local renewal status instead of stale no-follow-up lifecycle copy", async () => {

--- a/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseWorkflowPage.tsx
@@ -33,6 +33,12 @@ import {
 } from "@/api/landlordDecisionQueueApi";
 import { fetchReviewTimeline, reviewTimelinePath, type ReviewTimelineEntry } from "@/api/reviewTimelineApi";
 import { evidencePackPath } from "@/api/evidencePackApi";
+import {
+  activateRenewalContinuity,
+  getRenewalContinuityContext,
+  type RenewalContinuityContext,
+  type RenewalContinuityReason,
+} from "@/api/renewalContinuityApi";
 
 type WorkflowKey = "execution" | "rent-increase" | "notice" | "deposit" | "renewal" | "move-out";
 
@@ -696,6 +702,108 @@ function RenewalOperatorInputsWorkspace({ lease }: { lease: LandlordActiveLease 
         </>
       ) : null}
     </>
+  );
+}
+
+const renewalReasonLabels: Record<RenewalContinuityReason, string> = {
+  RENEWAL_LINK_MISSING: "The predecessor/successor renewal link is incomplete.",
+  RENEWAL_LINK_CONFLICT: "Renewal links conflict and require review.",
+  RENEWAL_CONTEXT_MISMATCH: "The renewal does not match the predecessor property and unit.",
+  RENEWAL_TERM_NOT_CONTIGUOUS: "The renewal term is not contiguous with the predecessor term.",
+  RENEWAL_TOO_EARLY: "This renewal is fully prepared but is not effective yet.",
+  RENEWAL_EXECUTION_INCOMPLETE: "All required signing evidence must be complete before handoff.",
+  RENEWAL_PARTICIPANTS_MISMATCH: "Participant changes require a separate review workflow.",
+  RENEWAL_PREDECESSOR_NOT_CURRENT: "The predecessor is not the current projected lease context.",
+  RENEWAL_SUCCESSOR_INELIGIBLE: "The successor lease is not currently eligible.",
+  RENEWAL_SUCCESSOR_SUPERSEDED: "This successor has already been superseded.",
+  MULTIPLE_RENEWAL_SUCCESSORS: "Multiple successor renewals require review.",
+  MULTIPLE_CURRENT_LEASES: "Multiple current leases must be resolved first.",
+  RENEWAL_PROJECTION_MISMATCH: "Occupancy projections changed and must be reviewed.",
+};
+
+function createRenewalIdempotencyKey() {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") return `renewal-${crypto.randomUUID()}`;
+  return `renewal-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+function RenewalContinuityCard({ leaseId, onCompleted }: { leaseId: string; onCompleted: () => Promise<void> }) {
+  const [context, setContext] = React.useState<RenewalContinuityContext | null>(null);
+  const [loading, setLoading] = React.useState(true);
+  const [activating, setActivating] = React.useState(false);
+  const [message, setMessage] = React.useState<string | null>(null);
+  const idempotencyKey = React.useRef(createRenewalIdempotencyKey());
+
+  const load = React.useCallback(async () => {
+    setLoading(true);
+    try {
+      const response = await getRenewalContinuityContext(leaseId);
+      setContext(response.context);
+      setMessage(null);
+    } catch (error) {
+      const detail = errorMessage(error, "Renewal handoff context is unavailable.");
+      if (detail.includes("renewal_context_ambiguous")) setContext(null);
+      else setMessage(detail);
+    } finally {
+      setLoading(false);
+    }
+  }, [leaseId]);
+
+  React.useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function activate() {
+    if (!context?.handoffEligible) return;
+    setActivating(true);
+    setMessage(null);
+    try {
+      await activateRenewalContinuity(leaseId, {
+        expectedStateToken: context.expectedStateToken,
+        evaluationInstant: context.evaluationInstant,
+      }, idempotencyKey.current);
+      await onCompleted();
+      await load();
+      setMessage("Renewal handoff completed. Occupancy remained continuous.");
+    } catch (error) {
+      setMessage(errorMessage(error, "Renewal handoff failed safely. Refresh the context before retrying."));
+    } finally {
+      setActivating(false);
+    }
+  }
+
+  if (loading) return <div style={{ color: workflowTheme.muted }}>Loading renewal handoff context…</div>;
+  if (!context && !message) return null;
+  return (
+    <div style={sourceContextStyle} aria-label="Renewal continuity">
+      <div style={sourceContextTitleStyle}>Renewal continuity</div>
+      {context ? (
+        <>
+          <div style={{ color: workflowTheme.muted, lineHeight: 1.55 }}>
+            {context.handoffEligible
+              ? "This fully executed renewal is effective and ready for an atomic occupancy handoff."
+              : context.successorCanonicalState === "upcoming"
+                ? "Upcoming renewal — the predecessor remains current until this renewal is effective."
+                : "Renewal handoff is blocked until the server-authoritative issues below are resolved."}
+          </div>
+          <dl style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(170px, 1fr))", gap: 12, margin: "12px 0 0" }}>
+            <ReviewFact label="Term continuity" value={context.termContinuity ? "Contiguous" : "Review needed"} />
+            <ReviewFact label="Execution" value={context.executionReady ? "Fully executed" : "Incomplete"} />
+            <ReviewFact label="Occupancy status" value={context.handoffEligible ? "Ready for handoff" : "No pointer changes"} />
+          </dl>
+          {context.blockingReasons.length > 0 ? (
+            <ul style={{ margin: "12px 0 0", paddingLeft: 20, color: workflowTheme.muted }}>
+              {context.blockingReasons.map((reason) => <li key={reason}>{renewalReasonLabels[reason]}</li>)}
+            </ul>
+          ) : null}
+          {context.handoffEligible ? (
+            <button type="button" style={{ ...primaryButtonStyle, marginTop: 14 }} disabled={activating} onClick={() => void activate()}>
+              {activating ? "Activating renewal…" : "Activate renewal"}
+            </button>
+          ) : null}
+        </>
+      ) : null}
+      {message ? <div role="status" style={{ marginTop: 12, color: message.includes("completed") ? workflowTheme.pine : "#b91c1c" }}>{message}</div> : null}
+    </div>
   );
 }
 
@@ -1943,6 +2051,13 @@ export default function LandlordLeaseWorkflowPage() {
                 Review and save unit-specific renewal inputs such as proposed rent, term dates, and tenant response target date
                 before preparing tenant-facing notices.
               </div>
+              <RenewalContinuityCard
+                leaseId={lease.id}
+                onCompleted={async () => {
+                  const response = await getLeaseById(lease.id);
+                  setLease(response.lease || null);
+                }}
+              />
               <RenewalOperatorInputsWorkspace lease={lease} />
             </section>
           ) : null}

--- a/rentchain-frontend/src/platform/previewBackendProxy.test.ts
+++ b/rentchain-frontend/src/platform/previewBackendProxy.test.ts
@@ -190,6 +190,21 @@ describe("Preview backend proxy", () => {
     });
   });
 
+  it("couples the authorized PR #1568 service URL and audience internally", () => {
+    const target = resolvePreviewBackendTarget({
+      vercelEnvironment: "preview",
+      targetKey: PREVIEW_BACKEND_TARGET_KEYS.pr1568,
+    });
+    expect(target).toEqual({
+      key: "pr1568-renewal-continuity-cert",
+      cloudRunServiceUrl:
+        "https://rentchain-pr1568-qa-renewal-glistw4pya-nn.a.run.app",
+      cloudRunIdTokenAudience:
+        "https://rentchain-pr1568-qa-renewal-glistw4pya-nn.a.run.app",
+      temporary: true,
+    });
+  });
+
   it.each([
     ["production", PREVIEW_BACKEND_TARGET_KEYS.pr1555],
     ["development", PREVIEW_BACKEND_TARGET_KEYS.pr1555],
@@ -201,6 +216,8 @@ describe("Preview backend proxy", () => {
     ["development", PREVIEW_BACKEND_TARGET_KEYS.pr1566],
     ["production", PREVIEW_BACKEND_TARGET_KEYS.pr1567],
     ["development", PREVIEW_BACKEND_TARGET_KEYS.pr1567],
+    ["production", PREVIEW_BACKEND_TARGET_KEYS.pr1568],
+    ["development", PREVIEW_BACKEND_TARGET_KEYS.pr1568],
     ["preview", ""],
     ["preview", "unknown"],
     ["preview", "pr1562"],
@@ -212,6 +229,11 @@ describe("Preview backend proxy", () => {
     ["preview", "https://rentchain-pr1566-qa-multicurrent-glistw4pya-nn.a.run.app"],
     ["preview", "rentchain-pr1555-qa-wrong-region"],
     ["preview", "rentchain-pr1555-qa-cross-project"],
+    ["preview", "pr1568-renewal-continuity-cert-evil"],
+    ["preview", "PR1568-RENEWAL-CONTINUITY-CERT"],
+    ["preview", "rentchain-pr1568-qa-renewal"],
+    ["preview", "*.run.app"],
+    ["preview", "https://rentchain-pr1568-qa-renewal-glistw4pya-nn.a.run.app"],
   ])("rejects unsafe target selection for %s / %s", (vercelEnvironment, targetKey) => {
     expect(() => resolvePreviewBackendTarget({ vercelEnvironment, targetKey })).toThrow(
       "PREVIEW_PROXY_TARGET_REJECTED",
@@ -442,6 +464,35 @@ describe("Preview backend proxy", () => {
     );
   });
 
+  it.each([
+    ["mismatched audience", {
+      key: PREVIEW_BACKEND_TARGET_KEYS.pr1568,
+      cloudRunServiceUrl:
+        "https://rentchain-pr1568-qa-renewal-glistw4pya-nn.a.run.app",
+      cloudRunIdTokenAudience:
+        "https://rentchain-preview-backend-glistw4pya-nn.a.run.app",
+      temporary: true,
+    }],
+    ["attacker host", {
+      key: PREVIEW_BACKEND_TARGET_KEYS.pr1568,
+      cloudRunServiceUrl: "https://attacker.example",
+      cloudRunIdTokenAudience: "https://attacker.example",
+      temporary: true,
+    }],
+    ["temporary flag", {
+      key: PREVIEW_BACKEND_TARGET_KEYS.pr1568,
+      cloudRunServiceUrl:
+        "https://rentchain-pr1568-qa-renewal-glistw4pya-nn.a.run.app",
+      cloudRunIdTokenAudience:
+        "https://rentchain-pr1568-qa-renewal-glistw4pya-nn.a.run.app",
+      temporary: false,
+    }],
+  ])("rejects a tampered PR #1568 mapping: %s", (_label, target) => {
+    expect(() => assertPreviewBackendTarget(target, "preview")).toThrow(
+      "PREVIEW_PROXY_TARGET_REJECTED",
+    );
+  });
+
   it("routes the authorized target using the same URL for ID-token audience and upstream", async () => {
     process.env.PREVIEW_BACKEND_TARGET = PREVIEW_BACKEND_TARGET_KEYS.pr1555;
     const { requests, dependencies } = successfulDependencies();
@@ -561,6 +612,36 @@ describe("Preview backend proxy", () => {
     );
     expect(requests[2].url).toBe(`${expected}/api/occupancy-reviews`);
     expect(requests[2].init?.method).toBe("GET");
+  });
+
+  it("routes PR #1568 only to its fixed backend despite caller-controlled target-like input", async () => {
+    process.env.PREVIEW_BACKEND_TARGET = PREVIEW_BACKEND_TARGET_KEYS.pr1568;
+    const { requests, dependencies } = successfulDependencies();
+    const res = responseRecorder();
+
+    await handlePreviewBackendProxy(
+      request("/api/preview-backend/api/leases/renewal-continuity/context?target=https://attacker.example", "POST", {
+        headers: {
+          host: "attacker.example",
+          cookie: "PREVIEW_BACKEND_TARGET=https://attacker.example",
+          "x-preview-backend-target": "https://attacker.example",
+        },
+        query: { target: "https://attacker.example" },
+        body: { target: "https://attacker.example" },
+      }),
+      res,
+      dependencies,
+    );
+
+    const expected =
+      "https://rentchain-pr1568-qa-renewal-glistw4pya-nn.a.run.app";
+    expect(requests[1].init?.body).toBe(
+      JSON.stringify({ audience: expected, includeEmail: false }),
+    );
+    expect(requests[2].url).toBe(
+      `${expected}/api/leases/renewal-continuity/context?target=https://attacker.example`,
+    );
+    expect(requests.every(({ url }) => !url.startsWith("https://attacker.example"))).toBe(true);
   });
 
   it("accepts only Preview and rejects Production or Development", async () => {


### PR DESCRIPTION
## Summary

- add an explicit predecessor/successor renewal-continuity contract
- add read-only server context and an idempotent, expected-state guarded atomic occupancy handoff
- preserve predecessor and successor legal lease records while updating canonical occupancy projections and one append-safe event
- add a minimal server-authoritative Renewal Continuity card to the existing landlord renewal workflow

## Safety contract

- future signed renewals never displace the predecessor
- overlap, gap, incomplete execution, participant mismatch, stale state, ambiguous links, multiple current leases, and projection conflicts fail closed
- no scheduler, passive handoff, second canonical engine, infrastructure, Preview target, or deployment change
- End Lease authority and PR E/PR F boundaries remain unchanged

## Validation

- backend canonical/renewal/creation/signing/recovery/review matrix: 19 files, 252 tests passed
- backend End Lease/Unit Edit/tenant/projection matrix: 9 files, 146 tests passed
- frontend focused matrix: 5 files, 79 tests passed
- full frontend suite with CI environment: 369 files, 1,910 tests passed
- backend TypeScript build: passed
- frontend TypeScript (`npx tsc --noEmit`): passed
- frontend production build: passed
- `git diff --check`: passed
- credential, infrastructure, workflow, and deployment-scope scans: passed

## Runtime boundary

Source review only. No runtime certification target, deployment, Preview mutation, Production mutation, Terraform change, or merge is authorized by this PR publication.
