### PR TITLE
PR H: canonicalize tenant onboarding occupancy activation

### DIFF
--- a/rentchain-api/src/lib/leases/renewalContinuity.ts
+++ b/rentchain-api/src/lib/leases/renewalContinuity.ts
@@ -77,6 +77,19 @@ function successorLinks(lease: RenewalContinuityLease): string[] {
   ].map(text).filter(Boolean))].sort();
 }
 
+/**
+ * Returns whether one authoritative lease snapshot participates in the
+ * durable renewal-continuity linkage governed by this module. This is link
+ * detection only; renewal eligibility remains exclusively owned by
+ * evaluateRenewalContinuity().
+ */
+export function hasRenewalContinuityLink(lease: Record<string, unknown>): boolean {
+  return Boolean(
+    text(lease.predecessorLeaseId) ||
+    successorLinks(lease as RenewalContinuityLease).length > 0
+  );
+}
+
 function sameValues(left: string[], right: string[]): boolean {
   return left.length === right.length && left.every((value, index) => value === right[index]);
 }

--- a/rentchain-api/src/routes/__tests__/authOnboardTenantInvites.test.ts
+++ b/rentchain-api/src/routes/__tests__/authOnboardTenantInvites.test.ts
@@ -353,6 +353,9 @@ describe("auth onboard tenant invites", () => {
       landlordId: "landlord-1",
       propertyId: "property-1",
       unitId: "unit-1",
+      tenantId: "converted-tenant-1",
+      primaryTenantId: "converted-tenant-1",
+      tenantIds: ["converted-tenant-1"],
       status: "active",
     });
     ensureCollection("units").set("unit-doc-1", {
@@ -399,6 +402,143 @@ describe("auth onboard tenant invites", () => {
     expect(ensureCollection("units").get("unit-doc-1")).toMatchObject({ status: "vacant", occupancyStatus: "vacant" });
     expect(ensureCollection("properties").get("property-1").units[0]).toMatchObject({ status: "vacant", occupancyStatus: "vacant" });
     expect(ensureCollection("tenants").get("converted-tenant-1")).not.toHaveProperty("currentLeaseId");
+    expect(ensureCollection("leases").get("lease-1")).toEqual({
+      id: "lease-1",
+      landlordId: "landlord-1",
+      propertyId: "property-1",
+      unitId: "unit-1",
+      tenantId: "converted-tenant-1",
+      primaryTenantId: "converted-tenant-1",
+      tenantIds: ["converted-tenant-1"],
+      status: "active",
+    });
+  });
+
+  it("keeps a secondary lease participant authorized without rewriting primary or participant order", async () => {
+    ensureCollection("rentalApplications").set("app-secondary", {
+      id: "app-secondary",
+      landlordId: "landlord-1",
+      propertyId: "property-1",
+      unitId: "unit-1",
+      leaseId: "lease-multi",
+      convertedTenantId: "tenant-b",
+      applicantEmail: "tenant-b@example.com",
+      status: "converted",
+    });
+    const leaseBefore = {
+      id: "lease-multi",
+      landlordId: "landlord-1",
+      propertyId: "property-1",
+      unitId: "unit-1",
+      tenantId: "tenant-a",
+      primaryTenantId: "tenant-a",
+      tenantIds: ["tenant-b", "tenant-a"],
+      status: "active",
+    };
+    ensureCollection("leases").set("lease-multi", leaseBefore);
+
+    const { createTenancyInvite } = await import("../../services/tenantPortal/tenantInviteService");
+    const created = await createTenancyInvite({
+      landlordId: "landlord-1",
+      propertyId: "property-1",
+      tenantId: "tenant-b",
+      applicationId: "app-secondary",
+      unitId: "unit-1",
+      leaseId: "lease-multi",
+      invitedEmail: "tenant-b@example.com",
+      createdBy: "landlord-1",
+    });
+
+    const router = (await import("../authRoutes")).default;
+    const acceptRes = await invokeRouter(router, {
+      method: "POST",
+      url: "/onboard/accept",
+      body: { source: "tenant", token: created.token },
+    });
+
+    expect(acceptRes.status).toBe(200);
+    expect(occupancySyncMock).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId: "tenant-b",
+      leaseId: "lease-multi",
+    }));
+    expect(ensureCollection("leases").get("lease-multi")).toEqual(leaseBefore);
+  });
+
+  it("keeps a foreign invite account-only with zero lease or occupancy mutation", async () => {
+    ensureCollection("rentalApplications").set("app-foreign", {
+      id: "app-foreign",
+      landlordId: "landlord-1",
+      propertyId: "property-1",
+      unitId: "unit-1",
+      leaseId: "lease-multi",
+      convertedTenantId: "tenant-c",
+      applicantEmail: "tenant-c@example.com",
+      status: "converted",
+    });
+    const leaseBefore = {
+      id: "lease-multi",
+      landlordId: "landlord-1",
+      propertyId: "property-1",
+      unitId: "unit-1",
+      tenantId: "tenant-a",
+      primaryTenantId: "tenant-a",
+      tenantIds: ["tenant-a", "tenant-b"],
+      status: "active",
+      executionStatus: "fully_executed",
+      occupancyEffective: false,
+      startDate: "2026-01-01",
+      endDate: "2027-01-01",
+      rent: 1800,
+    };
+    ensureCollection("leases").set("lease-multi", leaseBefore);
+    ensureCollection("units").set("unit-1", {
+      id: "unit-1",
+      landlordId: "landlord-1",
+      propertyId: "property-1",
+      status: "vacant",
+      occupancyStatus: "vacant",
+    });
+    ensureCollection("properties").set("property-1", {
+      id: "property-1",
+      landlordId: "landlord-1",
+      units: [{ id: "unit-1", status: "vacant", occupancyStatus: "vacant" }],
+    });
+    const propertyBefore = clone(ensureCollection("properties").get("property-1"));
+    const unitBefore = clone(ensureCollection("units").get("unit-1"));
+
+    const { createTenancyInvite } = await import("../../services/tenantPortal/tenantInviteService");
+    const created = await createTenancyInvite({
+      landlordId: "landlord-1",
+      propertyId: "property-1",
+      tenantId: "tenant-c",
+      applicationId: "app-foreign",
+      unitId: "unit-1",
+      leaseId: "lease-multi",
+      invitedEmail: "tenant-c@example.com",
+      createdBy: "landlord-1",
+    });
+
+    const router = (await import("../authRoutes")).default;
+    const acceptRes = await invokeRouter(router, {
+      method: "POST",
+      url: "/onboard/accept",
+      body: { source: "tenant", token: created.token },
+    });
+
+    expect(acceptRes.status).toBe(200);
+    expect(acceptRes.body).toMatchObject({ ok: true, accepted: true, role: "tenant" });
+    expect(occupancySyncMock).not.toHaveBeenCalled();
+    expect(ensureCollection("leases").get("lease-multi")).toEqual(leaseBefore);
+    expect(ensureCollection("units").get("unit-1")).toEqual(unitBefore);
+    expect(ensureCollection("properties").get("property-1")).toEqual(propertyBefore);
+    expect(ensureCollection("tenants").get("tenant-c")).toMatchObject({
+      tenantId: "tenant-c",
+      leaseId: null,
+    });
+    expect(ensureCollection("tenants").get("tenant-c")).not.toHaveProperty("currentLeaseId");
+    expect(Array.from(ensureCollection("tenancies").values())).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ tenantId: "tenant-c", status: "active" })])
+    );
   });
 
   it("reports replaced tenancy_invites tokens as expired instead of not found", async () => {

--- a/rentchain-api/src/routes/__tests__/authOnboardTenantInvites.test.ts
+++ b/rentchain-api/src/routes/__tests__/authOnboardTenantInvites.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const { occupancySyncMock } = vi.hoisted(() => ({
+  occupancySyncMock: vi.fn(async () => ({ updated: false, reason: "missing_context" })),
+}));
+
 const collections = new Map<string, Map<string, any>>();
 
 function ensureCollection(name: string) {
@@ -72,6 +76,10 @@ vi.mock("../../services/tenantPortal/tenantEventLogService", () => ({
   recordTenantEvent: vi.fn(async () => ({ id: "event-1" })),
 }));
 
+vi.mock("../../services/tenantPortal/tenantOccupancySyncService", () => ({
+  syncPropertyUnitOccupancyForTenantContext: occupancySyncMock,
+}));
+
 async function invokeRouter(router: any, options: { method: string; url: string; body?: any }) {
   return await new Promise<{ status: number; body: any }>((resolve, reject) => {
     const [pathWithQuery, queryRaw = ""] = options.url.split("?");
@@ -119,6 +127,7 @@ async function invokeRouter(router: any, options: { method: string; url: string;
 describe("auth onboard tenant invites", () => {
   beforeEach(() => {
     collections.clear();
+    occupancySyncMock.mockClear();
     process.env.JWT_SECRET = "test-secret";
   });
 
@@ -327,7 +336,7 @@ describe("auth onboard tenant invites", () => {
     });
   });
 
-  it("syncs property and unit occupancy from an active lease after invite acceptance", async () => {
+  it("delegates an eligible-looking lease to the canonical occupancy adapter after invite acceptance", async () => {
     ensureCollection("rentalApplications").set("app-with-lease", {
       id: "app-with-lease",
       landlordId: "landlord-1",
@@ -379,20 +388,17 @@ describe("auth onboard tenant invites", () => {
     });
 
     expect(acceptRes.status).toBe(200);
-    expect(ensureCollection("units").get("unit-doc-1")).toMatchObject({
-      status: "occupied",
-      occupancyStatus: "occupied",
+    expect(occupancySyncMock).toHaveBeenCalledWith(expect.objectContaining({
       tenantId: "converted-tenant-1",
       leaseId: "lease-1",
-      occupancySource: "canonical_lease",
-    });
-    expect(ensureCollection("properties").get("property-1").units[0]).toMatchObject({
-      status: "occupied",
-      occupancyStatus: "occupied",
-      tenantId: "converted-tenant-1",
-      leaseId: "lease-1",
-      occupancySource: "canonical_lease",
-    });
+      landlordId: "landlord-1",
+      propertyId: "property-1",
+      unitId: "unit-1",
+      source: "tenant_invite_onboarding",
+    }));
+    expect(ensureCollection("units").get("unit-doc-1")).toMatchObject({ status: "vacant", occupancyStatus: "vacant" });
+    expect(ensureCollection("properties").get("property-1").units[0]).toMatchObject({ status: "vacant", occupancyStatus: "vacant" });
+    expect(ensureCollection("tenants").get("converted-tenant-1")).not.toHaveProperty("currentLeaseId");
   });
 
   it("reports replaced tenancy_invites tokens as expired instead of not found", async () => {

--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -8,8 +8,9 @@ const getPrimaryLeaseDocumentSummaryMock = vi.fn(async () => null);
 const generatePrimaryLeaseDocumentMock = vi.fn();
 const lockPrimaryLeaseDocumentForSigningMock = vi.fn();
 
-const { fakeDb, listDocs, resetFakeDb, seedDoc } = vi.hoisted(() => {
+const { clearWriteLog, fakeDb, listDocs, resetFakeDb, seedDoc, writeLog } = vi.hoisted(() => {
   const store = new Map<string, Map<string, any>>();
+  const writes: Array<{ collection: string; id: string }> = [];
   let idSeq = 0;
 
   function ensureCollection(name: string) {
@@ -48,6 +49,7 @@ const { fakeDb, listDocs, resetFakeDb, seedDoc } = vi.hoisted(() => {
     return {
       id: actualId,
       set: async (value: any, options?: { merge?: boolean }) => {
+        writes.push({ collection: name, id: actualId });
         const current = col.get(actualId)?.data || {};
         col.set(actualId, { id: actualId, data: options?.merge ? { ...current, ...value } : value });
       },
@@ -61,8 +63,11 @@ const { fakeDb, listDocs, resetFakeDb, seedDoc } = vi.hoisted(() => {
   return {
     resetFakeDb: () => {
       store.clear();
+      writes.splice(0);
       idSeq = 0;
     },
+    clearWriteLog: () => writes.splice(0),
+    writeLog: writes,
     seedDoc: (name: string, id: string, data: any) => ensureCollection(name).set(id, { id, data }),
     listDocs: (name: string) => Array.from(ensureCollection(name).values()).map((doc) => ({ id: doc.id, data: doc.data })),
     fakeDb: {
@@ -143,6 +148,7 @@ async function invokeRouter(router: any, options: {
   url: string;
   body?: any;
   headers?: Record<string, string>;
+  user?: any;
 }) {
   return await new Promise<{ status: number; body: any; headers: Record<string, any> }>((resolve, reject) => {
     const headers: Record<string, any> = {};
@@ -153,7 +159,9 @@ async function invokeRouter(router: any, options: {
       path: options.url,
       body: options.body ?? {},
       headers: options.headers ?? {},
-      user: { id: "landlord-1", landlordId: "landlord-1", role: "landlord" },
+      user: Object.prototype.hasOwnProperty.call(options, "user")
+        ? options.user
+        : { id: "landlord-1", landlordId: "landlord-1", role: "landlord" },
     };
     const res: any = {
       statusCode: 200,
@@ -193,6 +201,7 @@ describe("leaseRoutes GET /active", () => {
     lockPrimaryLeaseDocumentForSigningMock.mockRejectedValue(Object.assign(new Error("signing_document_url_required"), { status: 400 }));
     sendEmailMock.mockResolvedValue(undefined);
     process.env.EMAIL_FROM = "noreply@example.com";
+    process.env.JWT_SECRET = "test-secret";
     process.env.SIGNING_PROVIDER = "mock";
     process.env.PUBLIC_APP_URL = "http://localhost:5173";
   });
@@ -3346,6 +3355,181 @@ describe("leaseRoutes GET /active", () => {
     expect(review.status).toBe(200);
     const fixtureReviewItems = review.body.items.filter((item: any) => item.propertyId === propertyId && item.unitId === unitId);
     expect(fixtureReviewItems).toEqual([]);
+  });
+
+  it("keeps one foreign invite account-only across Properties, Leases, Tenants, tenant detail, and Review Needed", async () => {
+    const propertyId = "property-onboarding-foreign";
+    const unitId = "unit-onboarding-foreign";
+    const leaseId = "lease-onboarding-foreign";
+    const contractualTenantId = "tenant-onboarding-contractual";
+    const foreignTenantId = "tenant-onboarding-foreign";
+    const applicationId = "application-onboarding-foreign";
+    const occupiedUnit = {
+      id: unitId,
+      unitId,
+      unitNumber: "X1",
+      status: "occupied",
+      occupancyStatus: "occupied",
+      tenantId: contractualTenantId,
+      currentTenantId: contractualTenantId,
+      leaseId,
+      currentLeaseId: leaseId,
+    };
+    const leaseBefore = {
+      landlordId: "landlord-1",
+      propertyId,
+      unitId,
+      tenantId: contractualTenantId,
+      primaryTenantId: contractualTenantId,
+      tenantIds: [contractualTenantId],
+      status: "active",
+      executionStatus: "fully_executed",
+      executionEvidence: { provider: "synthetic", completedAt: "2026-07-31T12:00:00.000Z" },
+      occupancyEffective: true,
+      startDate: "2026-08-01",
+      endDate: "2027-07-31",
+      predecessorLeaseId: "lease-onboarding-foreign-predecessor",
+      renewalSequence: 2,
+    };
+    seedDoc("properties", propertyId, {
+      landlordId: "landlord-1",
+      ownerUserId: "landlord-1",
+      name: "Foreign Invite House",
+      units: [occupiedUnit],
+    });
+    seedDoc("units", unitId, { ...occupiedUnit, landlordId: "landlord-1", propertyId });
+    seedDoc("leases", leaseId, leaseBefore);
+    seedDoc("tenants", contractualTenantId, {
+      landlordId: "landlord-1",
+      fullName: "Contractual Tenant",
+      status: "current",
+      currentLeaseId: leaseId,
+      propertyId,
+      unitId,
+    });
+    seedDoc("tenancies", "tenancy-onboarding-contractual", {
+      landlordId: "landlord-1",
+      propertyId,
+      unitId,
+      tenantId: contractualTenantId,
+      leaseId,
+      status: "active",
+    });
+    seedDoc("rentalApplications", applicationId, {
+      id: applicationId,
+      landlordId: "landlord-1",
+      propertyId,
+      unitId,
+      leaseId,
+      convertedTenantId: foreignTenantId,
+      applicantEmail: "foreign-tenant@example.com",
+      applicantFullName: "Foreign Invite Tenant",
+      status: "converted",
+    });
+
+    const leaseRouter = (await import("../leaseRoutes")).default;
+    const propertiesRouter = (await import("../propertiesRoutes")).default;
+    const tenantsRouter = (await import("../tenantsRoutes")).default;
+    const occupancyReviewRouter = (await import("../occupancyReviewRoutes")).default;
+    const authRouter = (await import("../authRoutes")).default;
+    const { createTenancyInvite } = await import("../../services/tenantPortal/tenantInviteService");
+
+    const reviewBefore = await invokeRouter(occupancyReviewRouter, { method: "GET", url: "/" });
+    expect(reviewBefore.status).toBe(200);
+    const fixtureReviewBefore = reviewBefore.body.items
+      .filter((item: any) => item.propertyId === propertyId && item.unitId === unitId)
+      .map((item: any) => ({ reasons: item.reasons, tenantId: item.tenantId, supportingLeaseId: item.supportingLeaseId }));
+    const foreignReviewBefore = reviewBefore.body.items.filter((item: any) => item.tenantId === foreignTenantId);
+    const propertyBefore = JSON.parse(JSON.stringify(listDocs("properties").find((doc) => doc.id === propertyId)?.data));
+    const unitBefore = JSON.parse(JSON.stringify(listDocs("units").find((doc) => doc.id === unitId)?.data));
+    const canonicalEventCountBefore = listDocs("canonicalEvents").length;
+    const leaseStartRequestCountBefore = listDocs("leaseStartRequests").length;
+
+    const created = await createTenancyInvite({
+      landlordId: "landlord-1",
+      propertyId,
+      tenantId: foreignTenantId,
+      applicationId,
+      unitId,
+      leaseId,
+      invitedEmail: "foreign-tenant@example.com",
+      invitedName: "Foreign Invite Tenant",
+      createdBy: "landlord-1",
+    });
+    clearWriteLog();
+    const accepted = await invokeRouter(authRouter, {
+      method: "POST",
+      url: "/onboard/accept",
+      body: { source: "tenant", token: created.token },
+      user: null,
+    });
+    expect(accepted.status).toBe(200);
+    expect(accepted.body).toMatchObject({ ok: true, accepted: true, role: "tenant", redirectTo: "/tenant" });
+
+    expect(listDocs("leases").find((doc) => doc.id === leaseId)?.data).toEqual(leaseBefore);
+    expect(listDocs("properties").find((doc) => doc.id === propertyId)?.data).toEqual(propertyBefore);
+    expect(listDocs("units").find((doc) => doc.id === unitId)?.data).toEqual(unitBefore);
+    expect(listDocs("tenants").find((doc) => doc.id === foreignTenantId)?.data).toMatchObject({
+      tenantId: foreignTenantId,
+      leaseId: null,
+    });
+    expect(listDocs("tenants").find((doc) => doc.id === foreignTenantId)?.data).not.toHaveProperty("currentLeaseId");
+    expect(listDocs("tenancies").filter((doc) =>
+      doc.data.tenantId === foreignTenantId && doc.data.status === "active"
+    )).toEqual([]);
+    expect(listDocs("canonicalEvents")).toHaveLength(canonicalEventCountBefore);
+    expect(listDocs("leaseStartRequests")).toHaveLength(leaseStartRequestCountBefore);
+    expect(writeLog.filter((write) =>
+      ["properties", "units", "leases", "canonicalEvents", "leaseStartRequests"].includes(write.collection)
+    )).toEqual([]);
+
+    const properties = await invokeRouter(propertiesRouter, { method: "GET", url: "/" });
+    expect(properties.status).toBe(200);
+    const property = properties.body.items.find((entry: any) => entry.id === propertyId);
+    expect(property.units.find((entry: any) => entry.id === unitId)).toMatchObject({
+      status: "occupied",
+      occupancyStatus: "occupied",
+      currentLeaseId: leaseId,
+      currentTenantId: contractualTenantId,
+    });
+    expect(property.units.find((entry: any) => entry.id === unitId).currentTenantId).not.toBe(foreignTenantId);
+
+    const leases = await invokeRouter(leaseRouter, { method: "GET", url: `/tenant/${foreignTenantId}` });
+    expect(leases.status).toBe(200);
+    expect(leases.body.leases.find((entry: any) => entry.id === leaseId)).toBeUndefined();
+
+    const tenants = await invokeRouter(tenantsRouter, { method: "GET", url: "/" });
+    expect(tenants.status).toBe(200);
+    const foreignTenant = tenants.body.tenants.find((entry: any) => entry.id === foreignTenantId);
+    expect(foreignTenant).toBeDefined();
+    expect(foreignTenant.currentLeaseId ?? null).toBeNull();
+    expect(foreignTenant.canonicalState).toMatchObject({ supportingLeaseId: null });
+    expect(foreignTenant.canonicalState.tenantRelationshipState).not.toBe("current_occupant");
+    expect(tenants.body.tenants.find((entry: any) => entry.id === contractualTenantId)).toMatchObject({
+      currentLeaseId: leaseId,
+      canonicalState: expect.objectContaining({
+        occupancyState: "occupied",
+        tenantRelationshipState: "current_occupant",
+        supportingLeaseId: leaseId,
+      }),
+    });
+
+    const detail = await invokeRouter(tenantsRouter, { method: "GET", url: `/${foreignTenantId}` });
+    expect(detail.status).toBe(200);
+    expect(detail.body.tenant.currentLeaseId ?? null).toBeNull();
+    expect(detail.body.lease ?? null).toBeNull();
+    expect(detail.body.canonicalState).toMatchObject({ supportingLeaseId: null });
+    expect(detail.body.canonicalState.tenantRelationshipState).not.toBe("current_occupant");
+
+    const reviewAfter = await invokeRouter(occupancyReviewRouter, { method: "GET", url: "/" });
+    expect(reviewAfter.status).toBe(200);
+    const fixtureReviewAfter = reviewAfter.body.items
+      .filter((item: any) => item.propertyId === propertyId && item.unitId === unitId)
+      .map((item: any) => ({ reasons: item.reasons, tenantId: item.tenantId, supportingLeaseId: item.supportingLeaseId }));
+    expect(fixtureReviewAfter).toEqual(fixtureReviewBefore);
+    expect(reviewAfter.body.items.filter((item: any) => item.tenantId === foreignTenantId)).toEqual(foreignReviewBefore);
+    expect(fixtureReviewAfter.flatMap((item: any) => item.reasons)).not.toContain("TENANT_CURRENT_WITHOUT_CURRENT_LEASE");
+    expect(fixtureReviewAfter.map((item: any) => item.tenantId)).not.toContain(foreignTenantId);
   });
 
   it("projects one coherent renewal handoff through Properties, Leases, Tenants, tenant detail, and Review Needed", async () => {

--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -3222,6 +3222,132 @@ describe("leaseRoutes GET /active", () => {
     ]);
   });
 
+  it.each([
+    ["eligible current", "2026-08-01", true],
+    ["future ineligible", "2027-01-01", false],
+  ] as const)("projects the exact %s onboarding fixture through all five product paths", async (_label, startDate, eligible) => {
+    const propertyId = `property-onboarding-${eligible ? "current" : "future"}`;
+    const unitId = `unit-onboarding-${eligible ? "current" : "future"}`;
+    const tenantId = `tenant-onboarding-${eligible ? "current" : "future"}`;
+    const leaseId = `lease-onboarding-${eligible ? "current" : "future"}`;
+    const tenancyId = `tenancy-onboarding-${eligible ? "current" : "future"}`;
+    const unit = {
+      id: unitId,
+      unitId,
+      unitNumber: eligible ? "C1" : "F1",
+      status: "vacant",
+      occupancyStatus: "vacant",
+    };
+    seedDoc("properties", propertyId, {
+      landlordId: "landlord-1",
+      ownerUserId: "landlord-1",
+      name: eligible ? "Current Onboarding House" : "Future Onboarding House",
+      units: [unit],
+    });
+    seedDoc("units", unitId, { ...unit, landlordId: "landlord-1", propertyId });
+    seedDoc("tenants", tenantId, {
+      landlordId: "landlord-1",
+      fullName: eligible ? "Current Onboarding Tenant" : "Future Onboarding Tenant",
+      status: "invited",
+      propertyId,
+      unitId,
+    });
+    seedDoc("tenancies", tenancyId, {
+      landlordId: "landlord-1",
+      propertyId,
+      unitId,
+      tenantId,
+      leaseId,
+      status: "inactive",
+      source: "application_conversion",
+    });
+    seedDoc("leases", leaseId, {
+      landlordId: "landlord-1",
+      propertyId,
+      unitId,
+      tenantId,
+      tenantIds: [tenantId],
+      primaryTenantId: tenantId,
+      status: "active",
+      executionStatus: "fully_executed",
+      startDate,
+      endDate: "2027-07-31",
+    });
+
+    const { syncPropertyUnitOccupancyForTenantContext } = await import("../../services/tenantPortal/tenantOccupancySyncService");
+    const sync = await syncPropertyUnitOccupancyForTenantContext({
+      tenantId,
+      leaseId,
+      applicationId: `application-${eligible ? "current" : "future"}`,
+      landlordId: "landlord-1",
+      propertyId,
+      unitId,
+      actorId: "landlord-1",
+      idempotencyKey: `application-${eligible ? "current" : "future"}`,
+      source: "application_conversion",
+      firestore: fakeDb,
+      evaluationInstant: "2026-08-23T12:00:00.000Z",
+    });
+    expect(sync).toMatchObject(eligible
+      ? { updated: true, reason: "occupancy_effective" }
+      : { updated: false, reason: "created_without_occupancy" });
+
+    const leaseRouter = (await import("../leaseRoutes")).default;
+    const propertiesRouter = (await import("../propertiesRoutes")).default;
+    const tenantsRouter = (await import("../tenantsRoutes")).default;
+    const occupancyReviewRouter = (await import("../occupancyReviewRoutes")).default;
+
+    const properties = await invokeRouter(propertiesRouter, { method: "GET", url: "/" });
+    expect(properties.status).toBe(200);
+    const property = properties.body.items.find((entry: any) => entry.id === propertyId);
+    const projectedUnit = property.units.find((entry: any) => entry.id === unitId);
+    expect(projectedUnit).toMatchObject(eligible
+      ? { status: "occupied", occupancyStatus: "occupied", currentLeaseId: leaseId, currentTenantId: tenantId }
+      : { status: "vacant", occupancyStatus: "vacant" });
+    if (!eligible) {
+      expect(projectedUnit.currentLeaseId ?? null).toBeNull();
+      expect(projectedUnit.currentTenantId ?? null).toBeNull();
+    }
+
+    const leases = await invokeRouter(leaseRouter, { method: "GET", url: `/tenant/${tenantId}` });
+    expect(leases.status).toBe(200);
+    const projectedLease = leases.body.leases.find((entry: any) => entry.id === leaseId);
+    expect(projectedLease).toBeDefined();
+    expect(projectedLease.canonicalState).toMatchObject(eligible
+      ? { occupancyState: "occupied", tenantRelationshipState: "current_occupant", supportingLeaseId: leaseId, reasons: [] }
+      : { leaseTermState: "upcoming", occupancyState: "vacant", supportingLeaseId: null });
+    expect(leases.body.leases.filter((entry: any) =>
+      entry.canonicalState?.supportingLeaseId === leaseId && entry.canonicalState?.tenantRelationshipState === "current_occupant"
+    )).toHaveLength(eligible ? 1 : 0);
+
+    const tenants = await invokeRouter(tenantsRouter, { method: "GET", url: "/" });
+    expect(tenants.status).toBe(200);
+    const projectedTenant = tenants.body.tenants.find((entry: any) => entry.id === tenantId);
+    expect(projectedTenant).toBeDefined();
+    expect(projectedTenant.currentLeaseId ?? null).toBe(eligible ? leaseId : null);
+    expect(projectedTenant.canonicalState).toMatchObject(eligible
+      ? { occupancyState: "occupied", tenantRelationshipState: "current_occupant", supportingLeaseId: leaseId }
+      : { occupancyState: "vacant", supportingLeaseId: null });
+    if (!eligible) expect(projectedTenant.canonicalState.tenantRelationshipState).not.toBe("current_occupant");
+
+    const detail = await invokeRouter(tenantsRouter, { method: "GET", url: `/${tenantId}` });
+    expect(detail.status).toBe(200);
+    expect(detail.body.tenant.currentLeaseId ?? null).toBe(eligible ? leaseId : null);
+    expect(detail.body.canonicalState).toMatchObject(eligible
+      ? { occupancyState: "occupied", tenantRelationshipState: "current_occupant", supportingLeaseId: leaseId }
+      : { occupancyState: "vacant", supportingLeaseId: null });
+    if (eligible) expect(detail.body.lease).toMatchObject({ id: leaseId });
+    else {
+      expect(detail.body.canonicalState.tenantRelationshipState).not.toBe("current_occupant");
+      expect(detail.body.lease).toMatchObject({ id: leaseId });
+    }
+
+    const review = await invokeRouter(occupancyReviewRouter, { method: "GET", url: "/" });
+    expect(review.status).toBe(200);
+    const fixtureReviewItems = review.body.items.filter((item: any) => item.propertyId === propertyId && item.unitId === unitId);
+    expect(fixtureReviewItems).toEqual([]);
+  });
+
   it("projects one coherent renewal handoff through Properties, Leases, Tenants, tenant detail, and Review Needed", async () => {
     const futureUnit = {
       id: "unit-renewal-future", unitNumber: "F1", status: "occupied", occupancyStatus: "occupied",

--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -2423,7 +2423,7 @@ describe("leaseRoutes GET /active", () => {
       leaseId: "lease-1",
       currentLeaseId: "lease-1",
     });
-    seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", currentLeaseId: "lease-1" });
+    seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", status: "current", currentLeaseId: "lease-1" });
     seedDoc("tenancies", "tenancy-1", { landlordId: "landlord-1", propertyId: "prop-1", unitId: "unit-1", tenantId: "tenant-1", leaseId: "lease-1", status: "active" });
 
     const router = (await import("../leaseRoutes")).default;
@@ -2447,8 +2447,8 @@ describe("leaseRoutes GET /active", () => {
         occupancySource: "lease_end",
       })
     );
-    expect((await fakeDb.collection("leases").doc("lease-1").get()).data()).toMatchObject({ status: "ended" });
-    expect((await fakeDb.collection("tenants").doc("tenant-1").get()).data()).toMatchObject({ currentLeaseId: null });
+    expect((await fakeDb.collection("leases").doc("lease-1").get()).data()).toMatchObject({ status: "ended", occupancyEffective: false });
+    expect((await fakeDb.collection("tenants").doc("tenant-1").get()).data()).toMatchObject({ status: "Past", currentLeaseId: null });
     expect((await fakeDb.collection("tenancies").doc("tenancy-1").get()).data()).toMatchObject({ status: "inactive" });
     expect(listDocs("canonicalEvents")).toHaveLength(1);
     expect(listDocs("canonicalEvents")[0].data).toMatchObject({
@@ -2483,8 +2483,8 @@ describe("leaseRoutes GET /active", () => {
   it("ends every participating tenancy and clears every matching tenant pointer for a multi-party lease", async () => {
     seedDoc("properties", "prop-multi-party", { landlordId: "landlord-1", units: [{ id: "unit-multi-party", unitNumber: "501", status: "occupied", tenantId: "tenant-b", currentTenantId: "tenant-b", currentLeaseId: "lease-multi-party" }] });
     seedDoc("units", "unit-multi-party", { landlordId: "landlord-1", propertyId: "prop-multi-party", unitNumber: "501", status: "occupied", occupancyStatus: "occupied", tenantId: "tenant-b", currentTenantId: "tenant-b", leaseId: "lease-multi-party", currentLeaseId: "lease-multi-party" });
-    seedDoc("tenants", "tenant-a", { landlordId: "landlord-1", currentLeaseId: "lease-multi-party" });
-    seedDoc("tenants", "tenant-b", { landlordId: "landlord-1", currentLeaseId: "lease-multi-party" });
+    seedDoc("tenants", "tenant-a", { landlordId: "landlord-1", status: "current", currentLeaseId: "lease-multi-party" });
+    seedDoc("tenants", "tenant-b", { landlordId: "landlord-1", status: "current", currentLeaseId: "lease-multi-party" });
     seedDoc("leases", "lease-multi-party", { landlordId: "landlord-1", propertyId: "prop-multi-party", unitId: "unit-multi-party", unitNumber: "501", tenantId: "tenant-a", primaryTenantId: "tenant-a", tenantIds: ["tenant-a", "tenant-b", "tenant-a", ""], status: "active" });
     seedDoc("tenancies", "tenancy-a", { landlordId: "landlord-1", propertyId: "prop-multi-party", unitId: "unit-multi-party", tenantId: "tenant-a", leaseId: "lease-multi-party", status: "active" });
     seedDoc("tenancies", "tenancy-b", { landlordId: "landlord-1", propertyId: "prop-multi-party", unitId: "unit-multi-party", tenantId: "tenant-b", leaseId: "lease-multi-party", status: "active" });
@@ -2494,11 +2494,11 @@ describe("leaseRoutes GET /active", () => {
     const res = await invokeRouter(router, { method: "POST", url: "/lease-multi-party/end", body: {} });
 
     expect(res.status).toBe(200);
-    expect((await fakeDb.collection("leases").doc("lease-multi-party").get()).data()).toMatchObject({ status: "ended" });
+    expect((await fakeDb.collection("leases").doc("lease-multi-party").get()).data()).toMatchObject({ status: "ended", occupancyEffective: false });
     expect((await fakeDb.collection("units").doc("unit-multi-party").get()).data()).toMatchObject({ status: "vacant", currentLeaseId: null });
     expect((await fakeDb.collection("properties").doc("prop-multi-party").get()).data()?.units[0]).toMatchObject({ status: "vacant", currentLeaseId: null });
-    expect((await fakeDb.collection("tenants").doc("tenant-a").get()).data()).toMatchObject({ currentLeaseId: null });
-    expect((await fakeDb.collection("tenants").doc("tenant-b").get()).data()).toMatchObject({ currentLeaseId: null });
+    expect((await fakeDb.collection("tenants").doc("tenant-a").get()).data()).toMatchObject({ status: "Past", currentLeaseId: null });
+    expect((await fakeDb.collection("tenants").doc("tenant-b").get()).data()).toMatchObject({ status: "Past", currentLeaseId: null });
     expect((await fakeDb.collection("tenancies").doc("tenancy-a").get()).data()).toMatchObject({ status: "inactive" });
     expect((await fakeDb.collection("tenancies").doc("tenancy-b").get()).data()).toMatchObject({ status: "inactive" });
     expect((await fakeDb.collection("tenancies").doc("unrelated-tenancy").get()).data()).toMatchObject({ status: "active" });
@@ -2511,6 +2511,72 @@ describe("leaseRoutes GET /active", () => {
     expect((await fakeDb.collection("tenancies").doc("tenancy-a").get()).data()).toMatchObject({ status: "inactive" });
     expect((await fakeDb.collection("tenancies").doc("tenancy-b").get()).data()).toMatchObject({ status: "inactive" });
     expect((await fakeDb.collection("tenancies").doc("unrelated-tenancy").get()).data()).toMatchObject({ status: "active" });
+  });
+
+  it("preserves another canonical current lease when ending one participant lease", async () => {
+    seedDoc("properties", "prop-ending", { landlordId: "landlord-1", units: [{ id: "unit-ending", unitNumber: "601", status: "occupied", currentTenantId: "tenant-shared", currentLeaseId: "lease-ending" }] });
+    seedDoc("properties", "prop-current", { landlordId: "landlord-1", units: [{ id: "unit-current", unitNumber: "602", status: "occupied", currentTenantId: "tenant-shared", currentLeaseId: "lease-current" }] });
+    seedDoc("units", "unit-ending", { landlordId: "landlord-1", propertyId: "prop-ending", unitNumber: "601", status: "occupied", occupancyStatus: "occupied", tenantId: "tenant-shared", currentTenantId: "tenant-shared", leaseId: "lease-ending", currentLeaseId: "lease-ending" });
+    seedDoc("units", "unit-current", { landlordId: "landlord-1", propertyId: "prop-current", unitNumber: "602", status: "occupied", occupancyStatus: "occupied", tenantId: "tenant-shared", currentTenantId: "tenant-shared", leaseId: "lease-current", currentLeaseId: "lease-current" });
+    seedDoc("tenants", "tenant-shared", { landlordId: "landlord-1", status: "current", currentLeaseId: "lease-ending" });
+    seedDoc("leases", "lease-ending", { landlordId: "landlord-1", propertyId: "prop-ending", unitId: "unit-ending", unitNumber: "601", tenantId: "tenant-shared", tenantIds: ["tenant-shared"], status: "active", executionStatus: "fully_executed", startDate: "2026-01-01", endDate: "2027-01-01", occupancyEffective: true });
+    seedDoc("leases", "lease-current", { landlordId: "landlord-1", propertyId: "prop-current", unitId: "unit-current", unitNumber: "602", tenantId: "tenant-shared", tenantIds: ["tenant-shared"], status: "active", executionStatus: "fully_executed", startDate: "2026-02-01", endDate: "2027-02-01", occupancyEffective: true });
+    seedDoc("tenancies", "tenancy-ending", { landlordId: "landlord-1", propertyId: "prop-ending", unitId: "unit-ending", tenantId: "tenant-shared", leaseId: "lease-ending", status: "active" });
+    seedDoc("tenancies", "tenancy-current", { landlordId: "landlord-1", propertyId: "prop-current", unitId: "unit-current", tenantId: "tenant-shared", leaseId: "lease-current", status: "active" });
+    const router = (await import("../leaseRoutes")).default;
+
+    const res = await invokeRouter(router, { method: "POST", url: "/lease-ending/end", body: { endDate: "2026-08-23T12:00:00.000Z" } });
+
+    expect(res.status).toBe(200);
+    expect((await fakeDb.collection("leases").doc("lease-ending").get()).data()).toMatchObject({ status: "ended", occupancyEffective: false });
+    expect((await fakeDb.collection("tenants").doc("tenant-shared").get()).data()).toMatchObject({ status: "current", currentLeaseId: "lease-current" });
+    expect((await fakeDb.collection("tenancies").doc("tenancy-ending").get()).data()).toMatchObject({ status: "inactive" });
+    expect((await fakeDb.collection("tenancies").doc("tenancy-current").get()).data()).toMatchObject({ status: "active" });
+  });
+
+  it("projects one completed End Lease postcondition through all five product paths without Review Needed", async () => {
+    const propertyId = "prop-end-cross-surface";
+    const unitId = "unit-end-cross-surface";
+    const tenantId = "tenant-end-cross-surface";
+    const leaseId = "lease-end-cross-surface";
+    seedDoc("properties", propertyId, {
+      landlordId: "landlord-1",
+      ownerUserId: "landlord-1",
+      name: "End Lease House",
+      units: [{ id: unitId, unitId, unitNumber: "701", status: "occupied", occupancyStatus: "occupied", tenantId, currentTenantId: tenantId, leaseId, currentLeaseId: leaseId }],
+    });
+    seedDoc("units", unitId, { landlordId: "landlord-1", propertyId, unitNumber: "701", status: "occupied", occupancyStatus: "occupied", tenantId, currentTenantId: tenantId, leaseId, currentLeaseId: leaseId });
+    seedDoc("tenants", tenantId, { landlordId: "landlord-1", fullName: "Ended Tenant", status: "current", propertyId, unitId, currentLeaseId: leaseId });
+    seedDoc("leases", leaseId, { landlordId: "landlord-1", propertyId, unitId, unitNumber: "701", tenantId, primaryTenantId: tenantId, tenantIds: [tenantId], status: "active", executionStatus: "fully_executed", startDate: "2026-01-01", endDate: "2027-01-01", occupancyEffective: true });
+    seedDoc("tenancies", "tenancy-end-cross-surface", { landlordId: "landlord-1", propertyId, unitId, tenantId, leaseId, status: "active" });
+
+    const leaseRouter = (await import("../leaseRoutes")).default;
+    const propertiesRouter = (await import("../propertiesRoutes")).default;
+    const tenantsRouter = (await import("../tenantsRoutes")).default;
+    const occupancyReviewRouter = (await import("../occupancyReviewRoutes")).default;
+    const ended = await invokeRouter(leaseRouter, { method: "POST", url: `/${leaseId}/end`, body: { endDate: "2026-08-23T12:00:00.000Z" } });
+    expect(ended.status).toBe(200);
+
+    const properties = await invokeRouter(propertiesRouter, { method: "GET", url: "/" });
+    const property = properties.body.items.find((entry: any) => entry.id === propertyId);
+    expect(property.units.find((entry: any) => entry.id === unitId)).toMatchObject({ status: "vacant", occupancyStatus: "vacant", tenantId: null, currentTenantId: null, leaseId: null, currentLeaseId: null });
+
+    const leases = await invokeRouter(leaseRouter, { method: "GET", url: `/tenant/${tenantId}` });
+    const historicalLease = leases.body.leases.find((entry: any) => entry.id === leaseId);
+    expect(historicalLease).toMatchObject({ status: "ended", occupancyEffective: false, canonicalState: expect.objectContaining({ leaseTermState: "ended", occupancyState: "vacant", tenantRelationshipState: "past_tenant", supportingLeaseId: null }) });
+
+    const tenants = await invokeRouter(tenantsRouter, { method: "GET", url: "/" });
+    const tenant = tenants.body.tenants.find((entry: any) => entry.id === tenantId);
+    expect(tenant).toMatchObject({ status: "Past", currentLeaseId: null, canonicalState: expect.objectContaining({ occupancyState: "vacant", tenantRelationshipState: "past_tenant", supportingLeaseId: null }) });
+
+    const detail = await invokeRouter(tenantsRouter, { method: "GET", url: `/${tenantId}` });
+    expect(detail.body.tenant).toMatchObject({ status: "Past", currentLeaseId: null });
+    expect(detail.body.canonicalState).toMatchObject({ occupancyState: "vacant", tenantRelationshipState: "past_tenant", supportingLeaseId: null });
+    expect(detail.body.lease).toBeNull();
+
+    const review = await invokeRouter(occupancyReviewRouter, { method: "GET", url: "/" });
+    expect(review.body.items.filter((item: any) => item.propertyId === propertyId || item.unitId === unitId || item.tenantId === tenantId)).toEqual([]);
+    expect(listDocs("canonicalEvents")).toHaveLength(1);
   });
 
   it.each([

--- a/rentchain-api/src/routes/authRoutes.ts
+++ b/rentchain-api/src/routes/authRoutes.ts
@@ -167,6 +167,14 @@ async function loadApplicationForTenantInvite(applicationId: string | null) {
   return null;
 }
 
+function leaseParticipantIds(lease: any): Set<string> {
+  return new Set(
+    [lease?.tenantId, lease?.primaryTenantId, ...(Array.isArray(lease?.tenantIds) ? lease.tenantIds : [])]
+      .map(asOnboardString)
+      .filter((tenantId): tenantId is string => Boolean(tenantId))
+  );
+}
+
 async function normalizeTenantInviteIdentity(input: {
   tenantId: string;
   uid: string;
@@ -201,6 +209,11 @@ async function normalizeTenantInviteIdentity(input: {
     asOnboardString(input.application?.data?.phone) ||
     asOnboardString(input.application?.data?.applicant?.phoneHome) ||
     asOnboardString(input.application?.data?.applicant?.phoneWork);
+  let leaseParticipantMatch = false;
+  if (leaseId) {
+    const leaseSnap = await db.collection("leases").doc(leaseId).get();
+    leaseParticipantMatch = leaseSnap.exists && leaseParticipantIds(leaseSnap.data()).has(input.tenantId);
+  }
 
   if (input.application) {
     const applicationPatch = {
@@ -225,19 +238,6 @@ async function normalizeTenantInviteIdentity(input: {
         { merge: true }
       );
     }
-  }
-
-  if (leaseId) {
-    await db.collection("leases").doc(leaseId).set(
-      {
-        tenantId: input.tenantId,
-        tenantIds: FieldValue.arrayUnion(input.tenantId),
-        primaryTenantId: input.tenantId,
-        applicationId: applicationId || null,
-        updatedAt: now,
-      },
-      { merge: true }
-    );
   }
 
   if (landlordId) {
@@ -266,7 +266,7 @@ async function normalizeTenantInviteIdentity(input: {
       propertyId,
       unitId,
       unit: unitId,
-      leaseId,
+      leaseId: leaseParticipantMatch ? leaseId : null,
       applicationId,
       applicantUserId: input.uid,
       source: "invite",
@@ -275,26 +275,28 @@ async function normalizeTenantInviteIdentity(input: {
     { merge: true }
   );
 
-  try {
-    await syncPropertyUnitOccupancyForTenantContext({
-      tenantId: input.tenantId,
-      leaseId,
-      applicationId,
-      landlordId,
-      propertyId,
-      unitId,
-      actorId: input.uid,
-      idempotencyKey: asOnboardString(input.invite?.id) || applicationId,
-      source: "tenant_invite_onboarding",
-    });
-  } catch (error) {
-    console.warn("[auth.onboard.tenant_occupancy_sync_failed]", {
-      applicationId,
-      leaseId,
-      propertyId,
-      unitId,
-      reason: error instanceof Error ? error.message : "unknown",
-    });
+  if (leaseParticipantMatch) {
+    try {
+      await syncPropertyUnitOccupancyForTenantContext({
+        tenantId: input.tenantId,
+        leaseId,
+        applicationId,
+        landlordId,
+        propertyId,
+        unitId,
+        actorId: input.uid,
+        idempotencyKey: asOnboardString(input.invite?.id) || applicationId,
+        source: "tenant_invite_onboarding",
+      });
+    } catch (error) {
+      console.warn("[auth.onboard.tenant_occupancy_sync_failed]", {
+        applicationId,
+        leaseId,
+        propertyId,
+        unitId,
+        reason: error instanceof Error ? error.message : "unknown",
+      });
+    }
   }
 }
 

--- a/rentchain-api/src/routes/authRoutes.ts
+++ b/rentchain-api/src/routes/authRoutes.ts
@@ -251,6 +251,7 @@ async function normalizeTenantInviteIdentity(input: {
         asOnboardString(input.application?.data?.leaseStartDate) ||
         asOnboardString(input.application?.data?.moveInDate) ||
         null,
+      status: "inactive",
     });
   }
 
@@ -266,7 +267,6 @@ async function normalizeTenantInviteIdentity(input: {
       unitId,
       unit: unitId,
       leaseId,
-      currentLeaseId: leaseId || null,
       applicationId,
       applicantUserId: input.uid,
       source: "invite",
@@ -283,6 +283,9 @@ async function normalizeTenantInviteIdentity(input: {
       landlordId,
       propertyId,
       unitId,
+      actorId: input.uid,
+      idempotencyKey: asOnboardString(input.invite?.id) || applicationId,
+      source: "tenant_invite_onboarding",
     });
   } catch (error) {
     console.warn("[auth.onboard.tenant_occupancy_sync_failed]", {

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -76,7 +76,7 @@ import {
   resolveCanonicalUnitProjectionInputs,
   toCanonicalLeaseStateInput,
 } from "../lib/leases/canonicalLeaseOccupancyProjection";
-import { deriveCanonicalLeaseTermState } from "../lib/leases/canonicalLeaseOccupancyState";
+import { deriveCanonicalLeaseTermState, selectCanonicalCurrentLease } from "../lib/leases/canonicalLeaseOccupancyState";
 import { readMutationIdempotencyKey } from "../lib/http/mutationIdempotency";
 import { createCanonicalLease } from "../services/leaseStart/leaseCreationService";
 import { leaseStartDeterministicId } from "../services/leaseStart/leaseStartExpectedState";
@@ -444,11 +444,13 @@ async function endFirestoreLeaseAtomically(
     const leaseRef = db.collection("leases").doc(leaseId);
     const propertyRef = db.collection("properties").doc(propertyId);
     const tenanciesQuery = db.collection("tenancies").where("leaseId", "==", leaseId);
-    const [leaseSnap, propertySnap, unitSnap, tenanciesSnap] = await Promise.all([
+    const landlordLeasesQuery = db.collection("leases").where("landlordId", "==", authority.landlordId);
+    const [leaseSnap, propertySnap, unitSnap, tenanciesSnap, landlordLeasesSnap] = await Promise.all([
       transaction.get(leaseRef),
       transaction.get(propertyRef),
       transaction.get(db.collection("units").where("propertyId", "==", propertyId)),
       transaction.get(tenanciesQuery),
+      transaction.get(landlordLeasesQuery),
     ]);
     if (!leaseSnap.exists) throw new Error("lease_end_lease_not_found");
     if (!propertySnap.exists) throw new Error("lease_end_property_not_found");
@@ -527,6 +529,23 @@ async function endFirestoreLeaseAtomically(
     // or rewrite any occupancy projection for an already-ended lease.
     if (normalizeStatus((leaseSnap.data() || {}).status) === "ended") return;
 
+    const postEndLandlordLeases = (landlordLeasesSnap?.docs || []).map((doc: any) => {
+      const data = { id: doc.id, ...(doc.data() || {}) };
+      return doc.id === leaseId
+        ? { ...data, status: "ended", occupancyEffective: false, endDate }
+        : data;
+    });
+    const participantLeaseSelections = participantTenantIds.map((participantTenantId) => {
+      const selection = selectCanonicalCurrentLease(
+        postEndLandlordLeases.map(toCanonicalLeaseStateInput),
+        { landlordId: authority.landlordId, tenantId: participantTenantId, asOfDate: endDate }
+      );
+      if (!selection.lease && selection.reasons.includes("MULTIPLE_CURRENT_LEASES")) {
+        throw new Error("lease_end_participant_occupancy_ambiguous");
+      }
+      return selection.lease?.id || null;
+    });
+
     const nextEmbeddedUnits = embeddedUnits.map((unit: any, index: number) =>
       index === matchingEmbedded[0].index
         ? { ...unit, status: "vacant", occupancyStatus: "vacant", tenantId: null, currentTenantId: null, leaseId: null, currentLeaseId: null, occupancySource: "lease_end", occupancyUpdatedAt: nowIso, updatedAt: nowIso }
@@ -571,12 +590,21 @@ async function endFirestoreLeaseAtomically(
       transaction.set(unitDocs[0].ref, { status: "vacant", occupancyStatus: "vacant", tenantId: null, currentTenantId: null, leaseId: null, currentLeaseId: null, occupancySource: "lease_end", occupancyUpdatedAt: nowIso, updatedAt: nowIso }, { merge: true });
     }
 
-    transaction.set(leaseRef, { status: "ended", endDate, updatedAt: nowIso }, { merge: true });
+    transaction.set(leaseRef, { status: "ended", occupancyEffective: false, endDate, updatedAt: nowIso }, { merge: true });
     tenantSnaps.forEach((tenantSnap: any, index: number) => {
       if (tenantSnap?.exists) {
         const tenant = tenantSnap.data() || {};
         if (String(tenant.currentLeaseId || "").trim() === leaseId) {
-          transaction.set(tenantRefs[index], { currentLeaseId: null, updatedAt: nowIso }, { merge: true });
+          const supportingLeaseId = participantLeaseSelections[index];
+          transaction.set(
+            tenantRefs[index],
+            {
+              currentLeaseId: supportingLeaseId,
+              status: supportingLeaseId ? "current" : "Past",
+              updatedAt: nowIso,
+            },
+            { merge: true }
+          );
         }
       }
     });

--- a/rentchain-api/src/services/__tests__/applicationConversionService.test.ts
+++ b/rentchain-api/src/services/__tests__/applicationConversionService.test.ts
@@ -12,10 +12,11 @@ function clone(value: any) {
   return JSON.parse(JSON.stringify(value));
 }
 
-const { sendEmailMock, logAuditEventMock, createTenancyIfMissingMock } = vi.hoisted(() => ({
+const { sendEmailMock, logAuditEventMock, createTenancyIfMissingMock, occupancySyncMock } = vi.hoisted(() => ({
   sendEmailMock: vi.fn(async () => undefined),
   logAuditEventMock: vi.fn(async () => undefined),
   createTenancyIfMissingMock: vi.fn(async () => undefined),
+  occupancySyncMock: vi.fn(async () => ({ updated: false, reason: "missing_context" })),
 }));
 
 const dbMock = {
@@ -62,6 +63,9 @@ vi.mock("../../email/templates/baseEmailTemplate", () => ({
   buildEmailText: vi.fn(() => "invite"),
 }));
 vi.mock("../tenanciesService", () => ({ createTenancyIfMissing: createTenancyIfMissingMock }));
+vi.mock("../tenantPortal/tenantOccupancySyncService", () => ({
+  syncPropertyUnitOccupancyForTenantContext: occupancySyncMock,
+}));
 vi.mock("../tenantPortal/tenantEventLogService", () => ({
   recordTenantEvent: vi.fn(async () => ({ id: "event-1" })),
 }));
@@ -72,6 +76,7 @@ describe("applicationConversionService", () => {
     sendEmailMock.mockClear();
     logAuditEventMock.mockClear();
     createTenancyIfMissingMock.mockClear();
+    occupancySyncMock.mockClear();
     process.env.EMAIL_FROM = "noreply@rentchain.test";
     process.env.PUBLIC_APP_URL = "https://www.rentchain.test";
   });
@@ -137,6 +142,14 @@ describe("applicationConversionService", () => {
     expect(ensureCollection("messages").size).toBe(0);
     expect(ensureCollection("emailOutbox").size).toBe(0);
     expect(ensureCollection("outbox").size).toBe(0);
+    expect(createTenancyIfMissingMock).toHaveBeenCalledWith(expect.objectContaining({ status: "inactive" }));
+    expect(occupancySyncMock).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId: result.tenantId,
+      leaseId: null,
+      applicationId: "app-1",
+      idempotencyKey: "app-1",
+      source: "application_conversion",
+    }));
   });
 
   it("does not create another tenant when conversion is repeated for the same application", async () => {

--- a/rentchain-api/src/services/applicationConversionService.ts
+++ b/rentchain-api/src/services/applicationConversionService.ts
@@ -93,7 +93,7 @@ export async function convertApplicationToTenant(params: {
     leaseStart: application.leaseStartDate ?? application.moveInDate ?? null,
     leaseEnd: null,
     monthlyRent: application.requestedRent ?? null,
-    status: "active",
+    status: "invited",
     balance: 0,
     riskLevel: "Low",
     source: "application_conversion",
@@ -115,6 +115,7 @@ export async function convertApplicationToTenant(params: {
       unitId,
       unitLabel: unitId,
       moveInAt: application.leaseStartDate ?? application.moveInDate ?? null,
+      status: "inactive",
     });
   } catch (err) {
     console.warn("[applicationConversion] tenancy backfill failed", err);
@@ -128,6 +129,9 @@ export async function convertApplicationToTenant(params: {
       landlordId: params.landlordId,
       propertyId: application.propertyId ?? null,
       unitId,
+      actorId: params.actorUserId || params.landlordId,
+      idempotencyKey: application.id,
+      source: "application_conversion",
     });
   } catch (err) {
     console.warn("[applicationConversion] occupancy sync skipped", err);

--- a/rentchain-api/src/services/leaseStart/__tests__/leaseStartService.test.ts
+++ b/rentchain-api/src/services/leaseStart/__tests__/leaseStartService.test.ts
@@ -214,6 +214,25 @@ describe("leaseStartService", () => {
     expect(result.expectedStateToken).toBe(fresh.expectedStateToken);
   });
 
+  it("runs a caller eligibility guard against the authoritative transaction snapshot", async () => {
+    seedBase({ lease: { predecessorLeaseId: "lease-predecessor" } });
+    const before = domainSnapshot();
+    const input = await mutationInput({
+      operationKind: "conversion",
+      trigger: "conversion",
+      transactionEligibilityGuard: ({ candidateLease }) =>
+        candidateLease.predecessorLeaseId ? "renewal_handoff_required" : null,
+    });
+
+    await expect(startCanonicalLeaseOccupancy(input)).rejects.toMatchObject({
+      code: "lease_start_transaction_ineligible",
+      transactionEligibilityReason: "renewal_handoff_required",
+      freshContext: expect.objectContaining({ expectedStateToken: input.expectedStateToken }),
+    });
+    expect(domainSnapshot()).toEqual(before);
+    expect(fake.list("leaseStartRequests")).toEqual([]);
+  });
+
   it("reuses a coherent active tenancy without rewriting it", async () => {
     fake.seed("tenancies", "tenancy-existing", { landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-1", leaseId: "lease-1", status: "active", moveInAt: "2026-04-01T12:00:00.000Z" });
     const result = await startCanonicalLeaseOccupancy(await mutationInput());

--- a/rentchain-api/src/services/leaseStart/leaseStartService.ts
+++ b/rentchain-api/src/services/leaseStart/leaseStartService.ts
@@ -25,7 +25,13 @@ export type LeaseStartErrorCode =
   | "lease_start_state_stale"
   | "lease_start_idempotency_key_reused"
   | "lease_start_postcondition_failed"
-  | "lease_start_context_ambiguous";
+  | "lease_start_context_ambiguous"
+  | "lease_start_transaction_ineligible";
+
+export type LeaseStartTransactionEligibilityContext = {
+  candidateLease: Record<string, unknown>;
+  contextLeases: Array<Record<string, unknown>>;
+};
 
 export type LeaseStartContext = {
   expectedStateToken: string;
@@ -67,13 +73,18 @@ export type StartCanonicalLeaseOccupancyInput = {
   source?: string | null;
   leasePatch?: Record<string, unknown> | null;
   persistRejectedAttempt?: boolean;
+  transactionEligibilityGuard?: (context: LeaseStartTransactionEligibilityContext) => string | null;
   firestore?: any;
 };
 
 type ContextInput = Pick<StartCanonicalLeaseOccupancyInput, "landlordId" | "propertyId" | "unitId" | "tenantId" | "leaseId" | "evaluationInstant" | "leasePatch"> & { firestore?: any };
 
 export class LeaseStartServiceError extends Error {
-  constructor(public code: LeaseStartErrorCode, public freshContext?: LeaseStartContext) {
+  constructor(
+    public code: LeaseStartErrorCode,
+    public freshContext?: LeaseStartContext,
+    public transactionEligibilityReason?: string
+  ) {
     super(code);
   }
 }
@@ -256,6 +267,17 @@ export async function startCanonicalLeaseOccupancy(input: StartCanonicalLeaseOcc
     loadAuthoritativeState: (transaction) => readContext(transaction, { ...input, evaluationInstant: normalizedInstant, firestore }),
     getExpectedStateToken: (loaded) => loaded.context.expectedStateToken,
     buildPlan: async ({ transaction, loaded }) => {
+    const transactionEligibilityReason = input.transactionEligibilityGuard?.({
+      candidateLease: loaded.records.candidateLease,
+      contextLeases: loaded.records.canonicalInput.contextLeases,
+    });
+    if (transactionEligibilityReason) {
+      throw new LeaseStartServiceError(
+        "lease_start_transaction_ineligible",
+        loaded.context,
+        transactionEligibilityReason
+      );
+    }
     // D2 has no live route caller. Canonical rejected and deferred decisions
     // therefore return deterministically with no durable audit or idempotency
     // record. D3 must define authenticated route-attempt persistence policy.

--- a/rentchain-api/src/services/tenanciesService.ts
+++ b/rentchain-api/src/services/tenanciesService.ts
@@ -225,6 +225,7 @@ export async function createTenancyIfMissing(input: {
   unitId?: string | null;
   unitLabel?: string | null;
   moveInAt?: string | null;
+  status?: TenancyStatus;
 }): Promise<TenancyRecord | null> {
   const tenantId = String(input.tenantId || "").trim();
   const landlordId = String(input.landlordId || "").trim();
@@ -253,7 +254,7 @@ export async function createTenancyIfMissing(input: {
     propertyId: propertyId || null,
     unitId: unitId || unitLabel || null,
     unitLabel: unitLabel || unitId || null,
-    status: "active" as TenancyStatus,
+    status: input.status === "inactive" ? "inactive" as TenancyStatus : "active" as TenancyStatus,
     moveInAt: toIso(input.moveInAt) || now.toISOString(),
     moveOutAt: null,
     moveOutReason: null,

--- a/rentchain-api/src/services/tenantPortal/__tests__/tenantOccupancySyncService.test.ts
+++ b/rentchain-api/src/services/tenantPortal/__tests__/tenantOccupancySyncService.test.ts
@@ -1,0 +1,250 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { buildCanonicalLeaseOccupancyProjection, resolveCanonicalUnitProjectionInputs } from "../../../lib/leases/canonicalLeaseOccupancyProjection";
+import { aggregateOccupancyReviewWorkspace } from "../../occupancyReviewWorkspaceService";
+import { syncPropertyUnitOccupancyForTenantContext } from "../tenantOccupancySyncService";
+
+function createFakeFirestore() {
+  const store = new Map<string, Map<string, any>>();
+  const collectionData = (name: string) => {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  };
+  const ref = (name: string, id: string): any => ({
+    id,
+    collectionName: name,
+    get: async () => {
+      const value = collectionData(name).get(id);
+      return { id, exists: value !== undefined, data: () => structuredClone(value), ref: ref(name, id) };
+    },
+    set: async (value: any, options?: any) => {
+      const current = collectionData(name).get(id) || {};
+      collectionData(name).set(id, options?.merge ? { ...current, ...structuredClone(value) } : structuredClone(value));
+    },
+    create: async (value: any) => {
+      if (collectionData(name).has(id)) throw new Error("already_exists");
+      collectionData(name).set(id, structuredClone(value));
+    },
+  });
+  const query = (name: string, filters: any[] = []): any => ({
+    collectionName: name,
+    filters,
+    where: (field: string, op: string, value: any) => query(name, [...filters, { field, op, value }]),
+    get: async () => ({
+      docs: [...collectionData(name).entries()]
+        .filter(([, value]) => filters.every((filter) => filter.op === "==" && value[filter.field] === filter.value))
+        .map(([id, value]) => ({ id, exists: true, data: () => structuredClone(value), ref: ref(name, id) })),
+    }),
+  });
+  const firestore: any = {
+    collection: (name: string) => ({ ...query(name), doc: (id: string) => ref(name, id) }),
+    runTransaction: async (callback: any) => {
+      const writes: Array<{ kind: "set" | "create"; target: any; value: any; options?: any }> = [];
+      const result = await callback({
+        get: (target: any) => target.get(),
+        set: (target: any, value: any, options?: any) => writes.push({ kind: "set", target, value, options }),
+        create: (target: any, value: any) => writes.push({ kind: "create", target, value }),
+      });
+      for (const write of writes) {
+        if (write.kind === "create") await write.target.create(write.value);
+        else await write.target.set(write.value, write.options);
+      }
+      return result;
+    },
+  };
+  return {
+    firestore,
+    seed: (name: string, id: string, value: any) => collectionData(name).set(id, structuredClone(value)),
+    read: (name: string, id: string) => structuredClone(collectionData(name).get(id)),
+    list: (name: string) => [...collectionData(name).entries()].map(([id, value]) => ({ id, ...structuredClone(value) })),
+    domain: () => structuredClone({
+      properties: [...collectionData("properties")],
+      units: [...collectionData("units")],
+      leases: [...collectionData("leases")],
+      tenants: [...collectionData("tenants")],
+      tenancies: [...collectionData("tenancies")],
+    }),
+  };
+}
+
+const instant = "2026-08-23T12:00:00.000Z";
+let fake: ReturnType<typeof createFakeFirestore>;
+
+function seedBase(lease: Record<string, unknown> = {}, unit: Record<string, unknown> = {}) {
+  fake.seed("properties", "property-1", {
+    id: "property-1", landlordId: "landlord-1", name: "Harbour House",
+    units: [{ id: "unit-1", unitId: "unit-1", unitNumber: "1A", status: "vacant", occupancyStatus: "vacant" }],
+  });
+  fake.seed("units", "unit-1", {
+    id: "unit-1", landlordId: "landlord-1", propertyId: "property-1", unitNumber: "1A",
+    status: "vacant", occupancyStatus: "vacant", ...unit,
+  });
+  fake.seed("tenants", "tenant-1", { id: "tenant-1", landlordId: "landlord-1", status: "invited", applicationId: "app-1" });
+  fake.seed("tenancies", "tenancy-1", {
+    id: "tenancy-1", landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1",
+    tenantId: "tenant-1", leaseId: "lease-1", status: "inactive", source: "application_conversion",
+  });
+  fake.seed("leases", "lease-1", {
+    id: "lease-1", landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1",
+    tenantId: "tenant-1", tenantIds: ["tenant-1"], status: "active", executionStatus: "fully_executed",
+    startDate: "2026-08-01", endDate: "2027-07-31", ...lease,
+  });
+}
+
+async function activate(overrides: Record<string, unknown> = {}) {
+  return syncPropertyUnitOccupancyForTenantContext({
+    tenantId: "tenant-1", leaseId: "lease-1", applicationId: "app-1", landlordId: "landlord-1",
+    propertyId: "property-1", unitId: "unit-1", actorId: "landlord-1", idempotencyKey: "app-1",
+    source: "application_conversion", firestore: fake.firestore, evaluationInstant: instant, ...overrides,
+  });
+}
+
+describe("tenantOccupancySyncService canonical adapter", () => {
+  beforeEach(() => { fake = createFakeFirestore(); seedBase(); });
+
+  it("uses the canonical transaction for one eligible current fully executed lease", async () => {
+    const result = await activate();
+    expect(result).toMatchObject({ updated: true, reason: "occupancy_effective", canonicalResult: { occupancyEffective: true } });
+    expect(fake.read("leases", "lease-1")).toMatchObject({ occupancyEffective: true });
+    expect(fake.read("units", "unit-1")).toMatchObject({ status: "occupied", occupancyStatus: "occupied", currentLeaseId: "lease-1", currentTenantId: "tenant-1", occupancySource: "canonical_lease_start" });
+    expect(fake.read("properties", "property-1").units[0]).toMatchObject({ status: "occupied", currentLeaseId: "lease-1", currentTenantId: "tenant-1" });
+    expect(fake.read("tenants", "tenant-1")).toMatchObject({ status: "current", currentLeaseId: "lease-1" });
+    expect(fake.list("tenancies")).toEqual([expect.objectContaining({ id: "tenancy-1", tenantId: "tenant-1", leaseId: "lease-1", status: "active" })]);
+    expect(fake.list("canonicalEvents")).toEqual([expect.objectContaining({ type: "lease.occupancy_started", status: "succeeded" })]);
+
+    const unit = fake.read("units", "unit-1");
+    const projection = buildCanonicalLeaseOccupancyProjection({
+      leases: fake.list("leases"), context: { landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-1" },
+      ...resolveCanonicalUnitProjectionInputs(unit), persistedTenancyStatus: "active", persistedTenantStatus: "current",
+      currentLeasePointerId: "lease-1", tenantId: "tenant-1",
+    });
+    expect(projection).toMatchObject({ occupancyState: "occupied", tenantRelationshipState: "current_occupant", supportingLeaseId: "lease-1", reasons: [] });
+    expect(aggregateOccupancyReviewWorkspace("landlord-1", {
+      properties: fake.list("properties"), units: fake.list("units"), leases: fake.list("leases"),
+      tenants: fake.list("tenants"), tenancies: fake.list("tenancies"),
+    }).items).toEqual([]);
+  });
+
+  it("is replay-safe once the canonical state is already coherent", async () => {
+    expect((await activate()).updated).toBe(true);
+    const eventsBefore = fake.list("canonicalEvents");
+    expect(await activate()).toMatchObject({ updated: false, reason: "already_coherent" });
+    expect(fake.list("canonicalEvents")).toEqual(eventsBefore);
+    expect(fake.list("tenancies")).toHaveLength(1);
+  });
+
+  it("uses the same canonical authority for tenant invite onboarding", async () => {
+    expect(await activate({
+      source: "tenant_invite_onboarding",
+      actorId: "tenant-1",
+      idempotencyKey: "invite-1",
+    })).toMatchObject({ updated: true, reason: "occupancy_effective" });
+    expect(fake.read("units", "unit-1")).toMatchObject({
+      status: "occupied",
+      currentLeaseId: "lease-1",
+      currentTenantId: "tenant-1",
+    });
+    expect(fake.list("canonicalEvents")).toEqual([
+      expect.objectContaining({ type: "lease.occupancy_started", status: "succeeded" }),
+    ]);
+  });
+
+  it.each([
+    ["future signed", { status: "signed", executionStatus: undefined, startDate: "2027-01-01", signedAt: instant }],
+    ["future executed", { status: "executed", executionStatus: "fully_executed", startDate: "2027-01-01", executedAt: instant }],
+    ["renewal pending status", { status: "renewal_pending", executionStatus: undefined }],
+    ["renewal accepted status", { status: "renewal_accepted", executionStatus: undefined }],
+    ["active status only", { status: "active", executionStatus: undefined }],
+    ["signing timestamps only", { status: "unknown", executionStatus: undefined, signedAt: instant, tenantSignedAt: instant, landlordSignedAt: instant }],
+    ["draft", { status: "draft", executionStatus: "draft" }],
+    ["past", { startDate: "2025-01-01", endDate: "2026-01-01" }],
+    ["ended", { status: "ended", endedAt: instant }],
+    ["invalid dates", { startDate: "2027-01-01", endDate: "2026-01-01" }],
+  ])("keeps %s metadata-only with zero occupancy writes", async (_label, lease) => {
+    fake = createFakeFirestore(); seedBase(lease);
+    const before = fake.domain();
+    const result = await activate();
+    expect(result.updated).toBe(false);
+    expect(fake.domain()).toEqual(before);
+    expect(fake.list("canonicalEvents")).toEqual([]);
+    expect(fake.list("leaseStartRequests")).toEqual([]);
+  });
+
+  it("keeps future executed onboarding non-current across canonical projections", async () => {
+    fake = createFakeFirestore();
+    seedBase({ status: "executed", executionStatus: "fully_executed", startDate: "2027-01-01" });
+    expect(await activate({ source: "tenant_invite_onboarding", idempotencyKey: "invite-future" }))
+      .toMatchObject({ updated: false, reason: "created_without_occupancy" });
+
+    const unit = fake.read("units", "unit-1");
+    expect(unit).toMatchObject({ status: "vacant", occupancyStatus: "vacant" });
+    expect(fake.read("tenants", "tenant-1")).toMatchObject({ status: "invited" });
+    expect(fake.read("tenancies", "tenancy-1")).toMatchObject({ status: "inactive" });
+    expect(buildCanonicalLeaseOccupancyProjection({
+      leases: fake.list("leases"),
+      context: {
+        landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1",
+        tenantId: "tenant-1", asOfDate: "2026-08-23",
+      },
+      ...resolveCanonicalUnitProjectionInputs(unit),
+      persistedTenancyStatus: "inactive",
+      persistedTenantStatus: "invited",
+      currentLeasePointerId: null,
+      tenantId: "tenant-1",
+    })).toMatchObject({
+      leaseTermState: "upcoming",
+      occupancyState: "vacant",
+      supportingLeaseId: null,
+    });
+  });
+
+  it("fails closed for multiple current leases with zero occupancy writes", async () => {
+    fake.seed("leases", "lease-2", { ...fake.read("leases", "lease-1"), id: "lease-2" });
+    const before = fake.domain();
+    expect(await activate()).toMatchObject({ updated: false, reason: "rejected", canonicalResult: { reasons: ["MULTIPLE_CURRENT_LEASES"] } });
+    expect(fake.domain()).toEqual(before);
+  });
+
+  it.each([
+    ["foreign landlord lease", { lease: { landlordId: "landlord-2" } }],
+    ["foreign property lease", { lease: { propertyId: "property-2" } }],
+    ["foreign unit lease", { lease: { unitId: "unit-2" } }],
+    ["foreign participant", { lease: { tenantId: "tenant-2", tenantIds: ["tenant-2"] } }],
+    ["foreign property owner", { property: { landlordId: "landlord-2" } }],
+    ["missing unit landlord", { unit: { landlordId: undefined } }],
+  ])("rejects %s without occupancy writes", async (_label, change) => {
+    if (change.lease) fake.seed("leases", "lease-1", { ...fake.read("leases", "lease-1"), ...change.lease });
+    if (change.property) fake.seed("properties", "property-1", { ...fake.read("properties", "property-1"), ...change.property });
+    if (change.unit) fake.seed("units", "unit-1", { ...fake.read("units", "unit-1"), ...change.unit });
+    const before = fake.domain();
+    try {
+      const result = await activate();
+      expect(result).toMatchObject({ updated: false, reason: "rejected" });
+    } catch (error) {
+      expect(error).toMatchObject({ code: "lease_start_context_ambiguous" });
+    }
+    expect(fake.domain()).toEqual(before);
+  });
+
+  it("rejects caller-provided property, unit, and tenant mismatches", async () => {
+    for (const overrides of [{ propertyId: "property-2" }, { unitId: "unit-2" }, { tenantId: "tenant-2" }]) {
+      const before = fake.domain();
+      await expect(activate(overrides)).rejects.toMatchObject({ code: "lease_start_context_ambiguous" });
+      expect(fake.domain()).toEqual(before);
+    }
+  });
+
+  it("does not bypass renewal handoff or reactivate an occupancy-excluded lease", async () => {
+    fake.seed("leases", "lease-1", { ...fake.read("leases", "lease-1"), predecessorLeaseId: "lease-old" });
+    expect(await activate()).toEqual({ updated: false, reason: "renewal_handoff_required" });
+    fake.seed("leases", "lease-1", { ...fake.read("leases", "lease-1"), predecessorLeaseId: null, occupancyDisposition: { status: "excluded_from_current_occupancy_by_resolution" } });
+    expect(await activate()).toEqual({ updated: false, reason: "occupancy_excluded" });
+    expect(fake.read("units", "unit-1")).toMatchObject({ status: "vacant", occupancyStatus: "vacant" });
+    expect(fake.list("canonicalEvents")).toEqual([]);
+  });
+
+  it("does nothing without one complete durable context", async () => {
+    expect(await activate({ leaseId: null })).toEqual({ updated: false, reason: "missing_context" });
+    fake = createFakeFirestore();
+    expect(await activate()).toEqual({ updated: false, reason: "lease_not_found" });
+  });
+});

--- a/rentchain-api/src/services/tenantPortal/__tests__/tenantOccupancySyncService.test.ts
+++ b/rentchain-api/src/services/tenantPortal/__tests__/tenantOccupancySyncService.test.ts
@@ -5,6 +5,7 @@ import { syncPropertyUnitOccupancyForTenantContext } from "../tenantOccupancySyn
 
 function createFakeFirestore() {
   const store = new Map<string, Map<string, any>>();
+  let afterRead: { collection: string; id: string; callback: () => void } | null = null;
   const collectionData = (name: string) => {
     if (!store.has(name)) store.set(name, new Map());
     return store.get(name)!;
@@ -14,7 +15,13 @@ function createFakeFirestore() {
     collectionName: name,
     get: async () => {
       const value = collectionData(name).get(id);
-      return { id, exists: value !== undefined, data: () => structuredClone(value), ref: ref(name, id) };
+      const snapshot = { id, exists: value !== undefined, data: () => structuredClone(value), ref: ref(name, id) };
+      if (afterRead?.collection === name && afterRead.id === id) {
+        const callback = afterRead.callback;
+        afterRead = null;
+        callback();
+      }
+      return snapshot;
     },
     set: async (value: any, options?: any) => {
       const current = collectionData(name).get(id) || {};
@@ -56,6 +63,9 @@ function createFakeFirestore() {
     seed: (name: string, id: string, value: any) => collectionData(name).set(id, structuredClone(value)),
     read: (name: string, id: string) => structuredClone(collectionData(name).get(id)),
     list: (name: string) => [...collectionData(name).entries()].map(([id, value]) => ({ id, ...structuredClone(value) })),
+    afterNextRead: (collection: string, id: string, callback: () => void) => {
+      afterRead = { collection, id, callback };
+    },
     domain: () => structuredClone({
       properties: [...collectionData("properties")],
       units: [...collectionData("units")],
@@ -233,9 +243,44 @@ describe("tenantOccupancySyncService canonical adapter", () => {
     }
   });
 
-  it("does not bypass renewal handoff or reactivate an occupancy-excluded lease", async () => {
-    fake.seed("leases", "lease-1", { ...fake.read("leases", "lease-1"), predecessorLeaseId: "lease-old" });
+  it.each([
+    ["successor", { predecessorLeaseId: "lease-old" }],
+    ["predecessor", { renewedByLeaseId: "lease-new" }],
+    ["ambiguous predecessor", { renewedByLeaseId: "lease-new", successorLeaseId: "lease-other" }],
+  ])("rejects a stable renewal-linked %s from the fresh transaction snapshot", async (_label, link) => {
+    fake.seed("leases", "lease-1", { ...fake.read("leases", "lease-1"), ...link });
     expect(await activate()).toEqual({ updated: false, reason: "renewal_handoff_required" });
+    expect(fake.read("units", "unit-1")).toMatchObject({ status: "vacant", occupancyStatus: "vacant" });
+    expect(fake.read("tenancies", "tenancy-1")).toMatchObject({ status: "inactive" });
+    expect(fake.list("canonicalEvents")).toEqual([]);
+    expect(fake.list("leaseStartRequests")).toEqual([]);
+  });
+
+  it.each([
+    ["application conversion", "application_conversion", "app-race"],
+    ["tenant invite onboarding", "tenant_invite_onboarding", "invite-race"],
+  ] as const)("closes the renewal-link TOCTOU window for %s", async (_label, source, idempotencyKey) => {
+    fake.afterNextRead("leases", "lease-1", () => {
+      fake.seed("leases", "lease-1", {
+        ...fake.read("leases", "lease-1"),
+        predecessorLeaseId: "lease-old",
+      });
+    });
+
+    expect(await activate({ source, idempotencyKey })).toEqual({
+      updated: false,
+      reason: "renewal_handoff_required",
+    });
+    expect(fake.read("leases", "lease-1")).not.toHaveProperty("occupancyEffective");
+    expect(fake.read("units", "unit-1")).toMatchObject({ status: "vacant", occupancyStatus: "vacant" });
+    expect(fake.read("properties", "property-1").units[0]).toMatchObject({ status: "vacant", occupancyStatus: "vacant" });
+    expect(fake.read("tenants", "tenant-1")).not.toHaveProperty("currentLeaseId");
+    expect(fake.read("tenancies", "tenancy-1")).toMatchObject({ status: "inactive" });
+    expect(fake.list("canonicalEvents")).toEqual([]);
+    expect(fake.list("leaseStartRequests")).toEqual([]);
+  });
+
+  it("does not reactivate an occupancy-excluded lease", async () => {
     fake.seed("leases", "lease-1", { ...fake.read("leases", "lease-1"), predecessorLeaseId: null, occupancyDisposition: { status: "excluded_from_current_occupancy_by_resolution" } });
     expect(await activate()).toEqual({ updated: false, reason: "occupancy_excluded" });
     expect(fake.read("units", "unit-1")).toMatchObject({ status: "vacant", occupancyStatus: "vacant" });

--- a/rentchain-api/src/services/tenantPortal/tenantOccupancySyncService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantOccupancySyncService.ts
@@ -1,4 +1,9 @@
 import { db } from "../../firebase";
+import {
+  getCanonicalLeaseStartContext,
+  startCanonicalLeaseOccupancy,
+  type LeaseStartServiceResult,
+} from "../leaseStart/leaseStartService";
 
 type OccupancySyncInput = {
   tenantId: string;
@@ -7,173 +12,109 @@ type OccupancySyncInput = {
   landlordId?: string | null;
   propertyId?: string | null;
   unitId?: string | null;
+  actorId?: string | null;
+  idempotencyKey?: string | null;
+  source: "application_conversion" | "tenant_invite_onboarding";
+  firestore?: any;
+  evaluationInstant?: string;
 };
 
-type OccupancySyncResult = {
+export type OccupancySyncResult = {
   updated: boolean;
   reason:
     | "missing_context"
     | "lease_not_found"
-    | "lease_not_occupying"
-    | "unit_not_found"
-    | "occupied";
+    | "renewal_handoff_required"
+    | "occupancy_excluded"
+    | "created_without_occupancy"
+    | "rejected"
+    | "occupancy_effective"
+    | "already_coherent";
+  canonicalResult?: LeaseStartServiceResult;
 };
 
-const OCCUPYING_LEASE_STATUSES = new Set([
-  "active",
-  "current",
-  "signed",
-  "executed",
-  "notice_pending",
-  "renewal_pending",
-  "renewal_accepted",
-  "move_out_pending",
-]);
-
-const NON_OCCUPYING_LEASE_STATUSES = new Set([
-  "draft",
-  "pending",
-  "sent",
-  "expired",
-  "ended",
-  "terminated",
-  "cancelled",
-  "canceled",
-  "revoked",
-  "archived",
-]);
-
-function asString(value: unknown): string | null {
-  const next = String(value || "").trim();
-  return next || null;
+function text(value: unknown): string {
+  return String(value ?? "").trim();
 }
 
-function normalizeUnitToken(value: unknown): string {
-  return String(value || "").trim().toUpperCase().replace(/[\s_-]+/g, "");
+function isRenewalLease(lease: Record<string, unknown>): boolean {
+  return [
+    lease.predecessorLeaseId,
+    lease.renewalOfLeaseId,
+    lease.renewedFromLeaseId,
+    lease.replacesLeaseId,
+  ].some((value) => Boolean(text(value)));
 }
 
-function unitMatches(unit: any, unitId: string): boolean {
-  const targetRaw = String(unitId || "").trim();
-  const targetToken = normalizeUnitToken(targetRaw);
-  if (!targetRaw && !targetToken) return false;
-  const candidates = [
-    unit?.id,
-    unit?.unitId,
-    unit?.unitNumber,
-    unit?.unit,
-    unit?.label,
-    unit?.name,
-    unit?.displayLabel,
-  ];
-  return candidates.some((candidate) => {
-    const raw = String(candidate || "").trim();
-    return raw === targetRaw || normalizeUnitToken(raw) === targetToken;
-  });
+function isOccupancyExcluded(lease: Record<string, any>): boolean {
+  return text(lease.occupancyDisposition?.status) === "excluded_from_current_occupancy_by_resolution";
 }
 
-function isOccupyingLease(lease: any): boolean {
-  const status = String(lease?.status || lease?.lifecycleStatus || "").trim().toLowerCase();
-  if (NON_OCCUPYING_LEASE_STATUSES.has(status)) return false;
-  if (OCCUPYING_LEASE_STATUSES.has(status)) return true;
-  return Boolean(lease?.activatedAt || lease?.signedAt || lease?.fullySignedAt || lease?.executedAt);
-}
-
-async function findUnitDoc(propertyId: string, landlordId: string | null, unitId: string) {
-  const snap = await db.collection("units").where("propertyId", "==", propertyId).get();
-  const matches = snap.docs
-    .map((doc: any) => ({ id: doc.id, data: doc.data() || {} }))
-    .filter(({ id, data }: any) => {
-      if (landlordId && asString(data?.landlordId) && asString(data?.landlordId) !== landlordId) return false;
-      return unitMatches({ ...data, id: data?.id || data?.unitId || id }, unitId);
-    });
-  if (matches.length !== 1) return null;
-  return matches[0];
-}
-
-async function updateEmbeddedPropertyUnit(propertyId: string, unitId: string, patch: Record<string, unknown>) {
-  const propertyRef = db.collection("properties").doc(propertyId);
-  const propertySnap = await propertyRef.get();
-  if (!propertySnap.exists) return false;
-  const property = propertySnap.data() || {};
-  const units = Array.isArray((property as any)?.units) ? (property as any).units : [];
-  const matchingIndexes = units
-    .map((unit: any, index: number) => ({ unit, index }))
-    .filter(({ unit }: any) => unitMatches(unit, unitId));
-  if (matchingIndexes.length !== 1) return false;
-  const nextUnits = units.map((unit: any, index: number) =>
-    index === matchingIndexes[0].index ? { ...unit, ...patch } : unit
-  );
-  await propertyRef.set({ units: nextUnits, updatedAt: Date.now() }, { merge: true });
-  return true;
-}
-
-async function loadTenantDisplayFields(tenantId: string): Promise<Record<string, string>> {
-  const snap = await db.collection("tenants").doc(tenantId).get().catch(() => null);
-  if (!snap?.exists) return {};
-  const tenant = snap.data() || {};
-  const displayName = asString(
-    (tenant as any)?.fullName ||
-      (tenant as any)?.name ||
-      (tenant as any)?.tenantName ||
-      (tenant as any)?.displayName
-  );
-  if (!displayName) return {};
-  return {
-    tenantName: displayName,
-    tenantFullName: displayName,
-    currentTenantName: displayName,
-  };
-}
-
+/**
+ * Narrow adapter from tenant setup workflows to the canonical lease-start
+ * authority. This service never writes occupancy projections itself.
+ */
 export async function syncPropertyUnitOccupancyForTenantContext(
   input: OccupancySyncInput
 ): Promise<OccupancySyncResult> {
-  const tenantId = asString(input.tenantId);
-  const leaseId = asString(input.leaseId);
-  const propertyId = asString(input.propertyId);
-  const unitId = asString(input.unitId);
-  if (!tenantId || !leaseId || !propertyId || !unitId) {
+  const tenantId = text(input.tenantId);
+  const leaseId = text(input.leaseId);
+  const landlordId = text(input.landlordId);
+  const propertyId = text(input.propertyId);
+  const unitId = text(input.unitId);
+  const idempotencyKey = text(input.idempotencyKey || input.applicationId);
+  if (!tenantId || !leaseId || !landlordId || !propertyId || !unitId || !idempotencyKey) {
     return { updated: false, reason: "missing_context" };
   }
 
-  const leaseSnap = await db.collection("leases").doc(leaseId).get();
-  if (!leaseSnap.exists) {
-    return { updated: false, reason: "lease_not_found" };
-  }
-  const lease = leaseSnap.data() || {};
-  if (!isOccupyingLease(lease)) {
-    return { updated: false, reason: "lease_not_occupying" };
-  }
+  const firestore = input.firestore || db;
+  const leaseSnap = await firestore.collection("leases").doc(leaseId).get();
+  if (!leaseSnap.exists) return { updated: false, reason: "lease_not_found" };
+  const lease = { id: leaseSnap.id, ...(leaseSnap.data() || {}) };
 
-  const leasePropertyId = asString((lease as any)?.propertyId);
-  const leaseUnitId = asString((lease as any)?.unitId || (lease as any)?.unitNumber || (lease as any)?.unit);
-  if (leasePropertyId && leasePropertyId !== propertyId) {
-    return { updated: false, reason: "missing_context" };
-  }
-  const unitReference = leaseUnitId || unitId;
+  // Renewal occupancy is governed exclusively by the explicit PR G handoff.
+  // The expected-state token generated below includes the complete lease, so
+  // a concurrent linkage/disposition change makes the canonical commit stale.
+  if (isRenewalLease(lease)) return { updated: false, reason: "renewal_handoff_required" };
+  if (isOccupancyExcluded(lease)) return { updated: false, reason: "occupancy_excluded" };
 
-  const now = Date.now();
-  const tenantDisplayFields = await loadTenantDisplayFields(tenantId);
-  const occupancyPatch = {
-    status: "occupied",
-    occupancyStatus: "occupied",
+  const evaluationInstant = input.evaluationInstant || new Date().toISOString();
+  const context = await getCanonicalLeaseStartContext({
+    landlordId,
+    propertyId,
+    unitId,
     tenantId,
-    currentTenantId: tenantId,
     leaseId,
-    currentLeaseId: leaseId,
-    applicationId: asString(input.applicationId),
-    ...tenantDisplayFields,
-    occupancySource: "canonical_lease",
-    occupancyUpdatedAt: now,
-    updatedAt: now,
+    evaluationInstant,
+    firestore,
+  });
+
+  // A replay after a successful setup is already coherent and needs no new
+  // request record. Ineligible decisions still pass through the canonical
+  // engine, which guarantees zero occupancy-bearing writes.
+  if (context.decision.outcome === "already_coherent") {
+    return { updated: false, reason: "already_coherent" };
+  }
+  const canonicalResult = await startCanonicalLeaseOccupancy({
+    landlordId,
+    propertyId,
+    unitId,
+    tenantId,
+    leaseId,
+    operationKind: "conversion",
+    trigger: "conversion",
+    idempotencyKey,
+    expectedStateToken: context.expectedStateToken,
+    evaluationInstant: context.evaluationInstant,
+    actorId: text(input.actorId) || landlordId,
+    source: input.source,
+    persistRejectedAttempt: false,
+    firestore,
+  });
+  const reason = canonicalResult.canonicalOutcome;
+  return {
+    updated: canonicalResult.occupancyEffective,
+    reason,
+    canonicalResult,
   };
-  const unitDoc = await findUnitDoc(propertyId, asString(input.landlordId), unitReference);
-  const updatedEmbedded = await updateEmbeddedPropertyUnit(propertyId, unitReference, occupancyPatch);
-  if (!unitDoc && !updatedEmbedded) {
-    return { updated: false, reason: "unit_not_found" };
-  }
-  if (unitDoc) {
-    await db.collection("units").doc(unitDoc.id).set(occupancyPatch, { merge: true });
-  }
-  return { updated: true, reason: "occupied" };
 }

--- a/rentchain-api/src/services/tenantPortal/tenantOccupancySyncService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantOccupancySyncService.ts
@@ -1,4 +1,5 @@
 import { db } from "../../firebase";
+import { hasRenewalContinuityLink } from "../../lib/leases/renewalContinuity";
 import {
   getCanonicalLeaseStartContext,
   startCanonicalLeaseOccupancy,
@@ -37,15 +38,6 @@ function text(value: unknown): string {
   return String(value ?? "").trim();
 }
 
-function isRenewalLease(lease: Record<string, unknown>): boolean {
-  return [
-    lease.predecessorLeaseId,
-    lease.renewalOfLeaseId,
-    lease.renewedFromLeaseId,
-    lease.replacesLeaseId,
-  ].some((value) => Boolean(text(value)));
-}
-
 function isOccupancyExcluded(lease: Record<string, any>): boolean {
   return text(lease.occupancyDisposition?.status) === "excluded_from_current_occupancy_by_resolution";
 }
@@ -72,10 +64,6 @@ export async function syncPropertyUnitOccupancyForTenantContext(
   if (!leaseSnap.exists) return { updated: false, reason: "lease_not_found" };
   const lease = { id: leaseSnap.id, ...(leaseSnap.data() || {}) };
 
-  // Renewal occupancy is governed exclusively by the explicit PR G handoff.
-  // The expected-state token generated below includes the complete lease, so
-  // a concurrent linkage/disposition change makes the canonical commit stale.
-  if (isRenewalLease(lease)) return { updated: false, reason: "renewal_handoff_required" };
   if (isOccupancyExcluded(lease)) return { updated: false, reason: "occupancy_excluded" };
 
   const evaluationInstant = input.evaluationInstant || new Date().toISOString();
@@ -95,22 +83,33 @@ export async function syncPropertyUnitOccupancyForTenantContext(
   if (context.decision.outcome === "already_coherent") {
     return { updated: false, reason: "already_coherent" };
   }
-  const canonicalResult = await startCanonicalLeaseOccupancy({
-    landlordId,
-    propertyId,
-    unitId,
-    tenantId,
-    leaseId,
-    operationKind: "conversion",
-    trigger: "conversion",
-    idempotencyKey,
-    expectedStateToken: context.expectedStateToken,
-    evaluationInstant: context.evaluationInstant,
-    actorId: text(input.actorId) || landlordId,
-    source: input.source,
-    persistRejectedAttempt: false,
-    firestore,
-  });
+  let canonicalResult: LeaseStartServiceResult;
+  try {
+    canonicalResult = await startCanonicalLeaseOccupancy({
+      landlordId,
+      propertyId,
+      unitId,
+      tenantId,
+      leaseId,
+      operationKind: "conversion",
+      trigger: "conversion",
+      idempotencyKey,
+      expectedStateToken: context.expectedStateToken,
+      evaluationInstant: context.evaluationInstant,
+      actorId: text(input.actorId) || landlordId,
+      source: input.source,
+      persistRejectedAttempt: false,
+      transactionEligibilityGuard: ({ candidateLease }) =>
+        hasRenewalContinuityLink(candidateLease) ? "renewal_handoff_required" : null,
+      firestore,
+    });
+  } catch (error: any) {
+    if (error?.code === "lease_start_transaction_ineligible" &&
+        error?.transactionEligibilityReason === "renewal_handoff_required") {
+      return { updated: false, reason: "renewal_handoff_required" };
+    }
+    throw error;
+  }
   const reason = canonicalResult.canonicalOutcome;
   return {
     updated: canonicalResult.occupancyEffective,

--- a/rentchain-frontend/server/previewBackendProxy.ts
+++ b/rentchain-frontend/server/previewBackendProxy.ts
@@ -24,6 +24,7 @@ export const PREVIEW_BACKEND_TARGET_KEYS = {
   pr1566: "pr1566-multiple-current-cert",
   pr1567: "pr1567-review-needed-cert",
   pr1568: "pr1568-renewal-continuity-cert",
+  pr1569: "pr1569-onboarding-occupancy-cert",
 } as const;
 
 export type PreviewBackendTarget = {
@@ -86,6 +87,14 @@ const PREVIEW_BACKEND_TARGETS: Record<string, PreviewBackendTarget> = {
       "https://rentchain-pr1568-qa-renewal-glistw4pya-nn.a.run.app",
     cloudRunIdTokenAudience:
       "https://rentchain-pr1568-qa-renewal-glistw4pya-nn.a.run.app",
+    temporary: true,
+  },
+  [PREVIEW_BACKEND_TARGET_KEYS.pr1569]: {
+    key: PREVIEW_BACKEND_TARGET_KEYS.pr1569,
+    cloudRunServiceUrl:
+      "https://rentchain-pr1569-qa-onboarding-glistw4pya-nn.a.run.app",
+    cloudRunIdTokenAudience:
+      "https://rentchain-pr1569-qa-onboarding-glistw4pya-nn.a.run.app",
     temporary: true,
   },
 };

--- a/rentchain-frontend/src/platform/previewBackendProxy.test.ts
+++ b/rentchain-frontend/src/platform/previewBackendProxy.test.ts
@@ -96,6 +96,7 @@ function successfulDependencies(upstreamStatus = 200) {
 describe("Preview backend proxy", () => {
   const originalVercelEnv = process.env.VERCEL_ENV;
   const originalPreviewBackendTarget = process.env.PREVIEW_BACKEND_TARGET;
+  const originalPreviewBackendUrl = process.env.PREVIEW_BACKEND_URL;
 
   beforeEach(() => {
     process.env.VERCEL_ENV = "preview";
@@ -108,6 +109,8 @@ describe("Preview backend proxy", () => {
     else process.env.VERCEL_ENV = originalVercelEnv;
     if (originalPreviewBackendTarget == null) delete process.env.PREVIEW_BACKEND_TARGET;
     else process.env.PREVIEW_BACKEND_TARGET = originalPreviewBackendTarget;
+    if (originalPreviewBackendUrl == null) delete process.env.PREVIEW_BACKEND_URL;
+    else process.env.PREVIEW_BACKEND_URL = originalPreviewBackendUrl;
   });
 
   it("keeps the permanent Preview backend as the default target", () => {
@@ -205,6 +208,21 @@ describe("Preview backend proxy", () => {
     });
   });
 
+  it("couples the authorized PR #1569 service URL and audience internally", () => {
+    const target = resolvePreviewBackendTarget({
+      vercelEnvironment: "preview",
+      targetKey: PREVIEW_BACKEND_TARGET_KEYS.pr1569,
+    });
+    expect(target).toEqual({
+      key: "pr1569-onboarding-occupancy-cert",
+      cloudRunServiceUrl:
+        "https://rentchain-pr1569-qa-onboarding-glistw4pya-nn.a.run.app",
+      cloudRunIdTokenAudience:
+        "https://rentchain-pr1569-qa-onboarding-glistw4pya-nn.a.run.app",
+      temporary: true,
+    });
+  });
+
   it.each([
     ["production", PREVIEW_BACKEND_TARGET_KEYS.pr1555],
     ["development", PREVIEW_BACKEND_TARGET_KEYS.pr1555],
@@ -218,7 +236,10 @@ describe("Preview backend proxy", () => {
     ["development", PREVIEW_BACKEND_TARGET_KEYS.pr1567],
     ["production", PREVIEW_BACKEND_TARGET_KEYS.pr1568],
     ["development", PREVIEW_BACKEND_TARGET_KEYS.pr1568],
+    ["production", PREVIEW_BACKEND_TARGET_KEYS.pr1569],
+    ["development", PREVIEW_BACKEND_TARGET_KEYS.pr1569],
     ["preview", ""],
+    ["preview", "   "],
     ["preview", "unknown"],
     ["preview", "pr1562"],
     ["preview", "arbitrary"],
@@ -234,6 +255,10 @@ describe("Preview backend proxy", () => {
     ["preview", "rentchain-pr1568-qa-renewal"],
     ["preview", "*.run.app"],
     ["preview", "https://rentchain-pr1568-qa-renewal-glistw4pya-nn.a.run.app"],
+    ["preview", "pr1569-onboarding-occupancy-cert-evil"],
+    ["preview", "PR1569-ONBOARDING-OCCUPANCY-CERT"],
+    ["preview", "rentchain-pr1569-qa-onboarding"],
+    ["preview", "https://rentchain-pr1569-qa-onboarding-glistw4pya-nn.a.run.app"],
   ])("rejects unsafe target selection for %s / %s", (vercelEnvironment, targetKey) => {
     expect(() => resolvePreviewBackendTarget({ vercelEnvironment, targetKey })).toThrow(
       "PREVIEW_PROXY_TARGET_REJECTED",
@@ -493,6 +518,35 @@ describe("Preview backend proxy", () => {
     );
   });
 
+  it.each([
+    ["mismatched audience", {
+      key: PREVIEW_BACKEND_TARGET_KEYS.pr1569,
+      cloudRunServiceUrl:
+        "https://rentchain-pr1569-qa-onboarding-glistw4pya-nn.a.run.app",
+      cloudRunIdTokenAudience:
+        "https://rentchain-preview-backend-glistw4pya-nn.a.run.app",
+      temporary: true,
+    }],
+    ["attacker host", {
+      key: PREVIEW_BACKEND_TARGET_KEYS.pr1569,
+      cloudRunServiceUrl: "https://attacker.example",
+      cloudRunIdTokenAudience: "https://attacker.example",
+      temporary: true,
+    }],
+    ["temporary flag", {
+      key: PREVIEW_BACKEND_TARGET_KEYS.pr1569,
+      cloudRunServiceUrl:
+        "https://rentchain-pr1569-qa-onboarding-glistw4pya-nn.a.run.app",
+      cloudRunIdTokenAudience:
+        "https://rentchain-pr1569-qa-onboarding-glistw4pya-nn.a.run.app",
+      temporary: false,
+    }],
+  ])("rejects a tampered PR #1569 mapping: %s", (_label, target) => {
+    expect(() => assertPreviewBackendTarget(target, "preview")).toThrow(
+      "PREVIEW_PROXY_TARGET_REJECTED",
+    );
+  });
+
   it("routes the authorized target using the same URL for ID-token audience and upstream", async () => {
     process.env.PREVIEW_BACKEND_TARGET = PREVIEW_BACKEND_TARGET_KEYS.pr1555;
     const { requests, dependencies } = successfulDependencies();
@@ -641,6 +695,38 @@ describe("Preview backend proxy", () => {
     expect(requests[2].url).toBe(
       `${expected}/api/leases/renewal-continuity/context?target=https://attacker.example`,
     );
+    expect(requests.every(({ url }) => !url.startsWith("https://attacker.example"))).toBe(true);
+  });
+
+  it("routes PR #1569 only to its fixed backend despite caller-controlled target-like input", async () => {
+    process.env.PREVIEW_BACKEND_TARGET = PREVIEW_BACKEND_TARGET_KEYS.pr1569;
+    process.env.PREVIEW_BACKEND_URL = "https://attacker.example";
+    const { requests, dependencies } = successfulDependencies();
+    const res = responseRecorder();
+
+    await handlePreviewBackendProxy(
+      request("/api/preview-backend/api/leases/tenant/synthetic-tenant?target=https://attacker.example", "GET", {
+        headers: {
+          host: "attacker.example",
+          cookie: "PREVIEW_BACKEND_TARGET=https://attacker.example",
+          "x-preview-backend-target": "https://attacker.example",
+        },
+        query: { target: "https://attacker.example" },
+        body: { target: "https://attacker.example" },
+      }),
+      res,
+      dependencies,
+    );
+
+    const expected =
+      "https://rentchain-pr1569-qa-onboarding-glistw4pya-nn.a.run.app";
+    expect(requests[1].init?.body).toBe(
+      JSON.stringify({ audience: expected, includeEmail: false }),
+    );
+    expect(requests[2].url).toBe(
+      `${expected}/api/leases/tenant/synthetic-tenant?target=https://attacker.example`,
+    );
+    expect(requests[2].init?.method).toBe("GET");
     expect(requests.every(({ url }) => !url.startsWith("https://attacker.example"))).toBe(true);
   });
 


### PR DESCRIPTION
## Summary
- retire legacy status/timestamp-based tenant onboarding occupancy writes
- route eligible application conversion and tenant invite activation through the canonical lease-start transaction
- keep conversion/onboarding metadata inactive until canonical occupancy is genuinely effective
- fail closed for future, incomplete, conflicting, foreign-context, renewal-linked, and occupancy-excluded leases

## Validation
- PR H focused tests: 32 passed
- canonical lease/occupancy regression matrix: 367 passed
- backend build: passed
- complete backend suite: 3549 passed, 29 baseline failures
- exact-base suite: 3526 passed, 30 baseline failures
- new backend failures versus base: 0
- git diff --check: passed

## Boundaries
- backend-only; seven scoped files
- no frontend, infrastructure, Preview target, runtime, IAM, Terraform, or Production changes
- Draft only; not ready and not merged