### PR TITLE
Fix Tenant Detail payment lease provenance

### DIFF
--- a/rentchain-frontend/src/components/tenants/TenantDetailPanel.test.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantDetailPanel.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { TenantDetailPanel } from "./TenantDetailPanel";
@@ -102,8 +102,39 @@ vi.mock("./LeasePackWizardModal", () => ({
   LeasePackWizardModal: () => null,
 }));
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function tenantDetailBundle(tenantId: string, currentLeaseId: string | null, displayLeaseId?: string) {
+  return {
+    tenant: { id: tenantId, fullName: `${tenantId} name`, currentLeaseId: `stale-${tenantId}` },
+    currentLease: currentLeaseId
+      ? { id: currentLeaseId, tenantId, leaseStart: "2026-01-01", leaseEnd: "2026-12-31", status: "active" }
+      : null,
+    lease: displayLeaseId ? { id: displayLeaseId, tenantId, status: "ended" } : null,
+    canonicalState: {
+      supportingLeaseId: currentLeaseId,
+      leaseTermState: currentLeaseId ? "current" : "none",
+      occupancyState: currentLeaseId ? "occupied" : "vacant",
+      tenantRelationshipState: currentLeaseId ? "current" : "past",
+      reasons: [],
+    },
+    property: { id: `property-${tenantId}`, name: "Harbour View" },
+    unit: { id: `unit-${tenantId}`, unitNumber: "101", status: currentLeaseId ? "occupied" : "vacant" },
+    moveInReadiness: null,
+  };
+}
+
 describe("TenantDetailPanel", () => {
   beforeEach(() => {
+    cleanup();
     vi.clearAllMocks();
     mocks.getTenantSignals.mockResolvedValue({ signals: null });
     mocks.printSummaryDocument.mockResolvedValue(undefined);
@@ -380,5 +411,91 @@ describe("TenantDetailPanel", () => {
     expect((await screen.findAllByText("Expired")).length).toBeGreaterThan(0);
     expect(screen.getAllByText("Review needed").length).toBeGreaterThanOrEqual(2);
     expect(screen.queryByText("Current")).not.toBeInTheDocument();
+  });
+
+  it("keeps authoritative current-lease copy coherent while its ledger request is pending and after success", async () => {
+    const leaseLedger = deferred<any>();
+    mocks.fetchLeaseLedger.mockReturnValueOnce(leaseLedger.promise);
+    mocks.useTenantDetail.mockReturnValue({
+      loading: false,
+      error: null,
+      bundle: tenantDetailBundle("tenant-1", "lease-current", "lease-historical"),
+    });
+
+    render(<MemoryRouter><TenantDetailPanel tenantId="tenant-1" /></MemoryRouter>);
+
+    expect(await screen.findByText("Loading ledger...")).toBeInTheDocument();
+    expect(screen.queryByText(/No current lease is linked/i)).not.toBeInTheDocument();
+    expect(mocks.fetchLeaseLedger).toHaveBeenCalledWith("lease-current");
+    expect(mocks.fetchLeaseLedger).not.toHaveBeenCalledWith("lease-historical");
+    expect(mocks.fetchLeaseLedger).not.toHaveBeenCalledWith("stale-tenant-1");
+
+    leaseLedger.resolve({
+      entries: [{
+        id: "entry-current",
+        leaseId: "lease-current",
+        entryType: "charge",
+        category: "rent",
+        amountCents: 100000,
+        effectiveDate: "2026-08-01",
+        signedAmountCents: 100000,
+        balanceCents: 100000,
+      }],
+    });
+
+    expect(await screen.findByText(/Charge · rent/i)).toBeInTheDocument();
+    expect(screen.queryByText(/No current lease is linked/i)).not.toBeInTheDocument();
+  });
+
+  it("does not deny the authoritative current lease when its ledger request fails", async () => {
+    const leaseLedger = deferred<any>();
+    mocks.fetchLeaseLedger.mockReturnValueOnce(leaseLedger.promise);
+    mocks.useTenantDetail.mockReturnValue({
+      loading: false,
+      error: null,
+      bundle: tenantDetailBundle("tenant-1", "lease-current"),
+    });
+
+    render(<MemoryRouter><TenantDetailPanel tenantId="tenant-1" /></MemoryRouter>);
+    expect(await screen.findByText("Loading ledger...")).toBeInTheDocument();
+
+    leaseLedger.reject(new Error("Lease payment history is temporarily unavailable."));
+
+    expect(await screen.findByText("Lease payment history is temporarily unavailable.")).toBeInTheDocument();
+    expect(screen.queryByText(/No current lease is linked/i)).not.toBeInTheDocument();
+  });
+
+  it("ignores a prior tenant's late lease-ledger result after selection changes", async () => {
+    const tenantALedger = deferred<any>();
+    mocks.fetchLeaseLedger.mockReturnValueOnce(tenantALedger.promise);
+    mocks.fetchLedger.mockResolvedValueOnce([]);
+    mocks.useTenantDetail.mockImplementation((tenantId: string) => ({
+      loading: false,
+      error: null,
+      bundle: tenantDetailBundle(tenantId, tenantId === "tenant-a" ? "lease-a" : null),
+    }));
+
+    const view = render(<MemoryRouter><TenantDetailPanel tenantId="tenant-a" /></MemoryRouter>);
+    expect(await screen.findByText("Loading ledger...")).toBeInTheDocument();
+
+    view.rerender(<MemoryRouter><TenantDetailPanel tenantId="tenant-b" /></MemoryRouter>);
+    expect(await screen.findByText(/No current lease is linked/i)).toBeInTheDocument();
+    await waitFor(() => expect(mocks.fetchLedger).toHaveBeenCalledWith({ tenantId: "tenant-b", limit: 50 }));
+
+    tenantALedger.resolve({
+      entries: [{
+        id: "late-a-entry",
+        leaseId: "lease-a",
+        entryType: "charge",
+        category: "late-a-only",
+        amountCents: 100,
+        effectiveDate: "2026-08-01",
+        signedAmountCents: 100,
+        balanceCents: 100,
+      }],
+    });
+
+    await waitFor(() => expect(screen.queryByText(/late-a-only/i)).not.toBeInTheDocument());
+    expect(screen.getByText(/No current lease is linked/i)).toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/components/tenants/TenantDetailPanel.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantDetailPanel.tsx
@@ -170,7 +170,8 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityR
   const ledgerEnabled = features?.ledger !== false;
 
   const tenant = bundle.tenant || bundle;
-  const lease = bundle.currentLease || bundle.lease;
+  const lease = bundle.currentLease || null;
+  const currentLeaseId = typeof bundle.currentLease?.id === "string" ? bundle.currentLease.id.trim() : "";
   const lifecycle = bundle.lifecycle || tenant.lifecycle || null;
   const stateCoherence = bundle.stateCoherence || null;
   const canonicalState = bundle.canonicalState || null;
@@ -194,6 +195,7 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityR
   const [financialActivityLoading, setFinancialActivityLoading] = useState(false);
   const [financialActivityError, setFinancialActivityError] = useState<string | null>(null);
   const cancelledRef = useRef(false);
+  const ledgerRequestGenerationRef = useRef(0);
 
   const [signals, setSignals] = useState<TenantSignals | null>(null);
   const [signalsError, setSignalsError] = useState<string | null>(null);
@@ -232,9 +234,8 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityR
   const hasMoveInReadiness = entitlements.hasMoveInReadiness;
 
   const handleViewInLedger = () => {
-    const leaseId = String(lease?.id || tenant?.currentLeaseId || tenant?.leaseId || "").trim();
-    if (leaseId) {
-      navigate(`/leases/${encodeURIComponent(leaseId)}/ledger`);
+    if (currentLeaseId) {
+      navigate(`/leases/${encodeURIComponent(currentLeaseId)}/ledger`);
       return;
     }
     showToast({
@@ -245,47 +246,55 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityR
   };
 
   const loadLedger = React.useCallback(async () => {
-    const currentLeaseId = String(lease?.id || tenant?.currentLeaseId || tenant?.leaseId || "").trim();
+    const requestGeneration = ++ledgerRequestGenerationRef.current;
+    const isCurrentRequest = () => ledgerRequestGenerationRef.current === requestGeneration;
     if (!tenantId) {
       setLedgerItems([]);
       setLeaseLedgerItems([]);
+      setLedgerLoading(false);
+      setLedgerError(null);
       return;
     }
     if (!ledgerEnabled) {
       setLedgerItems([]);
       setLeaseLedgerItems([]);
+      setLedgerLoading(false);
+      setLedgerError(null);
       return;
+    }
+    setLedgerMode(currentLeaseId ? "lease" : "tenant");
+    if (currentLeaseId) {
+      setLedgerItems([]);
+    } else {
+      setLeaseLedgerItems([]);
     }
     setLedgerLoading(true);
     setLedgerError(null);
     try {
       if (currentLeaseId) {
         const ledger = await fetchLeaseLedger(currentLeaseId);
-        if (!cancelledRef.current) {
-          setLedgerMode("lease");
+        if (isCurrentRequest()) {
           setLeaseLedgerItems(Array.isArray(ledger.entries) ? ledger.entries : []);
           setLedgerItems([]);
         }
       } else {
         const items = await fetchLedger({ tenantId, limit: 50 });
-        if (!cancelledRef.current) {
-          setLedgerMode("tenant");
+        if (isCurrentRequest()) {
           setLedgerItems(items || []);
           setLeaseLedgerItems([]);
         }
       }
     } catch (err: any) {
-      if (!cancelledRef.current) setLedgerError(err?.message || "Failed to load ledger");
+      if (isCurrentRequest()) setLedgerError(err?.message || "Lease payment history is temporarily unavailable.");
     } finally {
-      if (!cancelledRef.current) setLedgerLoading(false);
+      if (isCurrentRequest()) setLedgerLoading(false);
     }
-  }, [lease?.id, ledgerEnabled, tenant?.currentLeaseId, tenant?.leaseId, tenantId]);
+  }, [currentLeaseId, ledgerEnabled, tenantId]);
 
   useEffect(() => {
-    cancelledRef.current = false;
     void loadLedger();
     return () => {
-      cancelledRef.current = true;
+      ledgerRequestGenerationRef.current += 1;
     };
   }, [loadLedger]);
 
@@ -929,7 +938,7 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityR
                 Showing the latest {RECENT_LEASE_LEDGER_ENTRY_LIMIT} entries here. Open payment ledger for the full history.
               </span>
             ) : null}
-            {ledgerMode === "tenant" ? (
+            {!currentLeaseId ? (
               <span style={{ color: text.muted, fontSize: "0.75rem", fontWeight: 400 }}>
                 No current lease is linked, so this view is showing the existing tenant-level ledger source.
               </span>
@@ -952,7 +961,7 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityR
             >
               Record tenant activity
             </button>
-            {ledgerMode === "tenant" ? <VerifyLedgerButton onVerified={() => void loadLedger()} /> : null}
+            {!currentLeaseId ? <VerifyLedgerButton onVerified={() => void loadLedger()} /> : null}
           </div>
         </div>
         {ledgerLoading ? (


### PR DESCRIPTION
## Summary

- make `detailBundle.currentLease` the sole current-lease authority inside Tenant Detail payment rendering
- separate lease-linkage copy from ledger loading/error state
- prevent stale ledger requests from a prior tenant selection from mutating the current tenant
- preserve true null/null tenant-level ledger behavior

## Causality and scope

This defect exists on base `f98694855c3dcdcce362b0474ad9a3e29ac5923c`; PR #1570 did not introduce it. It blocks final PR #1570 runtime certification and is therefore delivered as a separate prerequisite correction.

Current lease authority remains `detailBundle.currentLease`. Ledger loading or failure no longer changes lease-linkage truth. This PR contains no backend lifecycle changes and no PR J Archive implementation.

## Validation

- `npx vitest run src/components/tenants/TenantDetailPanel.test.tsx src/pages/TenantsPage.test.tsx` — 25 passed
- `npx tsc --noEmit` — passed
- `npm run build` with Node 24.19.0 — passed
- `git diff --check` — passed
- new pending-ledger regression fails on the pinned base and passes on this correction