### PR TITLE
Fix End Lease tenant relationship status

### DIFF
--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -2423,7 +2423,7 @@ describe("leaseRoutes GET /active", () => {
       leaseId: "lease-1",
       currentLeaseId: "lease-1",
     });
-    seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", status: "current", currentLeaseId: "lease-1" });
+    seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", status: "current", relationshipStatus: "current", currentLeaseId: "lease-1" });
     seedDoc("tenancies", "tenancy-1", { landlordId: "landlord-1", propertyId: "prop-1", unitId: "unit-1", tenantId: "tenant-1", leaseId: "lease-1", status: "active" });
 
     const router = (await import("../leaseRoutes")).default;
@@ -2448,7 +2448,7 @@ describe("leaseRoutes GET /active", () => {
       })
     );
     expect((await fakeDb.collection("leases").doc("lease-1").get()).data()).toMatchObject({ status: "ended", occupancyEffective: false });
-    expect((await fakeDb.collection("tenants").doc("tenant-1").get()).data()).toMatchObject({ status: "Past", currentLeaseId: null });
+    expect((await fakeDb.collection("tenants").doc("tenant-1").get()).data()).toMatchObject({ status: "Past", relationshipStatus: "past", currentLeaseId: null });
     expect((await fakeDb.collection("tenancies").doc("tenancy-1").get()).data()).toMatchObject({ status: "inactive" });
     expect(listDocs("canonicalEvents")).toHaveLength(1);
     expect(listDocs("canonicalEvents")[0].data).toMatchObject({
@@ -2483,8 +2483,8 @@ describe("leaseRoutes GET /active", () => {
   it("ends every participating tenancy and clears every matching tenant pointer for a multi-party lease", async () => {
     seedDoc("properties", "prop-multi-party", { landlordId: "landlord-1", units: [{ id: "unit-multi-party", unitNumber: "501", status: "occupied", tenantId: "tenant-b", currentTenantId: "tenant-b", currentLeaseId: "lease-multi-party" }] });
     seedDoc("units", "unit-multi-party", { landlordId: "landlord-1", propertyId: "prop-multi-party", unitNumber: "501", status: "occupied", occupancyStatus: "occupied", tenantId: "tenant-b", currentTenantId: "tenant-b", leaseId: "lease-multi-party", currentLeaseId: "lease-multi-party" });
-    seedDoc("tenants", "tenant-a", { landlordId: "landlord-1", status: "current", currentLeaseId: "lease-multi-party" });
-    seedDoc("tenants", "tenant-b", { landlordId: "landlord-1", status: "current", currentLeaseId: "lease-multi-party" });
+    seedDoc("tenants", "tenant-a", { landlordId: "landlord-1", status: "current", relationshipStatus: "current", currentLeaseId: "lease-multi-party" });
+    seedDoc("tenants", "tenant-b", { landlordId: "landlord-1", status: "current", relationshipStatus: "current", currentLeaseId: "lease-multi-party" });
     seedDoc("leases", "lease-multi-party", { landlordId: "landlord-1", propertyId: "prop-multi-party", unitId: "unit-multi-party", unitNumber: "501", tenantId: "tenant-a", primaryTenantId: "tenant-a", tenantIds: ["tenant-a", "tenant-b", "tenant-a", ""], status: "active" });
     seedDoc("tenancies", "tenancy-a", { landlordId: "landlord-1", propertyId: "prop-multi-party", unitId: "unit-multi-party", tenantId: "tenant-a", leaseId: "lease-multi-party", status: "active" });
     seedDoc("tenancies", "tenancy-b", { landlordId: "landlord-1", propertyId: "prop-multi-party", unitId: "unit-multi-party", tenantId: "tenant-b", leaseId: "lease-multi-party", status: "active" });
@@ -2497,8 +2497,8 @@ describe("leaseRoutes GET /active", () => {
     expect((await fakeDb.collection("leases").doc("lease-multi-party").get()).data()).toMatchObject({ status: "ended", occupancyEffective: false });
     expect((await fakeDb.collection("units").doc("unit-multi-party").get()).data()).toMatchObject({ status: "vacant", currentLeaseId: null });
     expect((await fakeDb.collection("properties").doc("prop-multi-party").get()).data()?.units[0]).toMatchObject({ status: "vacant", currentLeaseId: null });
-    expect((await fakeDb.collection("tenants").doc("tenant-a").get()).data()).toMatchObject({ status: "Past", currentLeaseId: null });
-    expect((await fakeDb.collection("tenants").doc("tenant-b").get()).data()).toMatchObject({ status: "Past", currentLeaseId: null });
+    expect((await fakeDb.collection("tenants").doc("tenant-a").get()).data()).toMatchObject({ status: "Past", relationshipStatus: "past", currentLeaseId: null });
+    expect((await fakeDb.collection("tenants").doc("tenant-b").get()).data()).toMatchObject({ status: "Past", relationshipStatus: "past", currentLeaseId: null });
     expect((await fakeDb.collection("tenancies").doc("tenancy-a").get()).data()).toMatchObject({ status: "inactive" });
     expect((await fakeDb.collection("tenancies").doc("tenancy-b").get()).data()).toMatchObject({ status: "inactive" });
     expect((await fakeDb.collection("tenancies").doc("unrelated-tenancy").get()).data()).toMatchObject({ status: "active" });
@@ -2513,12 +2513,32 @@ describe("leaseRoutes GET /active", () => {
     expect((await fakeDb.collection("tenancies").doc("unrelated-tenancy").get()).data()).toMatchObject({ status: "active" });
   });
 
+  it("derives End Lease relationship status independently for each participant", async () => {
+    seedDoc("properties", "prop-mixed-participants", { landlordId: "landlord-1", units: [{ id: "unit-mixed-participants", unitNumber: "511", status: "occupied", tenantId: "tenant-b", currentTenantId: "tenant-b", currentLeaseId: "lease-mixed-participants" }] });
+    seedDoc("units", "unit-mixed-participants", { landlordId: "landlord-1", propertyId: "prop-mixed-participants", unitNumber: "511", status: "occupied", occupancyStatus: "occupied", tenantId: "tenant-b", currentTenantId: "tenant-b", leaseId: "lease-mixed-participants", currentLeaseId: "lease-mixed-participants" });
+    seedDoc("tenants", "tenant-a", { landlordId: "landlord-1", status: "current", relationshipStatus: "current", currentLeaseId: "lease-mixed-participants" });
+    seedDoc("tenants", "tenant-b", { landlordId: "landlord-1", status: "current", relationshipStatus: "current", currentLeaseId: "lease-mixed-participants" });
+    seedDoc("leases", "lease-mixed-participants", { landlordId: "landlord-1", propertyId: "prop-mixed-participants", unitId: "unit-mixed-participants", unitNumber: "511", tenantId: "tenant-a", primaryTenantId: "tenant-a", tenantIds: ["tenant-a", "tenant-b"], status: "active" });
+    seedDoc("leases", "lease-tenant-b-current", { landlordId: "landlord-1", propertyId: "prop-tenant-b-current", unitId: "unit-tenant-b-current", unitNumber: "512", tenantId: "tenant-b", tenantIds: ["tenant-b"], status: "active", executionStatus: "fully_executed", startDate: "2026-02-01", endDate: "2027-02-01", occupancyEffective: true });
+    seedDoc("tenancies", "tenancy-mixed-a", { landlordId: "landlord-1", propertyId: "prop-mixed-participants", unitId: "unit-mixed-participants", tenantId: "tenant-a", leaseId: "lease-mixed-participants", status: "active" });
+    seedDoc("tenancies", "tenancy-mixed-b", { landlordId: "landlord-1", propertyId: "prop-mixed-participants", unitId: "unit-mixed-participants", tenantId: "tenant-b", leaseId: "lease-mixed-participants", status: "active" });
+    const router = (await import("../leaseRoutes")).default;
+
+    const res = await invokeRouter(router, { method: "POST", url: "/lease-mixed-participants/end", body: { endDate: "2026-08-23T12:00:00.000Z" } });
+
+    expect(res.status).toBe(200);
+    expect((await fakeDb.collection("tenants").doc("tenant-a").get()).data()).toMatchObject({ status: "Past", relationshipStatus: "past", currentLeaseId: null });
+    expect((await fakeDb.collection("tenants").doc("tenant-b").get()).data()).toMatchObject({ status: "current", relationshipStatus: "current", currentLeaseId: "lease-tenant-b-current" });
+    expect((await fakeDb.collection("tenancies").doc("tenancy-mixed-a").get()).data()).toMatchObject({ status: "inactive" });
+    expect((await fakeDb.collection("tenancies").doc("tenancy-mixed-b").get()).data()).toMatchObject({ status: "inactive" });
+  });
+
   it("preserves another canonical current lease when ending one participant lease", async () => {
     seedDoc("properties", "prop-ending", { landlordId: "landlord-1", units: [{ id: "unit-ending", unitNumber: "601", status: "occupied", currentTenantId: "tenant-shared", currentLeaseId: "lease-ending" }] });
     seedDoc("properties", "prop-current", { landlordId: "landlord-1", units: [{ id: "unit-current", unitNumber: "602", status: "occupied", currentTenantId: "tenant-shared", currentLeaseId: "lease-current" }] });
     seedDoc("units", "unit-ending", { landlordId: "landlord-1", propertyId: "prop-ending", unitNumber: "601", status: "occupied", occupancyStatus: "occupied", tenantId: "tenant-shared", currentTenantId: "tenant-shared", leaseId: "lease-ending", currentLeaseId: "lease-ending" });
     seedDoc("units", "unit-current", { landlordId: "landlord-1", propertyId: "prop-current", unitNumber: "602", status: "occupied", occupancyStatus: "occupied", tenantId: "tenant-shared", currentTenantId: "tenant-shared", leaseId: "lease-current", currentLeaseId: "lease-current" });
-    seedDoc("tenants", "tenant-shared", { landlordId: "landlord-1", status: "current", currentLeaseId: "lease-ending" });
+    seedDoc("tenants", "tenant-shared", { landlordId: "landlord-1", status: "current", relationshipStatus: "current", currentLeaseId: "lease-ending" });
     seedDoc("leases", "lease-ending", { landlordId: "landlord-1", propertyId: "prop-ending", unitId: "unit-ending", unitNumber: "601", tenantId: "tenant-shared", tenantIds: ["tenant-shared"], status: "active", executionStatus: "fully_executed", startDate: "2026-01-01", endDate: "2027-01-01", occupancyEffective: true });
     seedDoc("leases", "lease-current", { landlordId: "landlord-1", propertyId: "prop-current", unitId: "unit-current", unitNumber: "602", tenantId: "tenant-shared", tenantIds: ["tenant-shared"], status: "active", executionStatus: "fully_executed", startDate: "2026-02-01", endDate: "2027-02-01", occupancyEffective: true });
     seedDoc("tenancies", "tenancy-ending", { landlordId: "landlord-1", propertyId: "prop-ending", unitId: "unit-ending", tenantId: "tenant-shared", leaseId: "lease-ending", status: "active" });
@@ -2529,7 +2549,7 @@ describe("leaseRoutes GET /active", () => {
 
     expect(res.status).toBe(200);
     expect((await fakeDb.collection("leases").doc("lease-ending").get()).data()).toMatchObject({ status: "ended", occupancyEffective: false });
-    expect((await fakeDb.collection("tenants").doc("tenant-shared").get()).data()).toMatchObject({ status: "current", currentLeaseId: "lease-current" });
+    expect((await fakeDb.collection("tenants").doc("tenant-shared").get()).data()).toMatchObject({ status: "current", relationshipStatus: "current", currentLeaseId: "lease-current" });
     expect((await fakeDb.collection("tenancies").doc("tenancy-ending").get()).data()).toMatchObject({ status: "inactive" });
     expect((await fakeDb.collection("tenancies").doc("tenancy-current").get()).data()).toMatchObject({ status: "active" });
   });
@@ -2546,7 +2566,7 @@ describe("leaseRoutes GET /active", () => {
       units: [{ id: unitId, unitId, unitNumber: "701", status: "occupied", occupancyStatus: "occupied", tenantId, currentTenantId: tenantId, leaseId, currentLeaseId: leaseId }],
     });
     seedDoc("units", unitId, { landlordId: "landlord-1", propertyId, unitNumber: "701", status: "occupied", occupancyStatus: "occupied", tenantId, currentTenantId: tenantId, leaseId, currentLeaseId: leaseId });
-    seedDoc("tenants", tenantId, { landlordId: "landlord-1", fullName: "Ended Tenant", status: "current", propertyId, unitId, currentLeaseId: leaseId });
+    seedDoc("tenants", tenantId, { landlordId: "landlord-1", fullName: "Ended Tenant", status: "current", relationshipStatus: "current", propertyId, unitId, currentLeaseId: leaseId });
     seedDoc("leases", leaseId, { landlordId: "landlord-1", propertyId, unitId, unitNumber: "701", tenantId, primaryTenantId: tenantId, tenantIds: [tenantId], status: "active", executionStatus: "fully_executed", startDate: "2026-01-01", endDate: "2027-01-01", occupancyEffective: true });
     seedDoc("tenancies", "tenancy-end-cross-surface", { landlordId: "landlord-1", propertyId, unitId, tenantId, leaseId, status: "active" });
 
@@ -2573,6 +2593,7 @@ describe("leaseRoutes GET /active", () => {
     expect(detail.body.tenant).toMatchObject({ status: "Past", currentLeaseId: null });
     expect(detail.body.canonicalState).toMatchObject({ occupancyState: "vacant", tenantRelationshipState: "past_tenant", supportingLeaseId: null });
     expect(detail.body.lease).toBeNull();
+    expect((await fakeDb.collection("tenants").doc(tenantId).get()).data()).toMatchObject({ relationshipStatus: "past" });
 
     const review = await invokeRouter(occupancyReviewRouter, { method: "GET", url: "/" });
     expect(review.body.items.filter((item: any) => item.propertyId === propertyId || item.unitId === unitId || item.tenantId === tenantId)).toEqual([]);

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -601,6 +601,7 @@ async function endFirestoreLeaseAtomically(
             {
               currentLeaseId: supportingLeaseId,
               status: supportingLeaseId ? "current" : "Past",
+              relationshipStatus: supportingLeaseId ? "current" : "past",
               updatedAt: nowIso,
             },
             { merge: true }


### PR DESCRIPTION
## Summary

- add `relationshipStatus` to the existing atomic End Lease participant-tenant patch
- derive it from the same post-End canonical alternate-current result as `status` and `currentLeaseId`
- preserve sole-current, alternate-current, multi-participant, null/null detail, occupancy, tenancy, unit, and audit behavior

## Causality and scope

The defect existed on the pre-PR #1570 base and PR #1570 did not introduce it. PR #1571 also did not introduce it; that merged prerequisite changed frontend Tenant Detail payment provenance only. This defect blocks final PR #1570 certification.

End Lease already updates canonical occupancy correctly. This correction only adds `relationshipStatus` to the existing atomic participant patch and reuses the existing alternate-current canonical decision. It contains no Archive implementation, no default tenant filtering, and no PR J product work.

## Validation

- focused backend lifecycle and projection suites — 231 passed
- `npm run build` with Node 24.19.0 — passed
- `git diff --check` — passed
- decisive sole-current regression fails on pre-fix main with persisted `relationshipStatus=current` and passes with this correction