### PR TITLE
PR J: add tenant lifecycle archive workspace

### DIFF
--- a/docs/strategy/tenant-lifecycle-archive-backlog-pr-j.md
+++ b/docs/strategy/tenant-lifecycle-archive-backlog-pr-j.md
@@ -5,3 +5,13 @@ Status: backlog after PR I. This document records design inputs only and does no
 The default tenant workspace should distinguish current, upcoming, past/inactive, and archived relationships. Ended leases must not present a tenant as current or visually resemble a current connected lease. Ending the sole current relationship should make the tenant past/inactive, without automatically archiving the tenant. Archive is a separate, reversible landlord action that requires no current lease and no unresolved occupancy conflict. Past is not archived, and neither transition deletes lease, payment, note, document, application, or audit history.
 
 Future design must cover active/upcoming/past/archived filters, explicit ended-lease and actual-end-date presentation, Archive and Restore actions, and cross-surface lifecycle coherence. `CURRENT_LEASE_CONTEXT_MISMATCH` and legacy `TENANT_CURRENT_WITHOUT_CURRENT_LEASE` remediation remain separate later workstreams.
+
+## PR J implemented contract
+
+PR J implements a server-projected tenant workspace category of Current, Upcoming, Past, or Archived. Current, Upcoming, and Past reuse the canonical lease-term and occupancy projection; Archived is a durable `archivedAt` administrative overlay and is not an occupancy or relationship status. The landlord workspace consumes this projection for its Active, Current, Upcoming, Past, and Archived filters, so the frontend does not infer lifecycle from dates or stale pointers.
+
+Archive and Restore are explicit landlord commands. Each command revalidates tenant ownership and authoritative lease/unit context inside one Firestore transaction, writes the tenant overlay and its append-only canonical lifecycle event atomically, and preserves all historical business records. Archive is rejected for a canonical current relationship, a valid upcoming relationship, or unresolved occupancy conflict. Upcoming blocks Archive because it is an operational future relationship that must remain visible in the active workspace. Restore removes only the archive overlay and lets the canonical projection return the tenant to Current, Upcoming, or Past; it never forces Current.
+
+Tenant detail presents the workspace lifecycle and uses only persisted `endedAt`, `terminatedAt`, or `terminationDate` as the actual end date. A scheduled lease end is never relabelled as the actual end. End Lease continues to produce Past rather than Archived, and signing completion remains execution-only.
+
+The separate `CURRENT_LEASE_CONTEXT_MISMATCH` and legacy `TENANT_CURRENT_WITHOUT_CURRENT_LEASE` remediation workstreams remain unimplemented. PR J does not change the canonical occupancy reason set or introduce a second current-lease or occupancy evaluator.

--- a/rentchain-api/src/lib/tenants/__tests__/deriveTenantWorkspaceLifecycle.test.ts
+++ b/rentchain-api/src/lib/tenants/__tests__/deriveTenantWorkspaceLifecycle.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { buildCanonicalLeaseOccupancyProjection } from "../../leases/canonicalLeaseOccupancyProjection";
+import { deriveTenantWorkspaceLifecycle } from "../deriveTenantWorkspaceLifecycle";
+
+const context = { landlordId: "landlord-1", tenantId: "tenant-1", asOfDate: "2026-08-26" };
+
+function project(leases: any[], persisted: any = {}) {
+  const canonicalState = buildCanonicalLeaseOccupancyProjection({
+    leases,
+    context,
+    tenantId: "tenant-1",
+    ...persisted,
+  });
+  return deriveTenantWorkspaceLifecycle({ canonicalState, leases, asOfDate: context.asOfDate, archivedAt: persisted.archivedAt });
+}
+
+describe("deriveTenantWorkspaceLifecycle", () => {
+  it("classifies explicit current occupancy as Current", () => {
+    const result = project([
+      { id: "lease-current", landlordId: "landlord-1", tenantId: "tenant-1", status: "active", executionStatus: "fully_executed", startDate: "2026-01-01", endDate: "2026-12-31" },
+    ], { persistedUnitOccupancy: "occupied", currentLeasePointerId: "lease-current", persistedTenantStatus: "current" });
+    expect(result).toMatchObject({ category: "current", hasCanonicalCurrentLease: true, archiveEligibility: { allowed: false, reason: "current_relationship" } });
+  });
+
+  it("gives Upcoming precedence over past history without creating current occupancy", () => {
+    const result = project([
+      { id: "lease-past", landlordId: "landlord-1", tenantId: "tenant-1", status: "ended", endedAt: "2026-06-01T00:00:00.000Z" },
+      { id: "lease-upcoming", landlordId: "landlord-1", tenantId: "tenant-1", status: "signed", executionStatus: "fully_executed", startDate: "2026-10-01", endDate: "2027-09-30" },
+    ], { persistedUnitOccupancy: "vacant", persistedTenantStatus: "past" });
+    expect(result).toMatchObject({ category: "upcoming", hasCanonicalCurrentLease: false, hasUpcomingLease: true, archiveEligibility: { allowed: false, reason: "upcoming_relationship" } });
+    expect(result.actualEndDate).toBe("2026-06-01T00:00:00.000Z");
+  });
+
+  it("keeps ended tenants Past and archive-eligible without an unresolved conflict", () => {
+    const result = project([
+      { id: "lease-ended", landlordId: "landlord-1", tenantId: "tenant-1", status: "ended", endedAt: "2026-08-20T12:00:00.000Z", endDate: "2026-12-31" },
+    ], { persistedUnitOccupancy: "vacant", persistedTenantStatus: "past" });
+    expect(result).toMatchObject({ category: "past", actualEndDate: "2026-08-20T12:00:00.000Z", archiveEligibility: { allowed: true, reason: null } });
+  });
+
+  it("uses the archive overlay without changing canonical relationship facts", () => {
+    const result = project([], { archivedAt: "2026-08-25T00:00:00.000Z", persistedUnitOccupancy: "vacant", persistedTenantStatus: "past" });
+    expect(result).toMatchObject({ category: "archived", isArchived: true, hasCanonicalCurrentLease: false, archiveEligibility: { allowed: false, reason: "already_archived" } });
+  });
+
+  it("rejects archive for unresolved canonical occupancy conflicts", () => {
+    const leases = [
+      { id: "lease-a", landlordId: "landlord-1", tenantId: "tenant-1", status: "active", executionStatus: "fully_executed", startDate: "2026-01-01", endDate: "2026-12-31" },
+      { id: "lease-b", landlordId: "landlord-1", tenantId: "tenant-1", status: "active", executionStatus: "fully_executed", startDate: "2026-02-01", endDate: "2027-01-31" },
+    ];
+    const result = project(leases, { persistedUnitOccupancy: "occupied", persistedTenantStatus: "current" });
+    expect(result).toMatchObject({ hasUnresolvedOccupancyConflict: true, archiveEligibility: { allowed: false, reason: "occupancy_conflict" } });
+  });
+});

--- a/rentchain-api/src/lib/tenants/__tests__/deriveTenantWorkspaceLifecycle.test.ts
+++ b/rentchain-api/src/lib/tenants/__tests__/deriveTenantWorkspaceLifecycle.test.ts
@@ -43,6 +43,20 @@ describe("deriveTenantWorkspaceLifecycle", () => {
     expect(result).toMatchObject({ category: "archived", isArchived: true, hasCanonicalCurrentLease: false, archiveEligibility: { allowed: false, reason: "already_archived" } });
   });
 
+  it("keeps canonical Current visible when an archive overlay is also present", () => {
+    const result = project([
+      { id: "lease-current", landlordId: "landlord-1", tenantId: "tenant-1", status: "active", executionStatus: "fully_executed", startDate: "2026-01-01", endDate: "2026-12-31" },
+    ], { archivedAt: "2026-08-25T00:00:00.000Z", persistedUnitOccupancy: "occupied", currentLeasePointerId: "lease-current", persistedTenantStatus: "current" });
+    expect(result).toMatchObject({ category: "current", isArchived: true, hasCanonicalCurrentLease: true, archiveEligibility: { allowed: false, reason: "already_archived" } });
+  });
+
+  it("keeps canonical Upcoming visible when an archive overlay is also present", () => {
+    const result = project([
+      { id: "lease-upcoming", landlordId: "landlord-1", tenantId: "tenant-1", status: "signed", executionStatus: "fully_executed", startDate: "2026-10-01", endDate: "2027-09-30" },
+    ], { archivedAt: "2026-08-25T00:00:00.000Z", persistedUnitOccupancy: "vacant", persistedTenantStatus: "past" });
+    expect(result).toMatchObject({ category: "upcoming", isArchived: true, hasCanonicalCurrentLease: false, hasUpcomingLease: true, archiveEligibility: { allowed: false, reason: "already_archived" } });
+  });
+
   it("rejects archive for unresolved canonical occupancy conflicts", () => {
     const leases = [
       { id: "lease-a", landlordId: "landlord-1", tenantId: "tenant-1", status: "active", executionStatus: "fully_executed", startDate: "2026-01-01", endDate: "2026-12-31" },

--- a/rentchain-api/src/lib/tenants/deriveTenantWorkspaceLifecycle.ts
+++ b/rentchain-api/src/lib/tenants/deriveTenantWorkspaceLifecycle.ts
@@ -66,12 +66,12 @@ export function deriveTenantWorkspaceLifecycle(input: {
     input.canonicalState.occupancyState === "review_needed" ||
     input.canonicalState.reasons.some((reason) => UNRESOLVED_OCCUPANCY_REASONS.has(reason));
 
-  const category: TenantWorkspaceCategory = archivedAt
-    ? "archived"
-    : hasCanonicalCurrentLease
-      ? "current"
-      : hasUpcomingLease
-        ? "upcoming"
+  const category: TenantWorkspaceCategory = hasCanonicalCurrentLease
+    ? "current"
+    : hasUpcomingLease
+      ? "upcoming"
+      : archivedAt
+        ? "archived"
         : "past";
   const label = `${category.charAt(0).toUpperCase()}${category.slice(1)}` as TenantWorkspaceLifecycle["label"];
 

--- a/rentchain-api/src/lib/tenants/deriveTenantWorkspaceLifecycle.ts
+++ b/rentchain-api/src/lib/tenants/deriveTenantWorkspaceLifecycle.ts
@@ -1,0 +1,99 @@
+import {
+  deriveCanonicalLeaseTermState,
+  type CanonicalLeaseConflictReason,
+  type CanonicalLeaseStateInput,
+} from "../leases/canonicalLeaseOccupancyState";
+import type { CanonicalLeaseOccupancyProjection } from "../leases/canonicalLeaseOccupancyProjection";
+
+export type TenantWorkspaceCategory = "current" | "upcoming" | "past" | "archived";
+export type TenantArchiveEligibilityReason =
+  | "already_archived"
+  | "current_relationship"
+  | "upcoming_relationship"
+  | "occupancy_conflict"
+  | null;
+
+export interface TenantWorkspaceLifecycle {
+  category: TenantWorkspaceCategory;
+  label: "Current" | "Upcoming" | "Past" | "Archived";
+  isArchived: boolean;
+  archivedAt: string | null;
+  actualEndDate: string | null;
+  hasCanonicalCurrentLease: boolean;
+  hasUpcomingLease: boolean;
+  hasUnresolvedOccupancyConflict: boolean;
+  archiveEligibility: {
+    allowed: boolean;
+    reason: TenantArchiveEligibilityReason;
+  };
+}
+const UNRESOLVED_OCCUPANCY_REASONS = new Set<CanonicalLeaseConflictReason>([
+  "MULTIPLE_CURRENT_LEASES",
+  "INVALID_LEASE_DATE_RANGE",
+  "CURRENT_LEASE_CONTEXT_MISMATCH",
+  "OCCUPIED_WITHOUT_CURRENT_LEASE",
+  "VACANT_WITH_CURRENT_LEASE",
+  "STALE_CURRENT_LEASE_POINTER",
+  "TENANT_CURRENT_WITHOUT_CURRENT_LEASE",
+]);
+
+function isoDate(value: unknown): string | null {
+  if (!value) return null;
+  const parsed = typeof (value as any)?.toDate === "function"
+    ? (value as any).toDate()
+    : new Date(typeof (value as any)?.toMillis === "function" ? (value as any).toMillis() : String(value));
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+}
+
+function actualEndDate(leases: CanonicalLeaseStateInput[]): string | null {
+  return leases
+    .map((lease) => isoDate(lease.endedAt ?? lease.terminatedAt ?? lease.terminationDate))
+    .filter((value): value is string => Boolean(value))
+    .sort((left, right) => right.localeCompare(left))[0] || null;
+}
+
+export function deriveTenantWorkspaceLifecycle(input: {
+  canonicalState: CanonicalLeaseOccupancyProjection;
+  leases: CanonicalLeaseStateInput[];
+  archivedAt?: unknown;
+  asOfDate?: unknown;
+}): TenantWorkspaceLifecycle {
+  const archivedAt = isoDate(input.archivedAt);
+  const termStates = input.leases.map((lease) => deriveCanonicalLeaseTermState(lease, input.asOfDate));
+  const hasUpcomingLease = termStates.some((state) => state.state === "upcoming");
+  const hasCanonicalCurrentLease = input.canonicalState.tenantRelationshipState === "current_occupant";
+  const hasUnresolvedOccupancyConflict =
+    input.canonicalState.occupancyState === "review_needed" ||
+    input.canonicalState.reasons.some((reason) => UNRESOLVED_OCCUPANCY_REASONS.has(reason));
+
+  const category: TenantWorkspaceCategory = archivedAt
+    ? "archived"
+    : hasCanonicalCurrentLease
+      ? "current"
+      : hasUpcomingLease
+        ? "upcoming"
+        : "past";
+  const label = `${category.charAt(0).toUpperCase()}${category.slice(1)}` as TenantWorkspaceLifecycle["label"];
+
+  const reason: TenantArchiveEligibilityReason = archivedAt
+    ? "already_archived"
+    : hasCanonicalCurrentLease
+      ? "current_relationship"
+      : hasUnresolvedOccupancyConflict
+        ? "occupancy_conflict"
+        : hasUpcomingLease
+          ? "upcoming_relationship"
+          : null;
+
+  return {
+    category,
+    label,
+    isArchived: Boolean(archivedAt),
+    archivedAt,
+    actualEndDate: actualEndDate(input.leases),
+    hasCanonicalCurrentLease,
+    hasUpcomingLease,
+    hasUnresolvedOccupancyConflict,
+    archiveEligibility: { allowed: reason === null, reason },
+  };
+}

--- a/rentchain-api/src/routes/__tests__/leaseConflictResponses.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseConflictResponses.test.ts
@@ -167,14 +167,14 @@ describe("lease conflict responses", () => {
     });
   }
 
-  function seedExplicitStartContext(overrides: any = {}) {
+  function seedExplicitStartContext(overrides: any = {}, tenantOverrides: any = {}) {
     const now = new Date();
     const startDate = new Date(now.getTime() - 30 * 86_400_000).toISOString().slice(0, 10);
     const endDate = new Date(now.getTime() + 300 * 86_400_000).toISOString().slice(0, 10);
     const unit = { id: "unit-1", unitNumber: "A", status: "vacant", occupancyStatus: "vacant", updatedAt: "2026-08-01T00:00:00.000Z" };
     seedDoc("properties", "prop-1", { landlordId: "landlord-1", name: "Harbour House", units: [unit], updatedAt: unit.updatedAt });
     seedDoc("units", "unit-1", { landlordId: "landlord-1", propertyId: "prop-1", ...unit });
-    seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", name: "Taylor Tenant", status: "past", updatedAt: unit.updatedAt });
+    seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", name: "Taylor Tenant", status: "past", updatedAt: unit.updatedAt, ...tenantOverrides });
     seedLease("lease-start", { executionStatus: "fully_executed", startDate, endDate, occupancyEffective: false, ...overrides });
   }
 
@@ -201,6 +201,21 @@ describe("lease conflict responses", () => {
     expect(replay.body.result).toMatchObject({ outcome: "idempotent_replay" });
     expect(getSeededDoc("units", "unit-1")).toMatchObject({ status: "occupied", currentLeaseId: "lease-start", currentTenantId: "tenant-1" });
     expect(getSeededDoc("leases", "lease-start")).toMatchObject({ occupancyEffective: true });
+  });
+
+  it("hides the explicit Start action and rejects the command while the tenant is archived", async () => {
+    seedExplicitStartContext({}, { archivedAt: "2026-08-20T00:00:00.000Z" });
+    const app = await makeApp();
+    const context = (await request(app).get("/lease-start/occupancy-start-context")).body.context;
+    expect(context).toMatchObject({ eligible: false, availableAction: null, canonicalBlocker: "tenant_archived_restore_required" });
+
+    const response = await request(app).post("/lease-start/start-occupancy")
+      .set("Idempotency-Key", "explicit-archived")
+      .send({ expectedStateToken: context.expectedStateToken, evaluationInstant: context.evaluationInstant, possessionConfirmed: true });
+    expect(response).toMatchObject({ status: 409, body: { error: "tenant_archived_restore_required" } });
+    expect(getSeededDoc("tenants", "tenant-1")).toMatchObject({ archivedAt: "2026-08-20T00:00:00.000Z", status: "past" });
+    expect(getSeededDoc("leases", "lease-start")).toMatchObject({ occupancyEffective: false });
+    expect(getSeededDoc("units", "unit-1")).toMatchObject({ status: "vacant", occupancyStatus: "vacant" });
   });
 
   it.each([

--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -2560,6 +2560,8 @@ describe("leaseRoutes GET /active", () => {
   });
 
   it("projects one completed End Lease postcondition through all five product paths without Review Needed", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-23T12:00:00.000Z"));
     const propertyId = "prop-end-cross-surface";
     const unitId = "unit-end-cross-surface";
     const tenantId = "tenant-end-cross-surface";
@@ -2579,8 +2581,20 @@ describe("leaseRoutes GET /active", () => {
     const propertiesRouter = (await import("../propertiesRoutes")).default;
     const tenantsRouter = (await import("../tenantsRoutes")).default;
     const occupancyReviewRouter = (await import("../occupancyReviewRoutes")).default;
-    const ended = await invokeRouter(leaseRouter, { method: "POST", url: `/${leaseId}/end`, body: { endDate: "2026-08-23T12:00:00.000Z" } });
-    expect(ended.status).toBe(200);
+    try {
+      const ended = await invokeRouter(leaseRouter, { method: "POST", url: `/${leaseId}/end`, body: { endDate: "2099-01-01T00:00:00.000Z" } });
+      expect(ended.status).toBe(200);
+      expect((await fakeDb.collection("leases").doc(leaseId).get()).data()).toMatchObject({
+        status: "ended",
+        occupancyEffective: false,
+        startDate: "2026-01-01",
+        endDate: "2027-01-01",
+        endedAt: "2026-08-23T12:00:00.000Z",
+      });
+      expect((await fakeDb.collection("tenancies").doc("tenancy-end-cross-surface").get()).data()).toMatchObject({
+        status: "inactive",
+        moveOutAt: "2026-08-23T12:00:00.000Z",
+      });
 
     const properties = await invokeRouter(propertiesRouter, { method: "GET", url: "/" });
     const property = properties.body.items.find((entry: any) => entry.id === propertyId);
@@ -2595,14 +2609,31 @@ describe("leaseRoutes GET /active", () => {
     expect(tenant).toMatchObject({ status: "Past", currentLeaseId: null, canonicalState: expect.objectContaining({ occupancyState: "vacant", tenantRelationshipState: "past_tenant", supportingLeaseId: null }) });
 
     const detail = await invokeRouter(tenantsRouter, { method: "GET", url: `/${tenantId}` });
-    expect(detail.body.tenant).toMatchObject({ status: "Past", currentLeaseId: null });
-    expect(detail.body.canonicalState).toMatchObject({ occupancyState: "vacant", tenantRelationshipState: "past_tenant", supportingLeaseId: null });
-    expect(detail.body.lease).toBeNull();
+      expect(detail.body.tenant).toMatchObject({ status: "Past", currentLeaseId: null, leaseStart: "2026-01-01", leaseEnd: "2027-01-01" });
+      expect(detail.body.canonicalState).toMatchObject({ occupancyState: "vacant", tenantRelationshipState: "past_tenant", supportingLeaseId: null });
+      expect(detail.body.currentLease).toBeNull();
+      expect(detail.body.lease).toMatchObject({ id: leaseId, status: "ended", leaseStart: "2026-01-01", leaseEnd: "2027-01-01" });
+      expect(detail.body.workspaceLifecycle).toMatchObject({ category: "past", isArchived: false, actualEndDate: "2026-08-23T12:00:00.000Z" });
     expect((await fakeDb.collection("tenants").doc(tenantId).get()).data()).toMatchObject({ relationshipStatus: "past" });
 
     const review = await invokeRouter(occupancyReviewRouter, { method: "GET", url: "/" });
     expect(review.body.items.filter((item: any) => item.propertyId === propertyId || item.unitId === unitId || item.tenantId === tenantId)).toEqual([]);
-    expect(listDocs("canonicalEvents")).toHaveLength(1);
+      const events = listDocs("canonicalEvents");
+      expect(events).toHaveLength(1);
+      expect(events[0].data).toMatchObject({
+        occurredAt: "2026-08-23T12:00:00.000Z",
+        recordedAt: "2026-08-23T12:00:00.000Z",
+        metadata: { effectiveDate: "2026-08-23T12:00:00.000Z" },
+      });
+
+      vi.setSystemTime(new Date("2026-08-24T12:00:00.000Z"));
+      const replay = await invokeRouter(leaseRouter, { method: "POST", url: `/${leaseId}/end`, body: { endDate: "2099-02-01T00:00:00.000Z" } });
+      expect(replay.status).toBe(200);
+      expect((await fakeDb.collection("leases").doc(leaseId).get()).data()).toMatchObject({ endedAt: "2026-08-23T12:00:00.000Z", endDate: "2027-01-01" });
+      expect(listDocs("canonicalEvents")).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it.each([

--- a/rentchain-api/src/routes/__tests__/tenantsRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantsRoutes.test.ts
@@ -4,6 +4,7 @@ const setMock = vi.fn(async () => undefined);
 const getTenantDetailBundleMock = vi.fn();
 const getTenantsListMock = vi.fn();
 const deriveFinancialProjectionRowsMock = vi.fn();
+const mutateTenantArchiveStateMock = vi.fn();
 const leaseDocs = new Map<string, any>();
 const propertyDocs = new Map<string, any>();
 
@@ -81,6 +82,13 @@ vi.mock("../../services/capabilityGuard", () => ({
   requireCapability: vi.fn(async () => ({ ok: true })),
 }));
 
+vi.mock("../../services/tenantLifecycleArchiveService", () => ({
+  mutateTenantArchiveState: mutateTenantArchiveStateMock,
+  TenantArchiveCommandError: class TenantArchiveCommandError extends Error {
+    constructor(public code: string, public status: number) { super(code); }
+  },
+}));
+
 async function invokeRouter(router: any, options: {
   method: string;
   url: string;
@@ -125,6 +133,7 @@ describe("tenantsRoutes", () => {
     getTenantDetailBundleMock.mockReset();
     getTenantsListMock.mockReset();
     deriveFinancialProjectionRowsMock.mockReset();
+    mutateTenantArchiveStateMock.mockReset();
     leaseDocs.clear();
     propertyDocs.clear();
   });
@@ -180,6 +189,24 @@ describe("tenantsRoutes", () => {
       { merge: true }
     );
     expect(result.body?.tenant?.fullName).toBe("Taylor Tenant");
+  });
+
+  it.each(["archive", "restore"] as const)("runs the explicit %s command and returns refreshed server lifecycle", async (command) => {
+    mutateTenantArchiveStateMock.mockResolvedValue({ command });
+    getTenantDetailBundleMock.mockResolvedValue({
+      tenant: { id: "tenant-1", landlordId: "landlord-1" },
+      workspaceLifecycle: { category: command === "archive" ? "archived" : "past" },
+    });
+    const router = (await import("../tenantsRoutes")).default;
+    const result = await invokeRouter(router, { method: "POST", url: `/tenant-1/${command}` });
+    expect(result.status).toBe(200);
+    expect(mutateTenantArchiveStateMock).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId: "tenant-1",
+      landlordId: "landlord-1",
+      actorRole: "landlord",
+      command,
+    }));
+    expect(result.body.workspaceLifecycle.category).toBe(command === "archive" ? "archived" : "past");
   });
 
   it("returns landlord-safe lease labels for tenant lease history", async () => {

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -2937,6 +2937,7 @@ router.get("/renewals/:successorLeaseId/context", requireLandlord, async (req: a
 });
 
 function explicitStartBlocker(lease: any, context: any): string | null {
+  if (context?.tenantArchived === true) return "tenant_archived_restore_required";
   const renewalLinked = [lease?.predecessorLeaseId, lease?.renewedByLeaseId, lease?.renewalLeaseId, lease?.successorLeaseId, lease?.replacedByLeaseId]
     .some((value) => String(value || "").trim());
   if (renewalLinked) return "renewal_handoff_required";

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -431,7 +431,6 @@ async function resolvePropertyUnitForLease(lease: any, errorPrefix: string) {
 async function endFirestoreLeaseAtomically(
   leaseId: string,
   lease: any,
-  endDate: string,
   authority: { landlordId: string; actorId: string }
 ) {
   const propertyId = String(lease?.propertyId || "").trim();
@@ -532,13 +531,13 @@ async function endFirestoreLeaseAtomically(
     const postEndLandlordLeases = (landlordLeasesSnap?.docs || []).map((doc: any) => {
       const data = { id: doc.id, ...(doc.data() || {}) };
       return doc.id === leaseId
-        ? { ...data, status: "ended", occupancyEffective: false, endDate }
+        ? { ...data, status: "ended", occupancyEffective: false, endedAt: nowIso }
         : data;
     });
     const participantLeaseSelections = participantTenantIds.map((participantTenantId) => {
       const selection = selectCanonicalCurrentLease(
         postEndLandlordLeases.map(toCanonicalLeaseStateInput),
-        { landlordId: authority.landlordId, tenantId: participantTenantId, asOfDate: endDate }
+        { landlordId: authority.landlordId, tenantId: participantTenantId, asOfDate: nowIso }
       );
       if (!selection.lease && selection.reasons.includes("MULTIPLE_CURRENT_LEASES")) {
         throw new Error("lease_end_participant_occupancy_ambiguous");
@@ -576,7 +575,7 @@ async function endFirestoreLeaseAtomically(
         source: "lease_end_route",
         previousCanonicalOccupancyState: "occupied",
         resultingCanonicalOccupancyState: "vacant",
-        effectiveDate: endDate,
+        effectiveDate: nowIso,
         legalDetermination: false,
       },
       tags: ["lease_end", "occupancy_ended"],
@@ -590,7 +589,9 @@ async function endFirestoreLeaseAtomically(
       transaction.set(unitDocs[0].ref, { status: "vacant", occupancyStatus: "vacant", tenantId: null, currentTenantId: null, leaseId: null, currentLeaseId: null, occupancySource: "lease_end", occupancyUpdatedAt: nowIso, updatedAt: nowIso }, { merge: true });
     }
 
-    transaction.set(leaseRef, { status: "ended", occupancyEffective: false, endDate, updatedAt: nowIso }, { merge: true });
+    // `endDate` remains the scheduled contractual term end. `endedAt` is the
+    // canonical, server-authoritative actual End Lease timestamp.
+    transaction.set(leaseRef, { status: "ended", occupancyEffective: false, endedAt: nowIso, updatedAt: nowIso }, { merge: true });
     tenantSnaps.forEach((tenantSnap: any, index: number) => {
       if (tenantSnap?.exists) {
         const tenant = tenantSnap.data() || {};
@@ -610,7 +611,7 @@ async function endFirestoreLeaseAtomically(
       }
     });
     activeTenancies.forEach((tenancy: any) => {
-      transaction.set(tenancy.ref, { status: "inactive", moveOutAt: endDate, updatedAt: nowIso }, { merge: true });
+      transaction.set(tenancy.ref, { status: "inactive", moveOutAt: nowIso, updatedAt: nowIso }, { merge: true });
     });
   });
 }
@@ -3999,7 +4000,6 @@ router.put("/:id", requireLandlord, async (req: any, res: Response) => {
 router.post("/:id/end", requireLandlord, async (req: any, res: Response) => {
   try {
     if (!(await enforceLeaseCapability(req, res))) return;
-    const endDate: string = req.body?.endDate || new Date().toISOString();
     const landlordId = String(req.user?.landlordId || req.user?.id || "").trim();
     const leaseResult = await getLeaseEntityForLandlord(String(req.params?.id || "").trim(), landlordId);
     if (!leaseResult.ok) {
@@ -4010,7 +4010,6 @@ router.post("/:id/end", requireLandlord, async (req: any, res: Response) => {
         await endFirestoreLeaseAtomically(
           String(req.params?.id || "").trim(),
           leaseResult.lease as any,
-          endDate,
           {
             landlordId,
             actorId: String(req.user?.id || req.user?.email || landlordId).trim() || landlordId,
@@ -4032,7 +4031,7 @@ router.post("/:id/end", requireLandlord, async (req: any, res: Response) => {
       if (!refreshed.ok) return res.status(refreshed.status).json({ error: refreshed.error });
       return res.json({ lease: await enrichLeaseRow({ id: String(req.params?.id || "").trim(), ...(refreshed.lease as any) }) });
     }
-    const lease = leaseService.endLease(req.params.id, endDate);
+    const lease = leaseService.endLease(req.params.id);
     if (!lease) {
       return res.status(404).json({ error: "Lease not found" });
     }

--- a/rentchain-api/src/routes/tenantsRoutes.ts
+++ b/rentchain-api/src/routes/tenantsRoutes.ts
@@ -17,6 +17,10 @@ import {
 } from "../services/tenantMoveInReadinessService";
 import { requireCapability } from "../services/capabilityGuard";
 import { slugifyOperationalReference } from "../lib/identityReferences";
+import {
+  mutateTenantArchiveState,
+  TenantArchiveCommandError,
+} from "../services/tenantLifecycleArchiveService";
 
 const router = Router();
 
@@ -118,6 +122,33 @@ router.patch("/:tenantId", async (req: any, res) => {
     });
   }
 });
+
+async function handleArchiveCommand(req: any, res: any, command: "archive" | "restore") {
+  const tenantId = String(req.params?.tenantId || "").trim();
+  const role = String(req.user?.role || "").trim().toLowerCase();
+  try {
+    await mutateTenantArchiveState({
+      tenantId,
+      landlordId: getLandlordId(req),
+      actorUserId: String(req.user?.id || req.user?.email || "").trim() || null,
+      actorRole: role === "admin" ? "admin" : "landlord",
+      command,
+    });
+    const refreshed = await getTenantDetailBundle(tenantId, {
+      landlordId: getLandlordId(req) || undefined,
+    });
+    return res.status(200).json({ ok: true, tenant: refreshed.tenant, workspaceLifecycle: refreshed.workspaceLifecycle });
+  } catch (error) {
+    if (error instanceof TenantArchiveCommandError) {
+      return res.status(error.status).json({ ok: false, error: error.code });
+    }
+    console.error(`[POST /api/tenants/:tenantId/${command}] error`, error);
+    return res.status(500).json({ ok: false, error: `tenant_${command}_failed` });
+  }
+}
+
+router.post("/:tenantId/archive", async (req: any, res) => handleArchiveCommand(req, res, "archive"));
+router.post("/:tenantId/restore", async (req: any, res) => handleArchiveCommand(req, res, "restore"));
 
 /**
  * GET /api/tenants/:tenantId

--- a/rentchain-api/src/services/__tests__/tenantLifecycleArchiveService.test.ts
+++ b/rentchain-api/src/services/__tests__/tenantLifecycleArchiveService.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fakeDb, seed, read, list, reset } = vi.hoisted(() => {
+  const store = new Map<string, Map<string, any>>();
+  let sequence = 0;
+  const collection = (name: string) => {
+    if (!store.has(name)) store.set(name, new Map());
+    const values = store.get(name)!;
+    const doc = (id = `generated-${++sequence}`) => ({
+      id,
+      get: async () => ({ exists: values.has(id), id, data: () => values.get(id) }),
+      set: async (value: any, options?: any) => values.set(id, options?.merge ? { ...(values.get(id) || {}), ...value } : value),
+    });
+    const query = (filters: Array<[string, string, any]>) => ({
+      get: async () => ({
+        docs: Array.from(values.entries())
+          .filter(([, value]) => filters.every(([field, op, expected]) => op === "==" && value[field] === expected))
+          .map(([id, value]) => ({ id, data: () => value })),
+      }),
+    });
+    return { doc, where: (field: string, op: string, value: any) => query([[field, op, value]]) };
+  };
+  return {
+    fakeDb: {
+      collection,
+      runTransaction: async (handler: any) => handler({
+        get: (target: any) => target.get(),
+        set: (ref: any, value: any, options?: any) => ref.set(value, options),
+        create: (ref: any, value: any) => ref.set(value),
+      }),
+    },
+    seed: (name: string, id: string, value: any) => {
+      if (!store.has(name)) store.set(name, new Map());
+      store.get(name)!.set(id, value);
+    },
+    read: (name: string, id: string) => store.get(name)?.get(id),
+    list: (name: string) => Array.from(store.get(name)?.values() || []),
+    reset: () => { store.clear(); sequence = 0; },
+  };
+});
+
+vi.mock("../../firebase", () => ({
+  db: fakeDb,
+  FieldValue: { serverTimestamp: () => "SERVER_TIMESTAMP" },
+}));
+
+import { mutateTenantArchiveState, TenantArchiveCommandError } from "../tenantLifecycleArchiveService";
+
+describe("tenantLifecycleArchiveService", () => {
+  beforeEach(() => {
+    reset();
+  });
+
+  it("archives and restores a past tenant atomically while retaining history", async () => {
+    seed("tenants", "tenant-past", { landlordId: "landlord-1", status: "Past", relationshipStatus: "past", currentLeaseId: null });
+    seed("leases", "lease-ended", { landlordId: "landlord-1", tenantId: "tenant-past", status: "ended", endedAt: "2026-08-20T00:00:00.000Z" });
+    seed("payments", "payment-1", { tenantId: "tenant-past", amount: 100 });
+
+    await mutateTenantArchiveState({ tenantId: "tenant-past", landlordId: "landlord-1", actorUserId: "landlord-1", actorRole: "landlord", command: "archive" });
+    expect(read("tenants", "tenant-past").archivedAt).toEqual(expect.any(String));
+    expect(read("leases", "lease-ended").status).toBe("ended");
+    expect(read("payments", "payment-1").amount).toBe(100);
+    expect(list("canonicalEvents")).toEqual(expect.arrayContaining([expect.objectContaining({ action: "tenant_archived", appendOnly: true })]));
+
+    await mutateTenantArchiveState({ tenantId: "tenant-past", landlordId: "landlord-1", actorUserId: "landlord-1", actorRole: "landlord", command: "restore" });
+    expect(read("tenants", "tenant-past")).toMatchObject({ archivedAt: null, restoredAt: expect.any(String), status: "Past", relationshipStatus: "past" });
+    expect(list("canonicalEvents").map((event: any) => event.action)).toEqual(expect.arrayContaining(["tenant_archived", "tenant_restored"]));
+  });
+
+  it("rejects archive when a canonical current lease exists", async () => {
+    seed("tenants", "tenant-current", { landlordId: "landlord-1", status: "current", currentLeaseId: "lease-current" });
+    seed("leases", "lease-current", { landlordId: "landlord-1", tenantId: "tenant-current", status: "active", executionStatus: "fully_executed", startDate: "2026-01-01", endDate: "2026-12-31" });
+    await expect(mutateTenantArchiveState({ tenantId: "tenant-current", landlordId: "landlord-1", actorRole: "landlord", command: "archive" }))
+      .rejects.toMatchObject<TenantArchiveCommandError>({ code: "tenant_archive_current_relationship", status: 409 });
+    expect(read("tenants", "tenant-current").archivedAt).toBeUndefined();
+  });
+
+  it("rejects archive for multiple-current conflict without resolving it", async () => {
+    seed("tenants", "tenant-conflict", { landlordId: "landlord-1", status: "past", currentLeaseId: null });
+    for (const id of ["lease-a", "lease-b"]) {
+      seed("leases", id, { landlordId: "landlord-1", tenantId: "tenant-conflict", status: "active", executionStatus: "fully_executed", startDate: "2026-01-01", endDate: "2026-12-31" });
+    }
+    await expect(mutateTenantArchiveState({ tenantId: "tenant-conflict", landlordId: "landlord-1", actorRole: "landlord", command: "archive" }))
+      .rejects.toMatchObject<TenantArchiveCommandError>({ code: "tenant_archive_occupancy_conflict", status: 409 });
+    expect(read("leases", "lease-a").status).toBe("active");
+    expect(read("leases", "lease-b").status).toBe("active");
+  });
+
+  it("rejects archive when an occupied unit remains linked without a current lease", async () => {
+    seed("tenants", "tenant-occupied", { landlordId: "landlord-1", status: "past", currentLeaseId: null });
+    seed("units", "unit-1", { landlordId: "landlord-1", tenantId: "tenant-occupied", occupancyStatus: "occupied" });
+    await expect(mutateTenantArchiveState({ tenantId: "tenant-occupied", landlordId: "landlord-1", actorRole: "landlord", command: "archive" }))
+      .rejects.toMatchObject<TenantArchiveCommandError>({ code: "tenant_archive_occupancy_conflict", status: 409 });
+    expect(read("tenants", "tenant-occupied").archivedAt).toBeUndefined();
+  });
+
+  it("rejects archive for an upcoming operational relationship", async () => {
+    seed("tenants", "tenant-upcoming", { landlordId: "landlord-1", status: "past", currentLeaseId: null });
+    seed("leases", "lease-upcoming", { landlordId: "landlord-1", tenantId: "tenant-upcoming", status: "signed", executionStatus: "fully_executed", startDate: "2099-01-01", endDate: "2099-12-31" });
+    await expect(mutateTenantArchiveState({ tenantId: "tenant-upcoming", landlordId: "landlord-1", actorRole: "landlord", command: "archive" }))
+      .rejects.toMatchObject<TenantArchiveCommandError>({ code: "tenant_archive_upcoming_relationship", status: 409 });
+  });
+});

--- a/rentchain-api/src/services/__tests__/tenantLifecycleArchiveService.test.ts
+++ b/rentchain-api/src/services/__tests__/tenantLifecycleArchiveService.test.ts
@@ -100,4 +100,22 @@ describe("tenantLifecycleArchiveService", () => {
     await expect(mutateTenantArchiveState({ tenantId: "tenant-upcoming", landlordId: "landlord-1", actorRole: "landlord", command: "archive" }))
       .rejects.toMatchObject<TenantArchiveCommandError>({ code: "tenant_archive_upcoming_relationship", status: 409 });
   });
+
+  it("rejects foreign Archive at the real service boundary with no mutation or audit", async () => {
+    seed("tenants", "tenant-foreign", { landlordId: "landlord-a", status: "past", currentLeaseId: null });
+    const before = { ...read("tenants", "tenant-foreign") };
+    await expect(mutateTenantArchiveState({ tenantId: "tenant-foreign", landlordId: "landlord-b", actorRole: "landlord", command: "archive" }))
+      .rejects.toMatchObject<TenantArchiveCommandError>({ code: "tenant_forbidden", status: 403 });
+    expect(read("tenants", "tenant-foreign")).toEqual(before);
+    expect(list("canonicalEvents")).toEqual([]);
+  });
+
+  it("rejects foreign Restore at the real service boundary with no mutation or audit", async () => {
+    seed("tenants", "tenant-foreign", { landlordId: "landlord-a", status: "past", currentLeaseId: null, archivedAt: "2026-08-25T00:00:00.000Z" });
+    const before = { ...read("tenants", "tenant-foreign") };
+    await expect(mutateTenantArchiveState({ tenantId: "tenant-foreign", landlordId: "landlord-b", actorRole: "landlord", command: "restore" }))
+      .rejects.toMatchObject<TenantArchiveCommandError>({ code: "tenant_forbidden", status: 403 });
+    expect(read("tenants", "tenant-foreign")).toEqual(before);
+    expect(list("canonicalEvents")).toEqual([]);
+  });
 });

--- a/rentchain-api/src/services/leaseCanonicalizationService.ts
+++ b/rentchain-api/src/services/leaseCanonicalizationService.ts
@@ -28,6 +28,9 @@ export type CanonicalLeaseRecord = LeaseWorkflowLease & {
   occupancyEffective?: boolean;
   occupancyEffectiveAt?: unknown;
   occupancyDisposition?: unknown;
+  endedAt?: unknown;
+  terminatedAt?: unknown;
+  terminationDate?: unknown;
   sourceMonthlyRent: number;
   hasResolvedUnit: boolean;
   resolvedUnitId: string | null;
@@ -258,6 +261,9 @@ export function toCanonicalLeaseRecord(
     occupancyEffective: raw?.occupancyEffective === true,
     occupancyEffectiveAt: raw?.occupancyEffectiveAt,
     occupancyDisposition: raw?.occupancyDisposition,
+    endedAt: raw?.endedAt,
+    terminatedAt: raw?.terminatedAt,
+    terminationDate: raw?.terminationDate,
     sourceMonthlyRent: toNumberSafe(raw?.monthlyRent, raw?.currentRent, raw?.rent, raw?.rentAmount),
     hasResolvedUnit: Boolean(resolution.unit?.id) && !resolution.ambiguous,
     resolvedUnitId: resolution.unit?.id || null,

--- a/rentchain-api/src/services/leaseService.ts
+++ b/rentchain-api/src/services/leaseService.ts
@@ -14,6 +14,7 @@ export interface Lease {
   monthlyRent: number;
   startDate: string;
   endDate?: string | null;
+  endedAt?: string | null;
   automationEnabled: boolean;
   renewalStatus: LeaseRenewalStatus;
   status: LeaseStatus;
@@ -145,13 +146,16 @@ export const leaseService = {
     return existing;
   },
 
-  endLease(id: string, endDate: string): Lease | undefined {
+  endLease(id: string): Lease | undefined {
     const existing = leases.find((l) => l.id === id);
     if (!existing) return undefined;
 
+    if (existing.status === "ended") return existing;
+
+    const now = new Date().toISOString();
     existing.status = "ended";
-    existing.endDate = endDate;
-    existing.updatedAt = new Date().toISOString();
+    existing.endedAt = now;
+    existing.updatedAt = now;
 
     return existing;
   },

--- a/rentchain-api/src/services/leaseStart/__tests__/leaseStartService.test.ts
+++ b/rentchain-api/src/services/leaseStart/__tests__/leaseStartService.test.ts
@@ -213,6 +213,39 @@ describe("leaseStartService", () => {
     expect(result.expectedStateToken).toBe(fresh.expectedStateToken);
   });
 
+  it("rejects an archived tenant inside the authoritative start transaction with zero writes", async () => {
+    seedBase({ tenant: { archivedAt: "2026-04-30T13:00:00.000Z" } });
+    const context = await getCanonicalLeaseStartContext({ ...base, firestore: fake.firestore });
+    const before = domainSnapshot();
+
+    expect(context).toMatchObject({ tenantArchived: true, decision: { outcome: "occupancy_effective" } });
+    await expect(startCanonicalLeaseOccupancy(await mutationInput())).rejects.toMatchObject({
+      code: "lease_start_transaction_ineligible",
+      transactionEligibilityReason: "tenant_archived_restore_required",
+      freshContext: expect.objectContaining({ tenantArchived: true }),
+    });
+    expect(domainSnapshot()).toEqual(before);
+    expect(fake.list("leaseStartRequests")).toEqual([]);
+  });
+
+  it("supports explicit restore followed by the ordinary canonical start command", async () => {
+    seedBase({ tenant: { archivedAt: "2026-04-30T13:00:00.000Z" } });
+    expect((await getCanonicalLeaseStartContext({ ...base, firestore: fake.firestore })).tenantArchived).toBe(true);
+
+    fake.seed("tenants", "tenant-1", {
+      ...fake.read("tenants", "tenant-1"),
+      archivedAt: null,
+      restoredAt: "2026-05-01T11:00:00.000Z",
+      updatedAt: "2026-05-01T11:00:00.000Z",
+    });
+    const restoredContext = await getCanonicalLeaseStartContext({ ...base, firestore: fake.firestore });
+    expect(restoredContext).toMatchObject({ tenantArchived: false, decision: { outcome: "occupancy_effective" } });
+
+    const result = await startCanonicalLeaseOccupancy(await mutationInput());
+    expect(result).toMatchObject({ outcome: "occupancy_effective", occupancyEffective: true });
+    expect(fake.read("tenants", "tenant-1")).toMatchObject({ archivedAt: null, currentLeaseId: "lease-1" });
+  });
+
   it("runs a caller eligibility guard against the authoritative transaction snapshot", async () => {
     seedBase({ lease: { predecessorLeaseId: "lease-predecessor" } });
     const before = domainSnapshot();

--- a/rentchain-api/src/services/leaseStart/leaseStartService.ts
+++ b/rentchain-api/src/services/leaseStart/leaseStartService.ts
@@ -36,6 +36,7 @@ export type LeaseStartTransactionEligibilityContext = {
 export type LeaseStartContext = {
   expectedStateToken: string;
   evaluationInstant: string;
+  tenantArchived: boolean;
   decision: CanonicalLeaseStartResult;
   stateSummary: {
     leaseId: string;
@@ -195,7 +196,7 @@ async function readContext(reader: any, input: ContextInput): Promise<{ context:
     tenancyIds: [...decision.context.tenancyIds],
   };
   return {
-    context: { expectedStateToken, evaluationInstant: decision.context.evaluationInstant, decision, stateSummary },
+    context: { expectedStateToken, evaluationInstant: decision.context.evaluationInstant, tenantArchived: Boolean(tenant.archivedAt), decision, stateSummary },
     records: { propertyRef, unitRef, leaseRef, tenantRef, property, unit, candidateLease, tenant, embeddedUnits, embeddedIndex: matches[0].index, tenancies, canonicalInput },
   };
 }
@@ -267,6 +268,13 @@ export async function startCanonicalLeaseOccupancy(input: StartCanonicalLeaseOcc
     loadAuthoritativeState: (transaction) => readContext(transaction, { ...input, evaluationInstant: normalizedInstant, firestore }),
     getExpectedStateToken: (loaded) => loaded.context.expectedStateToken,
     buildPlan: async ({ transaction, loaded }) => {
+    if (loaded.context.tenantArchived) {
+      throw new LeaseStartServiceError(
+        "lease_start_transaction_ineligible",
+        loaded.context,
+        "tenant_archived_restore_required"
+      );
+    }
     const transactionEligibilityReason = input.transactionEligibilityGuard?.({
       candidateLease: loaded.records.candidateLease,
       contextLeases: loaded.records.canonicalInput.contextLeases,

--- a/rentchain-api/src/services/tenantDetailsService.ts
+++ b/rentchain-api/src/services/tenantDetailsService.ts
@@ -40,6 +40,10 @@ import {
   type CanonicalLeaseOccupancyProjection,
 } from "../lib/leases/canonicalLeaseOccupancyProjection";
 import { selectCanonicalCurrentLease } from "../lib/leases/canonicalLeaseOccupancyState";
+import {
+  deriveTenantWorkspaceLifecycle,
+  type TenantWorkspaceLifecycle,
+} from "../lib/tenants/deriveTenantWorkspaceLifecycle";
 import { getSignedLeaseDocumentDownload } from "./signing/leaseSigningService";
 
 export interface TenantRecord {
@@ -70,7 +74,11 @@ export interface TenantRecord {
   tenantScoreTimeline?: TenantScoreTimelineEntry[];
   source?: string | null;
   createdAt?: string | number | null;
+  archivedAt?: string | null;
+  archivedByUserId?: string | null;
+  restoredAt?: string | null;
   lifecycle?: TenantLifecycleResult;
+  workspaceLifecycle?: TenantWorkspaceLifecycle;
   canonicalState?: CanonicalLeaseOccupancyProjection;
 }
 
@@ -352,6 +360,9 @@ function mapTenant(docId: string, data: any): TenantRecord {
     tenantScoreTimeline: Array.isArray(data.tenantScoreTimeline) ? data.tenantScoreTimeline : [],
     source: data.source ?? null,
     createdAt: createdAtIso ?? createdAt ?? null,
+    archivedAt: data.archivedAt ?? null,
+    archivedByUserId: data.archivedByUserId ?? null,
+    restoredAt: data.restoredAt ?? null,
   };
 }
 
@@ -768,6 +779,11 @@ async function hydrateTenantDisplayFields(tenant: TenantRecord, landlordId?: str
     source: hydrated.source,
     hiddenFromActiveLists: hydrated.hiddenFromActiveLists,
   });
+  hydrated.workspaceLifecycle = deriveTenantWorkspaceLifecycle({
+    canonicalState,
+    leases: leaseResolution.leases.map(toCanonicalLeaseStateInput),
+    archivedAt: hydrated.archivedAt,
+  });
 
   return hydrated;
 }
@@ -936,6 +952,12 @@ export async function getTenantDetailBundle(tenantId: string, opts: TenantQueryO
   const canonicalCurrentLeaseRecord = canonicalState.supportingLeaseId
     ? leaseResolution.leases.find((candidate) => candidate.id === canonicalState.supportingLeaseId) || null
     : null;
+  const workspaceLifecycle = deriveTenantWorkspaceLifecycle({
+    canonicalState,
+    leases: leaseResolution.leases.map(toCanonicalLeaseStateInput),
+    archivedAt: tenant?.archivedAt,
+  });
+  if (tenant) tenant.workspaceLifecycle = workspaceLifecycle;
   let currentLease: TenantLease | null = null;
   if (canonicalCurrentLeaseRecord) {
     if (canonicalCurrentLeaseRecord.id === lease?.id) {
@@ -1028,6 +1050,7 @@ export async function getTenantDetailBundle(tenantId: string, opts: TenantQueryO
     moveInReadiness,
     ledgerSummary,
     lifecycle,
+    workspaceLifecycle,
     stateCoherence,
     canonicalState,
   };

--- a/rentchain-api/src/services/tenantDetailsService.ts
+++ b/rentchain-api/src/services/tenantDetailsService.ts
@@ -224,6 +224,9 @@ const TENANT_PROFILE_LEASE_STATUSES = new Set([
   "active", "current", "notice_pending", "renewal_pending", "renewal_accepted", "move_out_pending",
   "signed", "signed_future", "fully_executed", "pending_signature", "sent",
   "ready_for_tenant_signature", "tenant_signed", "ready_for_landlord_signature", "landlord_signed",
+  // Preserve the ended lease as historical display context after End Lease
+  // clears the canonical current-lease pointer.
+  "ended", "terminated",
 ]);
 
 function isTenantProfileLeaseCandidate(raw: Record<string, unknown>): boolean {

--- a/rentchain-api/src/services/tenantLifecycleArchiveService.ts
+++ b/rentchain-api/src/services/tenantLifecycleArchiveService.ts
@@ -1,0 +1,153 @@
+import { db, FieldValue } from "../firebase";
+import {
+  buildCanonicalLeaseOccupancyProjection,
+  resolveCanonicalUnitProjectionInputs,
+  toCanonicalLeaseStateInput,
+} from "../lib/leases/canonicalLeaseOccupancyProjection";
+import { deriveTenantWorkspaceLifecycle } from "../lib/tenants/deriveTenantWorkspaceLifecycle";
+
+export type TenantArchiveCommand = "archive" | "restore";
+
+export class TenantArchiveCommandError extends Error {
+  constructor(public readonly code: string, public readonly status: number) {
+    super(code);
+  }
+}
+
+function participantIds(lease: Record<string, any>): string[] {
+  return [lease.tenantId, lease.primaryTenantId, ...(Array.isArray(lease.tenantIds) ? lease.tenantIds : [])]
+    .map((value) => String(value || "").trim())
+    .filter(Boolean);
+}
+
+export async function mutateTenantArchiveState(input: {
+  tenantId: string;
+  landlordId?: string | null;
+  actorUserId?: string | null;
+  actorRole: "landlord" | "admin";
+  command: TenantArchiveCommand;
+}) {
+  const tenantId = String(input.tenantId || "").trim();
+  if (!tenantId) throw new TenantArchiveCommandError("tenant_id_required", 400);
+  if (typeof (db as any).runTransaction !== "function") {
+    throw new TenantArchiveCommandError("tenant_archive_transaction_unavailable", 503);
+  }
+
+  const eventRef = db.collection("canonicalEvents").doc();
+  return (db as any).runTransaction(async (transaction: any) => {
+    const tenantRef = db.collection("tenants").doc(tenantId);
+    const tenantSnap = await transaction.get(tenantRef);
+    if (!tenantSnap.exists) throw new TenantArchiveCommandError("tenant_not_found", 404);
+    const tenant = (tenantSnap.data() || {}) as Record<string, any>;
+    const authoritativeLandlordId = String(tenant.landlordId || "").trim();
+    const requestedLandlordId = String(input.landlordId || "").trim();
+    if (!authoritativeLandlordId || (input.actorRole !== "admin" && authoritativeLandlordId !== requestedLandlordId)) {
+      throw new TenantArchiveCommandError("tenant_forbidden", 403);
+    }
+
+    const [landlordLeases, landlordUnits, landlordProperties] = await Promise.all([
+      transaction.get(db.collection("leases").where("landlordId", "==", authoritativeLandlordId)),
+      transaction.get(db.collection("units").where("landlordId", "==", authoritativeLandlordId)),
+      transaction.get(db.collection("properties").where("landlordId", "==", authoritativeLandlordId)),
+    ]);
+    const leases = (landlordLeases.docs || [])
+      .map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) }))
+      .filter((lease: any) => participantIds(lease).includes(tenantId));
+    const standaloneUnits = (landlordUnits.docs || []).map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) }));
+    const embeddedUnits = (landlordProperties.docs || []).flatMap((doc: any) => {
+      const property = doc.data() || {};
+      return (Array.isArray(property.units) ? property.units : []).map((unit: any, index: number) => ({
+        ...unit,
+        id: String(unit.id || unit.unitId || `${doc.id}:${index}`),
+        propertyId: unit.propertyId || doc.id,
+      }));
+    });
+    const unitMatches = [...standaloneUnits, ...embeddedUnits].filter((unit: any) =>
+      [unit.tenantId, unit.currentTenantId].some((value) => String(value || "").trim() === tenantId) ||
+      (tenant.currentLeaseId && [unit.leaseId, unit.currentLeaseId].some((value) => String(value || "").trim() === String(tenant.currentLeaseId)))
+    );
+    const uniqueUnitMatches = Array.from(new Map(unitMatches.map((unit: any) => [`${unit.propertyId || ""}:${unit.id}`, unit])).values());
+    const unitInputs = uniqueUnitMatches.length === 1 ? resolveCanonicalUnitProjectionInputs(uniqueUnitMatches[0] as any) : {};
+    let canonicalState = buildCanonicalLeaseOccupancyProjection({
+      leases,
+      context: { landlordId: authoritativeLandlordId, tenantId },
+      ...unitInputs,
+      persistedTenantStatus: tenant.status ?? tenant.relationshipStatus,
+      currentLeasePointerId: tenant.currentLeaseId,
+      tenantId,
+    });
+    if (uniqueUnitMatches.length > 1) {
+      canonicalState = {
+        ...canonicalState,
+        occupancyState: "review_needed",
+        tenantRelationshipState: "occupancy_unresolved",
+        reasons: Array.from(new Set([...canonicalState.reasons, "CURRENT_LEASE_CONTEXT_MISMATCH" as const])),
+      };
+    }
+    const workspaceLifecycle = deriveTenantWorkspaceLifecycle({
+      canonicalState,
+      leases: leases.map(toCanonicalLeaseStateInput),
+      archivedAt: tenant.archivedAt,
+    });
+
+    if (input.command === "archive") {
+      if (workspaceLifecycle.isArchived) throw new TenantArchiveCommandError("tenant_already_archived", 409);
+      if (!workspaceLifecycle.archiveEligibility.allowed) {
+        throw new TenantArchiveCommandError(
+          `tenant_archive_${workspaceLifecycle.archiveEligibility.reason || "ineligible"}`,
+          409
+        );
+      }
+    } else if (!workspaceLifecycle.isArchived) {
+      throw new TenantArchiveCommandError("tenant_not_archived", 409);
+    }
+
+    const nowIso = new Date().toISOString();
+    const actorUserId = String(input.actorUserId || "").trim() || null;
+    const updates = input.command === "archive"
+      ? {
+          archivedAt: nowIso,
+          archivedByUserId: actorUserId,
+          restoredAt: null,
+          restoredByUserId: null,
+          updatedAt: nowIso,
+          updatedAtServer: FieldValue.serverTimestamp(),
+        }
+      : {
+          archivedAt: null,
+          archivedByUserId: null,
+          restoredAt: nowIso,
+          restoredByUserId: actorUserId,
+          updatedAt: nowIso,
+          updatedAtServer: FieldValue.serverTimestamp(),
+        };
+    const event = {
+      id: eventRef.id,
+      type: `tenant.lifecycle_${input.command}d`,
+      eventType: `tenant_lifecycle_${input.command}d`,
+      action: `tenant_${input.command}d`,
+      tenantId,
+      landlordId: authoritativeLandlordId,
+      actorUserId,
+      actorRole: input.actorRole,
+      occurredAt: nowIso,
+      recordedAt: nowIso,
+      metadataOnly: true,
+      appendOnly: true,
+      immutable: true,
+      historyDeleted: false,
+    };
+
+    transaction.set(tenantRef, updates, { merge: true });
+    if (typeof transaction.create === "function") transaction.create(eventRef, event);
+    else transaction.set(eventRef, event, { merge: false });
+
+    return {
+      tenantId,
+      command: input.command,
+      eventId: eventRef.id,
+      archivedAt: input.command === "archive" ? nowIso : null,
+      restoredAt: input.command === "restore" ? nowIso : null,
+    };
+  });
+}

--- a/rentchain-frontend/src/api/tenantDetail.ts
+++ b/rentchain-frontend/src/api/tenantDetail.ts
@@ -1,5 +1,5 @@
 // rentchain-frontend/src/api/tenantDetail.ts
-import type { TenantApiModel, TenantLifecycle } from "./tenants";
+import type { TenantApiModel, TenantLifecycle, TenantWorkspaceLifecycle } from "./tenants";
 import type { CredibilityInsights } from "@/types/credibilityInsights";
 import type { LeaseStateCoherence } from "./leasesApi";
 import type { CanonicalLeaseOccupancyState } from "@/lib/leases/canonicalStatePresentation";
@@ -246,6 +246,7 @@ export interface TenantDetailBundle {
   moveInRequirements?: MoveInRequirements | null;
   moveInReadiness?: MoveInReadiness | null;
   lifecycle?: TenantLifecycle | null;
+  workspaceLifecycle?: TenantWorkspaceLifecycle | null;
   stateCoherence?: LeaseStateCoherence | null;
   canonicalState?: CanonicalLeaseOccupancyState | null;
 }

--- a/rentchain-frontend/src/api/tenantsApi.ts
+++ b/rentchain-frontend/src/api/tenantsApi.ts
@@ -74,6 +74,23 @@ export interface TenantLifecycle {
   };
 }
 
+export type TenantWorkspaceCategory = "current" | "upcoming" | "past" | "archived";
+
+export interface TenantWorkspaceLifecycle {
+  category: TenantWorkspaceCategory;
+  label: "Current" | "Upcoming" | "Past" | "Archived";
+  isArchived: boolean;
+  archivedAt: string | null;
+  actualEndDate: string | null;
+  hasCanonicalCurrentLease: boolean;
+  hasUpcomingLease: boolean;
+  hasUnresolvedOccupancyConflict: boolean;
+  archiveEligibility: {
+    allowed: boolean;
+    reason: "already_archived" | "current_relationship" | "upcoming_relationship" | "occupancy_conflict" | null;
+  };
+}
+
 export interface TenantApiModel {
   id: string;
   name?: string;
@@ -91,6 +108,7 @@ export interface TenantApiModel {
   hiddenFromActiveLists?: boolean;
   tenancies?: TenancyApiModel[];
   lifecycle?: TenantLifecycle;
+  workspaceLifecycle?: TenantWorkspaceLifecycle;
   canonicalState?: CanonicalLeaseOccupancyState;
 }
 
@@ -224,6 +242,20 @@ export async function updateTenantRecord(
   });
   if (data?.tenant) return data.tenant as TenantApiModel;
   return data as TenantApiModel;
+}
+
+export async function archiveTenant(tenantId: string): Promise<TenantApiModel> {
+  const data = await apiJson<{ ok: true; tenant: TenantApiModel }>(`/tenants/${encodeURIComponent(tenantId)}/archive`, {
+    method: "POST",
+  });
+  return data.tenant;
+}
+
+export async function restoreTenant(tenantId: string): Promise<TenantApiModel> {
+  const data = await apiJson<{ ok: true; tenant: TenantApiModel }>(`/tenants/${encodeURIComponent(tenantId)}/restore`, {
+    method: "POST",
+  });
+  return data.tenant;
 }
 
 export async function impersonateTenant(tenantId: string): Promise<{ ok: boolean; token: string; tenantId: string; exp?: number }> {

--- a/rentchain-frontend/src/components/tenants/TenantDetailPanel.test.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantDetailPanel.test.tsx
@@ -465,6 +465,54 @@ describe("TenantDetailPanel", () => {
     expect(screen.queryByText(/No current lease is linked/i)).not.toBeInTheDocument();
   });
 
+  it("shows scheduled lease dates and the authoritative actual end date for a Past tenant", async () => {
+    mocks.useTenantDetail.mockReturnValue({
+      loading: false,
+      error: null,
+      bundle: {
+        tenant: {
+          id: "tenant-past",
+          fullName: "Past Tenant",
+          status: "Past",
+          currentLeaseId: null,
+          leaseStart: "2026-01-01",
+          leaseEnd: "2027-01-01",
+        },
+        currentLease: null,
+        lease: {
+          id: "lease-ended",
+          tenantId: "tenant-past",
+          leaseStart: "2026-01-01",
+          leaseEnd: "2027-01-01",
+          status: "ended",
+        },
+        workspaceLifecycle: {
+          category: "past",
+          label: "Past",
+          isArchived: false,
+          actualEndDate: "2026-08-23T12:00:00.000Z",
+        },
+        canonicalState: {
+          leaseTermState: "ended",
+          occupancyState: "vacant",
+          tenantRelationshipState: "past_tenant",
+          supportingLeaseId: null,
+          reasons: ["ENDED_LEASE_CANNOT_SUPPORT_OCCUPANCY"],
+        },
+        property: { id: "property-1", name: "Harbour View" },
+        unit: { id: "unit-1", unitNumber: "101", status: "vacant" },
+        moveInReadiness: null,
+      },
+    });
+
+    render(<MemoryRouter><TenantDetailPanel tenantId="tenant-past" /></MemoryRouter>);
+
+    expect(await screen.findAllByText("Past")).not.toHaveLength(0);
+    expect(screen.getAllByText("Jan 1, 2026").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Jan 1, 2027").length).toBeGreaterThan(0);
+    expect(screen.getByText("Aug 23, 2026")).toBeInTheDocument();
+  });
+
   it("ignores a prior tenant's late lease-ledger result after selection changes", async () => {
     const tenantALedger = deferred<any>();
     mocks.fetchLeaseLedger.mockReturnValueOnce(tenantALedger.promise);

--- a/rentchain-frontend/src/components/tenants/TenantDetailPanel.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantDetailPanel.tsx
@@ -616,7 +616,7 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityR
         />
         <DetailField label="Workspace lifecycle" value={workspaceLifecycle?.label ?? "--"} />
         <DetailField label="Lease lifecycle" value={canonicalState ? canonicalLeaseTermLabel(canonicalState.leaseTermState) : lifecycle?.lifecycleLabel ?? "--"} />
-        {workspaceLifecycle?.actualEndDate ? <DetailField label="Actual end date" value={formatDate(workspaceLifecycle.actualEndDate)} /> : null}
+        {workspaceLifecycle?.actualEndDate ? <DetailField label="Actual end date" value={formatDateLabel(workspaceLifecycle.actualEndDate)} /> : null}
         {canonicalState ? <DetailField label="Occupancy" value={canonicalOccupancyLabel(canonicalState.occupancyState)} /> : null}
         {stateCoherence ? (
           <DetailField

--- a/rentchain-frontend/src/components/tenants/TenantDetailPanel.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantDetailPanel.tsx
@@ -173,6 +173,7 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityR
   const lease = bundle.currentLease || null;
   const currentLeaseId = typeof bundle.currentLease?.id === "string" ? bundle.currentLease.id.trim() : "";
   const lifecycle = bundle.lifecycle || tenant.lifecycle || null;
+  const workspaceLifecycle = bundle.workspaceLifecycle || tenant.workspaceLifecycle || null;
   const stateCoherence = bundle.stateCoherence || null;
   const canonicalState = bundle.canonicalState || null;
   const property = bundle.property || null;
@@ -453,7 +454,7 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityR
             }}
           >
             {tenant.fullName || tenant.name || tenant.email || "Tenant"}
-            {lifecycle?.lifecycleLabel ? (
+            {workspaceLifecycle?.label || lifecycle?.lifecycleLabel ? (
               <span
                 style={{
                   padding: "0.15rem 0.45rem",
@@ -464,7 +465,7 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityR
                   color: text.primary,
                 }}
               >
-                {lifecycle.lifecycleLabel}
+                {workspaceLifecycle?.label || lifecycle.lifecycleLabel}
               </span>
             ) : null}
           </div>
@@ -613,7 +614,9 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityR
           label="Lease Status"
           value={canonicalState ? canonicalLeaseTermLabel(canonicalState.leaseTermState) : lease?.status ? formatLeaseStatus(lease.status) : activeOccupantWithoutLease ? "Active occupant — no lease linked" : "--"}
         />
-        <DetailField label="Lifecycle" value={canonicalState ? canonicalLeaseTermLabel(canonicalState.leaseTermState) : lifecycle?.lifecycleLabel ?? "--"} />
+        <DetailField label="Workspace lifecycle" value={workspaceLifecycle?.label ?? "--"} />
+        <DetailField label="Lease lifecycle" value={canonicalState ? canonicalLeaseTermLabel(canonicalState.leaseTermState) : lifecycle?.lifecycleLabel ?? "--"} />
+        {workspaceLifecycle?.actualEndDate ? <DetailField label="Actual end date" value={formatDate(workspaceLifecycle.actualEndDate)} /> : null}
         {canonicalState ? <DetailField label="Occupancy" value={canonicalOccupancyLabel(canonicalState.occupancyState)} /> : null}
         {stateCoherence ? (
           <DetailField

--- a/rentchain-frontend/src/components/tenants/TenantLeasePanel.test.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantLeasePanel.test.tsx
@@ -93,7 +93,7 @@ describe("TenantLeasePanel", () => {
     fireEvent.click(screen.getAllByRole("button", { name: "End lease" })[0]);
     fireEvent.click(screen.getByRole("button", { name: "Confirm end lease" }));
 
-    await waitFor(() => expect(mocks.endLease).toHaveBeenCalledWith("lease-1", expect.any(String)));
+    await waitFor(() => expect(mocks.endLease).toHaveBeenCalledWith("lease-1"));
   });
 
   it("restores End Lease for the runtime-shaped canonical multi-party response", async () => {

--- a/rentchain-frontend/src/components/tenants/TenantLeasePanel.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantLeasePanel.tsx
@@ -253,7 +253,7 @@ export const TenantLeasePanel: React.FC<TenantLeasePanelProps> = ({ tenantId, on
     try {
       setEndingLeaseId(leaseId);
       setError(null);
-      await endLease(leaseId, new Date().toISOString());
+      await endLease(leaseId);
       await loadLeases();
       await onLeaseEnded?.();
       setConfirmingLeaseId(null);

--- a/rentchain-frontend/src/pages/TenantsPage.test.tsx
+++ b/rentchain-frontend/src/pages/TenantsPage.test.tsx
@@ -27,6 +27,8 @@ const mocks = vi.hoisted(() => ({
   fetchTenantTenanciesMock: vi.fn(),
   updateTenantRecordMock: vi.fn(),
   updateTenancyMock: vi.fn(),
+  archiveTenantMock: vi.fn(),
+  restoreTenantMock: vi.fn(),
   useTenantDetailMock: vi.fn(),
   createTenantEventMock: vi.fn(),
   hydrateTenantSummariesBatchMock: vi.fn(),
@@ -53,6 +55,8 @@ vi.mock("@/api/tenantsApi", () => ({
   fetchTenantTenancies: mocks.fetchTenantTenanciesMock,
   updateTenantRecord: mocks.updateTenantRecordMock,
   updateTenancy: mocks.updateTenancyMock,
+  archiveTenant: mocks.archiveTenantMock,
+  restoreTenant: mocks.restoreTenantMock,
 }));
 
 vi.mock("@/hooks/useTenantDetail", () => ({
@@ -131,6 +135,8 @@ describe("TenantsPage", () => {
     mocks.fetchTenantTenanciesMock.mockResolvedValue([]);
     mocks.updateTenantRecordMock.mockResolvedValue({});
     mocks.updateTenancyMock.mockResolvedValue({});
+    mocks.archiveTenantMock.mockResolvedValue({});
+    mocks.restoreTenantMock.mockResolvedValue({});
     mocks.useTenantDetailMock.mockReturnValue({ bundle: null, loading: false, error: null });
     mocks.createTenantEventMock.mockResolvedValue({ ok: true });
     mocks.hydrateTenantSummariesBatchMock.mockResolvedValue(undefined);
@@ -171,6 +177,59 @@ describe("TenantsPage", () => {
     expect(master.closest(".rc-master-detail-master")).toBeInTheDocument();
     expect(document.querySelector(".rc-master-detail-detail")).toBeInTheDocument();
     expect(document.querySelector(".rc-tenants-list-scroll")).toBeInTheDocument();
+  });
+
+  it("excludes Archived from the default active workspace and supports all lifecycle filters", async () => {
+    mocks.fetchTenantsMock.mockResolvedValue([
+      { id: "current", fullName: "Current Tenant", workspaceLifecycle: { category: "current", label: "Current" } },
+      { id: "upcoming", fullName: "Upcoming Tenant", workspaceLifecycle: { category: "upcoming", label: "Upcoming" } },
+      { id: "past", fullName: "Past Tenant", workspaceLifecycle: { category: "past", label: "Past" } },
+      { id: "archived", fullName: "Archived Tenant", workspaceLifecycle: { category: "archived", label: "Archived", isArchived: true } },
+    ]);
+    render(<MemoryRouter><TenantsPage /></MemoryRouter>);
+
+    expect(await screen.findByText("Current Tenant")).toBeInTheDocument();
+    expect(screen.getByText("Upcoming Tenant")).toBeInTheDocument();
+    expect(screen.getByText("Past Tenant")).toBeInTheDocument();
+    expect(screen.queryByText("Archived Tenant")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "archived" }));
+    expect(await screen.findByText("Archived Tenant")).toBeInTheDocument();
+    expect(screen.queryByText("Current Tenant")).not.toBeInTheDocument();
+    for (const filter of ["current", "upcoming", "past"] as const) {
+      fireEvent.click(screen.getByRole("button", { name: filter }));
+      expect(await screen.findByText(`${filter[0].toUpperCase()}${filter.slice(1)} Tenant`)).toBeInTheDocument();
+    }
+  });
+
+  it("shows only the server-authorized Archive action and confirms history preservation", async () => {
+    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
+    const workspaceLifecycle = { category: "past", label: "Past", isArchived: false, actualEndDate: "2026-08-20T00:00:00.000Z", archiveEligibility: { allowed: true, reason: null } };
+    mocks.fetchTenantsMock.mockResolvedValue([{ id: "tenant-1", fullName: "Past Tenant", workspaceLifecycle }]);
+    mocks.useTenantDetailMock.mockReturnValue({
+      bundle: { tenant: { id: "tenant-1", fullName: "Past Tenant", workspaceLifecycle }, workspaceLifecycle, canonicalState: { leaseTermState: "ended", occupancyState: "vacant", tenantRelationshipState: "past_tenant", supportingLeaseId: null, reasons: ["ENDED_LEASE_CANNOT_SUPPORT_OCCUPANCY"] }, currentLease: null },
+      loading: false,
+      error: null,
+    });
+    render(<MemoryRouter initialEntries={["/tenants?tenantId=tenant-1"]}><TenantsPage /></MemoryRouter>);
+
+    const archive = await screen.findByRole("button", { name: "Archive tenant" });
+    expect(screen.queryByRole("button", { name: "Restore tenant" })).not.toBeInTheDocument();
+    expect(screen.getByText(/Actual end date:/)).toHaveTextContent("2026-08-20");
+    fireEvent.click(archive);
+    expect(confirm).toHaveBeenCalledWith(expect.stringContaining("history will be preserved"));
+    expect(mocks.archiveTenantMock).toHaveBeenCalledWith("tenant-1");
+    confirm.mockRestore();
+  });
+
+  it("shows Restore only for server-projected Archived tenants", async () => {
+    const workspaceLifecycle = { category: "archived", label: "Archived", isArchived: true, archiveEligibility: { allowed: false, reason: "already_archived" } };
+    mocks.fetchTenantsMock.mockResolvedValue([{ id: "tenant-1", fullName: "Archived Tenant", workspaceLifecycle }]);
+    mocks.useTenantDetailMock.mockReturnValue({ bundle: { tenant: { id: "tenant-1", workspaceLifecycle }, workspaceLifecycle, canonicalState: { leaseTermState: "ended", occupancyState: "vacant", tenantRelationshipState: "past_tenant", supportingLeaseId: null, reasons: [] }, currentLease: null }, loading: false, error: null });
+    render(<MemoryRouter initialEntries={["/tenants?tenantId=tenant-1"]}><TenantsPage /></MemoryRouter>);
+    fireEvent.click(screen.getByRole("button", { name: "archived" }));
+    expect(await screen.findByRole("button", { name: "Restore tenant" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Archive tenant" })).not.toBeInTheDocument();
   });
 
   it("fails closed when cached invite capability is true but the authenticated plan is free", async () => {

--- a/rentchain-frontend/src/pages/TenantsPage.tsx
+++ b/rentchain-frontend/src/pages/TenantsPage.tsx
@@ -8,6 +8,8 @@ import { TenantPaymentsPanel } from "../components/tenants/TenantPaymentsPanel";
 import {
   fetchTenantTenancies,
   fetchTenants,
+  archiveTenant,
+  restoreTenant,
   type TenancyApiModel,
   type TenantApiModel,
   updateTenantRecord,
@@ -149,6 +151,7 @@ function tenantLifecycleLabel(
   tenant?: TenantApiModel | null,
   canonicalState: CanonicalLeaseOccupancyState | null | undefined = tenant?.canonicalState
 ): string {
+  if (tenant?.workspaceLifecycle?.label) return tenant.workspaceLifecycle.label;
   if (canonicalState) return canonicalTenantRelationshipLabel(canonicalState.tenantRelationshipState);
   return tenant?.lifecycle?.lifecycleLabel || tenant?.status || "Unknown";
 }
@@ -371,6 +374,8 @@ export const TenantsPage: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
+  const [lifecycleFilter, setLifecycleFilter] = useState<"active" | "current" | "upcoming" | "past" | "archived">("active");
+  const [savingArchiveState, setSavingArchiveState] = useState(false);
   const [inviteOpen, setInviteOpen] = useState(false);
   const [tenantEdit, setTenantEdit] = useState<TenantEditState>(EMPTY_TENANT_EDIT);
   const [tenantNote, setTenantNote] = useState<TenantNoteState>(EMPTY_TENANT_NOTE);
@@ -611,16 +616,44 @@ const loadTenants = useCallback(async () => {
   const selectedLeaseLink = buildTenantLeaseLink(selectedTenant, selectedCurrentLease);
 
   const filteredTenants = useMemo(() => {
-    const base = tenants || [];
-    if (!searchQuery.trim()) return base;
+    const lifecycleRows = (tenants || []).filter((tenant) => {
+      const category = tenant.workspaceLifecycle?.category;
+      return lifecycleFilter === "active" ? category !== "archived" : category === lifecycleFilter;
+    });
+    if (!searchQuery.trim()) return lifecycleRows;
     const q = searchQuery.toLowerCase();
-    return base.filter((t) => {
+    return lifecycleRows.filter((t) => {
       const name = (t.name || t.fullName || "").toLowerCase();
       const property = (t.propertyName || t.propertyId || "").toLowerCase();
       const unit = (t.unitLabel || t.unit || "").toLowerCase();
       return name.includes(q) || property.includes(q) || unit.includes(q);
     });
-  }, [tenants, searchQuery]);
+  }, [lifecycleFilter, tenants, searchQuery]);
+
+  const selectedWorkspaceLifecycle = selectedTenantDetailBundle?.workspaceLifecycle || selectedTenant?.workspaceLifecycle || null;
+
+  const handleArchiveStateChange = async (command: "archive" | "restore") => {
+    if (!selectedTenantId) return;
+    const tenantName = selectedTenant?.name || selectedTenant?.fullName || "this tenant";
+    const confirmed = window.confirm(
+      command === "archive"
+        ? `Archive ${tenantName}? Lease, payment, note, document, application, tenancy, and audit history will be preserved.`
+        : `Restore ${tenantName}? Their canonical relationship will determine the workspace category.`
+    );
+    if (!confirmed) return;
+    try {
+      setSavingArchiveState(true);
+      if (command === "archive") await archiveTenant(selectedTenantId);
+      else await restoreTenant(selectedTenantId);
+      await loadTenants();
+      setActivityRefreshKey((value) => value + 1);
+      showToast({ message: command === "archive" ? "Tenant archived" : "Tenant restored", variant: "success" });
+    } catch (error) {
+      showToast({ message: command === "archive" ? "Unable to archive tenant" : "Unable to restore tenant", description: getErrorMessage(error, "Please refresh and try again."), variant: "error" });
+    } finally {
+      setSavingArchiveState(false);
+    }
+  };
 
   const visibleTenantIds = useMemo(
     () => (filteredTenants || []).slice(0, 50).map((t) => t.id).filter(Boolean),
@@ -802,7 +835,28 @@ const loadTenants = useCallback(async () => {
         <ResponsiveMasterDetail
           title={undefined}
           searchSlot={
-            <div className="rc-tenants-search">
+            <div className="rc-tenants-search" style={{ display: "grid", gap: 8 }}>
+              <div role="group" aria-label="Tenant lifecycle filters" style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+                {(["active", "current", "upcoming", "past", "archived"] as const).map((filter) => (
+                  <button
+                    key={filter}
+                    type="button"
+                    aria-pressed={lifecycleFilter === filter}
+                    onClick={() => setLifecycleFilter(filter)}
+                    style={{
+                      padding: "6px 9px",
+                      borderRadius: radius.pill,
+                      border: `1px solid ${lifecycleFilter === filter ? landlordWorkspaceTheme.borderStrong : colors.border}`,
+                      background: lifecycleFilter === filter ? landlordWorkspaceTheme.pineSoft : colors.panel,
+                      color: text.primary,
+                      textTransform: "capitalize",
+                      cursor: "pointer",
+                    }}
+                  >
+                    {filter}
+                  </button>
+                ))}
+              </div>
               <Input
                 type="text"
                 placeholder="Search by name, property, unit"
@@ -1072,9 +1126,31 @@ const loadTenants = useCallback(async () => {
                             color: text.primary,
                             cursor: "pointer",
                           }}
-                        >
-                          {inviteEnabled ? "Send tenant invite" : "Unlock Tenant Invites"}
-                        </button>
+                          >
+                            {inviteEnabled ? "Send tenant invite" : "Unlock Tenant Invites"}
+                          </button>
+                        {selectedWorkspaceLifecycle?.archiveEligibility.allowed ? (
+                          <button
+                            type="button"
+                            className="rc-tenants-action-button"
+                            disabled={savingArchiveState}
+                            onClick={() => void handleArchiveStateChange("archive")}
+                            style={{ padding: "8px 10px", borderRadius: radius.md, border: `1px solid ${landlordWorkspaceTheme.borderStrong}`, background: landlordWorkspaceTheme.card, color: text.primary, cursor: savingArchiveState ? "wait" : "pointer" }}
+                          >
+                            Archive tenant
+                          </button>
+                        ) : null}
+                        {selectedWorkspaceLifecycle?.isArchived ? (
+                          <button
+                            type="button"
+                            className="rc-tenants-action-button"
+                            disabled={savingArchiveState}
+                            onClick={() => void handleArchiveStateChange("restore")}
+                            style={{ padding: "8px 10px", borderRadius: radius.md, border: `1px solid ${landlordWorkspaceTheme.borderStrong}`, background: landlordWorkspaceTheme.card, color: text.primary, cursor: savingArchiveState ? "wait" : "pointer" }}
+                          >
+                            Restore tenant
+                          </button>
+                        ) : null}
                       </div>
                     </div>
                     {selectedTenantLinkage ? <><div
@@ -1087,8 +1163,13 @@ const loadTenants = useCallback(async () => {
                       <Card style={tenantWorkspaceCardStyle}>
                         <div style={{ fontSize: 11, fontWeight: 700, color: text.muted }}>Lifecycle</div>
                         <div style={{ marginTop: 4, fontSize: 14, color: text.primary }}>
-                          {tenantLifecycleLabel(selectedTenant, selectedCanonicalState)}
+                          {selectedWorkspaceLifecycle?.label || tenantLifecycleLabel(selectedTenant, selectedCanonicalState)}
                         </div>
+                        {selectedWorkspaceLifecycle?.actualEndDate ? (
+                          <div style={{ marginTop: 4, fontSize: 12, color: text.muted }}>
+                            Actual end date: {formatDate(selectedWorkspaceLifecycle.actualEndDate)}
+                          </div>
+                        ) : null}
                         {selectedCanonicalState?.tenantRelationshipState === "occupancy_unresolved" && selectedTenant.propertyId && selectedTenant.unitId ? <button type="button" onClick={() => setResolveOccupancyOpen(true)}>Resolve occupancy</button> : null}
                       </Card>
                       <Card style={tenantWorkspaceCardStyle}>


### PR DESCRIPTION
## Summary

- adds one server-authoritative tenant workspace lifecycle projection: Current, Upcoming, Past, or Archived
- adds explicit reversible Archive and Restore landlord commands with mutation-time ownership, lease, unit, upcoming, and occupancy-conflict revalidation
- writes the tenant archive overlay and append-only lifecycle audit event atomically while preserving lease, payment, note, document, application, tenancy, and audit history
- keeps End Lease as Past rather than Archived and presents only authoritative actual-end timestamps
- adds Active, Current, Upcoming, Past, and Archived workspace filters plus server-gated Archive/Restore confirmation UX

## Boundaries

- no second current-lease evaluator or occupancy engine
- canonical 12-reason occupancy set unchanged
- no CURRENT_LEASE_CONTEXT_MISMATCH remediation
- no TENANT_CURRENT_WITHOUT_CURRENT_LEASE remediation
- no payment, signing, lease-start, End Lease, or occupancy-resolution mutation changes
- no image build, deployment, Preview/Production mutation, or Terraform apply

## Validation

- backend focused/composition: 126 tests passed
- frontend focused/composition: 177 tests passed
- backend build: passed
- frontend TypeScript: passed (`npx tsc --noEmit`)
- frontend build: passed
- `git diff --check`: passed

## Product decisions

- a valid upcoming lease blocks Archive because it is an operational future relationship that must remain visible
- Restore removes only the archive overlay; canonical lifecycle determines the restored category
- signing completion remains execution-only and does not itself make a tenant Current

Draft only. Requires founder-authorized exact-head source review before any merge or runtime certification.