### PR TITLE
Add closed PR 1573 Preview backend target

### DIFF
--- a/rentchain-frontend/server/previewBackendProxy.ts
+++ b/rentchain-frontend/server/previewBackendProxy.ts
@@ -26,6 +26,7 @@ export const PREVIEW_BACKEND_TARGET_KEYS = {
   pr1568: "pr1568-renewal-continuity-cert",
   pr1569: "pr1569-onboarding-occupancy-cert",
   pr1570: "pr1570-occupancy-start-cert",
+  pr1573: "pr1573-tenant-lifecycle-cert",
 } as const;
 
 export type PreviewBackendTarget = {
@@ -104,6 +105,14 @@ const PREVIEW_BACKEND_TARGETS: Record<string, PreviewBackendTarget> = {
       "https://rentchain-pr1570-qa-occupancy-start-glistw4pya-nn.a.run.app",
     cloudRunIdTokenAudience:
       "https://rentchain-pr1570-qa-occupancy-start-glistw4pya-nn.a.run.app",
+    temporary: true,
+  },
+  [PREVIEW_BACKEND_TARGET_KEYS.pr1573]: {
+    key: PREVIEW_BACKEND_TARGET_KEYS.pr1573,
+    cloudRunServiceUrl:
+      "https://rentchain-pr1573-qa-tenant-lifecycle-glistw4pya-nn.a.run.app",
+    cloudRunIdTokenAudience:
+      "https://rentchain-pr1573-qa-tenant-lifecycle-glistw4pya-nn.a.run.app",
     temporary: true,
   },
 };

--- a/rentchain-frontend/src/platform/previewBackendProxy.test.ts
+++ b/rentchain-frontend/src/platform/previewBackendProxy.test.ts
@@ -238,6 +238,21 @@ describe("Preview backend proxy", () => {
     });
   });
 
+  it("couples the authorized PR #1573 service URL and audience internally", () => {
+    const target = resolvePreviewBackendTarget({
+      vercelEnvironment: "preview",
+      targetKey: PREVIEW_BACKEND_TARGET_KEYS.pr1573,
+    });
+    expect(target).toEqual({
+      key: "pr1573-tenant-lifecycle-cert",
+      cloudRunServiceUrl:
+        "https://rentchain-pr1573-qa-tenant-lifecycle-glistw4pya-nn.a.run.app",
+      cloudRunIdTokenAudience:
+        "https://rentchain-pr1573-qa-tenant-lifecycle-glistw4pya-nn.a.run.app",
+      temporary: true,
+    });
+  });
+
   it.each([
     ["production", PREVIEW_BACKEND_TARGET_KEYS.pr1555],
     ["development", PREVIEW_BACKEND_TARGET_KEYS.pr1555],
@@ -255,6 +270,8 @@ describe("Preview backend proxy", () => {
     ["development", PREVIEW_BACKEND_TARGET_KEYS.pr1569],
     ["production", PREVIEW_BACKEND_TARGET_KEYS.pr1570],
     ["development", PREVIEW_BACKEND_TARGET_KEYS.pr1570],
+    ["production", PREVIEW_BACKEND_TARGET_KEYS.pr1573],
+    ["development", PREVIEW_BACKEND_TARGET_KEYS.pr1573],
     ["preview", ""],
     ["preview", "   "],
     ["preview", "unknown"],
@@ -588,6 +605,43 @@ describe("Preview backend proxy", () => {
       temporary: false,
     }],
   ])("rejects a tampered PR #1570 mapping: %s", (_label, target) => {
+    expect(() => assertPreviewBackendTarget(target, "preview")).toThrow(
+      "PREVIEW_PROXY_TARGET_REJECTED",
+    );
+  });
+
+  it.each([
+    ["altered URL", {
+      key: PREVIEW_BACKEND_TARGET_KEYS.pr1573,
+      cloudRunServiceUrl: "https://attacker.example",
+      cloudRunIdTokenAudience:
+        "https://rentchain-pr1573-qa-tenant-lifecycle-glistw4pya-nn.a.run.app",
+      temporary: true,
+    }],
+    ["altered audience", {
+      key: PREVIEW_BACKEND_TARGET_KEYS.pr1573,
+      cloudRunServiceUrl:
+        "https://rentchain-pr1573-qa-tenant-lifecycle-glistw4pya-nn.a.run.app",
+      cloudRunIdTokenAudience: "https://attacker.example",
+      temporary: true,
+    }],
+    ["mismatched URL and audience", {
+      key: PREVIEW_BACKEND_TARGET_KEYS.pr1573,
+      cloudRunServiceUrl:
+        "https://rentchain-pr1573-qa-tenant-lifecycle-glistw4pya-nn.a.run.app",
+      cloudRunIdTokenAudience:
+        "https://rentchain-preview-backend-glistw4pya-nn.a.run.app",
+      temporary: true,
+    }],
+    ["temporary flag", {
+      key: PREVIEW_BACKEND_TARGET_KEYS.pr1573,
+      cloudRunServiceUrl:
+        "https://rentchain-pr1573-qa-tenant-lifecycle-glistw4pya-nn.a.run.app",
+      cloudRunIdTokenAudience:
+        "https://rentchain-pr1573-qa-tenant-lifecycle-glistw4pya-nn.a.run.app",
+      temporary: false,
+    }],
+  ])("rejects a tampered PR #1573 mapping: %s", (_label, target) => {
     expect(() => assertPreviewBackendTarget(target, "preview")).toThrow(
       "PREVIEW_PROXY_TARGET_REJECTED",
     );


### PR DESCRIPTION
## Summary

- prerequisite for PR #1573 runtime certification only
- adds one static symbolic selector: `pr1573-tenant-lifecycle-cert`
- adds one fixed Cloud Run URL and matching ID-token audience
- preserves the closed target registry; unknown targets still fail closed
- adds preview-only and target-tampering regressions

## Scope

- no product behavior change
- no backend product source change
- no deployment or runtime mutation
- PR #1573 remains untouched

## Validation

- 139 focused Preview proxy/auth tests passed
- frontend TypeScript passed
- frontend build passed
- `git diff --check` passed