### PR TITLE
Harden Cloud Build source credential exclusion

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+# Local credentials must never enter the repository-root Docker context.
+rentchain-api/secrets/
+rentchain-api/secrets/**
+**/*service-account*.json

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,10 @@
+# Keep Cloud Build source packaging aligned with repository exclusions.
+.gcloudignore
+.git
+.git/**
+#!include:.gitignore
+
+# Local credentials must never enter a Cloud Build source archive.
+rentchain-api/secrets/
+rentchain-api/secrets/**
+**/*service-account*.json

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,8 +1,48 @@
-# Keep Cloud Build source packaging aligned with repository exclusions.
+# Purpose-built Cloud Build source exclusions. Do not include the repository's
+# full .gitignore: it excludes tracked PNG, PDF, and ZIP runtime assets.
 .gcloudignore
 .git
 .git/**
-#!include:.gitignore
+
+# Dependencies, generated output, and local tooling state.
+node_modules/
+**/node_modules/**
+dist/
+**/dist/**
+build/
+**/build/**
+coverage/
+**/coverage/**
+.tmp/
+**/.tmp/**
+.temp/
+**/.temp/**
+.cache/
+**/.cache/**
+.vercel/
+**/.vercel/**
+.gcloud/
+**/.gcloud/**
+.firebase/
+**/.firebase/**
+playwright-report/
+**/playwright-report/**
+test-results/
+**/test-results/**
+
+# Local environment, log, editor, and OS files.
+.env
+.env.*
+**/.env
+**/.env.*
+*.log
+**/*.log
+.DS_Store
+**/.DS_Store
+.vscode/
+**/.vscode/**
+.idea/
+**/.idea/**
 
 # Local credentials must never enter a Cloud Build source archive.
 rentchain-api/secrets/

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,10 @@ yarn-error.log*
 pnpm-debug.log*
 rentchain-api/sendgrid.env
 
+# Local credential material
+rentchain-api/secrets/
+**/*service-account*.json
+
 # OS / editor noise
 .DS_Store
 Thumbs.db

--- a/rentchain-api/.dockerignore
+++ b/rentchain-api/.dockerignore
@@ -16,6 +16,9 @@ npm-debug.log*
 *.pem
 *.key
 credentials*.json
+secrets/
+secrets/**
+**/*service-account*.json
 .idea
 .vscode
 .DS_Store

--- a/scripts/security/validate-cloud-build-source-exclusions.sh
+++ b/scripts/security/validate-cloud-build-source-exclusions.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+probe_dir="${repo_root}/rentchain-api/secrets"
+probe_path="${probe_dir}/__cloud_build_exclusion_probe__.json"
+named_probe_path="${repo_root}/__cloud_build_service-account_probe__.json"
+source_list="$(mktemp)"
+
+cleanup() {
+  rm -f "${probe_path}" "${named_probe_path}" "${source_list}"
+  rmdir "${probe_dir}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+mkdir -p "${probe_dir}"
+printf '{"synthetic":true}\n' > "${probe_path}"
+printf '{"synthetic":true}\n' > "${named_probe_path}"
+
+gcloud meta list-files-for-upload "${repo_root}" > "${source_list}"
+
+if grep -Fq 'rentchain-api/secrets/' "${source_list}"; then
+  printf 'Cloud Build source exclusion failed for the protected secrets path.\n' >&2
+  exit 1
+fi
+
+if grep -Eq '(^|/)[^/]*service-account[^/]*\.json$' "${source_list}"; then
+  printf 'Cloud Build source exclusion failed for a service-account JSON path.\n' >&2
+  exit 1
+fi
+
+for required_path in \
+  'Dockerfile' \
+  'rentchain-api/Dockerfile' \
+  'rentchain-api/package.json' \
+  'rentchain-api/package-lock.json' \
+  'rentchain-api/src/index.ts'; do
+  if ! grep -Fxq "${required_path}" "${source_list}"; then
+    printf 'Required Cloud Build source path is missing: %s\n' "${required_path}" >&2
+    exit 1
+  fi
+done
+
+for ignore_file in \
+  "${repo_root}/.dockerignore" \
+  "${repo_root}/rentchain-api/.dockerignore"; do
+  if ! grep -Fq '**/*service-account*.json' "${ignore_file}"; then
+    printf 'Docker credential exclusion is missing from: %s\n' "${ignore_file}" >&2
+    exit 1
+  fi
+done
+
+printf 'Cloud Build source exclusions validated.\n'

--- a/scripts/security/validate-cloud-build-source-exclusions.sh
+++ b/scripts/security/validate-cloud-build-source-exclusions.sh
@@ -34,7 +34,11 @@ for required_path in \
   'rentchain-api/Dockerfile' \
   'rentchain-api/package.json' \
   'rentchain-api/package-lock.json' \
-  'rentchain-api/src/index.ts'; do
+  'rentchain-api/src/index.ts' \
+  'rentchain-frontend/src/main.tsx' \
+  'rentchain-frontend/public/brand/logo-wordmark.png' \
+  'rentchain-frontend/public/templates/ns/lease-data-summary.pdf' \
+  'rentchain-frontend/public/templates/ns/lease-pack-v1-bundle.zip'; do
   if ! grep -Fxq "${required_path}" "${source_list}"; then
     printf 'Required Cloud Build source path is missing: %s\n' "${required_path}" >&2
     exit 1


### PR DESCRIPTION
## Summary

- adds repository-controlled Cloud Build and Docker context exclusions for local credential paths
- adds a synthetic packaging regression proving protected paths are absent while required backend source remains present
- adds matching Git tracking protection

## Containment

- the local path implicated by prior uploads was confirmed to be an empty placeholder with no service-account or key metadata
- both deterministically attributable failed PR #1573 staging objects were removed
- no replacement JSON key was created
- PR #1573 remains untouched and frozen

## Validation

- `scripts/security/validate-cloud-build-source-exclusions.sh`
- `bash -n scripts/security/validate-cloud-build-source-exclusions.sh`
- `git diff --check`
- path-only tracked-content scan found no private-key markers

No Cloud Build, image build, deployment, runtime mutation, or product-code change was performed.