### PR TITLE
Preview: add closed PR #1576 certification backend selector

### DIFF
--- a/rentchain-frontend/server/previewBackendProxy.ts
+++ b/rentchain-frontend/server/previewBackendProxy.ts
@@ -27,6 +27,7 @@ export const PREVIEW_BACKEND_TARGET_KEYS = {
   pr1569: "pr1569-onboarding-occupancy-cert",
   pr1570: "pr1570-occupancy-start-cert",
   pr1573: "pr1573-tenant-lifecycle-cert",
+  pr1576: "pr1576-context-mismatch-cert",
 } as const;
 
 export type PreviewBackendTarget = {
@@ -113,6 +114,14 @@ const PREVIEW_BACKEND_TARGETS: Record<string, PreviewBackendTarget> = {
       "https://rentchain-pr1573-qa-tenant-lifecycle-glistw4pya-nn.a.run.app",
     cloudRunIdTokenAudience:
       "https://rentchain-pr1573-qa-tenant-lifecycle-glistw4pya-nn.a.run.app",
+    temporary: true,
+  },
+  [PREVIEW_BACKEND_TARGET_KEYS.pr1576]: {
+    key: PREVIEW_BACKEND_TARGET_KEYS.pr1576,
+    cloudRunServiceUrl:
+      "https://rentchain-pr1576-qa-context-mismatch-501298948635.northamerica-northeast1.run.app",
+    cloudRunIdTokenAudience:
+      "https://rentchain-pr1576-qa-context-mismatch-501298948635.northamerica-northeast1.run.app",
     temporary: true,
   },
 };

--- a/rentchain-frontend/src/platform/previewBackendProxy.test.ts
+++ b/rentchain-frontend/src/platform/previewBackendProxy.test.ts
@@ -253,6 +253,21 @@ describe("Preview backend proxy", () => {
     });
   });
 
+  it("couples the authorized PR #1576 service URL and audience internally", () => {
+    const target = resolvePreviewBackendTarget({
+      vercelEnvironment: "preview",
+      targetKey: PREVIEW_BACKEND_TARGET_KEYS.pr1576,
+    });
+    expect(target).toEqual({
+      key: "pr1576-context-mismatch-cert",
+      cloudRunServiceUrl:
+        "https://rentchain-pr1576-qa-context-mismatch-501298948635.northamerica-northeast1.run.app",
+      cloudRunIdTokenAudience:
+        "https://rentchain-pr1576-qa-context-mismatch-501298948635.northamerica-northeast1.run.app",
+      temporary: true,
+    });
+  });
+
   it.each([
     ["production", PREVIEW_BACKEND_TARGET_KEYS.pr1555],
     ["development", PREVIEW_BACKEND_TARGET_KEYS.pr1555],
@@ -272,6 +287,8 @@ describe("Preview backend proxy", () => {
     ["development", PREVIEW_BACKEND_TARGET_KEYS.pr1570],
     ["production", PREVIEW_BACKEND_TARGET_KEYS.pr1573],
     ["development", PREVIEW_BACKEND_TARGET_KEYS.pr1573],
+    ["production", PREVIEW_BACKEND_TARGET_KEYS.pr1576],
+    ["development", PREVIEW_BACKEND_TARGET_KEYS.pr1576],
     ["preview", ""],
     ["preview", "   "],
     ["preview", "unknown"],


### PR DESCRIPTION
Adds one static Preview-only closed selector for PR #1576 runtime certification.\n\n- Fixed symbolic key, Cloud Run URL, and identical ID-token audience\n- Preserves permanent Preview default and unknown-key rejection\n- No product, backend, infrastructure, deployment, or dynamic-target changes\n\nValidation: 134 focused proxy tests, frontend TypeScript, frontend build, and git diff check passed.