### PR TITLE
PR L: prevent unsupported tenant current-state writes

### DIFF
--- a/rentchain-api/src/lib/tenants/tenantCreationStatus.ts
+++ b/rentchain-api/src/lib/tenants/tenantCreationStatus.ts
@@ -1,0 +1,13 @@
+export const SAFE_TENANT_CREATION_STATUS = "invited" as const;
+
+const CURRENT_LIKE_TENANT_STATUSES = new Set([
+  "active",
+  "current",
+  "occupied",
+  "leased",
+  "rented",
+]);
+
+export function isCurrentLikeTenantStatus(value: unknown): boolean {
+  return CURRENT_LIKE_TENANT_STATUSES.has(String(value || "").trim().toLowerCase());
+}

--- a/rentchain-api/src/routes/__tests__/tenantCurrentStateWriterGuards.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantCurrentStateWriterGuards.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { buildCanonicalLeaseOccupancyProjection } from "../../lib/leases/canonicalLeaseOccupancyProjection";
+import { deriveCanonicalLeaseTermState } from "../../lib/leases/canonicalLeaseOccupancyState";
+import { evaluateCanonicalLeaseStart } from "../../lib/leases/canonicalLeaseStart";
 
 const { collections, resetDb } = vi.hoisted(() => {
   const collections = new Map<string, Map<string, any>>();
@@ -65,6 +67,22 @@ describe("tenant current-state writer guards", () => {
     const lease = [...collection("leases").values()][0];
     expect(tenant).toMatchObject({ status: "invited", currentLeaseId: null });
     expect(lease).not.toHaveProperty("occupancyEffective", true);
+    const lifecycle = deriveCanonicalLeaseTermState({ id: "onboarding-lease", ...lease }, "2026-09-01T12:00:00.000Z");
+    expect(lifecycle).toMatchObject({ state: "unknown", supportsCurrentOccupancy: false });
+    const startEligibility = evaluateCanonicalLeaseStart({
+      landlordId: "landlord-1",
+      propertyId: "property-1",
+      unitId: "unit-1",
+      tenantId: tenant.id,
+      evaluationInstant: "2026-09-01T12:00:00.000Z",
+      candidateLease: { id: "onboarding-lease", ...lease },
+      contextLeases: [],
+      standaloneUnits: [{ id: "unit-1", landlordId: "landlord-1", propertyId: "property-1", status: "vacant" }],
+      embeddedUnits: [{ id: "unit-1", landlordId: "landlord-1", propertyId: "property-1", status: "vacant" }],
+      tenant,
+      tenancies: [],
+    });
+    expect(startEligibility).toMatchObject({ outcome: "rejected", occupancyEffective: false, reasons: ["CURRENT_LEASE_CONTEXT_MISMATCH"] });
     expect(collection("units")).toHaveLength(0);
     expect(collection("tenancies")).toHaveLength(0);
     expect(collection("canonicalEvents")).toHaveLength(0);

--- a/rentchain-api/src/routes/__tests__/tenantCurrentStateWriterGuards.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantCurrentStateWriterGuards.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildCanonicalLeaseOccupancyProjection } from "../../lib/leases/canonicalLeaseOccupancyProjection";
+
+const { collections, resetDb } = vi.hoisted(() => {
+  const collections = new Map<string, Map<string, any>>();
+  return { collections, resetDb: () => collections.clear() };
+});
+
+function collection(name: string) {
+  let rows = collections.get(name);
+  if (!rows) { rows = new Map(); collections.set(name, rows); }
+  return rows;
+}
+
+vi.mock("../../firebase", () => ({
+  db: { collection: (name: string) => ({
+    doc: (id: string) => ({ set: async (value: any, options?: { merge?: boolean }) => {
+      const current = collection(name).get(id) || {};
+      collection(name).set(id, options?.merge ? { ...current, ...value } : value);
+    } }),
+    add: async (value: any) => {
+      const id = `${name}-${collection(name).size + 1}`;
+      collection(name).set(id, value);
+      return { id, set: async (patch: any, options?: { merge?: boolean }) => {
+        const current = collection(name).get(id) || {};
+        collection(name).set(id, options?.merge ? { ...current, ...patch } : patch);
+      } };
+    },
+  }) },
+}));
+
+vi.mock("../../middleware/requireAuth", () => ({ requireAuth: (req: any, _res: any, next: any) => {
+  req.user ||= { id: "landlord-1", landlordId: "landlord-1", role: "landlord" };
+  next();
+} }));
+vi.mock("bcryptjs", () => ({ default: { hash: vi.fn(async () => "password-hash") } }));
+vi.mock("firebase-admin", () => ({ default: { firestore: { FieldValue: { serverTimestamp: () => "server-timestamp" } } } }));
+
+async function invokeRouter(router: any, options: { method: string; url: string; body?: any }) {
+  return new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const req: any = { method: options.method, url: options.url, originalUrl: options.url, path: options.url,
+      body: options.body || {}, headers: {}, query: {}, user: { id: "landlord-1", landlordId: "landlord-1", role: "landlord" } };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) { this.statusCode = code; return this; },
+      json(payload: any) { resolve({ status: this.statusCode, body: payload }); return this; },
+      send(payload: any) { resolve({ status: this.statusCode, body: payload }); return this; },
+    };
+    router.handle(req, res, (error: any) => error ? reject(error) : resolve({ status: 404, body: null }));
+  });
+}
+
+describe("tenant current-state writer guards", () => {
+  beforeEach(resetDb);
+
+  it("onboards a tenant and incomplete lease without creating current occupancy", async () => {
+    const router = (await import("../tenantOnboardRoutes")).default;
+    const response = await invokeRouter(router, { method: "POST", url: "/tenants/onboard", body: {
+      fullName: "Taylor Tenant", email: "tenant@example.com", propertyId: "property-1",
+      propertyName: "Harbour House", unit: "1A", moveInDate: "2026-09-01", monthlyRent: 1800,
+    } });
+
+    expect(response.status).toBe(201);
+    const tenant = [...collection("tenants").values()][0];
+    const lease = [...collection("leases").values()][0];
+    expect(tenant).toMatchObject({ status: "invited", currentLeaseId: null });
+    expect(lease).not.toHaveProperty("occupancyEffective", true);
+    expect(collection("units")).toHaveLength(0);
+    expect(collection("tenancies")).toHaveLength(0);
+    expect(collection("canonicalEvents")).toHaveLength(0);
+
+    const canonicalState = buildCanonicalLeaseOccupancyProjection({
+      leases: [{ id: "onboarding-lease", ...lease }],
+      context: { landlordId: "landlord-1", propertyId: "property-1", tenantId: tenant.id },
+      persistedTenantStatus: tenant.status, currentLeasePointerId: tenant.currentLeaseId, tenantId: tenant.id,
+    });
+    expect(canonicalState.reasons).not.toContain("TENANT_CURRENT_WITHOUT_CURRENT_LEASE");
+    expect(canonicalState.tenantRelationshipState).not.toBe("current_occupant");
+  });
+
+  it("defaults admin-created tenants to invited without occupancy side effects", async () => {
+    const router = (await import("../adminTenantToolsRoutes")).default;
+    const response = await invokeRouter(router, { method: "POST", url: "/create",
+      body: { email: "tenant@example.com", password: "safe-test-password" } });
+
+    expect(response.status).toBe(200);
+    expect(response.body.status).toBe("invited");
+    expect([...collection("tenants").values()][0]).toMatchObject({ status: "invited", currentLeaseId: null });
+    expect(collection("leases")).toHaveLength(0);
+    expect(collection("units")).toHaveLength(0);
+    expect(collection("tenancies")).toHaveLength(0);
+    expect(collection("canonicalEvents")).toHaveLength(0);
+  });
+
+  it.each(["active", "current", "occupied", "leased", "rented", " ACTIVE "])(
+    "rejects unguarded admin current-like status %j", async (status) => {
+      const router = (await import("../adminTenantToolsRoutes")).default;
+      const response = await invokeRouter(router, { method: "POST", url: "/create",
+        body: { email: "tenant@example.com", password: "safe-test-password", status } });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBe("current tenant status requires canonical occupancy authority");
+      expect(collection("tenants")).toHaveLength(0);
+      expect(collection("leases")).toHaveLength(0);
+      expect(collection("tenancies")).toHaveLength(0);
+      expect(collection("canonicalEvents")).toHaveLength(0);
+    }
+  );
+});

--- a/rentchain-api/src/routes/adminTenantToolsRoutes.ts
+++ b/rentchain-api/src/routes/adminTenantToolsRoutes.ts
@@ -4,6 +4,10 @@ import { db } from "../firebase";
 import { requireAuth } from "../middleware/requireAuth";
 import { requireRole } from "../middleware/requireRole";
 import admin from "firebase-admin";
+import {
+  isCurrentLikeTenantStatus,
+  SAFE_TENANT_CREATION_STATUS,
+} from "../lib/tenants/tenantCreationStatus";
 
 const router = Router();
 
@@ -11,6 +15,9 @@ router.post("/create", requireAuth, requireRole(["landlord", "admin"]), async (r
   const { email, password, landlordId, status } = req.body || {};
   if (!email || !password) {
     return res.status(400).json({ error: "email and password are required" });
+  }
+  if (isCurrentLikeTenantStatus(status)) {
+    return res.status(400).json({ error: "current tenant status requires canonical occupancy authority" });
   }
 
   const normalizedEmail = String(email).trim().toLowerCase();
@@ -23,7 +30,8 @@ router.post("/create", requireAuth, requireRole(["landlord", "admin"]), async (r
       email: normalizedEmail,
       landlordId: ownerLandlordId ?? null,
       role: "tenant",
-      status: status || "active",
+      status: status || SAFE_TENANT_CREATION_STATUS,
+      currentLeaseId: null,
       passwordHash: hash,
       createdAt: admin.firestore.FieldValue.serverTimestamp(),
     });
@@ -36,7 +44,7 @@ router.post("/create", requireAuth, requireRole(["landlord", "admin"]), async (r
       tenantId: docRef.id,
       email: normalizedEmail,
       landlordId: ownerLandlordId ?? null,
-      status: status || "active",
+      status: status || SAFE_TENANT_CREATION_STATUS,
     });
   } catch (err: any) {
     console.error("[admin tenant create] error", err);

--- a/rentchain-api/src/routes/tenantOnboardRoutes.ts
+++ b/rentchain-api/src/routes/tenantOnboardRoutes.ts
@@ -2,6 +2,7 @@
 import { Router } from "express";
 import { v4 as uuidv4 } from "uuid";
 import { db } from "../firebase";
+import { SAFE_TENANT_CREATION_STATUS } from "../lib/tenants/tenantCreationStatus";
 
 const router = Router();
 
@@ -46,7 +47,8 @@ router.post("/tenants/onboard", async (req, res) => {
       propertyName,
       unit,
       balance: 0,
-      status: "active",
+      status: SAFE_TENANT_CREATION_STATUS,
+      currentLeaseId: null,
       createdAt,
       sourceApplication: applicationId ?? null,
     };

--- a/rentchain-api/src/services/__tests__/occupancyReviewWorkspaceService.test.ts
+++ b/rentchain-api/src/services/__tests__/occupancyReviewWorkspaceService.test.ts
@@ -73,6 +73,33 @@ describe("occupancyReviewWorkspaceService", () => {
     expect(result.items[0]).toMatchObject({ scope: "tenant", reasons: expect.arrayContaining(["TENANT_CURRENT_WITHOUT_CURRENT_LEASE"]), action: "review_tenant_relationship" });
   });
 
+  it("classifies a current tenant without a current lease without repairing authoritative state", () => {
+    const authoritative: OccupancyReviewRecords & { canonicalEvents: Array<Record<string, unknown>> } = {
+      ...baseRecords(),
+      canonicalEvents: [],
+    };
+    authoritative.units[0] = { ...authoritative.units[0], status: "vacant", currentTenantId: null, currentLeaseId: null };
+    authoritative.tenants[0] = { ...authoritative.tenants[0], status: "current", currentLeaseId: null };
+    authoritative.leases = [];
+    authoritative.tenancies = [];
+    const before = structuredClone(authoritative);
+
+    const result = aggregateOccupancyReviewWorkspace(landlordId, authoritative);
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toMatchObject({
+      scope: "tenant",
+      canonicalState: { tenantRelationshipState: "occupancy_unresolved" },
+      reasons: expect.arrayContaining(["TENANT_CURRENT_WITHOUT_CURRENT_LEASE"]),
+    });
+    expect(authoritative).toEqual(before);
+    expect(authoritative.tenants[0].status).toBe(before.tenants[0].status);
+    expect(authoritative.leases).toHaveLength(before.leases.length);
+    expect(authoritative.tenancies).toEqual(before.tenancies);
+    expect(authoritative.units[0].status).toBe(before.units[0].status);
+    expect(authoritative.canonicalEvents).toHaveLength(before.canonicalEvents.length);
+  });
+
   it("omits coherent occupied and vacant units", () => {
     const occupied = baseRecords(); occupied.units[0].currentLeaseId = "lease-a"; occupied.leases = [activeLease("lease-a")]; occupied.tenancies = [{ id: "t", landlordId, propertyId: "property-1", unitId: "unit-1", leaseId: "lease-a", tenantId: "tenant-1", status: "active" }]; occupied.tenants[0].currentLeaseId = "lease-a";
     expect(aggregateOccupancyReviewWorkspace(landlordId, occupied).items).toEqual([]);

--- a/rentchain-api/src/services/leaseStart/__tests__/leaseStartService.test.ts
+++ b/rentchain-api/src/services/leaseStart/__tests__/leaseStartService.test.ts
@@ -213,6 +213,23 @@ describe("leaseStartService", () => {
     expect(result.expectedStateToken).toBe(fresh.expectedStateToken);
   });
 
+  it("allows an invited tenant to become current only through explicit Start Occupancy", async () => {
+    seedBase({ tenant: { status: "invited", currentLeaseId: null } });
+    expect(fake.read("tenants", "tenant-1")).toMatchObject({ status: "invited", currentLeaseId: null });
+
+    const result = await startCanonicalLeaseOccupancy(await mutationInput());
+
+    expect(result).toMatchObject({ outcome: "occupancy_effective", occupancyEffective: true });
+    expect(fake.read("tenants", "tenant-1")).toMatchObject({ status: "current", currentLeaseId: "lease-1" });
+    expect(fake.read("units", "unit-1")).toMatchObject({ status: "occupied", currentLeaseId: "lease-1" });
+    expect(fake.list("tenancies")).toEqual([
+      expect.objectContaining({ tenantId: "tenant-1", leaseId: "lease-1", status: "active" }),
+    ]);
+    expect(fake.list("canonicalEvents")).toEqual([
+      expect.objectContaining({ type: "lease.occupancy_started" }),
+    ]);
+  });
+
   it("rejects an archived tenant inside the authoritative start transaction with zero writes", async () => {
     seedBase({ tenant: { archivedAt: "2026-04-30T13:00:00.000Z" } });
     const context = await getCanonicalLeaseStartContext({ ...base, firestore: fake.firestore });

--- a/rentchain-api/src/services/leaseStart/__tests__/leaseStartService.test.ts
+++ b/rentchain-api/src/services/leaseStart/__tests__/leaseStartService.test.ts
@@ -1,10 +1,19 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildCanonicalLeaseOccupancyProjection } from "../../../lib/leases/canonicalLeaseOccupancyProjection";
 import {
   getCanonicalLeaseStartContext,
   LeaseStartServiceError,
   startCanonicalLeaseOccupancy,
   type StartCanonicalLeaseOccupancyInput,
 } from "../leaseStartService";
+
+const firebaseState = vi.hoisted(() => ({ firestore: null as any }));
+vi.mock("../../../firebase", () => ({
+  db: {
+    collection: (...args: any[]) => firebaseState.firestore.collection(...args),
+    runTransaction: (...args: any[]) => firebaseState.firestore.runTransaction(...args),
+  },
+}));
 
 function createFakeFirestore() {
   const store = new Map<string, Map<string, any>>();
@@ -114,7 +123,15 @@ function createFakeFirestore() {
     return result;
   };
   const firestore: any = {
-    collection: (name: string) => ({ ...query(name), doc: (id: string) => ref(name, id) }),
+    collection: (name: string) => ({
+      ...query(name),
+      doc: (id: string) => ref(name, id),
+      add: async (value: any) => {
+        const id = `${name}-${collectionData(name).size + 1}`;
+        await ref(name, id).set(value);
+        return ref(name, id);
+      },
+    }),
     runTransaction: async (callback: any) => {
       for (let attempt = 0; attempt < 4; attempt += 1) {
         try {
@@ -190,9 +207,32 @@ function domainSnapshot() {
   };
 }
 
+async function invokeRouter(router: any, options: { method: string; url: string; body?: any }) {
+  return new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path: options.url,
+      body: options.body || {},
+      headers: {},
+      query: {},
+      user: { id: "landlord-1", landlordId: "landlord-1", role: "landlord" },
+    };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) { this.statusCode = code; return this; },
+      json(payload: any) { resolve({ status: this.statusCode, body: payload }); return this; },
+      send(payload: any) { resolve({ status: this.statusCode, body: payload }); return this; },
+    };
+    router.handle(req, res, (error: any) => error ? reject(error) : resolve({ status: 404, body: null }));
+  });
+}
+
 describe("leaseStartService", () => {
   beforeEach(() => {
     fake = createFakeFirestore();
+    firebaseState.firestore = fake.firestore;
     seedBase();
   });
 
@@ -228,6 +268,94 @@ describe("leaseStartService", () => {
     expect(fake.list("canonicalEvents")).toEqual([
       expect.objectContaining({ type: "lease.occupancy_started" }),
     ]);
+  });
+
+  it("starts the same tenant and lease lineage created by the onboarding route only after explicit prerequisites", async () => {
+    fake = createFakeFirestore();
+    firebaseState.firestore = fake.firestore;
+    const onboardingRouter = (await import("../../../routes/tenantOnboardRoutes")).default;
+    const onboarded = await invokeRouter(onboardingRouter, {
+      method: "POST",
+      url: "/tenants/onboard",
+      body: {
+        fullName: "Taylor Tenant",
+        email: "tenant@example.com",
+        propertyId: "property-onboarded",
+        propertyName: "Harbour House",
+        unit: "1A",
+        moveInDate: "2026-04-01",
+        monthlyRent: 1800,
+      },
+    });
+
+    expect(onboarded.status).toBe(201);
+    const tenantId = onboarded.body.tenantId;
+    const leaseId = fake.ids("leases")[0];
+    const tenantBefore = fake.read("tenants", tenantId);
+    const onboardingLease = fake.read("leases", leaseId);
+    const beforeProjection = buildCanonicalLeaseOccupancyProjection({
+      leases: [{ id: leaseId, ...onboardingLease }],
+      context: { landlordId: "landlord-1", propertyId: "property-onboarded", tenantId, asOfDate: evaluationInstant },
+      persistedTenantStatus: tenantBefore.status,
+      currentLeasePointerId: tenantBefore.currentLeaseId,
+      tenantId,
+    });
+    expect(tenantBefore).toMatchObject({ status: "invited", currentLeaseId: null });
+    expect(beforeProjection.tenantRelationshipState).not.toBe("current_occupant");
+    expect(onboardingLease).not.toHaveProperty("occupancyEffective", true);
+    expect(fake.list("tenancies")).toEqual([]);
+
+    const unitId = "unit-onboarded";
+    const vacantUnit = { id: unitId, unitNumber: "1A", status: "vacant", occupancyStatus: "vacant", updatedAt: "2026-04-30T12:00:00.000Z" };
+    fake.seed("properties", "property-onboarded", { landlordId: "landlord-1", name: "Harbour House", units: [vacantUnit], updatedAt: vacantUnit.updatedAt });
+    fake.seed("units", unitId, { ...vacantUnit, landlordId: "landlord-1", propertyId: "property-onboarded" });
+    fake.seed("leases", leaseId, {
+      ...onboardingLease,
+      landlordId: "landlord-1",
+      unitId,
+      primaryTenantId: tenantId,
+      tenantIds: [tenantId],
+      status: "active",
+      executionStatus: "fully_executed",
+      startDate: onboardingLease.leaseStart,
+      endDate: "2027-04-30",
+      occupancyEffective: false,
+    });
+
+    const inputBase = { landlordId: "landlord-1", propertyId: "property-onboarded", unitId, tenantId, leaseId, evaluationInstant };
+    const context = await getCanonicalLeaseStartContext({ ...inputBase, firestore: fake.firestore });
+    expect(context.decision.outcome).toBe("occupancy_effective");
+    const auditCountBefore = fake.list("canonicalEvents").length;
+    const result = await startCanonicalLeaseOccupancy({
+      ...inputBase,
+      operationKind: "explicit_start",
+      trigger: "explicit_start",
+      idempotencyKey: "onboarding-lineage-explicit-start",
+      expectedStateToken: context.expectedStateToken,
+      actorId: "landlord-1",
+      source: "test",
+      firestore: fake.firestore,
+    });
+
+    const tenantAfter = fake.read("tenants", tenantId);
+    const unitAfter = fake.read("units", unitId);
+    const leaseAfter = fake.read("leases", leaseId);
+    const activeTenancies = fake.list("tenancies").filter((tenancy) => tenancy.status === "active");
+    const afterProjection = buildCanonicalLeaseOccupancyProjection({
+      leases: [{ id: leaseId, ...leaseAfter }],
+      context: { landlordId: "landlord-1", propertyId: "property-onboarded", unitId, tenantId, asOfDate: evaluationInstant },
+      persistedUnitOccupancy: unitAfter.occupancyStatus,
+      persistedTenancyStatus: activeTenancies[0]?.status,
+      persistedTenantStatus: tenantAfter.status,
+      currentLeasePointerId: tenantAfter.currentLeaseId,
+      tenantId,
+    });
+    expect(result).toMatchObject({ outcome: "occupancy_effective", occupancyEffective: true });
+    expect(afterProjection).toMatchObject({ tenantRelationshipState: "current_occupant", occupancyState: "occupied", supportingLeaseId: leaseId });
+    expect(activeTenancies).toEqual([expect.objectContaining({ tenantId, leaseId, status: "active" })]);
+    expect(unitAfter).toMatchObject({ status: "occupied", occupancyStatus: "occupied", currentTenantId: tenantId, currentLeaseId: leaseId });
+    expect(fake.list("canonicalEvents")).toHaveLength(auditCountBefore + 1);
+    expect(fake.list("canonicalEvents").filter((event) => event.type === "lease.occupancy_started")).toHaveLength(1);
   });
 
   it("rejects an archived tenant inside the authoritative start transaction with zero writes", async () => {


### PR DESCRIPTION
## Summary
- closes the two unsupported tenant current-state writers identified by the diagnosis
- makes onboarding create tenants as invited with no current lease pointer
- makes admin tenant creation default to invited and reject current-like status inputs without canonical occupancy authority
- preserves explicit Start Occupancy as the authority for becoming current

## Scope boundaries
- no historical tenant migration
- no tenant-status remediation command
- no automatic Start Occupancy
- no occupancy, tenancy, lease execution, infrastructure, or deployment changes
- TENANT_CURRENT_WITHOUT_CURRENT_LEASE remains canonical and the 12-reason set is unchanged

## Validation
- focused backend regressions: 217 passed across writer guards, canonical reason detection, Start Occupancy, End Lease, PR K reconciliation, and tenant lifecycle/archive
- backend build passed on Node 24.19.0
- git diff --check passed
- frontend validation not required because no frontend source changed