### PR TITLE
Preview: add closed PR #1578 certification backend selector

### DIFF
--- a/rentchain-frontend/server/previewBackendProxy.ts
+++ b/rentchain-frontend/server/previewBackendProxy.ts
@@ -28,6 +28,7 @@ export const PREVIEW_BACKEND_TARGET_KEYS = {
   pr1570: "pr1570-occupancy-start-cert",
   pr1573: "pr1573-tenant-lifecycle-cert",
   pr1576: "pr1576-context-mismatch-cert",
+  pr1578: "pr1578-writer-guards-cert",
 } as const;
 
 export type PreviewBackendTarget = {
@@ -122,6 +123,14 @@ const PREVIEW_BACKEND_TARGETS: Record<string, PreviewBackendTarget> = {
       "https://rentchain-pr1576-qa-context-mismatch-501298948635.northamerica-northeast1.run.app",
     cloudRunIdTokenAudience:
       "https://rentchain-pr1576-qa-context-mismatch-501298948635.northamerica-northeast1.run.app",
+    temporary: true,
+  },
+  [PREVIEW_BACKEND_TARGET_KEYS.pr1578]: {
+    key: PREVIEW_BACKEND_TARGET_KEYS.pr1578,
+    cloudRunServiceUrl:
+      "https://rentchain-pr1578-qa-writer-guards-501298948635.northamerica-northeast1.run.app",
+    cloudRunIdTokenAudience:
+      "https://rentchain-pr1578-qa-writer-guards-501298948635.northamerica-northeast1.run.app",
     temporary: true,
   },
 };

--- a/rentchain-frontend/src/platform/previewBackendProxy.test.ts
+++ b/rentchain-frontend/src/platform/previewBackendProxy.test.ts
@@ -268,6 +268,21 @@ describe("Preview backend proxy", () => {
     });
   });
 
+  it("couples the authorized PR #1578 service URL and audience internally", () => {
+    const target = resolvePreviewBackendTarget({
+      vercelEnvironment: "preview",
+      targetKey: PREVIEW_BACKEND_TARGET_KEYS.pr1578,
+    });
+    expect(target).toEqual({
+      key: "pr1578-writer-guards-cert",
+      cloudRunServiceUrl:
+        "https://rentchain-pr1578-qa-writer-guards-501298948635.northamerica-northeast1.run.app",
+      cloudRunIdTokenAudience:
+        "https://rentchain-pr1578-qa-writer-guards-501298948635.northamerica-northeast1.run.app",
+      temporary: true,
+    });
+  });
+
   it.each([
     ["production", PREVIEW_BACKEND_TARGET_KEYS.pr1555],
     ["development", PREVIEW_BACKEND_TARGET_KEYS.pr1555],
@@ -289,6 +304,8 @@ describe("Preview backend proxy", () => {
     ["development", PREVIEW_BACKEND_TARGET_KEYS.pr1573],
     ["production", PREVIEW_BACKEND_TARGET_KEYS.pr1576],
     ["development", PREVIEW_BACKEND_TARGET_KEYS.pr1576],
+    ["production", PREVIEW_BACKEND_TARGET_KEYS.pr1578],
+    ["development", PREVIEW_BACKEND_TARGET_KEYS.pr1578],
     ["preview", ""],
     ["preview", "   "],
     ["preview", "unknown"],


### PR DESCRIPTION
## Summary
- adds the closed symbolic selector pr1578-writer-guards-cert
- binds it to the predetermined temporary Cloud Run URL and identical ID-token audience
- keeps the target Preview-only and preserves the permanent default and fail-closed registry

## Scope
- exactly two frontend proxy/test files
- no backend product, tenant writer, Terraform, deployment workflow, or product logic changes
- no runtime build, Cloud Run service, Vercel selector mutation, or deployment

## Validation
- preview backend proxy tests: 137 passed
- targeted TypeScript validation for touched proxy/test modules: passed
- frontend production build: passed
- git diff --check: passed