### PR TITLE
Add PR #1580 Preview backend selector

### DIFF
--- a/rentchain-frontend/server/previewBackendProxy.ts
+++ b/rentchain-frontend/server/previewBackendProxy.ts
@@ -29,6 +29,7 @@ export const PREVIEW_BACKEND_TARGET_KEYS = {
   pr1573: "pr1573-tenant-lifecycle-cert",
   pr1576: "pr1576-context-mismatch-cert",
   pr1578: "pr1578-writer-guards-cert",
+  pr1580: "pr1580-tenant-status-reconcile-cert",
 } as const;
 
 export type PreviewBackendTarget = {
@@ -131,6 +132,14 @@ const PREVIEW_BACKEND_TARGETS: Record<string, PreviewBackendTarget> = {
       "https://rentchain-pr1578-qa-writer-guards-501298948635.northamerica-northeast1.run.app",
     cloudRunIdTokenAudience:
       "https://rentchain-pr1578-qa-writer-guards-501298948635.northamerica-northeast1.run.app",
+    temporary: true,
+  },
+  [PREVIEW_BACKEND_TARGET_KEYS.pr1580]: {
+    key: PREVIEW_BACKEND_TARGET_KEYS.pr1580,
+    cloudRunServiceUrl:
+      "https://rentchain-pr1580-qa-tenant-status-reconcile-501298948635.northamerica-northeast1.run.app",
+    cloudRunIdTokenAudience:
+      "https://rentchain-pr1580-qa-tenant-status-reconcile-501298948635.northamerica-northeast1.run.app",
     temporary: true,
   },
 };

--- a/rentchain-frontend/src/platform/previewBackendProxy.test.ts
+++ b/rentchain-frontend/src/platform/previewBackendProxy.test.ts
@@ -283,6 +283,21 @@ describe("Preview backend proxy", () => {
     });
   });
 
+  it("couples the authorized PR #1580 service URL and audience internally", () => {
+    const target = resolvePreviewBackendTarget({
+      vercelEnvironment: "preview",
+      targetKey: PREVIEW_BACKEND_TARGET_KEYS.pr1580,
+    });
+    expect(target).toEqual({
+      key: "pr1580-tenant-status-reconcile-cert",
+      cloudRunServiceUrl:
+        "https://rentchain-pr1580-qa-tenant-status-reconcile-501298948635.northamerica-northeast1.run.app",
+      cloudRunIdTokenAudience:
+        "https://rentchain-pr1580-qa-tenant-status-reconcile-501298948635.northamerica-northeast1.run.app",
+      temporary: true,
+    });
+  });
+
   it.each([
     ["production", PREVIEW_BACKEND_TARGET_KEYS.pr1555],
     ["development", PREVIEW_BACKEND_TARGET_KEYS.pr1555],
@@ -306,6 +321,8 @@ describe("Preview backend proxy", () => {
     ["development", PREVIEW_BACKEND_TARGET_KEYS.pr1576],
     ["production", PREVIEW_BACKEND_TARGET_KEYS.pr1578],
     ["development", PREVIEW_BACKEND_TARGET_KEYS.pr1578],
+    ["production", PREVIEW_BACKEND_TARGET_KEYS.pr1580],
+    ["development", PREVIEW_BACKEND_TARGET_KEYS.pr1580],
     ["preview", ""],
     ["preview", "   "],
     ["preview", "unknown"],


### PR DESCRIPTION
Adds the closed Preview-only backend selector required for PR #1580 runtime certification.\n\n- Maps the exact symbolic key to the reserved temporary Cloud Run URL and matching ID-token audience\n- Preserves permanent and existing temporary targets\n- Extends focused rejection and environment-boundary coverage