### PR TITLE
PR N1: contain unsupported occupied-without-lease states

### DIFF
--- a/rentchain-api/src/imports/unitCsv.schema.ts
+++ b/rentchain-api/src/imports/unitCsv.schema.ts
@@ -125,6 +125,10 @@ function normalizeStatus(value: any) {
   return text;
 }
 
+export function isUnsupportedInitialOccupancyStatus(...values: any[]): boolean {
+  return values.some((value) => ["occupied", "leased", "rented"].includes(String(value || "").trim().toLowerCase()));
+}
+
 function hasManualUnitValue(unit: any) {
   if (!unit || typeof unit !== "object") return false;
   const values = [
@@ -226,6 +230,16 @@ export function validateManualUnitInputs(units: any[]): ManualUnitValidationResu
 
   (Array.isArray(units) ? units : []).forEach((unit, index) => {
     if (!hasManualUnitValue(unit)) return;
+
+    if (isUnsupportedInitialOccupancyStatus(unit?.status, unit?.occupancyStatus)) {
+      issues.push({
+        index,
+        position: index + 1,
+        field: "status",
+        message: "Occupied units must be created as vacant and started through the occupancy workflow.",
+      });
+      return;
+    }
 
     const mapped = {
       unitNumber: cleanCell(unit?.unitNumber ?? unit?.unit ?? unit?.label),

--- a/rentchain-api/src/imports/unitCsvImport.service.test.ts
+++ b/rentchain-api/src/imports/unitCsvImport.service.test.ts
@@ -8,8 +8,8 @@ describe("parseUnitsCsv", () => {
     const result = parseUnitsCsv(csv);
 
     expect(result.headers).toMatchObject({ valid: true, missing: [], unknown: [] });
-    expect(result.preview.errors).toEqual([]);
-    expect(result.candidates).toHaveLength(2);
+    expect(result.preview.errors).toEqual([expect.objectContaining({ row: 3, code: "UNSUPPORTED_INITIAL_OCCUPANCY", field: "status" })]);
+    expect(result.candidates).toHaveLength(1);
     expect(result.candidates[0].data).toMatchObject({
       unitNumber: "101",
       rent: 1850,
@@ -31,8 +31,8 @@ describe("parseUnitsCsv", () => {
     const result = parseUnitsCsv(csv);
 
     expect(result.headers).toMatchObject({ valid: true, missing: [], unknown: [] });
-    expect(result.preview.errors).toEqual([]);
-    expect(result.candidates).toHaveLength(2);
+    expect(result.preview.errors).toEqual([expect.objectContaining({ row: 3, code: "UNSUPPORTED_INITIAL_OCCUPANCY", field: "status" })]);
+    expect(result.candidates).toHaveLength(1);
     expect(result.candidates[0].data).toMatchObject({
       unitNumber: "101",
       rent: 1850,
@@ -41,32 +41,16 @@ describe("parseUnitsCsv", () => {
       sqft: 610,
       status: "vacant",
     });
-    expect(result.candidates[1].data).toMatchObject({
-      unitNumber: "102",
-      rent: 1650,
-      bedrooms: 0,
-      bathrooms: 1,
-      sqft: 450,
-      status: "occupied",
-    });
   });
 
-  it("parses occupied metadata aliases for CSV imports", () => {
-    const csv = "unitNumber,marketRent,beds,baths,status,tenantName,leaseEndDate\n301,2100,2,1,occupied,Jane Tenant,2027-06-10";
+  it.each(["occupied", "leased", "rented", " OCCUPIED "])("rejects unsupported initial occupancy status %s", (status) => {
+    const csv = `unitNumber,marketRent,beds,baths,status,tenantName,leaseEndDate\n301,2100,2,1,${status},Jane Tenant,2027-06-10`;
 
     const result = parseUnitsCsv(csv);
 
     expect(result.headers).toMatchObject({ valid: true, missing: [], unknown: [] });
-    expect(result.preview.errors).toEqual([]);
-    expect(result.candidates[0].data).toMatchObject({
-      unitNumber: "301",
-      rent: 2100,
-      bedrooms: 2,
-      bathrooms: 1,
-      status: "occupied",
-      occupantName: "Jane Tenant",
-      leaseEndDate: "2027-06-10",
-    });
+    expect(result.preview.errors).toEqual([expect.objectContaining({ code: "UNSUPPORTED_INITIAL_OCCUPANCY", field: "status" })]);
+    expect(result.candidates).toEqual([]);
   });
 
   it("accepts the public template occupantName and leaseEndDate headers", () => {
@@ -80,17 +64,8 @@ describe("parseUnitsCsv", () => {
       unknown: [],
       expected: expect.arrayContaining(["occupantName", "leaseEndDate"]),
     });
-    expect(result.preview.errors).toEqual([]);
-    expect(result.candidates[0].data).toMatchObject({
-      unitNumber: "301",
-      rent: 2100,
-      bedrooms: 2,
-      bathrooms: 1,
-      sqft: 850,
-      status: "occupied",
-      occupantName: "Jane Tenant",
-      leaseEndDate: "2027-06-10",
-    });
+    expect(result.preview.errors).toEqual([expect.objectContaining({ code: "UNSUPPORTED_INITIAL_OCCUPANCY", field: "status" })]);
+    expect(result.candidates).toEqual([]);
   });
 
   it("recovers UTF-16 BOM text when upload decoding leaves null bytes", () => {

--- a/rentchain-api/src/imports/unitCsvImport.service.ts
+++ b/rentchain-api/src/imports/unitCsvImport.service.ts
@@ -4,6 +4,7 @@ import {
   UNIT_CSV_FIELD_MAP,
   UnitCsvRowSchema,
   cleanText,
+  isUnsupportedInitialOccupancyStatus,
   mapRow,
   resolveUnitCsvField,
 } from "./unitCsv.schema";
@@ -96,6 +97,18 @@ export function parseUnitsCsv(csvText: string): ParsedUnitsCsv {
     }
 
     const mapped = mapRow(raw);
+    if (isUnsupportedInitialOccupancyStatus(mapped.status)) {
+      const issue = {
+        row: rowNum,
+        code: "UNSUPPORTED_INITIAL_OCCUPANCY",
+        field: "status",
+        message: `Row ${rowNum}: status - occupied units must be created as vacant and started through the occupancy workflow`,
+        unitNumber: mapped.unitNumber ? String(mapped.unitNumber).trim() : undefined,
+      };
+      invalid.push(issue);
+      rows.push({ row: rowNum, status: "invalid", unitNumber: mapped.unitNumber, data: mapped, issues: [issue] });
+      return;
+    }
     const v = UnitCsvRowSchema.safeParse(mapped);
     if (!v.success) {
       const issues = v.error.issues.map((issue) => {

--- a/rentchain-api/src/routes/__tests__/propertiesRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/propertiesRoutes.test.ts
@@ -445,6 +445,22 @@ describe("properties routes publish + defaults", () => {
     });
   });
 
+  it.each(["occupied", "leased", "rented", " OCCUPIED "])("rejects unsupported initial property unit status %s without writes", async (status) => {
+    const app = await createApp();
+    const res = await request(app).post("/api/properties").send({
+      addressLine1: "102 Unit St",
+      city: "Halifax",
+      province: "NS",
+      units: [{ unitNumber: "101", rent: 1850, status }],
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: "manual_unit_validation_failed" });
+    expect(res.body.unitErrors).toEqual([expect.objectContaining({ field: "status" })]);
+    expect(listDocs("properties")).toEqual([]);
+    expect(listDocs("units")).toEqual([]);
+  });
+
   it("rejects invalid manually entered units before creating records", async () => {
     const app = await createApp();
     const res = await request(app)

--- a/rentchain-api/src/routes/__tests__/unitCsvPreviewRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/unitCsvPreviewRoutes.test.ts
@@ -103,18 +103,14 @@ describe("unit CSV preview routes", () => {
     });
 
     expect(res.status).toBe(200);
-    expect(res.body.ok).toBe(true);
+    expect(res.body.ok).toBe(false);
     expect(res.body.preview.rows).toEqual([
       expect.objectContaining({
         row: 2,
         status: "valid",
         data: expect.objectContaining({ unitNumber: "101", rent: 1850, status: "vacant" }),
       }),
-      expect.objectContaining({
-        row: 3,
-        status: "valid",
-        data: expect.objectContaining({ unitNumber: "102", rent: 1650, status: "occupied" }),
-      }),
+      expect.objectContaining({ row: 3, status: "invalid", issues: [expect.objectContaining({ code: "UNSUPPORTED_INITIAL_OCCUPANCY" })] }),
     ]);
   });
 
@@ -134,7 +130,7 @@ describe("unit CSV preview routes", () => {
     ]);
   });
 
-  it("accepts occupied metadata headers through the property-scoped route", async () => {
+  it("rejects occupied rows through the property-scoped route", async () => {
     seedDoc("properties", "prop-1", { landlordId: "landlord-1" });
     const app = await createUnitImportApp();
 
@@ -143,15 +139,15 @@ describe("unit CSV preview routes", () => {
     });
 
     expect(res.status).toBe(200);
-    expect(res.body.ok).toBe(true);
+    expect(res.body.ok).toBe(false);
     expect(res.body.headers.unknown).toEqual([]);
     expect(res.body.headers.expected).toEqual(
       expect.arrayContaining(["unitNumber", "marketRent", "beds", "baths", "sqft", "status", "occupantName", "leaseEndDate"])
     );
-    expect(res.body.preview.errors).toEqual([]);
+    expect(res.body.preview.errors).toEqual([expect.objectContaining({ code: "UNSUPPORTED_INITIAL_OCCUPANCY", field: "status" })]);
     expect(res.body.preview.rows[0]).toMatchObject({
       row: 2,
-      status: "valid",
+      status: "invalid",
       data: expect.objectContaining({
         unitNumber: "301",
         status: "occupied",

--- a/rentchain-api/src/routes/__tests__/unitsRoutes.patch.test.ts
+++ b/rentchain-api/src/routes/__tests__/unitsRoutes.patch.test.ts
@@ -293,7 +293,7 @@ describe("unitsRoutes PATCH aliases", () => {
     });
   });
 
-  it("returns persisted IDs when creating units for a property", async () => {
+  it("returns persisted IDs when creating vacant units for a property", async () => {
     seedDoc("properties", "prop-1", { landlordId: "landlord-1" });
     const app = await createApp();
 
@@ -302,22 +302,12 @@ describe("unitsRoutes PATCH aliases", () => {
       .send({
         units: [
           { unitNumber: "101", beds: 1, baths: 1, sqft: 500, marketRent: 1500, status: "vacant" },
-          {
-            unitNumber: "102",
-            beds: 2,
-            baths: 1,
-            sqft: 700,
-            marketRent: 1900,
-            status: "occupied",
-            occupantName: "Jane Tenant",
-            leaseEndDate: "2027-06-10",
-          },
         ],
       });
 
     expect(res.status).toBe(200);
-    expect(res.body).toMatchObject({ ok: true, created: 2 });
-    expect(res.body.units).toHaveLength(2);
+    expect(res.body).toMatchObject({ ok: true, created: 1 });
+    expect(res.body.units).toHaveLength(1);
     expect(res.body.units[0]).toMatchObject({
       id: "units-auto-1",
       unitNumber: "101",
@@ -334,26 +324,10 @@ describe("unitsRoutes PATCH aliases", () => {
       tenantName: null,
       leaseEndDate: null,
     });
-    expect(res.body.units[1]).toMatchObject({
-      id: "units-auto-2",
-      unitNumber: "102",
-      propertyId: "prop-1",
-      rent: 1900,
-      marketRent: 1900,
-      beds: 2,
-      bedrooms: 2,
-      baths: 1,
-      bathrooms: 1,
-      status: "occupied",
-      occupancyStatus: "occupied",
-      occupantName: "Jane Tenant",
-      tenantName: "Jane Tenant",
-      leaseEndDate: "2027-06-10",
-    });
     expect(res.body.items).toEqual(res.body.units);
     expect(getDoc("properties", "prop-1")).toMatchObject({
-      unitCount: 2,
-      unitsCount: 2,
+      unitCount: 1,
+      unitsCount: 1,
       units: [
         expect.objectContaining({
           id: "units-auto-1",
@@ -362,16 +336,18 @@ describe("unitsRoutes PATCH aliases", () => {
           occupantName: null,
           leaseEndDate: null,
         }),
-        expect.objectContaining({
-          id: "units-auto-2",
-          unitNumber: "102",
-          status: "occupied",
-          occupancyStatus: "occupied",
-          occupantName: "Jane Tenant",
-          tenantName: "Jane Tenant",
-          leaseEndDate: "2027-06-10",
-        }),
       ],
     });
+  });
+
+  it.each(["occupied", "leased", "rented", " OCCUPIED "])("rejects unsupported standalone unit status %s without writes", async (status) => {
+    seedDoc("properties", "prop-1", { landlordId: "landlord-1" });
+    const app = await createApp();
+    const res = await request(app).post("/api/properties/prop-1/units").send({ units: [{ unitNumber: "101", status }] });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ code: "UNSUPPORTED_INITIAL_OCCUPANCY" });
+    expect(getDoc("units", "units-auto-1")).toBeUndefined();
+    expect(getDoc("properties", "prop-1")).toEqual({ landlordId: "landlord-1" });
   });
 });

--- a/rentchain-api/src/routes/unitsRoutes.ts
+++ b/rentchain-api/src/routes/unitsRoutes.ts
@@ -6,6 +6,7 @@ import { requireCapability } from "../services/capabilityGuard";
 import { uploadBufferToGcs } from "../lib/gcs";
 import { getSignedDownloadUrl } from "../lib/gcsSignedUrl";
 import { applyGovernedUnitUpdate, GovernedUnitUpdateError } from "../services/governedUnitUpdateService";
+import { isUnsupportedInitialOccupancyStatus } from "../imports/unitCsv.schema";
 
 const router = Router();
 const leaseDocumentUpload = multer({
@@ -393,6 +394,14 @@ router.post(
 
     const units = Array.isArray(req.body?.units) ? req.body.units : [];
     if (!units.length) return res.status(400).json({ ok: false, error: "No units provided" });
+    if (units.some((unit: any) => isUnsupportedInitialOccupancyStatus(unit?.status, unit?.occupancyStatus))) {
+      return res.status(400).json({
+        ok: false,
+        error: "UNSUPPORTED_INITIAL_OCCUPANCY",
+        code: "UNSUPPORTED_INITIAL_OCCUPANCY",
+        message: "Occupied units must be created as vacant and started through the occupancy workflow.",
+      });
+    }
 
     let created = 0;
     const batch = db.batch();

--- a/rentchain-api/src/services/__tests__/occupancyResolutionService.test.ts
+++ b/rentchain-api/src/services/__tests__/occupancyResolutionService.test.ts
@@ -210,31 +210,75 @@ describe("occupancyResolutionService", () => {
     expect(read("canonicalEvents", result.auditEventId)).toMatchObject({ action: "occupancy_resolution_recorded", immutable: true });
   });
 
-  it("preserves stale occupied-without-lease recovery for a requested tenant", async () => {
+  it("removes generic vacancy clearing but preserves uniquely attributed operational move-out", async () => {
     seed("properties", "property-1", { landlordId: "landlord-1", name: "Harbour House", units: [{ id: "unit-1", unitNumber: "1A", status: "occupied", currentTenantId: "tenant-1" }] });
     seed("units", "unit-1", { landlordId: "landlord-1", propertyId: "property-1", unitNumber: "1A", status: "occupied", currentTenantId: "tenant-1" });
     seed("tenants", "tenant-1", { landlordId: "landlord-1", status: "Current", currentLeaseId: null });
     const context = await getOccupancyResolutionContext(base);
     expect(context.canonicalState.reasons).toContain("OCCUPIED_WITHOUT_CURRENT_LEASE");
-    expect(context.eligibleResolutionTypes).toEqual(expect.arrayContaining(["record_operational_move_out", "clear_stale_occupancy_record"]));
+    expect(context.eligibleResolutionTypes).toEqual(["record_operational_move_out"]);
+  });
+
+  it.each([
+    ["occupied marker only", () => {}],
+    ["tenant current", () => seed("tenants", "tenant-1", { landlordId: "landlord-1", status: "Current" })],
+    ["active tenancy", () => seed("tenancies", "tenancy-1", { landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-1", status: "active" })],
+    ["missing referenced lease", () => seed("units", "unit-1", { ...read("units", "unit-1"), currentLeaseId: "missing-lease" })],
+    ["past lease", () => seed("leases", "lease-1", { landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-1", status: "active", executionStatus: "fully_executed", startDate: "2025-01-01", endDate: "2025-12-31" })],
+    ["upcoming lease", () => seed("leases", "lease-1", { landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-1", status: "active", executionStatus: "fully_executed", startDate: "2027-01-01", endDate: "2027-12-31" })],
+    ["draft lease", () => seed("leases", "lease-1", { landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-1", status: "draft", executionStatus: "draft", startDate: "2026-01-01", endDate: "2027-01-01" })],
+    ["foreign tenancy", () => seed("tenancies", "tenancy-foreign", { landlordId: "landlord-2", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-2", status: "active" })],
+  ] as const)("does not offer generic stale occupancy clearing for %s", async (_label, arrange) => {
+    seed("properties", "property-1", { landlordId: "landlord-1", units: [{ id: "unit-1", unitNumber: "1A", status: "occupied", currentTenantId: "tenant-1" }] });
+    seed("units", "unit-1", { landlordId: "landlord-1", propertyId: "property-1", unitNumber: "1A", status: "occupied", currentTenantId: "tenant-1" });
+    seed("tenants", "tenant-1", { landlordId: "landlord-1", status: "Current" });
+    arrange();
+    const context = await getOccupancyResolutionContext(base);
+    expect(context.eligibleResolutionTypes).not.toContain("clear_stale_occupancy_record");
+  });
+
+  it.each([
+    ["no attributable tenant", () => {
+      seed("properties", "property-1", { landlordId: "landlord-1", units: [{ id: "unit-1", unitNumber: "1A", status: "occupied" }] });
+      seed("units", "unit-1", { landlordId: "landlord-1", propertyId: "property-1", unitNumber: "1A", status: "occupied" });
+    }],
+    ["multiple candidate tenants", () => {
+      seed("properties", "property-1", { landlordId: "landlord-1", units: [{ id: "unit-1", unitNumber: "1A", status: "occupied", currentTenantId: "tenant-1" }] });
+      seed("units", "unit-1", { landlordId: "landlord-1", propertyId: "property-1", unitNumber: "1A", status: "occupied", currentTenantId: "tenant-1" });
+      seed("tenancies", "tenancy-2", { landlordId: "landlord-1", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-2", status: "active" });
+    }],
+    ["foreign tenancy", () => {
+      seed("properties", "property-1", { landlordId: "landlord-1", units: [{ id: "unit-1", unitNumber: "1A", status: "occupied", currentTenantId: "tenant-1" }] });
+      seed("units", "unit-1", { landlordId: "landlord-1", propertyId: "property-1", unitNumber: "1A", status: "occupied", currentTenantId: "tenant-1" });
+      seed("tenancies", "tenancy-foreign", { landlordId: "landlord-2", propertyId: "property-1", unitId: "unit-1", tenantId: "tenant-1", status: "active" });
+    }],
+    ["conflicting unit linkage", () => {
+      seed("properties", "property-1", { landlordId: "landlord-1", units: [{ id: "unit-1", unitNumber: "1A", status: "occupied", currentTenantId: "tenant-2" }] });
+      seed("units", "unit-1", { landlordId: "landlord-1", propertyId: "property-1", unitNumber: "1A", status: "occupied", currentTenantId: "tenant-1" });
+    }],
+  ] as const)("fails closed for operational move-out with %s", async (_label, arrange) => {
+    arrange();
+    seed("tenants", "tenant-1", { landlordId: "landlord-1", status: "Current" });
+    const context = await getOccupancyResolutionContext(base);
+    expect(context.eligibleResolutionTypes).not.toContain("record_operational_move_out");
   });
 
   it("returns the committed result for an identical idempotent retry and rejects changed payload", async () => {
     seedExpiredReview();
     const context = await getOccupancyResolutionContext(base);
-    const input = { ...base, actorId: "landlord-1", type: "clear_stale_occupancy_record" as const, expectedStateToken: context.expectedStateToken, idempotencyKey: "retry-1", confirmation: true };
+    const input = { ...base, actorId: "landlord-1", type: "record_operational_move_out" as const, effectiveDate: "2026-08-18", expectedStateToken: context.expectedStateToken, idempotencyKey: "retry-1", confirmation: true };
     const first = await resolveOccupancy(input);
     const second = await resolveOccupancy(input);
     expect(second.idempotent).toBe(true);
     expect(second.auditEventId).toBe(first.auditEventId);
-    await expect(resolveOccupancy({ ...input, type: "record_operational_move_out", effectiveDate: "2026-08-18" })).rejects.toMatchObject({ code: "idempotency_key_reused" });
+    await expect(resolveOccupancy({ ...input, effectiveDate: "2026-08-19" })).rejects.toMatchObject({ code: "idempotency_key_reused" });
   });
 
   it("rolls back operational writes when immutable audit creation fails", async () => {
     seedExpiredReview();
     const context = await getOccupancyResolutionContext(base);
     failAudit(true);
-    await expect(resolveOccupancy({ ...base, actorId: "landlord-1", type: "clear_stale_occupancy_record", expectedStateToken: context.expectedStateToken, idempotencyKey: "audit-fail", confirmation: true })).rejects.toThrow("audit_failed");
+    await expect(resolveOccupancy({ ...base, actorId: "landlord-1", type: "record_operational_move_out", effectiveDate: "2026-08-18", expectedStateToken: context.expectedStateToken, idempotencyKey: "audit-fail", confirmation: true })).rejects.toThrow("audit_failed");
     expect(read("units", "unit-1")).toMatchObject({ occupancyStatus: "occupied", currentLeaseId: "lease-past" });
     expect(read("occupancyResolutionRequests", "6f04eb5f")).toBeUndefined();
   });

--- a/rentchain-api/src/services/occupancyResolutionService.ts
+++ b/rentchain-api/src/services/occupancyResolutionService.ts
@@ -131,6 +131,26 @@ function matchesTenancyUnitContext(row: any, propertyId: string, unitId: string,
   return rowUnitId === unitId || (Boolean(unitLabel) && rowUnitLabel === unitLabel);
 }
 
+function hasUniqueOperationalMoveOutAttribution(input: {
+  landlordId: string;
+  requestedTenantId: string | null;
+  unit: any;
+  embeddedUnitMatches: any[];
+  diagnosticLeases: any[];
+  diagnosticTenancies: any[];
+}): boolean {
+  if (!input.requestedTenantId || input.embeddedUnitMatches.length !== 1) return false;
+  if (input.diagnosticTenancies.some((row: any) => text(row.landlordId) !== input.landlordId)) return false;
+
+  const tenantIds = new Set([
+    ...pointerValues(input.unit, ["tenantId", "currentTenantId"]),
+    ...pointerValues(input.embeddedUnitMatches[0], ["tenantId", "currentTenantId"]),
+    ...input.diagnosticLeases.flatMap(participantTenantIds),
+    ...input.diagnosticTenancies.map((row: any) => text(row.tenantId)).filter(Boolean),
+  ]);
+  return tenantIds.size === 1 && tenantIds.has(input.requestedTenantId);
+}
+
 function classifyContextMismatch(input: {
   landlordId: string;
   propertyId: string;
@@ -380,12 +400,23 @@ async function readResolutionContext(
   });
   const activeLeaseRequiresEndWorkflow = reviewNeeded && candidates.length === 1 && canonicalState.supportingLeaseId === candidates[0].id;
   const eligibleResolutionTypes: OccupancyResolutionType[] = [];
+  const uniquelyAttributedOperationalMoveOut = hasUniqueOperationalMoveOutAttribution({
+    landlordId: input.landlordId,
+    requestedTenantId: tenantId,
+    unit,
+    embeddedUnitMatches,
+    diagnosticLeases,
+    diagnosticTenancies,
+  });
   if (reviewNeeded && !mutationBlocked) {
     if (canonicalState.reasons.includes("MULTIPLE_CURRENT_LEASES") && candidates.length >= 2) {
       eligibleResolutionTypes.push("resolve_multiple_current_leases");
     }
     if (!canonicalState.supportingLeaseId && !canonicalState.reasons.includes("MULTIPLE_CURRENT_LEASES")) {
-      eligibleResolutionTypes.push("record_operational_move_out", "clear_stale_occupancy_record");
+      if (uniquelyAttributedOperationalMoveOut) eligibleResolutionTypes.push("record_operational_move_out");
+      if (!canonicalState.reasons.includes("OCCUPIED_WITHOUT_CURRENT_LEASE")) {
+        eligibleResolutionTypes.push("clear_stale_occupancy_record");
+      }
     }
     if (candidates.length === 1 && canonicalState.reasons.includes("STALE_CURRENT_LEASE_POINTER")) {
       eligibleResolutionTypes.push("link_existing_lease");


### PR DESCRIPTION
## Purpose

Prevent recurrence of unsupported `OCCUPIED_WITHOUT_CURRENT_LEASE` states and remove unsafe generic remediation eligibility.

## Includes

- rejects occupancy-bearing initial values in all three live writers: initial property units, mounted standalone unit creation, and CSV import
- fails closed for generic `clear_stale_occupancy_record` eligibility on lease-less occupied states
- requires unique server-authoritative tenant attribution for `record_operational_move_out`
- adds focused writer, normalization, no-side-effect, eligibility, attribution, and regression coverage

## Explicitly excludes

- new occupied-to-vacant remediation subtype
- historical migration or repair
- Review Needed coverage expansion
- dormant admin/route cleanup
- renewal continuity changes
- canonical reason-set changes

## Validation

- focused writer and occupancy-resolution tests: 123 passed
- PR M tenant relationship regressions: 24 passed
- canonical Start Occupancy regressions: 29 passed
- lease-start service regressions: 38 passed
- End Lease and lifecycle route regressions: 68 passed
- occupancy-resolution route regressions: 8 passed
- canonical reason/projection regressions: 28 passed
- Review Needed regressions: 18 passed
- backend TypeScript build: passed
- `git diff --check`: passed

## Runtime

Runtime certification infrastructure has not been provisioned. This PR is not ready to merge.
