### PR TITLE
PR N1 prerequisite: add closed PR 1582 preview selector

### DIFF
--- a/rentchain-frontend/server/previewBackendProxy.ts
+++ b/rentchain-frontend/server/previewBackendProxy.ts
@@ -30,6 +30,7 @@ export const PREVIEW_BACKEND_TARGET_KEYS = {
   pr1576: "pr1576-context-mismatch-cert",
   pr1578: "pr1578-writer-guards-cert",
   pr1580: "pr1580-tenant-status-reconcile-cert",
+  pr1582: "pr1582-occupied-without-lease-containment-cert",
 } as const;
 
 export type PreviewBackendTarget = {
@@ -140,6 +141,14 @@ const PREVIEW_BACKEND_TARGETS: Record<string, PreviewBackendTarget> = {
       "https://rentchain-pr1580-qa-tenant-status-reconcile-501298948635.northamerica-northeast1.run.app",
     cloudRunIdTokenAudience:
       "https://rentchain-pr1580-qa-tenant-status-reconcile-501298948635.northamerica-northeast1.run.app",
+    temporary: true,
+  },
+  [PREVIEW_BACKEND_TARGET_KEYS.pr1582]: {
+    key: PREVIEW_BACKEND_TARGET_KEYS.pr1582,
+    cloudRunServiceUrl:
+      "https://rentchain-pr1582-qa-occupied-without-lease-containment-501298948635.northamerica-northeast1.run.app",
+    cloudRunIdTokenAudience:
+      "https://rentchain-pr1582-qa-occupied-without-lease-containment-501298948635.northamerica-northeast1.run.app",
     temporary: true,
   },
 };

--- a/rentchain-frontend/src/platform/previewBackendProxy.test.ts
+++ b/rentchain-frontend/src/platform/previewBackendProxy.test.ts
@@ -298,6 +298,21 @@ describe("Preview backend proxy", () => {
     });
   });
 
+  it("couples the authorized PR #1582 service URL and audience internally", () => {
+    const target = resolvePreviewBackendTarget({
+      vercelEnvironment: "preview",
+      targetKey: PREVIEW_BACKEND_TARGET_KEYS.pr1582,
+    });
+    expect(target).toEqual({
+      key: "pr1582-occupied-without-lease-containment-cert",
+      cloudRunServiceUrl:
+        "https://rentchain-pr1582-qa-occupied-without-lease-containment-501298948635.northamerica-northeast1.run.app",
+      cloudRunIdTokenAudience:
+        "https://rentchain-pr1582-qa-occupied-without-lease-containment-501298948635.northamerica-northeast1.run.app",
+      temporary: true,
+    });
+  });
+
   it.each([
     ["production", PREVIEW_BACKEND_TARGET_KEYS.pr1555],
     ["development", PREVIEW_BACKEND_TARGET_KEYS.pr1555],
@@ -323,6 +338,8 @@ describe("Preview backend proxy", () => {
     ["development", PREVIEW_BACKEND_TARGET_KEYS.pr1578],
     ["production", PREVIEW_BACKEND_TARGET_KEYS.pr1580],
     ["development", PREVIEW_BACKEND_TARGET_KEYS.pr1580],
+    ["production", PREVIEW_BACKEND_TARGET_KEYS.pr1582],
+    ["development", PREVIEW_BACKEND_TARGET_KEYS.pr1582],
     ["preview", ""],
     ["preview", "   "],
     ["preview", "unknown"],


### PR DESCRIPTION
## Purpose

Add the closed static Preview backend selector required to certify PR #1582 against its fixed temporary Cloud Run service.

## Scope

- adds symbolic selector `pr1582-occupied-without-lease-containment-cert`
- maps it to one fixed Cloud Run URL and identical ID-token audience
- keeps the target Preview-only and temporary
- adds focused coupling and non-Preview rejection coverage

## Security boundaries

- no arbitrary URL support
- no wildcard selector
- no request-driven target
- no Production or permanent Preview change
- no runtime deployment

## Validation

- `previewBackendProxy.test.ts`: 143 passed
- frontend production build: passed
- `git diff --check`: passed

This prerequisite must merge under normal governance before PR #1582 is updated and re-pinned for exact-head runtime certification.
